### PR TITLE
Infix contracts

### DIFF
--- a/lib/std/io/file.slop
+++ b/lib/std/io/file.slop
@@ -96,7 +96,7 @@
   (fn file-open ((path String) (mode FileMode))
     (@intent "Open a file with the specified mode, returning a File handle or error")
     (@spec ((String FileMode) -> (Result File FileError)))
-    (@pre (> (. path len) 0))
+    (@pre {(. path len) > 0})
     (@example ("test.txt" 'read) -> (ok (File _ 'read true)))
     (@example ("missing.txt" 'read) -> (error 'not-found))
     (@example ("output.txt" 'write) -> (ok (File _ 'write true)))
@@ -221,7 +221,7 @@
     (@intent "Seek to position in file (whence: 0=start, 1=current, 2=end)")
     (@spec (((Ptr File) I64 Int) -> (Result Bool FileError)))
     (@pre (. (deref f) is-open))
-    (@pre (and (>= whence 0) (<= whence 2)))
+    (@pre {whence >= 0 and whence <= 2})
     (@example (file 0 0) -> (ok true))
     (@example (file -10 2) -> (ok true))
 

--- a/lib/std/math/mathlib.slop
+++ b/lib/std/math/mathlib.slop
@@ -87,8 +87,8 @@
     (@intent "Return absolute value of integer")
     (@spec ((Int) -> (Int 0 ..)))
     (@pure)
-    (@post (>= $result 0))
-    (@post (or (== $result n) (== $result (- 0 n))))
+    (@post {$result >= 0})
+    (@post {$result == n or $result == -n})
     (@example (5) -> 5)
     (@example (-5) -> 5)
     (@example (0) -> 0)
@@ -98,7 +98,7 @@
     (@intent "Return sign of integer: -1, 0, or 1")
     (@spec ((Int) -> (Int -1 .. 1)))
     (@pure)
-    (@post (or (== $result -1) (== $result 0) (== $result 1)))
+    (@post {$result == -1 or $result == 0 or $result == 1})
     (@example (42) -> 1)
     (@example (-42) -> -1)
     (@example (0) -> 0)
@@ -110,9 +110,9 @@
   (fn clamp ((value Int) (min-val Int) (max-val Int))
     (@intent "Clamp integer to range [min-val, max-val]")
     (@spec ((Int Int Int) -> Int))
-    (@pre (<= min-val max-val))
-    (@post (>= $result min-val))
-    (@post (<= $result max-val))
+    (@pre {min-val <= max-val})
+    (@post {$result >= min-val})
+    (@post {$result <= max-val})
     (@pure)
     (@example (5 0 10) -> 5)
     (@example (-5 0 10) -> 0)
@@ -126,7 +126,7 @@
     (@intent "Compute greatest common divisor using Euclidean algorithm")
     (@spec ((Int Int) -> (Int 0 ..)))
     (@pure)
-    (@post (>= $result 0))
+    (@post {$result >= 0})
     (@example (48 18) -> 6)
     (@example (17 13) -> 1)
     (@example (0 5) -> 5)
@@ -146,7 +146,7 @@
     (@intent "Compute least common multiple")
     (@spec ((Int Int) -> (Int 0 ..)))
     (@pure)
-    (@post (>= $result 0))
+    (@post {$result >= 0})
     (@example (4 6) -> 12)
     (@example (3 5) -> 15)
     (@example (0 5) -> 0)
@@ -163,7 +163,7 @@
     (@intent "Return absolute value of float")
     (@spec ((Float) -> Float))
     (@pure)
-    (@assume (>= $result 0.0))  ;; Trusted FFI behavior
+    (@assume {$result >= 0.0})  ;; Trusted FFI behavior
     (@example (3.14) -> 3.14)
     (@example (-3.14) -> 3.14)
     (@example (0.0) -> 0.0)
@@ -173,7 +173,7 @@
     (@intent "Round down to nearest integer")
     (@spec ((Float) -> Float))
     (@pure)
-    (@assume (<= $result x))  ;; Trusted FFI behavior
+    (@assume {$result <= x})  ;; Trusted FFI behavior
     (@example (3.7) -> 3.0)
     (@example (-3.2) -> -4.0)
     (@example (5.0) -> 5.0)
@@ -183,7 +183,7 @@
     (@intent "Round up to nearest integer")
     (@spec ((Float) -> Float))
     (@pure)
-    (@assume (>= $result x))  ;; Trusted FFI behavior
+    (@assume {$result >= x})  ;; Trusted FFI behavior
     (@example (3.2) -> 4.0)
     (@example (-3.7) -> -3.0)
     (@example (5.0) -> 5.0)
@@ -217,9 +217,9 @@
   (fn clamp-float ((value Float) (min-val Float) (max-val Float))
     (@intent "Clamp float to range [min-val, max-val]")
     (@spec ((Float Float Float) -> Float))
-    (@pre (<= min-val max-val))
-    (@post (>= $result min-val))
-    (@post (<= $result max-val))
+    (@pre {min-val <= max-val})
+    (@post {$result >= min-val})
+    (@post {$result <= max-val})
     (@pure)
     (@example (0.5 0.0 1.0) -> 0.5)
     (@example (-0.5 0.0 1.0) -> 0.0)
@@ -236,8 +236,8 @@
   (fn sqrt ((x Float))
     (@intent "Compute square root")
     (@spec ((Float) -> Float))
-    (@pre (>= x 0.0))
-    (@assume (>= $result 0.0))  ;; Trusted FFI behavior
+    (@pre {x >= 0.0})
+    (@assume {$result >= 0.0})  ;; Trusted FFI behavior
     (@pure)
     (@example (4.0) -> 2.0)
     (@example (9.0) -> 3.0)
@@ -266,7 +266,7 @@
     (@intent "Compute e^x (natural exponential)")
     (@spec ((Float) -> Float))
     (@pure)
-    (@assume (> $result 0.0))  ;; Trusted FFI behavior
+    (@assume {$result > 0.0})  ;; Trusted FFI behavior
     (@example (0.0) -> 1.0)
     (@example (1.0) -> 2.71828182)
     (exp x))
@@ -275,7 +275,7 @@
     (@intent "Compute 2^x")
     (@spec ((Float) -> Float))
     (@pure)
-    (@assume (> $result 0.0))  ;; Trusted FFI behavior
+    (@assume {$result > 0.0})  ;; Trusted FFI behavior
     (@example (3.0) -> 8.0)
     (@example (0.0) -> 1.0)
     (exp2 x))
@@ -283,7 +283,7 @@
   (fn log ((x Float))
     (@intent "Compute natural logarithm (ln)")
     (@spec ((Float) -> Float))
-    (@pre (> x 0.0))
+    (@pre {x > 0.0})
     (@pure)
     (@example (1.0) -> 0.0)
     (@example (2.71828182) -> 1.0)
@@ -292,7 +292,7 @@
   (fn log10 ((x Float))
     (@intent "Compute base-10 logarithm")
     (@spec ((Float) -> Float))
-    (@pre (> x 0.0))
+    (@pre {x > 0.0})
     (@pure)
     (@example (10.0) -> 1.0)
     (@example (100.0) -> 2.0)
@@ -302,7 +302,7 @@
   (fn log2 ((x Float))
     (@intent "Compute base-2 logarithm")
     (@spec ((Float) -> Float))
-    (@pre (> x 0.0))
+    (@pre {x > 0.0})
     (@pure)
     (@example (2.0) -> 1.0)
     (@example (8.0) -> 3.0)
@@ -317,8 +317,8 @@
     (@intent "Compute sine (x in radians)")
     (@spec ((Float) -> Float))
     (@pure)
-    (@assume (>= $result -1.0))  ;; Trusted FFI behavior
-    (@assume (<= $result 1.0))
+    (@assume {$result >= -1.0})  ;; Trusted FFI behavior
+    (@assume {$result <= 1.0})
     (@example (0.0) -> 0.0)
     (sin x))
 
@@ -326,8 +326,8 @@
     (@intent "Compute cosine (x in radians)")
     (@spec ((Float) -> Float))
     (@pure)
-    (@assume (>= $result -1.0))  ;; Trusted FFI behavior
-    (@assume (<= $result 1.0))
+    (@assume {$result >= -1.0})  ;; Trusted FFI behavior
+    (@assume {$result <= 1.0})
     (@example (0.0) -> 1.0)
     (cos x))
 
@@ -341,8 +341,8 @@
   (fn asin ((x Float))
     (@intent "Compute arc sine, result in radians")
     (@spec ((Float) -> Float))
-    (@pre (>= x -1.0))
-    (@pre (<= x 1.0))
+    (@pre {x >= -1.0})
+    (@pre {x <= 1.0})
     (@pure)
     (@example (0.0) -> 0.0)
     (@example (1.0) -> 1.5707963)
@@ -351,9 +351,9 @@
   (fn acos ((x Float))
     (@intent "Compute arc cosine, result in radians")
     (@spec ((Float) -> Float))
-    (@pre (>= x -1.0))
-    (@pre (<= x 1.0))
-    (@assume (>= $result 0.0))  ;; Trusted FFI behavior
+    (@pre {x >= -1.0})
+    (@pre {x <= 1.0})
+    (@assume {$result >= 0.0})  ;; Trusted FFI behavior
     (@pure)
     (@example (1.0) -> 0.0)
     (@example (0.0) -> 1.5707963)
@@ -408,7 +408,7 @@
     (@intent "Compute hyperbolic cosine")
     (@spec ((Float) -> Float))
     (@pure)
-    (@assume (>= $result 1.0))  ;; Trusted FFI behavior
+    (@assume {$result >= 1.0})  ;; Trusted FFI behavior
     (@example (0.0) -> 1.0)
     (cosh x))
 
@@ -416,8 +416,8 @@
     (@intent "Compute hyperbolic tangent")
     (@spec ((Float) -> Float))
     (@pure)
-    (@assume (>= $result -1.0))  ;; Trusted FFI behavior
-    (@assume (<= $result 1.0))   ;; Trusted FFI behavior
+    (@assume {$result >= -1.0})  ;; Trusted FFI behavior
+    (@assume {$result <= 1.0})   ;; Trusted FFI behavior
     (@example (0.0) -> 0.0)
     (tanh x))
 
@@ -454,8 +454,8 @@
   (fn lerp ((a Float) (b Float) (t Float))
     (@intent "Linear interpolation between a and b by factor t")
     (@spec ((Float Float Float) -> Float))
-    (@pre (>= t 0.0))
-    (@pre (<= t 1.0))
+    (@pre {t >= 0.0})
+    (@pre {t <= 1.0})
     (@pure)
     (@example (0.0 10.0 0.5) -> 5.0)
     (@example (0.0 10.0 0.0) -> 0.0)

--- a/lib/std/os/env.slop
+++ b/lib/std/os/env.slop
@@ -54,7 +54,7 @@
   (fn set-env ((name String) (value String))
     (@intent "Set environment variable, overwriting if it exists")
     (@spec ((String String) -> (Result Bool EnvError)))
-    (@pre (> (. name len) 0))
+    (@pre {(. name len) > 0})
     (@example ("MY_VAR" "my_value") -> (ok true))
 
     (if (== (. name len) 0)
@@ -70,7 +70,7 @@
   (fn unset-env ((name String))
     (@intent "Remove environment variable")
     (@spec ((String) -> (Result Bool EnvError)))
-    (@pre (> (. name len) 0))
+    (@pre {(. name len) > 0})
     (@example ("MY_VAR") -> (ok true))
 
     (if (== (. name len) 0)

--- a/lib/std/strlib/strlib.slop
+++ b/lib/std/strlib/strlib.slop
@@ -469,7 +469,7 @@
     (@spec ((Arena String (Int 0 ..) (Int 0 ..)) -> String))
     (@alloc arena)
     (@pure)
-    (@pre (<= start (. s len)))
+    (@pre {start <= (. s len)})
     (@example (arena "hello world" 0 5) -> "hello")
     (@example (arena "hello world" 6 5) -> "world")
     (let ((slen (cast Int (. s len)))

--- a/spec/LANGUAGE.md
+++ b/spec/LANGUAGE.md
@@ -155,10 +155,18 @@ literal     = number | string | 'true | 'false | 'nil
 (@intent "Human-readable description")
 (@spec ((ParamTypes...) -> ReturnType))
 
-; Optional annotations
+; Optional annotations (prefix or infix notation)
 (@pre boolean-expr)              ; Precondition
 (@post boolean-expr)             ; Postcondition ($result for return value)
 (@assume boolean-expr)           ; Trusted axiom for verification (e.g., FFI behavior)
+
+; Infix notation (contracts only) - curly braces denote infix expressions
+(@pre {x > 0})                   ; Equivalent to (@pre (> x 0))
+(@pre {x >= 0 and x <= 100})     ; Equivalent to (@pre (and (>= x 0) (<= x 100)))
+(@post {$result == a + b})       ; Equivalent to (@post (== $result (+ a b)))
+; Precedence: *, /, % > +, - > comparisons > and > or
+; Use () for grouping: {(a + b) * c}
+; Use prefix for function calls: {(len arr) > 0}
 (@example (args...) -> result)   ; Example for testing
 (@property (forall (x T) expr))  ; Property that should hold
 (@deprecated "message")          ; Mark as deprecated with migration hint

--- a/src/slop/reference.py
+++ b/src/slop/reference.py
@@ -103,12 +103,21 @@ TOPICS = {
 (@pre condition)           ; Input validation, checked on entry
 (@post condition)          ; Output guarantee, $result = return value
 
-; Example
+; Contracts support optional infix notation with curly braces:
+(@pre {x > 0})             ; Equivalent to (@pre (> x 0))
+(@pre {x >= 0 and x <= 100})  ; Equivalent to (@pre (and (>= x 0) (<= x 100)))
+(@post {$result == a + b}) ; Equivalent to (@post (== $result (+ a b)))
+
+; Infix precedence: *, /, % > +, - > comparisons > and > or
+; Use () for grouping: {(a + b) * c}
+; Use prefix notation for function calls within infix: {(len arr) > 0}
+
+; Example (both styles work)
 (fn divide ((a Int) (b Int))
   (@intent "Divide a by b")
   (@spec ((Int Int) -> Int))
-  (@pre (!= b 0))
-  (@post (== (* $result b) a))
+  (@pre {b != 0})                  ; Infix style
+  (@post (== (* $result b) a))     ; Prefix style
   (/ a b))
 
 ### Assumptions (for FFI and trusted behavior)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,7 +3,7 @@ Parser tests for SLOP
 """
 
 import pytest
-from slop.parser import parse, parse_file, pretty_print, find_holes, is_form, SList, Symbol, Number, String
+from slop.parser import parse, parse_file, pretty_print, find_holes, is_form, SList, Symbol, Number, String, ParseError
 
 
 class TestBasicParsing:
@@ -183,3 +183,211 @@ class TestExampleFiles:
         result = parse(hello_source)
         assert len(result) >= 1
         assert is_form(result[0], 'module')
+
+
+class TestInfixContracts:
+    """Test infix notation in contracts (@pre, @post, @assume)"""
+
+    def test_simple_comparison(self):
+        """Basic infix comparison: {x > 0} -> (> x 0)"""
+        result = parse("(@pre {x > 0})")
+        assert len(result) == 1
+        pre = result[0]
+        assert is_form(pre, '@pre')
+        cond = pre[1]
+        assert is_form(cond, '>')
+        assert cond[1].name == 'x'
+        assert cond[2].value == 0
+
+    def test_arithmetic_precedence(self):
+        """Multiplication binds tighter than addition: {a + b * c} -> (+ a (* b c))"""
+        result = parse("(@pre {a + b * c == 0})")
+        pre = result[0]
+        cond = pre[1]  # (== (+ a (* b c)) 0)
+        assert is_form(cond, '==')
+        add = cond[1]  # (+ a (* b c))
+        assert is_form(add, '+')
+        assert add[1].name == 'a'
+        mul = add[2]  # (* b c)
+        assert is_form(mul, '*')
+        assert mul[1].name == 'b'
+        assert mul[2].name == 'c'
+
+    def test_boolean_operators(self):
+        """{x >= 0 and x <= 100} -> (and (>= x 0) (<= x 100))"""
+        result = parse("(@pre {x >= 0 and x <= 100})")
+        pre = result[0]
+        cond = pre[1]
+        assert is_form(cond, 'and')
+        left = cond[1]  # (>= x 0)
+        assert is_form(left, '>=')
+        right = cond[2]  # (<= x 100)
+        assert is_form(right, '<=')
+
+    def test_or_binds_looser_than_and(self):
+        """{a or b and c} -> (or a (and b c))"""
+        result = parse("(@pre {a or b and c})")
+        pre = result[0]
+        cond = pre[1]
+        assert is_form(cond, 'or')
+        assert cond[1].name == 'a'
+        and_expr = cond[2]
+        assert is_form(and_expr, 'and')
+
+    def test_grouping_with_parens(self):
+        """Parentheses for grouping: {(a + b) * c} -> (* (+ a b) c)"""
+        result = parse("(@pre {(a + b) * c == 0})")
+        pre = result[0]
+        cond = pre[1]  # (== (* (+ a b) c) 0)
+        assert is_form(cond, '==')
+        mul = cond[1]  # (* (+ a b) c)
+        assert is_form(mul, '*')
+        add = mul[1]  # (+ a b)
+        assert is_form(add, '+')
+        assert mul[2].name == 'c'
+
+    def test_function_call_in_infix(self):
+        """Prefix function call in infix: {(len arr) > 0} -> (> (len arr) 0)"""
+        result = parse("(@pre {(len arr) > 0})")
+        pre = result[0]
+        cond = pre[1]  # (> (len arr) 0)
+        assert is_form(cond, '>')
+        call = cond[1]  # (len arr)
+        assert is_form(call, 'len')
+        assert call[1].name == 'arr'
+        assert cond[2].value == 0
+
+    def test_field_access_in_infix(self):
+        """Field access in infix: {(. ptr field) > 0} -> (> (. ptr field) 0)"""
+        result = parse("(@pre {(. ptr field) > 0})")
+        pre = result[0]
+        cond = pre[1]
+        assert is_form(cond, '>')
+        access = cond[1]
+        assert is_form(access, '.')
+
+    def test_result_variable(self):
+        """$result in postconditions: {$result == a + b}"""
+        result = parse("(@post {$result == a + b})")
+        post = result[0]
+        cond = post[1]  # (== $result (+ a b))
+        assert is_form(cond, '==')
+        assert cond[1].name == '$result'
+        add = cond[2]
+        assert is_form(add, '+')
+
+    def test_unary_not(self):
+        """Unary not: {not valid} -> (not valid)"""
+        result = parse("(@pre {not valid})")
+        pre = result[0]
+        cond = pre[1]
+        assert is_form(cond, 'not')
+        assert cond[1].name == 'valid'
+
+    def test_unary_minus(self):
+        """Unary minus: {-x > 0} -> (> (- 0 x) 0)"""
+        result = parse("(@pre {-x > 0})")
+        pre = result[0]
+        cond = pre[1]
+        assert is_form(cond, '>')
+        neg = cond[1]  # (- 0 x)
+        assert is_form(neg, '-')
+        assert neg[1].value == 0
+        assert neg[2].name == 'x'
+
+    def test_complex_nested(self):
+        """{a > 0 or (b < 10 and c != 0)} -> (or (> a 0) (and (< b 10) (!= c 0)))"""
+        result = parse("(@pre {a > 0 or (b < 10 and c != 0)})")
+        pre = result[0]
+        cond = pre[1]
+        assert is_form(cond, 'or')
+        left = cond[1]  # (> a 0)
+        assert is_form(left, '>')
+        right = cond[2]  # (and (< b 10) (!= c 0))
+        assert is_form(right, 'and')
+
+    def test_infix_in_pre(self):
+        """Infix works in @pre"""
+        result = parse("(@pre {x > 0})")
+        assert is_form(result[0], '@pre')
+
+    def test_infix_in_post(self):
+        """Infix works in @post"""
+        result = parse("(@post {$result >= 0})")
+        assert is_form(result[0], '@post')
+
+    def test_infix_in_assume(self):
+        """Infix works in @assume"""
+        result = parse("(@assume {ptr != nil})")
+        assert is_form(result[0], '@assume')
+
+    def test_infix_outside_contract_error(self):
+        """Infix outside contract raises ParseError"""
+        with pytest.raises(ParseError) as exc_info:
+            parse("(let x {1 + 2})")
+        assert "only allowed inside @pre, @post, or @assume" in str(exc_info.value)
+
+    def test_infix_in_regular_expression_error(self):
+        """Infix in regular code raises ParseError"""
+        with pytest.raises(ParseError):
+            parse("{x + y}")
+
+    def test_prefix_still_works_in_contracts(self):
+        """Prefix notation still works in contracts"""
+        result = parse("(@pre (> x 0))")
+        pre = result[0]
+        cond = pre[1]
+        assert is_form(cond, '>')
+        assert cond[1].name == 'x'
+
+    def test_mixed_function_and_grouping(self):
+        """Mix of function calls and grouping in same expression"""
+        result = parse("(@pre {(len arr) > 0 and (x + 1) < 10})")
+        pre = result[0]
+        cond = pre[1]
+        assert is_form(cond, 'and')
+        # left: (> (len arr) 0)
+        left = cond[1]
+        assert is_form(left, '>')
+        assert is_form(left[1], 'len')  # function call
+        # right: (< (+ x 1) 10)
+        right = cond[2]
+        assert is_form(right, '<')
+        assert is_form(right[1], '+')  # grouping became addition
+
+    def test_quoted_symbol_in_infix(self):
+        """Quoted symbols in infix: {status == 'ok}"""
+        result = parse("(@post {status == 'ok})")
+        post = result[0]
+        cond = post[1]
+        assert is_form(cond, '==')
+        assert cond[1].name == 'status'
+        # The quote is normalized to a Symbol with 'ok name
+        quoted = cond[2]
+        assert isinstance(quoted, Symbol)
+        assert quoted.name == "'ok"
+
+    def test_not_equal(self):
+        """Not equal operator: {x != 0}"""
+        result = parse("(@pre {x != 0})")
+        pre = result[0]
+        cond = pre[1]
+        assert is_form(cond, '!=')
+
+    def test_all_comparison_operators(self):
+        """All comparison operators work"""
+        ops = ['>', '<', '>=', '<=', '==', '!=']
+        for op in ops:
+            result = parse(f"(@pre {{x {op} 0}})")
+            cond = result[0][1]
+            assert is_form(cond, op), f"Failed for operator {op}"
+
+    def test_all_arithmetic_operators(self):
+        """All arithmetic operators work"""
+        ops = ['+', '-', '*', '/', '%']
+        for op in ops:
+            result = parse(f"(@pre {{a {op} b == 0}})")
+            eq = result[0][1]
+            assert is_form(eq, '==')
+            arith = eq[1]
+            assert is_form(arith, op), f"Failed for operator {op}"

--- a/tree-sitter-slop/queries/highlights.scm
+++ b/tree-sitter-slop/queries/highlights.scm
@@ -116,3 +116,18 @@
 ; Brackets
 "(" @punctuation.bracket
 ")" @punctuation.bracket
+"{" @punctuation.bracket
+"}" @punctuation.bracket
+
+; Infix operators
+(infix_binary
+  ["and" "or"] @keyword.operator)
+
+(infix_binary
+  ["==" "!=" "<" "<=" ">" ">=" "+" "-" "*" "/" "%"] @operator)
+
+(infix_unary
+  "not" @keyword.operator)
+
+(infix_unary
+  "-" @operator)

--- a/tree-sitter-slop/slop-ts-mode.el
+++ b/tree-sitter-slop/slop-ts-mode.el
@@ -108,7 +108,14 @@
 
    :language 'slop
    :feature 'bracket
-   '(["(" ")"] @font-lock-bracket-face))
+   '(["(" ")" "{" "}"] @font-lock-bracket-face)
+
+   :language 'slop
+   :feature 'infix
+   '((infix_binary ["and" "or"] @font-lock-keyword-face)
+     (infix_binary ["==" "!=" "<" "<=" ">" ">=" "+" "-" "*" "/" "%"] @font-lock-operator-face)
+     (infix_unary "not" @font-lock-keyword-face)
+     (infix_unary "-" @font-lock-operator-face)))
   "Tree-sitter font-lock settings for SLOP.")
 
 ;; Indentation
@@ -116,7 +123,9 @@
   '((slop
      ((parent-is "source_file") column-0 0)
      ((node-is ")") parent-bol 0)
-     ((parent-is "list") parent-bol slop-ts-mode-indent-offset)))
+     ((node-is "}") parent-bol 0)
+     ((parent-is "list") parent-bol slop-ts-mode-indent-offset)
+     ((parent-is "infix_expr") parent-bol slop-ts-mode-indent-offset)))
   "Tree-sitter indentation rules for SLOP.")
 
 ;;;###autoload
@@ -141,7 +150,7 @@
   (setq-local treesit-font-lock-feature-list
               '((comment string)
                 (keyword type annotation)
-                (constant number property operator function definition)
+                (constant number property operator function definition infix)
                 (variable bracket)))
 
   ;; Indentation


### PR DESCRIPTION
@pre, @post, and @assume contract annotations shall support using optional infix notation using curly braces { }