### PR TITLE
Container codegen: list type naming (#72) and Ptr Map/Set deref (#82)

### DIFF
--- a/bootstrap/compiler/slop_compiler.c
+++ b/bootstrap/compiler/slop_compiler.c
@@ -103,11 +103,11 @@ slop_string compiler_lines_to_string(slop_arena* arena, slop_list_string lines) 
                 int64_t total = 0;
                 int64_t i = 0;
                 while (i < len) {
-                    __auto_type _mv_1819 = ({ __auto_type _lst = lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1819.has_value) {
-                        __auto_type line = _mv_1819.value;
+                    __auto_type _mv_1820 = ({ __auto_type _lst = lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1820.has_value) {
+                        __auto_type line = _mv_1820.value;
                         total = (total + (((int64_t)(line.len)) + 1));
-                    } else if (!_mv_1819.has_value) {
+                    } else if (!_mv_1820.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -116,9 +116,9 @@ slop_string compiler_lines_to_string(slop_arena* arena, slop_list_string lines) 
                     int64_t pos = 0;
                     int64_t j = 0;
                     while (j < len) {
-                        __auto_type _mv_1820 = ({ __auto_type _lst = lines; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1820.has_value) {
-                            __auto_type line = _mv_1820.value;
+                        __auto_type _mv_1821 = ({ __auto_type _lst = lines; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1821.has_value) {
+                            __auto_type line = _mv_1821.value;
                             {
                                 __auto_type line_len = ((int64_t)(line.len));
                                 __auto_type line_data = line.data;
@@ -131,7 +131,7 @@ slop_string compiler_lines_to_string(slop_arena* arena, slop_list_string lines) 
                                 buf[pos] = 10;
                                 pos = (pos + 1);
                             }
-                        } else if (!_mv_1820.has_value) {
+                        } else if (!_mv_1821.has_value) {
                         }
                         j = (j + 1);
                     }
@@ -147,43 +147,43 @@ slop_string compiler_extract_module_name(slop_list_types_SExpr_ptr exprs) {
     if (((int64_t)((exprs).len)) < 1) {
         return SLOP_STR("unknown");
     } else {
-        __auto_type _mv_1821 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1821.has_value) {
-            __auto_type first_expr = _mv_1821.value;
-            __auto_type _mv_1822 = (*first_expr);
-            switch (_mv_1822.tag) {
+        __auto_type _mv_1822 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1822.has_value) {
+            __auto_type first_expr = _mv_1822.value;
+            __auto_type _mv_1823 = (*first_expr);
+            switch (_mv_1823.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type lst = _mv_1822.data.lst;
+                    __auto_type lst = _mv_1823.data.lst;
                     {
                         __auto_type items = lst.items;
                         if (((int64_t)((items).len)) < 2) {
                             return SLOP_STR("unknown");
                         } else {
-                            __auto_type _mv_1823 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1823.has_value) {
-                                __auto_type head = _mv_1823.value;
-                                __auto_type _mv_1824 = (*head);
-                                switch (_mv_1824.tag) {
+                            __auto_type _mv_1824 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1824.has_value) {
+                                __auto_type head = _mv_1824.value;
+                                __auto_type _mv_1825 = (*head);
+                                switch (_mv_1825.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1824.data.sym;
+                                        __auto_type sym = _mv_1825.data.sym;
                                         if (string_eq(sym.name, SLOP_STR("module"))) {
-                                            __auto_type _mv_1825 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1825.has_value) {
-                                                __auto_type name_expr = _mv_1825.value;
-                                                __auto_type _mv_1826 = (*name_expr);
-                                                switch (_mv_1826.tag) {
+                                            __auto_type _mv_1826 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1826.has_value) {
+                                                __auto_type name_expr = _mv_1826.value;
+                                                __auto_type _mv_1827 = (*name_expr);
+                                                switch (_mv_1827.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type name_sym = _mv_1826.data.sym;
+                                                        __auto_type name_sym = _mv_1827.data.sym;
                                                         return name_sym.name;
                                                     }
                                                     default: {
                                                         return SLOP_STR("unknown");
                                                     }
                                                 }
-                                            } else if (!_mv_1825.has_value) {
+                                            } else if (!_mv_1826.has_value) {
                                                 return SLOP_STR("unknown");
                                             }
                                         } else {
@@ -194,7 +194,7 @@ slop_string compiler_extract_module_name(slop_list_types_SExpr_ptr exprs) {
                                         return SLOP_STR("unknown");
                                     }
                                 }
-                            } else if (!_mv_1823.has_value) {
+                            } else if (!_mv_1824.has_value) {
                                 return SLOP_STR("unknown");
                             }
                         }
@@ -204,7 +204,7 @@ slop_string compiler_extract_module_name(slop_list_types_SExpr_ptr exprs) {
                     return SLOP_STR("unknown");
                 }
             }
-        } else if (!_mv_1821.has_value) {
+        } else if (!_mv_1822.has_value) {
             return SLOP_STR("unknown");
         }
     }
@@ -230,9 +230,9 @@ void compiler_check_all_functions(env_TypeEnv* env, slop_list_types_SExpr_ptr as
     {
         __auto_type len = ((int64_t)((ast).len));
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_1827 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1827.has_value) {
-                __auto_type expr = _mv_1827.value;
+            __auto_type _mv_1828 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1828.has_value) {
+                __auto_type expr = _mv_1828.value;
                 if (parser_is_form(expr, SLOP_STR("fn"))) {
                     {
                         __auto_type _ = infer_infer_fn_body(env, expr);
@@ -241,7 +241,7 @@ void compiler_check_all_functions(env_TypeEnv* env, slop_list_types_SExpr_ptr as
                     compiler_check_module_functions(env, expr);
                 } else {
                 }
-            } else if (!_mv_1827.has_value) {
+            } else if (!_mv_1828.has_value) {
             }
         }
     }
@@ -249,11 +249,11 @@ void compiler_check_all_functions(env_TypeEnv* env, slop_list_types_SExpr_ptr as
 
 uint8_t compiler_is_annotation_form(types_SExpr* item) {
     if (parser_sexpr_is_list(item)) {
-        __auto_type _mv_1828 = parser_sexpr_list_get(item, 0);
-        if (_mv_1828.has_value) {
-            __auto_type head = _mv_1828.value;
+        __auto_type _mv_1829 = parser_sexpr_list_get(item, 0);
+        if (_mv_1829.has_value) {
+            __auto_type head = _mv_1829.value;
             return ((uint8_t)(({ __auto_type name = parser_sexpr_get_symbol_name(head); (((name.len > 0)) ? (name.data[0] == 64) : 0); })));
-        } else if (!_mv_1828.has_value) {
+        } else if (!_mv_1829.has_value) {
             return 0;
         }
     } else {
@@ -285,11 +285,11 @@ uint8_t compiler_is_valid_toplevel_form(types_SExpr* item) {
 
 slop_string compiler_get_form_name(types_SExpr* item) {
     if (parser_sexpr_is_list(item)) {
-        __auto_type _mv_1829 = parser_sexpr_list_get(item, 0);
-        if (_mv_1829.has_value) {
-            __auto_type head = _mv_1829.value;
+        __auto_type _mv_1830 = parser_sexpr_list_get(item, 0);
+        if (_mv_1830.has_value) {
+            __auto_type head = _mv_1830.value;
             return parser_sexpr_get_symbol_name(head);
-        } else if (!_mv_1829.has_value) {
+        } else if (!_mv_1830.has_value) {
             return SLOP_STR("<empty>");
         }
     } else {
@@ -301,23 +301,23 @@ void compiler_check_module_functions(env_TypeEnv* env, types_SExpr* module_form)
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((module_form != NULL)), "(!= module-form nil)");
     if (parser_sexpr_is_list(module_form)) {
-        __auto_type _mv_1830 = parser_sexpr_list_get(module_form, 1);
-        if (_mv_1830.has_value) {
-            __auto_type name_expr = _mv_1830.value;
+        __auto_type _mv_1831 = parser_sexpr_list_get(module_form, 1);
+        if (_mv_1831.has_value) {
+            __auto_type name_expr = _mv_1831.value;
             {
                 __auto_type mod_name = parser_sexpr_get_symbol_name(name_expr);
                 if (!(string_eq(mod_name, SLOP_STR("")))) {
                     env_env_set_module(env, (slop_option_string){.has_value = 1, .value = mod_name});
                 }
             }
-        } else if (!_mv_1830.has_value) {
+        } else if (!_mv_1831.has_value) {
         }
         {
             __auto_type len = parser_sexpr_list_len(module_form);
             for (int64_t i = 2; i < len; i++) {
-                __auto_type _mv_1831 = parser_sexpr_list_get(module_form, i);
-                if (_mv_1831.has_value) {
-                    __auto_type item = _mv_1831.value;
+                __auto_type _mv_1832 = parser_sexpr_list_get(module_form, i);
+                if (_mv_1832.has_value) {
+                    __auto_type item = _mv_1832.value;
                     if (parser_is_form(item, SLOP_STR("fn"))) {
                         {
                             __auto_type _ = infer_infer_fn_body(env, item);
@@ -330,7 +330,7 @@ void compiler_check_module_functions(env_TypeEnv* env, types_SExpr* module_form)
                             env_env_add_error(env, msg, parser_sexpr_line(item), parser_sexpr_col(item));
                         }
                     }
-                } else if (!_mv_1831.has_value) {
+                } else if (!_mv_1832.has_value) {
                 }
             }
         }
@@ -343,15 +343,15 @@ int64_t compiler_count_errors(slop_list_types_Diagnostic diagnostics) {
         int64_t errors = 0;
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1832 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1832.has_value) {
-                __auto_type diag = _mv_1832.value;
-                __auto_type _mv_1833 = diag.level;
-                if (_mv_1833 == types_DiagnosticLevel_diag_error) {
+            __auto_type _mv_1833 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1833.has_value) {
+                __auto_type diag = _mv_1833.value;
+                __auto_type _mv_1834 = diag.level;
+                if (_mv_1834 == types_DiagnosticLevel_diag_error) {
                     errors = (errors + 1);
-                } else if (_mv_1833 == types_DiagnosticLevel_diag_warning) {
+                } else if (_mv_1834 == types_DiagnosticLevel_diag_warning) {
                 }
-            } else if (!_mv_1832.has_value) {
+            } else if (!_mv_1833.has_value) {
             }
             i = (i + 1);
         }
@@ -366,10 +366,10 @@ void compiler_print_diagnostic(slop_arena* arena, slop_string filename, types_Di
     printf("%s", ":");
     printf("%lld", (long long)(diag.col));
     printf("%s", ": ");
-    __auto_type _mv_1834 = diag.level;
-    if (_mv_1834 == types_DiagnosticLevel_diag_warning) {
+    __auto_type _mv_1835 = diag.level;
+    if (_mv_1835 == types_DiagnosticLevel_diag_warning) {
         printf("%s", "warning: ");
-    } else if (_mv_1834 == types_DiagnosticLevel_diag_error) {
+    } else if (_mv_1835 == types_DiagnosticLevel_diag_error) {
         printf("%s", "error: ");
     }
     printf("%.*s\n", (int)(diag.message).len, (diag.message).data);
@@ -380,11 +380,11 @@ void compiler_output_diagnostics_text(slop_arena* arena, slop_string filename, s
         __auto_type len = ((int64_t)((diagnostics).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1835 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1835.has_value) {
-                __auto_type diag = _mv_1835.value;
+            __auto_type _mv_1836 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1836.has_value) {
+                __auto_type diag = _mv_1836.value;
                 compiler_print_diagnostic(arena, filename, diag);
-            } else if (!_mv_1835.has_value) {
+            } else if (!_mv_1836.has_value) {
             }
             i = (i + 1);
         }
@@ -400,11 +400,11 @@ void compiler_output_diagnostics_json(slop_arena* arena, slop_list_types_Diagnos
             if (i > 0) {
                 putchar(44);
             }
-            __auto_type _mv_1836 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1836.has_value) {
-                __auto_type diag = _mv_1836.value;
+            __auto_type _mv_1837 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1837.has_value) {
+                __auto_type diag = _mv_1837.value;
                 compiler_output_single_diagnostic_json(arena, diag);
-            } else if (!_mv_1836.has_value) {
+            } else if (!_mv_1837.has_value) {
             }
             i = (i + 1);
         }
@@ -415,10 +415,10 @@ void compiler_output_diagnostics_json(slop_arena* arena, slop_list_types_Diagnos
 void compiler_output_single_diagnostic_json(slop_arena* arena, types_Diagnostic diag) {
     putchar(123);
     compiler_print_str(((uint8_t*)(SLOP_STR("\"level\":").data)));
-    __auto_type _mv_1837 = diag.level;
-    if (_mv_1837 == types_DiagnosticLevel_diag_warning) {
+    __auto_type _mv_1838 = diag.level;
+    if (_mv_1838 == types_DiagnosticLevel_diag_warning) {
         compiler_print_str(((uint8_t*)(SLOP_STR("\"warning\"").data)));
-    } else if (_mv_1837 == types_DiagnosticLevel_diag_error) {
+    } else if (_mv_1838 == types_DiagnosticLevel_diag_error) {
         compiler_print_str(((uint8_t*)(SLOP_STR("\"error\"").data)));
     }
     putchar(44);
@@ -450,27 +450,27 @@ int64_t compiler_check_single_file(env_TypeEnv* env, slop_arena* arena, uint8_t*
     SLOP_PRE(((filename != NULL)), "(!= filename nil)");
     {
         __auto_type filename_str = strlib_cstring_to_string(filename);
-        __auto_type _mv_1838 = file_file_open(filename_str, file_FileMode_read);
-        if (!_mv_1838.is_ok) {
-            __auto_type e = _mv_1838.data.err;
+        __auto_type _mv_1839 = file_file_open(filename_str, file_FileMode_read);
+        if (!_mv_1839.is_ok) {
+            __auto_type e = _mv_1839.data.err;
             printf("%s", "Error: Could not open file: ");
             printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
             return 1;
-        } else if (_mv_1838.is_ok) {
-            __auto_type f = _mv_1838.data.ok;
-            __auto_type _mv_1839 = file_file_read_all(arena, (&f));
-            if (!_mv_1839.is_ok) {
-                __auto_type e = _mv_1839.data.err;
+        } else if (_mv_1839.is_ok) {
+            __auto_type f = _mv_1839.data.ok;
+            __auto_type _mv_1840 = file_file_read_all(arena, (&f));
+            if (!_mv_1840.is_ok) {
+                __auto_type e = _mv_1840.data.err;
                 file_file_close((&f));
                 printf("%s", "Error: Could not read file: ");
                 printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
                 return 1;
-            } else if (_mv_1839.is_ok) {
-                __auto_type source = _mv_1839.data.ok;
+            } else if (_mv_1840.is_ok) {
+                __auto_type source = _mv_1840.data.ok;
                 file_file_close((&f));
-                __auto_type _mv_1840 = parser_parse(arena, source);
-                if (_mv_1840.is_ok) {
-                    __auto_type ast = _mv_1840.data.ok;
+                __auto_type _mv_1841 = parser_parse(arena, source);
+                if (_mv_1841.is_ok) {
+                    __auto_type ast = _mv_1841.data.ok;
                     {
                         __auto_type mod_name = compiler_extract_module_name(ast);
                         env_env_clear_imports(env);
@@ -487,8 +487,8 @@ int64_t compiler_check_single_file(env_TypeEnv* env, slop_arena* arena, uint8_t*
                             return compiler_count_errors(diagnostics);
                         }
                     }
-                } else if (!_mv_1840.is_ok) {
-                    __auto_type parse_err = _mv_1840.data.err;
+                } else if (!_mv_1841.is_ok) {
+                    __auto_type parse_err = _mv_1841.data.err;
                     printf("%.*s", (int)(filename_str).len, (filename_str).data);
                     printf("%s", ":");
                     printf("%lld", (long long)(parse_err.line));
@@ -505,15 +505,15 @@ int64_t compiler_check_single_file(env_TypeEnv* env, slop_arena* arena, uint8_t*
 
 types_ResolvedType* compiler_resolve_type_string(env_TypeEnv* env, slop_arena* arena, slop_string type_str) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_1841 = parser_parse(arena, type_str);
-    if (_mv_1841.is_ok) {
-        __auto_type type_ast = _mv_1841.data.ok;
+    __auto_type _mv_1842 = parser_parse(arena, type_str);
+    if (_mv_1842.is_ok) {
+        __auto_type type_ast = _mv_1842.data.ok;
         if (((int64_t)((type_ast).len)) == 0) {
             return env_env_get_int_type(env);
         } else {
-            __auto_type _mv_1842 = ({ __auto_type _lst = type_ast; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1842.has_value) {
-                __auto_type type_expr = _mv_1842.value;
+            __auto_type _mv_1843 = ({ __auto_type _lst = type_ast; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1843.has_value) {
+                __auto_type type_expr = _mv_1843.value;
                 if (parser_sexpr_is_list(type_expr)) {
                     return infer_resolve_complex_type_expr(env, type_expr);
                 } else {
@@ -526,63 +526,63 @@ types_ResolvedType* compiler_resolve_type_string(env_TypeEnv* env, slop_arena* a
                         }
                     }
                 }
-            } else if (!_mv_1842.has_value) {
+            } else if (!_mv_1843.has_value) {
                 return env_env_get_int_type(env);
             }
         }
-    } else if (!_mv_1841.is_ok) {
-        __auto_type _ = _mv_1841.data.err;
+    } else if (!_mv_1842.is_ok) {
+        __auto_type _ = _mv_1842.data.err;
         return env_env_get_int_type(env);
     }
 }
 
 void compiler_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_string params_str) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_1843 = parser_parse(arena, params_str);
-    if (_mv_1843.is_ok) {
-        __auto_type params_ast = _mv_1843.data.ok;
+    __auto_type _mv_1844 = parser_parse(arena, params_str);
+    if (_mv_1844.is_ok) {
+        __auto_type params_ast = _mv_1844.data.ok;
         if (((int64_t)((params_ast).len)) > 0) {
-            __auto_type _mv_1844 = ({ __auto_type _lst = params_ast; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1844.has_value) {
-                __auto_type params_list = _mv_1844.value;
-                __auto_type _mv_1845 = (*params_list);
-                switch (_mv_1845.tag) {
+            __auto_type _mv_1845 = ({ __auto_type _lst = params_ast; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1845.has_value) {
+                __auto_type params_list = _mv_1845.value;
+                __auto_type _mv_1846 = (*params_list);
+                switch (_mv_1846.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type lst = _mv_1845.data.lst;
+                        __auto_type lst = _mv_1846.data.lst;
                         {
                             __auto_type items = lst.items;
                             __auto_type len = ((int64_t)((items).len));
                             for (int64_t i = 0; i < len; i++) {
-                                __auto_type _mv_1846 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1846.has_value) {
-                                    __auto_type param = _mv_1846.value;
-                                    __auto_type _mv_1847 = (*param);
-                                    switch (_mv_1847.tag) {
+                                __auto_type _mv_1847 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1847.has_value) {
+                                    __auto_type param = _mv_1847.value;
+                                    __auto_type _mv_1848 = (*param);
+                                    switch (_mv_1848.tag) {
                                         case types_SExpr_lst:
                                         {
-                                            __auto_type param_lst = _mv_1847.data.lst;
+                                            __auto_type param_lst = _mv_1848.data.lst;
                                             {
                                                 __auto_type param_items = param_lst.items;
                                                 if (((int64_t)((param_items).len)) >= 2) {
-                                                    __auto_type _mv_1848 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1848.has_value) {
-                                                        __auto_type name_expr = _mv_1848.value;
-                                                        __auto_type _mv_1849 = (*name_expr);
-                                                        switch (_mv_1849.tag) {
+                                                    __auto_type _mv_1849 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1849.has_value) {
+                                                        __auto_type name_expr = _mv_1849.value;
+                                                        __auto_type _mv_1850 = (*name_expr);
+                                                        switch (_mv_1850.tag) {
                                                             case types_SExpr_sym:
                                                             {
-                                                                __auto_type name_sym = _mv_1849.data.sym;
+                                                                __auto_type name_sym = _mv_1850.data.sym;
                                                                 {
                                                                     __auto_type param_name = name_sym.name;
-                                                                    __auto_type _mv_1850 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                    if (_mv_1850.has_value) {
-                                                                        __auto_type type_expr = _mv_1850.value;
-                                                                        __auto_type _mv_1851 = (*type_expr);
-                                                                        switch (_mv_1851.tag) {
+                                                                    __auto_type _mv_1851 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                    if (_mv_1851.has_value) {
+                                                                        __auto_type type_expr = _mv_1851.value;
+                                                                        __auto_type _mv_1852 = (*type_expr);
+                                                                        switch (_mv_1852.tag) {
                                                                             case types_SExpr_sym:
                                                                             {
-                                                                                __auto_type type_sym = _mv_1851.data.sym;
+                                                                                __auto_type type_sym = _mv_1852.data.sym;
                                                                                 {
                                                                                     __auto_type param_type = compiler_resolve_type_string(env, arena, type_sym.name);
                                                                                     env_env_bind_var(env, param_name, param_type);
@@ -591,7 +591,7 @@ void compiler_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_st
                                                                             }
                                                                             case types_SExpr_lst:
                                                                             {
-                                                                                __auto_type _ = _mv_1851.data.lst;
+                                                                                __auto_type _ = _mv_1852.data.lst;
                                                                                 {
                                                                                     __auto_type param_type = infer_resolve_complex_type_expr(env, type_expr);
                                                                                     env_env_bind_var(env, param_name, param_type);
@@ -603,7 +603,7 @@ void compiler_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_st
                                                                                 break;
                                                                             }
                                                                         }
-                                                                    } else if (!_mv_1850.has_value) {
+                                                                    } else if (!_mv_1851.has_value) {
                                                                     }
                                                                 }
                                                                 break;
@@ -612,7 +612,7 @@ void compiler_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_st
                                                                 break;
                                                             }
                                                         }
-                                                    } else if (!_mv_1848.has_value) {
+                                                    } else if (!_mv_1849.has_value) {
                                                     }
                                                 }
                                             }
@@ -622,7 +622,7 @@ void compiler_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_st
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1846.has_value) {
+                                } else if (!_mv_1847.has_value) {
                                 }
                             }
                         }
@@ -632,11 +632,11 @@ void compiler_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_st
                         break;
                     }
                 }
-            } else if (!_mv_1844.has_value) {
+            } else if (!_mv_1845.has_value) {
             }
         }
-    } else if (!_mv_1843.is_ok) {
-        __auto_type _ = _mv_1843.data.err;
+    } else if (!_mv_1844.is_ok) {
+        __auto_type _ = _mv_1844.data.err;
     }
 }
 
@@ -655,17 +655,17 @@ uint8_t compiler_types_names_equal(types_ResolvedType* a, types_ResolvedType* b)
         } else if (string_eq(a_name, SLOP_STR("Unknown")) || string_eq(b_name, SLOP_STR("Unknown"))) {
             return 1;
         } else if ((a_kind == types_ResolvedTypeKind_rk_option) && (b_kind == types_ResolvedTypeKind_rk_option)) {
-            __auto_type _mv_1852 = (*a).inner_type;
-            if (_mv_1852.has_value) {
-                __auto_type a_inner = _mv_1852.value;
-                __auto_type _mv_1853 = (*b).inner_type;
-                if (_mv_1853.has_value) {
-                    __auto_type b_inner = _mv_1853.value;
+            __auto_type _mv_1853 = (*a).inner_type;
+            if (_mv_1853.has_value) {
+                __auto_type a_inner = _mv_1853.value;
+                __auto_type _mv_1854 = (*b).inner_type;
+                if (_mv_1854.has_value) {
+                    __auto_type b_inner = _mv_1854.value;
                     return compiler_types_names_equal(a_inner, b_inner);
-                } else if (!_mv_1853.has_value) {
+                } else if (!_mv_1854.has_value) {
                     return 1;
                 }
-            } else if (!_mv_1852.has_value) {
+            } else if (!_mv_1853.has_value) {
                 return 1;
             }
         } else if ((a_kind == types_ResolvedTypeKind_rk_result) && (b_kind == types_ResolvedTypeKind_rk_result)) {
@@ -675,33 +675,33 @@ uint8_t compiler_types_names_equal(types_ResolvedType* a, types_ResolvedType* b)
                 return (ok_match && err_match);
             }
         } else if ((a_kind == types_ResolvedTypeKind_rk_ptr) && (b_kind == types_ResolvedTypeKind_rk_ptr)) {
-            __auto_type _mv_1854 = (*a).inner_type;
-            if (_mv_1854.has_value) {
-                __auto_type a_inner = _mv_1854.value;
-                __auto_type _mv_1855 = (*b).inner_type;
-                if (_mv_1855.has_value) {
-                    __auto_type b_inner = _mv_1855.value;
+            __auto_type _mv_1855 = (*a).inner_type;
+            if (_mv_1855.has_value) {
+                __auto_type a_inner = _mv_1855.value;
+                __auto_type _mv_1856 = (*b).inner_type;
+                if (_mv_1856.has_value) {
+                    __auto_type b_inner = _mv_1856.value;
                     return compiler_types_names_equal(a_inner, b_inner);
-                } else if (!_mv_1855.has_value) {
+                } else if (!_mv_1856.has_value) {
                     return 1;
                 }
-            } else if (!_mv_1854.has_value) {
+            } else if (!_mv_1855.has_value) {
                 return 1;
             }
         } else if (a_kind == types_ResolvedTypeKind_rk_range) {
-            __auto_type _mv_1856 = (*a).inner_type;
-            if (_mv_1856.has_value) {
-                __auto_type base = _mv_1856.value;
+            __auto_type _mv_1857 = (*a).inner_type;
+            if (_mv_1857.has_value) {
+                __auto_type base = _mv_1857.value;
                 return compiler_types_names_equal(base, b);
-            } else if (!_mv_1856.has_value) {
+            } else if (!_mv_1857.has_value) {
                 return 0;
             }
         } else if (b_kind == types_ResolvedTypeKind_rk_range) {
-            __auto_type _mv_1857 = (*b).inner_type;
-            if (_mv_1857.has_value) {
-                __auto_type base = _mv_1857.value;
+            __auto_type _mv_1858 = (*b).inner_type;
+            if (_mv_1858.has_value) {
+                __auto_type base = _mv_1858.value;
                 return compiler_types_names_equal(a, base);
-            } else if (!_mv_1857.has_value) {
+            } else if (!_mv_1858.has_value) {
                 return 0;
             }
         } else if ((a_kind == types_ResolvedTypeKind_rk_primitive) && (b_kind == types_ResolvedTypeKind_rk_primitive)) {
@@ -711,19 +711,19 @@ uint8_t compiler_types_names_equal(types_ResolvedType* a, types_ResolvedType* b)
                 return (a_match || b_match);
             }
         } else if (a_kind == types_ResolvedTypeKind_rk_primitive) {
-            __auto_type _mv_1858 = (*a).inner_type;
-            if (_mv_1858.has_value) {
-                __auto_type a_base = _mv_1858.value;
+            __auto_type _mv_1859 = (*a).inner_type;
+            if (_mv_1859.has_value) {
+                __auto_type a_base = _mv_1859.value;
                 return compiler_types_names_equal(a_base, b);
-            } else if (!_mv_1858.has_value) {
+            } else if (!_mv_1859.has_value) {
                 return 0;
             }
         } else if (b_kind == types_ResolvedTypeKind_rk_primitive) {
-            __auto_type _mv_1859 = (*b).inner_type;
-            if (_mv_1859.has_value) {
-                __auto_type b_base = _mv_1859.value;
+            __auto_type _mv_1860 = (*b).inner_type;
+            if (_mv_1860.has_value) {
+                __auto_type b_base = _mv_1860.value;
                 return compiler_types_names_equal(a, b_base);
-            } else if (!_mv_1859.has_value) {
+            } else if (!_mv_1860.has_value) {
                 return 0;
             }
         } else {
@@ -735,26 +735,26 @@ uint8_t compiler_types_names_equal(types_ResolvedType* a, types_ResolvedType* b)
 int64_t compiler_check_expr_mode(slop_arena* arena, env_TypeEnv* env, slop_string expr_str, slop_string type_str, slop_string context_file, slop_string params_str) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     if (string_len(context_file) > 0) {
-        __auto_type _mv_1860 = file_file_open(context_file, file_FileMode_read);
-        if (!_mv_1860.is_ok) {
-            __auto_type _ = _mv_1860.data.err;
-        } else if (_mv_1860.is_ok) {
-            __auto_type f = _mv_1860.data.ok;
-            __auto_type _mv_1861 = file_file_read_all(arena, (&f));
-            if (!_mv_1861.is_ok) {
-                __auto_type _ = _mv_1861.data.err;
+        __auto_type _mv_1861 = file_file_open(context_file, file_FileMode_read);
+        if (!_mv_1861.is_ok) {
+            __auto_type _ = _mv_1861.data.err;
+        } else if (_mv_1861.is_ok) {
+            __auto_type f = _mv_1861.data.ok;
+            __auto_type _mv_1862 = file_file_read_all(arena, (&f));
+            if (!_mv_1862.is_ok) {
+                __auto_type _ = _mv_1862.data.err;
                 file_file_close((&f));
-            } else if (_mv_1861.is_ok) {
-                __auto_type source = _mv_1861.data.ok;
+            } else if (_mv_1862.is_ok) {
+                __auto_type source = _mv_1862.data.ok;
                 file_file_close((&f));
-                __auto_type _mv_1862 = parser_parse(arena, source);
-                if (_mv_1862.is_ok) {
-                    __auto_type context_ast = _mv_1862.data.ok;
+                __auto_type _mv_1863 = parser_parse(arena, source);
+                if (_mv_1863.is_ok) {
+                    __auto_type context_ast = _mv_1863.data.ok;
                     collect_collect_module(env, context_ast);
                     resolve_resolve_imports(env, context_ast);
                     env_env_clear_diagnostics(env);
-                } else if (!_mv_1862.is_ok) {
-                    __auto_type _ = _mv_1862.data.err;
+                } else if (!_mv_1863.is_ok) {
+                    __auto_type _ = _mv_1863.data.err;
                 }
             }
         }
@@ -793,27 +793,27 @@ int64_t compiler_transpile_single_file(env_TypeEnv* env, context_TranspileContex
     {
         __auto_type filename_str = strlib_cstring_to_string(filename);
         context_ctx_set_file(ctx, filename_str);
-        __auto_type _mv_1863 = file_file_open(filename_str, file_FileMode_read);
-        if (!_mv_1863.is_ok) {
-            __auto_type e = _mv_1863.data.err;
+        __auto_type _mv_1864 = file_file_open(filename_str, file_FileMode_read);
+        if (!_mv_1864.is_ok) {
+            __auto_type e = _mv_1864.data.err;
             printf("%s", "Error: Could not open file: ");
             printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
             return 1;
-        } else if (_mv_1863.is_ok) {
-            __auto_type f = _mv_1863.data.ok;
-            __auto_type _mv_1864 = file_file_read_all(arena, (&f));
-            if (!_mv_1864.is_ok) {
-                __auto_type e = _mv_1864.data.err;
+        } else if (_mv_1864.is_ok) {
+            __auto_type f = _mv_1864.data.ok;
+            __auto_type _mv_1865 = file_file_read_all(arena, (&f));
+            if (!_mv_1865.is_ok) {
+                __auto_type e = _mv_1865.data.err;
                 file_file_close((&f));
                 printf("%s", "Error: Could not read file: ");
                 printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
                 return 1;
-            } else if (_mv_1864.is_ok) {
-                __auto_type source = _mv_1864.data.ok;
+            } else if (_mv_1865.is_ok) {
+                __auto_type source = _mv_1865.data.ok;
                 file_file_close((&f));
-                __auto_type _mv_1865 = parser_parse(arena, source);
-                if (_mv_1865.is_ok) {
-                    __auto_type ast = _mv_1865.data.ok;
+                __auto_type _mv_1866 = parser_parse(arena, source);
+                if (_mv_1866.is_ok) {
+                    __auto_type ast = _mv_1866.data.ok;
                     {
                         __auto_type mod_name = compiler_extract_module_name(ast);
                         env_env_clear_imports(env);
@@ -831,8 +831,8 @@ int64_t compiler_transpile_single_file(env_TypeEnv* env, context_TranspileContex
                         compiler_output_transpile_module_json(arena, ctx, mod_name, first);
                         return 0;
                     }
-                } else if (!_mv_1865.is_ok) {
-                    __auto_type parse_err = _mv_1865.data.err;
+                } else if (!_mv_1866.is_ok) {
+                    __auto_type parse_err = _mv_1866.data.err;
                     printf("%.*s", (int)(filename_str).len, (filename_str).data);
                     printf("%s", ":");
                     printf("%lld", (long long)(parse_err.line));
@@ -873,26 +873,26 @@ void compiler_output_transpile_module_json(slop_arena* arena, context_TranspileC
 
 slop_string compiler_emit_sexpr_inner(slop_arena* arena, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1866 = (*expr);
-    switch (_mv_1866.tag) {
+    __auto_type _mv_1867 = (*expr);
+    switch (_mv_1867.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1866.data.sym;
+            __auto_type sym = _mv_1867.data.sym;
             return sym.name;
         }
         case types_SExpr_str:
         {
-            __auto_type str = _mv_1866.data.str;
+            __auto_type str = _mv_1867.data.str;
             return string_concat(arena, SLOP_STR("\""), string_concat(arena, str.value, SLOP_STR("\"")));
         }
         case types_SExpr_num:
         {
-            __auto_type num = _mv_1866.data.num;
+            __auto_type num = _mv_1867.data.num;
             return num.raw;
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1866.data.lst;
+            __auto_type lst = _mv_1867.data.lst;
             return compiler_emit_typed_list(arena, lst.items);
         }
     }
@@ -903,14 +903,14 @@ slop_string compiler_emit_typed_sexpr(slop_arena* arena, types_SExpr* expr) {
     {
         __auto_type type_opt = ctype_get_node_resolved_type(expr);
         __auto_type inner = compiler_emit_sexpr_inner(arena, expr);
-        __auto_type _mv_1867 = type_opt;
-        if (_mv_1867.has_value) {
-            __auto_type rt = _mv_1867.value;
+        __auto_type _mv_1868 = type_opt;
+        if (_mv_1868.has_value) {
+            __auto_type rt = _mv_1868.value;
             {
                 __auto_type type_str = types_resolved_type_to_slop_string(arena, rt);
                 return string_concat(arena, SLOP_STR("(typed "), string_concat(arena, type_str, string_concat(arena, SLOP_STR(" "), string_concat(arena, inner, SLOP_STR(")")))));
             }
-        } else if (!_mv_1867.has_value) {
+        } else if (!_mv_1868.has_value) {
             return inner;
         }
     }
@@ -922,9 +922,9 @@ slop_string compiler_emit_typed_list(slop_arena* arena, slop_list_types_SExpr_pt
         __auto_type result = SLOP_STR("(");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1868 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1868.has_value) {
-                __auto_type item = _mv_1868.value;
+            __auto_type _mv_1869 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1869.has_value) {
+                __auto_type item = _mv_1869.value;
                 {
                     __auto_type child_str = compiler_emit_typed_sexpr(arena, item);
                     if (i > 0) {
@@ -933,7 +933,7 @@ slop_string compiler_emit_typed_list(slop_arena* arena, slop_list_types_SExpr_pt
                         result = string_concat(arena, result, child_str);
                     }
                 }
-            } else if (!_mv_1868.has_value) {
+            } else if (!_mv_1869.has_value) {
             }
             i = (i + 1);
         }
@@ -960,9 +960,9 @@ slop_string compiler_emit_typed_module(slop_arena* arena, types_SExpr* module_fo
             __auto_type result = SLOP_STR("(");
             int64_t i = 0;
             while (i < len) {
-                __auto_type _mv_1869 = parser_sexpr_list_get(module_form, i);
-                if (_mv_1869.has_value) {
-                    __auto_type item = _mv_1869.value;
+                __auto_type _mv_1870 = parser_sexpr_list_get(module_form, i);
+                if (_mv_1870.has_value) {
+                    __auto_type item = _mv_1870.value;
                     {
                         __auto_type child_str = ((parser_is_form(item, SLOP_STR("fn"))) ? compiler_emit_typed_sexpr(arena, item) : compiler_emit_typed_sexpr(arena, item));
                         if (i > 0) {
@@ -971,7 +971,7 @@ slop_string compiler_emit_typed_module(slop_arena* arena, types_SExpr* module_fo
                             result = string_concat(arena, result, child_str);
                         }
                     }
-                } else if (!_mv_1869.has_value) {
+                } else if (!_mv_1870.has_value) {
                 }
                 i = (i + 1);
             }
@@ -988,9 +988,9 @@ slop_string compiler_emit_typed_ast(slop_arena* arena, slop_list_types_SExpr_ptr
         __auto_type result = SLOP_STR("");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1870 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1870.has_value) {
-                __auto_type expr = _mv_1870.value;
+            __auto_type _mv_1871 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1871.has_value) {
+                __auto_type expr = _mv_1871.value;
                 {
                     __auto_type form_str = compiler_emit_typed_toplevel(arena, expr);
                     if (i > 0) {
@@ -999,7 +999,7 @@ slop_string compiler_emit_typed_ast(slop_arena* arena, slop_list_types_SExpr_ptr
                         result = form_str;
                     }
                 }
-            } else if (!_mv_1870.has_value) {
+            } else if (!_mv_1871.has_value) {
             }
             i = (i + 1);
         }
@@ -1012,27 +1012,27 @@ int64_t compiler_typed_ast_single_file(env_TypeEnv* env, slop_arena* arena, uint
     SLOP_PRE(((filename != NULL)), "(!= filename nil)");
     {
         __auto_type filename_str = strlib_cstring_to_string(filename);
-        __auto_type _mv_1871 = file_file_open(filename_str, file_FileMode_read);
-        if (!_mv_1871.is_ok) {
-            __auto_type e = _mv_1871.data.err;
+        __auto_type _mv_1872 = file_file_open(filename_str, file_FileMode_read);
+        if (!_mv_1872.is_ok) {
+            __auto_type e = _mv_1872.data.err;
             printf("%s", "Error: Could not open file: ");
             printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
             return 1;
-        } else if (_mv_1871.is_ok) {
-            __auto_type f = _mv_1871.data.ok;
-            __auto_type _mv_1872 = file_file_read_all(arena, (&f));
-            if (!_mv_1872.is_ok) {
-                __auto_type e = _mv_1872.data.err;
+        } else if (_mv_1872.is_ok) {
+            __auto_type f = _mv_1872.data.ok;
+            __auto_type _mv_1873 = file_file_read_all(arena, (&f));
+            if (!_mv_1873.is_ok) {
+                __auto_type e = _mv_1873.data.err;
                 file_file_close((&f));
                 printf("%s", "Error: Could not read file: ");
                 printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
                 return 1;
-            } else if (_mv_1872.is_ok) {
-                __auto_type source = _mv_1872.data.ok;
+            } else if (_mv_1873.is_ok) {
+                __auto_type source = _mv_1873.data.ok;
                 file_file_close((&f));
-                __auto_type _mv_1873 = parser_parse(arena, source);
-                if (_mv_1873.is_ok) {
-                    __auto_type ast = _mv_1873.data.ok;
+                __auto_type _mv_1874 = parser_parse(arena, source);
+                if (_mv_1874.is_ok) {
+                    __auto_type ast = _mv_1874.data.ok;
                     {
                         __auto_type mod_name = compiler_extract_module_name(ast);
                         env_env_clear_imports(env);
@@ -1060,8 +1060,8 @@ int64_t compiler_typed_ast_single_file(env_TypeEnv* env, slop_arena* arena, uint
                             }
                         }
                     }
-                } else if (!_mv_1873.is_ok) {
-                    __auto_type parse_err = _mv_1873.data.err;
+                } else if (!_mv_1874.is_ok) {
+                    __auto_type parse_err = _mv_1874.data.err;
                     printf("%.*s", (int)(filename_str).len, (filename_str).data);
                     printf("%s", ":");
                     printf("%lld", (long long)(parse_err.line));

--- a/bootstrap/compiler/slop_ctype.c
+++ b/bootstrap/compiler/slop_ctype.c
@@ -11,6 +11,7 @@ uint8_t ctype_is_numeric_type(slop_string name);
 slop_option_string ctype_builtin_type_c(slop_arena* arena, slop_string name);
 slop_string ctype_to_c_name(slop_arena* arena, slop_string name);
 slop_string ctype_type_to_identifier(slop_arena* arena, slop_string c_type);
+slop_string ctype_unwrap_ptr_container_type(slop_arena* arena, slop_string slop_type);
 uint8_t ctype_is_type_variable(slop_string name);
 slop_string ctype_to_c_type(slop_arena* arena, types_SExpr* expr);
 slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_ptr items);
@@ -148,6 +149,20 @@ slop_string ctype_type_to_identifier(slop_arena* arena, slop_string c_type) {
         }
         return result;
     }
+}
+
+slop_string ctype_unwrap_ptr_container_type(slop_arena* arena, slop_string slop_type) {
+    slop_string _retval = {0};
+    if (strlib_starts_with(slop_type, SLOP_STR("(Ptr (Map ")) || strlib_starts_with(slop_type, SLOP_STR("(Ptr (Set "))) {
+        {
+            __auto_type inner_len = ((int64_t)((string_len(slop_type) - 6)));
+            _retval = strlib_substring(arena, slop_type, 5, inner_len);
+        }
+    } else {
+        _retval = slop_type;
+    }
+    SLOP_POST(((string_len(_retval) <= string_len(slop_type))), "(<= (string-len $result) (string-len slop-type))");
+    return _retval;
 }
 
 uint8_t ctype_is_type_variable(slop_string name) {

--- a/bootstrap/compiler/slop_ctype.h
+++ b/bootstrap/compiler/slop_ctype.h
@@ -32,6 +32,7 @@ uint8_t ctype_is_numeric_type(slop_string name);
 slop_option_string ctype_builtin_type_c(slop_arena* arena, slop_string name);
 slop_string ctype_to_c_name(slop_arena* arena, slop_string name);
 slop_string ctype_type_to_identifier(slop_arena* arena, slop_string c_type);
+slop_string ctype_unwrap_ptr_container_type(slop_arena* arena, slop_string slop_type);
 uint8_t ctype_is_type_variable(slop_string name);
 slop_string ctype_to_c_type(slop_arena* arena, types_SExpr* expr);
 slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_ptr items);

--- a/bootstrap/compiler/slop_expr.c
+++ b/bootstrap/compiler/slop_expr.c
@@ -47,10 +47,10 @@ slop_string expr_infer_field_access_list_type(context_TranspileContext* ctx, typ
 slop_string expr_list_type_to_option_type(context_TranspileContext* ctx, slop_string c_type);
 slop_string expr_prefix_list_element_type(context_TranspileContext* ctx, slop_string elem_type);
 slop_string expr_substring_after_prefix(slop_arena* arena, slop_string s, slop_string prefix);
-slop_string expr_extract_map_value_from_slop_type(slop_arena* arena, slop_string slop_type);
+slop_string expr_extract_map_value_from_slop_type(slop_arena* arena, slop_string raw_slop_type);
 slop_string expr_slop_value_type_to_c_type(context_TranspileContext* ctx, slop_string slop_type);
 slop_string expr_get_var_name_from_expr(types_SExpr* expr);
-slop_string expr_extract_map_key_from_slop_type(slop_arena* arena, slop_string slop_type);
+slop_string expr_extract_map_key_from_slop_type(slop_arena* arena, slop_string raw_slop_type);
 slop_string expr_resolve_type_alias(context_TranspileContext* ctx, slop_string slop_type);
 slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr* expr);
 slop_string expr_infer_map_key_c_type_from_slop_type(context_TranspileContext* ctx, slop_string slop_type);
@@ -60,7 +60,7 @@ slop_string expr_extract_list_elem_from_inferred(context_TranspileContext* ctx, 
 slop_string expr_infer_map_key_c_type(context_TranspileContext* ctx, types_SExpr* map_expr);
 uint8_t expr_is_set_type(slop_string slop_type);
 uint8_t expr_is_map_type(slop_string slop_type);
-slop_string expr_extract_set_elem_from_slop_type(slop_arena* arena, slop_string slop_type);
+slop_string expr_extract_set_elem_from_slop_type(slop_arena* arena, slop_string raw_slop_type);
 slop_string expr_infer_set_elem_c_type(context_TranspileContext* ctx, types_SExpr* set_expr);
 slop_string expr_compound_slop_type_to_id(slop_arena* arena, slop_string slop_type);
 slop_string expr_slop_value_type_to_option_id(slop_arena* arena, slop_string slop_type);
@@ -129,6 +129,8 @@ slop_string expr_get_arena_from_field_access(context_TranspileContext* ctx, type
 slop_string expr_get_arena_from_base(context_TranspileContext* ctx, types_SExpr* base_expr);
 slop_string expr_get_arena_for_list_push(context_TranspileContext* ctx, slop_string list_c);
 uint8_t expr_is_ptr_to_ptr_map(context_TranspileContext* ctx, types_SExpr* expr);
+slop_string expr_deref_container_c(context_TranspileContext* ctx, slop_string container_c, slop_string slop_type);
+slop_string expr_resolve_container_c(context_TranspileContext* ctx, types_SExpr* container_expr);
 slop_string expr_transpile_record_new(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items);
 slop_string expr_transpile_record_fields(context_TranspileContext* ctx, slop_string type_name, slop_list_types_SExpr_ptr items, int64_t start_idx);
 slop_string expr_build_inline_struct_type(context_TranspileContext* ctx, slop_list_types_SExpr_ptr type_items);
@@ -1756,46 +1758,49 @@ slop_string expr_substring_after_prefix(slop_arena* arena, slop_string s, slop_s
     }
 }
 
-slop_string expr_extract_map_value_from_slop_type(slop_arena* arena, slop_string slop_type) {
+slop_string expr_extract_map_value_from_slop_type(slop_arena* arena, slop_string raw_slop_type) {
     {
-        __auto_type len = string_len(slop_type);
-        if (len < 10) {
-            return SLOP_STR("");
-        } else {
-            if (!(strlib_starts_with(slop_type, SLOP_STR("(Map ")))) {
+        __auto_type slop_type = ctype_unwrap_ptr_container_type(arena, raw_slop_type);
+        {
+            __auto_type len = string_len(slop_type);
+            if (len < 10) {
                 return SLOP_STR("");
             } else {
-                {
-                    int64_t i = 5;
-                    int64_t nesting = 1;
-                    int64_t key_space = 0;
-                    uint8_t found_key = 0;
-                    __auto_type end_idx = (len - 1);
-                    while ((i < end_idx) && !(found_key)) {
-                        {
-                            __auto_type c = strlib_char_at(slop_type, ((int64_t)(i)));
-                            if (c == 40) {
-                                nesting = (nesting + 1);
-                            } else if (c == 41) {
-                                nesting = (nesting - 1);
-                            } else if ((c == 32) && (nesting == 1)) {
-                                key_space = i;
-                                found_key = 1;
-                            } else {
+                if (!(strlib_starts_with(slop_type, SLOP_STR("(Map ")))) {
+                    return SLOP_STR("");
+                } else {
+                    {
+                        int64_t i = 5;
+                        int64_t nesting = 1;
+                        int64_t key_space = 0;
+                        uint8_t found_key = 0;
+                        __auto_type end_idx = (len - 1);
+                        while ((i < end_idx) && !(found_key)) {
+                            {
+                                __auto_type c = strlib_char_at(slop_type, ((int64_t)(i)));
+                                if (c == 40) {
+                                    nesting = (nesting + 1);
+                                } else if (c == 41) {
+                                    nesting = (nesting - 1);
+                                } else if ((c == 32) && (nesting == 1)) {
+                                    key_space = i;
+                                    found_key = 1;
+                                } else {
+                                }
                             }
+                            i = (i + 1);
                         }
-                        i = (i + 1);
-                    }
-                    if (!(found_key)) {
-                        return SLOP_STR("");
-                    } else {
-                        {
-                            __auto_type value_start = (key_space + 1);
-                            __auto_type value_len = (end_idx - value_start);
-                            if (value_len > 0) {
-                                return strlib_substring(arena, slop_type, ((int64_t)(value_start)), ((int64_t)(value_len)));
-                            } else {
-                                return SLOP_STR("");
+                        if (!(found_key)) {
+                            return SLOP_STR("");
+                        } else {
+                            {
+                                __auto_type value_start = (key_space + 1);
+                                __auto_type value_len = (end_idx - value_start);
+                                if (value_len > 0) {
+                                    return strlib_substring(arena, slop_type, ((int64_t)(value_start)), ((int64_t)(value_len)));
+                                } else {
+                                    return SLOP_STR("");
+                                }
                             }
                         }
                     }
@@ -1851,46 +1856,49 @@ slop_string expr_get_var_name_from_expr(types_SExpr* expr) {
     }
 }
 
-slop_string expr_extract_map_key_from_slop_type(slop_arena* arena, slop_string slop_type) {
+slop_string expr_extract_map_key_from_slop_type(slop_arena* arena, slop_string raw_slop_type) {
     {
-        __auto_type len = string_len(slop_type);
-        if (len < 10) {
-            return SLOP_STR("");
-        } else {
-            if (!(strlib_starts_with(slop_type, SLOP_STR("(Map ")))) {
+        __auto_type slop_type = ctype_unwrap_ptr_container_type(arena, raw_slop_type);
+        {
+            __auto_type len = string_len(slop_type);
+            if (len < 10) {
                 return SLOP_STR("");
             } else {
-                {
-                    int64_t i = 5;
-                    int64_t nesting = 1;
-                    int64_t key_space = 0;
-                    uint8_t found_key = 0;
-                    __auto_type end_idx = (len - 1);
-                    while ((i < end_idx) && !(found_key)) {
-                        {
-                            __auto_type c = strlib_char_at(slop_type, ((int64_t)(i)));
-                            if (c == 40) {
-                                nesting = (nesting + 1);
-                            } else if (c == 41) {
-                                nesting = (nesting - 1);
-                            } else if ((c == 32) && (nesting == 1)) {
-                                key_space = i;
-                                found_key = 1;
-                            } else {
+                if (!(strlib_starts_with(slop_type, SLOP_STR("(Map ")))) {
+                    return SLOP_STR("");
+                } else {
+                    {
+                        int64_t i = 5;
+                        int64_t nesting = 1;
+                        int64_t key_space = 0;
+                        uint8_t found_key = 0;
+                        __auto_type end_idx = (len - 1);
+                        while ((i < end_idx) && !(found_key)) {
+                            {
+                                __auto_type c = strlib_char_at(slop_type, ((int64_t)(i)));
+                                if (c == 40) {
+                                    nesting = (nesting + 1);
+                                } else if (c == 41) {
+                                    nesting = (nesting - 1);
+                                } else if ((c == 32) && (nesting == 1)) {
+                                    key_space = i;
+                                    found_key = 1;
+                                } else {
+                                }
                             }
+                            i = (i + 1);
                         }
-                        i = (i + 1);
-                    }
-                    if (!(found_key)) {
-                        return SLOP_STR("");
-                    } else {
-                        {
-                            __auto_type key_start = 5;
-                            __auto_type key_len = (key_space - key_start);
-                            if (key_len > 0) {
-                                return strlib_substring(arena, slop_type, ((int64_t)(key_start)), ((int64_t)(key_len)));
-                            } else {
-                                return SLOP_STR("");
+                        if (!(found_key)) {
+                            return SLOP_STR("");
+                        } else {
+                            {
+                                __auto_type key_start = 5;
+                                __auto_type key_len = (key_space - key_start);
+                                if (key_len > 0) {
+                                    return strlib_substring(arena, slop_type, ((int64_t)(key_start)), ((int64_t)(key_len)));
+                                } else {
+                                    return SLOP_STR("");
+                                }
                             }
                         }
                     }
@@ -2293,22 +2301,25 @@ uint8_t expr_is_map_type(slop_string slop_type) {
     return (strlib_starts_with(slop_type, SLOP_STR("(Map ")) || strlib_starts_with(slop_type, SLOP_STR("(Ptr (Map ")));
 }
 
-slop_string expr_extract_set_elem_from_slop_type(slop_arena* arena, slop_string slop_type) {
+slop_string expr_extract_set_elem_from_slop_type(slop_arena* arena, slop_string raw_slop_type) {
     {
-        __auto_type len = string_len(slop_type);
-        if (len < 7) {
-            return SLOP_STR("");
-        } else {
-            if (!(strlib_starts_with(slop_type, SLOP_STR("(Set ")))) {
+        __auto_type slop_type = ctype_unwrap_ptr_container_type(arena, raw_slop_type);
+        {
+            __auto_type len = string_len(slop_type);
+            if (len < 7) {
                 return SLOP_STR("");
             } else {
-                {
-                    __auto_type elem_start = 5;
-                    __auto_type elem_len = ((len - 1) - elem_start);
-                    if (elem_len > 0) {
-                        return strlib_substring(arena, slop_type, ((int64_t)(elem_start)), ((int64_t)(elem_len)));
-                    } else {
-                        return SLOP_STR("");
+                if (!(strlib_starts_with(slop_type, SLOP_STR("(Set ")))) {
+                    return SLOP_STR("");
+                } else {
+                    {
+                        __auto_type elem_start = 5;
+                        __auto_type elem_len = ((len - 1) - elem_start);
+                        if (elem_len > 0) {
+                            return strlib_substring(arena, slop_type, ((int64_t)(elem_start)), ((int64_t)(elem_len)));
+                        } else {
+                            return SLOP_STR("");
+                        }
                     }
                 }
             }
@@ -5171,12 +5182,12 @@ slop_string expr_slop_type_to_c_type(context_TranspileContext* ctx, slop_string 
             } else if (strlib_starts_with(slop_type, SLOP_STR("(List "))) {
                 {
                     __auto_type inner = strlib_substring(arena, slop_type, 6, ((0) > ((((int64_t)(string_len(slop_type))) - 7)) ? (0) : ((((int64_t)(string_len(slop_type))) - 7))));
-                    return context_ctx_str(ctx, SLOP_STR("slop_list_"), expr_slop_type_to_c_type(ctx, inner));
+                    return context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, expr_slop_type_to_c_type(ctx, inner)));
                 }
             } else if (strlib_starts_with(slop_type, SLOP_STR("(Option "))) {
                 {
                     __auto_type inner = strlib_substring(arena, slop_type, 8, ((0) > ((((int64_t)(string_len(slop_type))) - 9)) ? (0) : ((((int64_t)(string_len(slop_type))) - 9))));
-                    return context_ctx_str(ctx, SLOP_STR("slop_option_"), expr_slop_type_to_c_type(ctx, inner));
+                    return context_ctx_str(ctx, SLOP_STR("slop_option_"), ctype_type_to_identifier(arena, expr_slop_type_to_c_type(ctx, inner)));
                 }
             } else if (strlib_starts_with(slop_type, SLOP_STR("(Chan "))) {
                 {
@@ -6853,7 +6864,32 @@ uint8_t expr_is_ptr_to_ptr_map(context_TranspileContext* ctx, types_SExpr* expr)
             }
         }
         default: {
-            return 0;
+            {
+                __auto_type slop_type = expr_resolve_type_alias(ctx, expr_infer_expr_slop_type(ctx, expr));
+                return (strlib_starts_with(slop_type, SLOP_STR("(Ptr (Map ")) || strlib_starts_with(slop_type, SLOP_STR("(Ptr (Set ")));
+            }
+        }
+    }
+}
+
+slop_string expr_deref_container_c(context_TranspileContext* ctx, slop_string container_c, slop_string slop_type) {
+    SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
+    if (strlib_starts_with(slop_type, SLOP_STR("(Ptr (Map ")) || strlib_starts_with(slop_type, SLOP_STR("(Ptr (Set "))) {
+        return context_ctx_str3(ctx, SLOP_STR("(*"), container_c, SLOP_STR(")"));
+    } else {
+        return container_c;
+    }
+}
+
+slop_string expr_resolve_container_c(context_TranspileContext* ctx, types_SExpr* container_expr) {
+    SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
+    SLOP_PRE(((container_expr != NULL)), "(!= container-expr nil)");
+    {
+        __auto_type c = expr_transpile_expr(ctx, container_expr);
+        if (expr_is_ptr_to_ptr_map(ctx, container_expr)) {
+            return context_ctx_str3(ctx, SLOP_STR("(*"), c, SLOP_STR(")"));
+        } else {
+            return c;
         }
     }
 }
@@ -7471,33 +7507,20 @@ slop_string expr_transpile_map_put(context_TranspileContext* ctx, slop_list_type
                     if (_mv_489.has_value) {
                         __auto_type val_expr = _mv_489.value;
                         {
-                            __auto_type map_c = expr_transpile_expr(ctx, map_expr);
+                            __auto_type map_c = expr_resolve_container_c(ctx, map_expr);
                             __auto_type key_c = expr_transpile_expr(ctx, key_expr);
                             __auto_type val_c = expr_transpile_expr(ctx, val_expr);
                             __auto_type key_ptr = expr_wrap_map_key_as_ptr(ctx, key_c, key_expr, map_expr);
-                            __auto_type needs_deref = expr_is_ptr_to_ptr_map(ctx, map_expr);
                             __auto_type val_decl_type = expr_map_put_value_decl_type(ctx, map_expr);
                             __auto_type arena_c = expr_resolve_arena_c_name(ctx, SLOP_STR("map-put"), items);
-                            if (needs_deref) {
-                                {
-                                    __auto_type s1 = context_ctx_str4(ctx, SLOP_STR("({ "), val_decl_type, SLOP_STR(" _val = "), val_c);
-                                    __auto_type s2 = context_ctx_str(ctx, s1, context_ctx_str5(ctx, SLOP_STR("; void* _vptr = slop_arena_alloc("), arena_c, SLOP_STR(", sizeof(_val)); memcpy(_vptr, &_val, sizeof(_val)); slop_map_put("), arena_c, SLOP_STR(", (*")));
-                                    __auto_type s3 = context_ctx_str(ctx, s2, map_c);
-                                    __auto_type s4 = context_ctx_str(ctx, s3, SLOP_STR("), "));
-                                    __auto_type s5 = context_ctx_str(ctx, s4, key_ptr);
-                                    __auto_type s6 = context_ctx_str(ctx, s5, SLOP_STR(", _vptr); })"));
-                                    return s6;
-                                }
-                            } else {
-                                {
-                                    __auto_type s1 = context_ctx_str4(ctx, SLOP_STR("({ "), val_decl_type, SLOP_STR(" _val = "), val_c);
-                                    __auto_type s2 = context_ctx_str(ctx, s1, context_ctx_str5(ctx, SLOP_STR("; void* _vptr = slop_arena_alloc("), arena_c, SLOP_STR(", sizeof(_val)); memcpy(_vptr, &_val, sizeof(_val)); slop_map_put("), arena_c, SLOP_STR(", ")));
-                                    __auto_type s3 = context_ctx_str(ctx, s2, map_c);
-                                    __auto_type s4 = context_ctx_str(ctx, s3, SLOP_STR(", "));
-                                    __auto_type s5 = context_ctx_str(ctx, s4, key_ptr);
-                                    __auto_type s6 = context_ctx_str(ctx, s5, SLOP_STR(", _vptr); })"));
-                                    return s6;
-                                }
+                            {
+                                __auto_type s1 = context_ctx_str4(ctx, SLOP_STR("({ "), val_decl_type, SLOP_STR(" _val = "), val_c);
+                                __auto_type s2 = context_ctx_str(ctx, s1, context_ctx_str5(ctx, SLOP_STR("; void* _vptr = slop_arena_alloc("), arena_c, SLOP_STR(", sizeof(_val)); memcpy(_vptr, &_val, sizeof(_val)); slop_map_put("), arena_c, SLOP_STR(", ")));
+                                __auto_type s3 = context_ctx_str(ctx, s2, map_c);
+                                __auto_type s4 = context_ctx_str(ctx, s3, SLOP_STR(", "));
+                                __auto_type s5 = context_ctx_str(ctx, s4, key_ptr);
+                                __auto_type s6 = context_ctx_str(ctx, s5, SLOP_STR(", _vptr); })"));
+                                return s6;
                             }
                         }
                     } else if (!_mv_489.has_value) {
@@ -7532,7 +7555,7 @@ slop_string expr_transpile_map_get(context_TranspileContext* ctx, slop_list_type
                 if (_mv_491.has_value) {
                     __auto_type key_expr = _mv_491.value;
                     {
-                        __auto_type map_c = expr_transpile_expr(ctx, map_expr);
+                        __auto_type map_c = expr_resolve_container_c(ctx, map_expr);
                         __auto_type key_c = expr_transpile_expr(ctx, key_expr);
                         __auto_type key_ptr = expr_wrap_map_key_as_ptr(ctx, key_c, key_expr, map_expr);
                         __auto_type option_type = expr_infer_map_value_option_type(ctx, map_expr);
@@ -7574,7 +7597,7 @@ slop_string expr_transpile_map_has(context_TranspileContext* ctx, slop_list_type
                 if (_mv_493.has_value) {
                     __auto_type key_expr = _mv_493.value;
                     {
-                        __auto_type map_c = expr_transpile_expr(ctx, map_expr);
+                        __auto_type map_c = expr_resolve_container_c(ctx, map_expr);
                         __auto_type key_c = expr_transpile_expr(ctx, key_expr);
                         __auto_type key_ptr = expr_wrap_map_key_as_ptr(ctx, key_c, key_expr, map_expr);
                         return context_ctx_str(ctx, SLOP_STR("(slop_map_get("), context_ctx_str(ctx, map_c, context_ctx_str(ctx, SLOP_STR(", "), context_ctx_str(ctx, key_ptr, SLOP_STR(") != NULL)")))));
@@ -7606,15 +7629,10 @@ slop_string expr_transpile_map_remove(context_TranspileContext* ctx, slop_list_t
                 if (_mv_495.has_value) {
                     __auto_type key_expr = _mv_495.value;
                     {
-                        __auto_type map_c = expr_transpile_expr(ctx, map_expr);
+                        __auto_type map_c = expr_resolve_container_c(ctx, map_expr);
                         __auto_type key_c = expr_transpile_expr(ctx, key_expr);
                         __auto_type key_ptr = expr_wrap_map_key_as_ptr(ctx, key_c, key_expr, map_expr);
-                        __auto_type needs_deref = expr_is_ptr_to_ptr_map(ctx, map_expr);
-                        if (needs_deref) {
-                            return context_ctx_str(ctx, SLOP_STR("slop_map_remove((*"), context_ctx_str(ctx, map_c, context_ctx_str(ctx, SLOP_STR("), "), context_ctx_str(ctx, key_ptr, SLOP_STR(")")))));
-                        } else {
-                            return context_ctx_str(ctx, SLOP_STR("slop_map_remove("), context_ctx_str(ctx, map_c, context_ctx_str(ctx, SLOP_STR(", "), context_ctx_str(ctx, key_ptr, SLOP_STR(")")))));
-                        }
+                        return context_ctx_str(ctx, SLOP_STR("slop_map_remove("), context_ctx_str(ctx, map_c, context_ctx_str(ctx, SLOP_STR(", "), context_ctx_str(ctx, key_ptr, SLOP_STR(")")))));
                     }
                 } else if (!_mv_495.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("map-remove: missing key"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
@@ -7641,16 +7659,20 @@ slop_string expr_transpile_map_keys(context_TranspileContext* ctx, slop_list_typ
             if (_mv_496.has_value) {
                 __auto_type map_expr = _mv_496.value;
                 {
-                    __auto_type map_c = expr_transpile_expr(ctx, map_expr);
+                    __auto_type map_c = expr_resolve_container_c(ctx, map_expr);
                     __auto_type key_c_type = expr_infer_map_key_c_type(ctx, map_expr);
-                    __auto_type debug_var_name = expr_get_var_name_from_expr(map_expr);
-                    __auto_type debug_slop_type = ({ __auto_type _mv = context_ctx_lookup_var(ctx, debug_var_name); _mv.has_value ? ({ __auto_type entry = _mv.value; entry.slop_type; }) : (SLOP_STR("VAR_NOT_FOUND")); });
                     __auto_type arena_c = expr_resolve_arena_c_name(ctx, SLOP_STR("map-keys"), items);
-                    if (string_eq(key_c_type, SLOP_STR("slop_string")) || (string_len(key_c_type) == 0)) {
-                        return context_ctx_str(ctx, SLOP_STR("/* DEBUG: var="), context_ctx_str(ctx, debug_var_name, context_ctx_str(ctx, SLOP_STR(" slop="), context_ctx_str(ctx, debug_slop_type, context_ctx_str(ctx, SLOP_STR(" key="), context_ctx_str(ctx, key_c_type, context_ctx_str(ctx, context_ctx_str3(ctx, SLOP_STR(" */ slop_map_keys("), arena_c, SLOP_STR(", ")), context_ctx_str(ctx, map_c, SLOP_STR(")")))))))));
+                    if (string_eq(key_c_type, SLOP_STR("slop_string"))) {
+                        return context_ctx_str(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map_keys("), arena_c, SLOP_STR(", ")), context_ctx_str(ctx, map_c, SLOP_STR(")")));
+                    } else if (string_len(key_c_type) == 0) {
+                        context_ctx_add_error_at(ctx, SLOP_STR("map-keys: cannot infer key type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
+                        return SLOP_STR("NULL");
                     } else {
                         {
-                            __auto_type list_type = context_ctx_str(ctx, SLOP_STR("slop_list_"), key_c_type);
+                            __auto_type key_id = ctype_type_to_identifier(arena, key_c_type);
+                            __auto_type list_type = context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, key_c_type));
+                            context_ctx_register_list_type(ctx, key_c_type, list_type);
+                            context_ctx_register_option_type(ctx, key_c_type, context_ctx_str(ctx, SLOP_STR("slop_option_"), key_id));
                             return context_ctx_str(ctx, context_ctx_str3(ctx, SLOP_STR("({ slop_set_elements_result _r = slop_set_elements_raw("), arena_c, SLOP_STR(", ")), context_ctx_str(ctx, map_c, context_ctx_str(ctx, SLOP_STR("); ("), context_ctx_str(ctx, list_type, context_ctx_str(ctx, SLOP_STR("){.data = ("), context_ctx_str(ctx, key_c_type, context_ctx_str(ctx, SLOP_STR("*)_r.data, .len = _r.len, .cap = _r.cap}; })"), SLOP_STR(""))))))));
                         }
                     }
@@ -7709,7 +7731,7 @@ slop_string expr_transpile_set_put(context_TranspileContext* ctx, slop_list_type
                 if (_mv_500.has_value) {
                     __auto_type elem_expr = _mv_500.value;
                     {
-                        __auto_type set_c = expr_transpile_expr(ctx, set_expr);
+                        __auto_type set_c = expr_resolve_container_c(ctx, set_expr);
                         __auto_type elem_c = expr_transpile_expr(ctx, elem_expr);
                         __auto_type elem_ptr = expr_wrap_map_key_as_ptr(ctx, elem_c, elem_expr, set_expr);
                         __auto_type arena_c = expr_resolve_arena_c_name(ctx, SLOP_STR("set-put"), items);
@@ -7742,7 +7764,7 @@ slop_string expr_transpile_set_has(context_TranspileContext* ctx, slop_list_type
                 if (_mv_502.has_value) {
                     __auto_type elem_expr = _mv_502.value;
                     {
-                        __auto_type set_c = expr_transpile_expr(ctx, set_expr);
+                        __auto_type set_c = expr_resolve_container_c(ctx, set_expr);
                         __auto_type elem_c = expr_transpile_expr(ctx, elem_expr);
                         __auto_type elem_ptr = expr_wrap_map_key_as_ptr(ctx, elem_c, elem_expr, set_expr);
                         return context_ctx_str(ctx, SLOP_STR("(slop_map_get("), context_ctx_str(ctx, set_c, context_ctx_str(ctx, SLOP_STR(", "), context_ctx_str(ctx, elem_ptr, SLOP_STR(") != NULL)")))));
@@ -7774,7 +7796,7 @@ slop_string expr_transpile_set_remove(context_TranspileContext* ctx, slop_list_t
                 if (_mv_504.has_value) {
                     __auto_type elem_expr = _mv_504.value;
                     {
-                        __auto_type set_c = expr_transpile_expr(ctx, set_expr);
+                        __auto_type set_c = expr_resolve_container_c(ctx, set_expr);
                         __auto_type elem_c = expr_transpile_expr(ctx, elem_expr);
                         __auto_type elem_ptr = expr_wrap_map_key_as_ptr(ctx, elem_c, elem_expr, set_expr);
                         return context_ctx_str(ctx, SLOP_STR("slop_map_remove("), context_ctx_str(ctx, set_c, context_ctx_str(ctx, SLOP_STR(", "), context_ctx_str(ctx, elem_ptr, SLOP_STR(")")))));
@@ -7795,6 +7817,7 @@ slop_string expr_transpile_set_elements(context_TranspileContext* ctx, slop_list
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type len = ((int64_t)((items).len));
+        __auto_type arena = (*ctx).arena;
         if (len < 2) {
             context_ctx_add_error_at(ctx, SLOP_STR("set-elements: needs set"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             return SLOP_STR("NULL");
@@ -7803,14 +7826,20 @@ slop_string expr_transpile_set_elements(context_TranspileContext* ctx, slop_list
             if (_mv_505.has_value) {
                 __auto_type set_expr = _mv_505.value;
                 {
-                    __auto_type set_c = expr_transpile_expr(ctx, set_expr);
+                    __auto_type set_c = expr_resolve_container_c(ctx, set_expr);
                     __auto_type elem_c_type = expr_infer_set_elem_c_type(ctx, set_expr);
                     __auto_type arena_c = expr_resolve_arena_c_name(ctx, SLOP_STR("set-elements"), items);
-                    if (string_eq(elem_c_type, SLOP_STR("slop_string")) || (string_len(elem_c_type) == 0)) {
+                    if (string_eq(elem_c_type, SLOP_STR("slop_string"))) {
                         return context_ctx_str(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map_keys("), arena_c, SLOP_STR(", ")), context_ctx_str(ctx, set_c, SLOP_STR(")")));
+                    } else if (string_len(elem_c_type) == 0) {
+                        context_ctx_add_error_at(ctx, SLOP_STR("set-elements: cannot infer element type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
+                        return SLOP_STR("NULL");
                     } else {
                         {
-                            __auto_type list_type = context_ctx_str(ctx, SLOP_STR("slop_list_"), elem_c_type);
+                            __auto_type elem_id = ctype_type_to_identifier(arena, elem_c_type);
+                            __auto_type list_type = context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, elem_c_type));
+                            context_ctx_register_list_type(ctx, elem_c_type, list_type);
+                            context_ctx_register_option_type(ctx, elem_c_type, context_ctx_str(ctx, SLOP_STR("slop_option_"), elem_id));
                             return context_ctx_str(ctx, context_ctx_str3(ctx, SLOP_STR("({ slop_set_elements_result _r = slop_set_elements_raw("), arena_c, SLOP_STR(", ")), context_ctx_str(ctx, set_c, context_ctx_str(ctx, SLOP_STR("); ("), context_ctx_str(ctx, list_type, context_ctx_str(ctx, SLOP_STR("){.data = ("), context_ctx_str(ctx, elem_c_type, context_ctx_str(ctx, SLOP_STR("*)_r.data, .len = _r.len, .cap = _r.cap}; })"), SLOP_STR(""))))))));
                         }
                     }
@@ -8077,7 +8106,7 @@ slop_string expr_transpile_for_each_set_as_expr(context_TranspileContext* ctx, s
         __auto_type elem_slop_type = expr_extract_set_elem_from_slop_type(arena, resolved_type);
         __auto_type elem_c_type = expr_slop_value_type_to_c_type(ctx, elem_slop_type);
         {
-            __auto_type result = context_ctx_str3(ctx, SLOP_STR("({ slop_map* _coll = (slop_map*)"), coll_c, SLOP_STR("; for (size_t _i = 0; _i < _coll->cap; _i++) { "));
+            __auto_type result = context_ctx_str3(ctx, SLOP_STR("({ slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, coll_c, resolved_type), SLOP_STR("; for (size_t _i = 0; _i < _coll->cap; _i++) { "));
             __auto_type if_part = SLOP_STR("if (_coll->entries[_i].occupied) { ");
             __auto_type cast_part = context_ctx_str(ctx, elem_c_type, SLOP_STR("*)_coll->entries[_i].key"));
             __auto_type assign_prefix = context_ctx_str4(ctx, elem_c_type, SLOP_STR(" "), var_name, SLOP_STR(" = *("));
@@ -8115,7 +8144,7 @@ slop_string expr_transpile_for_each_map_keys_as_expr(context_TranspileContext* c
         __auto_type key_slop_type = expr_extract_map_key_from_slop_type(arena, resolved_type);
         __auto_type key_c_type = expr_slop_value_type_to_c_type(ctx, key_slop_type);
         {
-            __auto_type result = context_ctx_str3(ctx, SLOP_STR("({ slop_map* _coll = (slop_map*)"), coll_c, SLOP_STR("; for (size_t _i = 0; _i < _coll->cap; _i++) { "));
+            __auto_type result = context_ctx_str3(ctx, SLOP_STR("({ slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, coll_c, resolved_type), SLOP_STR("; for (size_t _i = 0; _i < _coll->cap; _i++) { "));
             __auto_type if_part = SLOP_STR("if (_coll->entries[_i].occupied) { ");
             __auto_type cast_part = context_ctx_str(ctx, key_c_type, SLOP_STR("*)_coll->entries[_i].key"));
             __auto_type assign_prefix = context_ctx_str4(ctx, key_c_type, SLOP_STR(" "), var_name, SLOP_STR(" = *("));
@@ -8191,7 +8220,7 @@ slop_string expr_transpile_for_each_map_kv_as_expr(context_TranspileContext* ctx
                                                             __auto_type key_c_type = expr_slop_value_type_to_c_type(ctx, key_slop_type);
                                                             __auto_type val_c_type = expr_slop_value_type_to_c_type(ctx, val_slop_type);
                                                             {
-                                                                __auto_type result = context_ctx_str3(ctx, SLOP_STR("({ slop_map* _coll = (slop_map*)"), map_c, SLOP_STR("; for (size_t _i = 0; _i < _coll->cap; _i++) { "));
+                                                                __auto_type result = context_ctx_str3(ctx, SLOP_STR("({ slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, map_c, resolved_type), SLOP_STR("; for (size_t _i = 0; _i < _coll->cap; _i++) { "));
                                                                 __auto_type if_part = SLOP_STR("if (_coll->entries[_i].occupied) { ");
                                                                 __auto_type k_cast = context_ctx_str(ctx, key_c_type, SLOP_STR("*)_coll->entries[_i].key"));
                                                                 __auto_type k_prefix = context_ctx_str4(ctx, key_c_type, SLOP_STR(" "), k_name, SLOP_STR(" = *("));
@@ -9926,9 +9955,9 @@ slop_string expr_infer_elem_from_type(context_TranspileContext* ctx, types_SExpr
                             return SLOP_STR("");
                         }
                     }
-                } else if (strlib_starts_with(resolved_type, SLOP_STR("(Set "))) {
+                } else if (expr_is_set_type(resolved_type)) {
                     return expr_extract_set_elem_from_slop_type(arena, resolved_type);
-                } else if (strlib_starts_with(resolved_type, SLOP_STR("(Map "))) {
+                } else if (expr_is_map_type(resolved_type)) {
                     return expr_extract_map_key_from_slop_type(arena, resolved_type);
                 } else {
                     return SLOP_STR("");

--- a/bootstrap/compiler/slop_expr.h
+++ b/bootstrap/compiler/slop_expr.h
@@ -65,10 +65,10 @@ slop_string expr_infer_field_access_list_type(context_TranspileContext* ctx, typ
 slop_string expr_list_type_to_option_type(context_TranspileContext* ctx, slop_string c_type);
 slop_string expr_prefix_list_element_type(context_TranspileContext* ctx, slop_string elem_type);
 slop_string expr_substring_after_prefix(slop_arena* arena, slop_string s, slop_string prefix);
-slop_string expr_extract_map_value_from_slop_type(slop_arena* arena, slop_string slop_type);
+slop_string expr_extract_map_value_from_slop_type(slop_arena* arena, slop_string raw_slop_type);
 slop_string expr_slop_value_type_to_c_type(context_TranspileContext* ctx, slop_string slop_type);
 slop_string expr_get_var_name_from_expr(types_SExpr* expr);
-slop_string expr_extract_map_key_from_slop_type(slop_arena* arena, slop_string slop_type);
+slop_string expr_extract_map_key_from_slop_type(slop_arena* arena, slop_string raw_slop_type);
 slop_string expr_resolve_type_alias(context_TranspileContext* ctx, slop_string slop_type);
 slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr* expr);
 slop_string expr_infer_map_key_c_type_from_slop_type(context_TranspileContext* ctx, slop_string slop_type);
@@ -78,7 +78,7 @@ slop_string expr_extract_list_elem_from_inferred(context_TranspileContext* ctx, 
 slop_string expr_infer_map_key_c_type(context_TranspileContext* ctx, types_SExpr* map_expr);
 uint8_t expr_is_set_type(slop_string slop_type);
 uint8_t expr_is_map_type(slop_string slop_type);
-slop_string expr_extract_set_elem_from_slop_type(slop_arena* arena, slop_string slop_type);
+slop_string expr_extract_set_elem_from_slop_type(slop_arena* arena, slop_string raw_slop_type);
 slop_string expr_infer_set_elem_c_type(context_TranspileContext* ctx, types_SExpr* set_expr);
 slop_string expr_compound_slop_type_to_id(slop_arena* arena, slop_string slop_type);
 slop_string expr_slop_value_type_to_option_id(slop_arena* arena, slop_string slop_type);
@@ -147,6 +147,8 @@ slop_string expr_get_arena_from_field_access(context_TranspileContext* ctx, type
 slop_string expr_get_arena_from_base(context_TranspileContext* ctx, types_SExpr* base_expr);
 slop_string expr_get_arena_for_list_push(context_TranspileContext* ctx, slop_string list_c);
 uint8_t expr_is_ptr_to_ptr_map(context_TranspileContext* ctx, types_SExpr* expr);
+slop_string expr_deref_container_c(context_TranspileContext* ctx, slop_string container_c, slop_string slop_type);
+slop_string expr_resolve_container_c(context_TranspileContext* ctx, types_SExpr* container_expr);
 slop_string expr_transpile_record_new(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items);
 slop_string expr_transpile_record_fields(context_TranspileContext* ctx, slop_string type_name, slop_list_types_SExpr_ptr items, int64_t start_idx);
 slop_string expr_build_inline_struct_type(context_TranspileContext* ctx, slop_list_types_SExpr_ptr type_items);

--- a/bootstrap/compiler/slop_infer.c
+++ b/bootstrap/compiler/slop_infer.c
@@ -230,18 +230,18 @@ slop_option_types_ResolvedType_ptr infer_find_binding(slop_list_string bind_name
         __auto_type len = ((int64_t)((bind_names).len));
         slop_option_types_ResolvedType_ptr found = (slop_option_types_ResolvedType_ptr){.has_value = false};
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_1626 = ({ __auto_type _lst = bind_names; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1626.has_value) {
-                __auto_type bn = _mv_1626.value;
+            __auto_type _mv_1627 = ({ __auto_type _lst = bind_names; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1627.has_value) {
+                __auto_type bn = _mv_1627.value;
                 if (string_eq(bn, name)) {
-                    __auto_type _mv_1627 = ({ __auto_type _lst = bind_types; size_t _idx = (size_t)i; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1627.has_value) {
-                        __auto_type bt = _mv_1627.value;
+                    __auto_type _mv_1628 = ({ __auto_type _lst = bind_types; size_t _idx = (size_t)i; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1628.has_value) {
+                        __auto_type bt = _mv_1628.value;
                         found = (slop_option_types_ResolvedType_ptr){.has_value = 1, .value = bt};
-                    } else if (!_mv_1627.has_value) {
+                    } else if (!_mv_1628.has_value) {
                     }
                 }
-            } else if (!_mv_1626.has_value) {
+            } else if (!_mv_1627.has_value) {
             }
         }
         return found;
@@ -256,107 +256,107 @@ void infer_unify_types(slop_arena* arena, types_ResolvedType* formal, types_Reso
         if (f_kind == types_ResolvedTypeKind_rk_typevar) {
             {
                 __auto_type tv_name = (*formal).name;
-                __auto_type _mv_1628 = infer_find_binding(bind_names, bind_types, tv_name);
-                if (_mv_1628.has_value) {
-                    __auto_type existing = _mv_1628.value;
-                } else if (!_mv_1628.has_value) {
+                __auto_type _mv_1629 = infer_find_binding(bind_names, bind_types, tv_name);
+                if (_mv_1629.has_value) {
+                    __auto_type existing = _mv_1629.value;
+                } else if (!_mv_1629.has_value) {
                     ({ __auto_type _lst_p = &(bind_names); __auto_type _item = (tv_name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                     ({ __auto_type _lst_p = &(bind_types); __auto_type _item = (actual); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                 }
             }
         } else if (f_kind == types_ResolvedTypeKind_rk_ptr) {
             if ((*actual).kind == types_ResolvedTypeKind_rk_ptr) {
-                __auto_type _mv_1629 = (*formal).inner_type;
-                if (_mv_1629.has_value) {
-                    __auto_type f_inner = _mv_1629.value;
-                    __auto_type _mv_1630 = (*actual).inner_type;
-                    if (_mv_1630.has_value) {
-                        __auto_type a_inner = _mv_1630.value;
+                __auto_type _mv_1630 = (*formal).inner_type;
+                if (_mv_1630.has_value) {
+                    __auto_type f_inner = _mv_1630.value;
+                    __auto_type _mv_1631 = (*actual).inner_type;
+                    if (_mv_1631.has_value) {
+                        __auto_type a_inner = _mv_1631.value;
                         infer_unify_types(arena, f_inner, a_inner, bind_names, bind_types);
-                    } else if (!_mv_1630.has_value) {
+                    } else if (!_mv_1631.has_value) {
                     }
-                } else if (!_mv_1629.has_value) {
+                } else if (!_mv_1630.has_value) {
                 }
             }
         } else if (f_kind == types_ResolvedTypeKind_rk_chan) {
             if ((*actual).kind == types_ResolvedTypeKind_rk_chan) {
-                __auto_type _mv_1631 = (*formal).inner_type;
-                if (_mv_1631.has_value) {
-                    __auto_type f_inner = _mv_1631.value;
-                    __auto_type _mv_1632 = (*actual).inner_type;
-                    if (_mv_1632.has_value) {
-                        __auto_type a_inner = _mv_1632.value;
+                __auto_type _mv_1632 = (*formal).inner_type;
+                if (_mv_1632.has_value) {
+                    __auto_type f_inner = _mv_1632.value;
+                    __auto_type _mv_1633 = (*actual).inner_type;
+                    if (_mv_1633.has_value) {
+                        __auto_type a_inner = _mv_1633.value;
                         infer_unify_types(arena, f_inner, a_inner, bind_names, bind_types);
-                    } else if (!_mv_1632.has_value) {
+                    } else if (!_mv_1633.has_value) {
                     }
-                } else if (!_mv_1631.has_value) {
+                } else if (!_mv_1632.has_value) {
                 }
             }
         } else if (f_kind == types_ResolvedTypeKind_rk_thread) {
             if ((*actual).kind == types_ResolvedTypeKind_rk_thread) {
-                __auto_type _mv_1633 = (*formal).inner_type;
-                if (_mv_1633.has_value) {
-                    __auto_type f_inner = _mv_1633.value;
-                    __auto_type _mv_1634 = (*actual).inner_type;
-                    if (_mv_1634.has_value) {
-                        __auto_type a_inner = _mv_1634.value;
+                __auto_type _mv_1634 = (*formal).inner_type;
+                if (_mv_1634.has_value) {
+                    __auto_type f_inner = _mv_1634.value;
+                    __auto_type _mv_1635 = (*actual).inner_type;
+                    if (_mv_1635.has_value) {
+                        __auto_type a_inner = _mv_1635.value;
                         infer_unify_types(arena, f_inner, a_inner, bind_names, bind_types);
-                    } else if (!_mv_1634.has_value) {
+                    } else if (!_mv_1635.has_value) {
                     }
-                } else if (!_mv_1633.has_value) {
+                } else if (!_mv_1634.has_value) {
                 }
             }
         } else if (f_kind == types_ResolvedTypeKind_rk_list) {
             if ((*actual).kind == types_ResolvedTypeKind_rk_list) {
-                __auto_type _mv_1635 = (*formal).inner_type;
-                if (_mv_1635.has_value) {
-                    __auto_type f_inner = _mv_1635.value;
-                    __auto_type _mv_1636 = (*actual).inner_type;
-                    if (_mv_1636.has_value) {
-                        __auto_type a_inner = _mv_1636.value;
+                __auto_type _mv_1636 = (*formal).inner_type;
+                if (_mv_1636.has_value) {
+                    __auto_type f_inner = _mv_1636.value;
+                    __auto_type _mv_1637 = (*actual).inner_type;
+                    if (_mv_1637.has_value) {
+                        __auto_type a_inner = _mv_1637.value;
                         infer_unify_types(arena, f_inner, a_inner, bind_names, bind_types);
-                    } else if (!_mv_1636.has_value) {
+                    } else if (!_mv_1637.has_value) {
                     }
-                } else if (!_mv_1635.has_value) {
+                } else if (!_mv_1636.has_value) {
                 }
             }
         } else if (f_kind == types_ResolvedTypeKind_rk_option) {
             if ((*actual).kind == types_ResolvedTypeKind_rk_option) {
-                __auto_type _mv_1637 = (*formal).inner_type;
-                if (_mv_1637.has_value) {
-                    __auto_type f_inner = _mv_1637.value;
-                    __auto_type _mv_1638 = (*actual).inner_type;
-                    if (_mv_1638.has_value) {
-                        __auto_type a_inner = _mv_1638.value;
+                __auto_type _mv_1638 = (*formal).inner_type;
+                if (_mv_1638.has_value) {
+                    __auto_type f_inner = _mv_1638.value;
+                    __auto_type _mv_1639 = (*actual).inner_type;
+                    if (_mv_1639.has_value) {
+                        __auto_type a_inner = _mv_1639.value;
                         infer_unify_types(arena, f_inner, a_inner, bind_names, bind_types);
-                    } else if (!_mv_1638.has_value) {
+                    } else if (!_mv_1639.has_value) {
                     }
-                } else if (!_mv_1637.has_value) {
+                } else if (!_mv_1638.has_value) {
                 }
             }
         } else if (f_kind == types_ResolvedTypeKind_rk_result) {
             if ((*actual).kind == types_ResolvedTypeKind_rk_result) {
-                __auto_type _mv_1639 = (*formal).inner_type;
-                if (_mv_1639.has_value) {
-                    __auto_type f_inner = _mv_1639.value;
-                    __auto_type _mv_1640 = (*actual).inner_type;
-                    if (_mv_1640.has_value) {
-                        __auto_type a_inner = _mv_1640.value;
+                __auto_type _mv_1640 = (*formal).inner_type;
+                if (_mv_1640.has_value) {
+                    __auto_type f_inner = _mv_1640.value;
+                    __auto_type _mv_1641 = (*actual).inner_type;
+                    if (_mv_1641.has_value) {
+                        __auto_type a_inner = _mv_1641.value;
                         infer_unify_types(arena, f_inner, a_inner, bind_names, bind_types);
-                    } else if (!_mv_1640.has_value) {
+                    } else if (!_mv_1641.has_value) {
                     }
-                } else if (!_mv_1639.has_value) {
+                } else if (!_mv_1640.has_value) {
                 }
-                __auto_type _mv_1641 = (*formal).inner_type2;
-                if (_mv_1641.has_value) {
-                    __auto_type f_inner2 = _mv_1641.value;
-                    __auto_type _mv_1642 = (*actual).inner_type2;
-                    if (_mv_1642.has_value) {
-                        __auto_type a_inner2 = _mv_1642.value;
+                __auto_type _mv_1642 = (*formal).inner_type2;
+                if (_mv_1642.has_value) {
+                    __auto_type f_inner2 = _mv_1642.value;
+                    __auto_type _mv_1643 = (*actual).inner_type2;
+                    if (_mv_1643.has_value) {
+                        __auto_type a_inner2 = _mv_1643.value;
                         infer_unify_types(arena, f_inner2, a_inner2, bind_names, bind_types);
-                    } else if (!_mv_1642.has_value) {
+                    } else if (!_mv_1643.has_value) {
                     }
-                } else if (!_mv_1641.has_value) {
+                } else if (!_mv_1642.has_value) {
                 }
             }
         } else {
@@ -371,18 +371,18 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
         if (kind == types_ResolvedTypeKind_rk_typevar) {
             {
                 __auto_type tv_name = (*t).name;
-                __auto_type _mv_1643 = infer_find_binding(bind_names, bind_types, tv_name);
-                if (_mv_1643.has_value) {
-                    __auto_type bound = _mv_1643.value;
+                __auto_type _mv_1644 = infer_find_binding(bind_names, bind_types, tv_name);
+                if (_mv_1644.has_value) {
+                    __auto_type bound = _mv_1644.value;
                     return bound;
-                } else if (!_mv_1643.has_value) {
+                } else if (!_mv_1644.has_value) {
                     return t;
                 }
             }
         } else if (kind == types_ResolvedTypeKind_rk_ptr) {
-            __auto_type _mv_1644 = (*t).inner_type;
-            if (_mv_1644.has_value) {
-                __auto_type inner = _mv_1644.value;
+            __auto_type _mv_1645 = (*t).inner_type;
+            if (_mv_1645.has_value) {
+                __auto_type inner = _mv_1645.value;
                 {
                     __auto_type new_inner = infer_substitute_type_vars(arena, inner, bind_names, bind_types);
                     __auto_type inner_name = (*new_inner).name;
@@ -391,52 +391,52 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
                     types_resolved_type_set_inner(new_ptr, new_inner);
                     return new_ptr;
                 }
-            } else if (!_mv_1644.has_value) {
+            } else if (!_mv_1645.has_value) {
                 return t;
             }
         } else if (kind == types_ResolvedTypeKind_rk_chan) {
-            __auto_type _mv_1645 = (*t).inner_type;
-            if (_mv_1645.has_value) {
-                __auto_type inner = _mv_1645.value;
+            __auto_type _mv_1646 = (*t).inner_type;
+            if (_mv_1646.has_value) {
+                __auto_type inner = _mv_1646.value;
                 {
                     __auto_type new_inner = infer_substitute_type_vars(arena, inner, bind_names, bind_types);
                     __auto_type new_chan = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_chan, SLOP_STR("Chan"), ((slop_option_string){.has_value = false}), SLOP_STR("slop_chan_int*"));
                     types_resolved_type_set_inner(new_chan, new_inner);
                     return new_chan;
                 }
-            } else if (!_mv_1645.has_value) {
+            } else if (!_mv_1646.has_value) {
                 return t;
             }
         } else if (kind == types_ResolvedTypeKind_rk_thread) {
-            __auto_type _mv_1646 = (*t).inner_type;
-            if (_mv_1646.has_value) {
-                __auto_type inner = _mv_1646.value;
+            __auto_type _mv_1647 = (*t).inner_type;
+            if (_mv_1647.has_value) {
+                __auto_type inner = _mv_1647.value;
                 {
                     __auto_type new_inner = infer_substitute_type_vars(arena, inner, bind_names, bind_types);
                     __auto_type new_thread = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_thread, SLOP_STR("Thread"), ((slop_option_string){.has_value = false}), SLOP_STR("slop_thread_int*"));
                     types_resolved_type_set_inner(new_thread, new_inner);
                     return new_thread;
                 }
-            } else if (!_mv_1646.has_value) {
+            } else if (!_mv_1647.has_value) {
                 return t;
             }
         } else if (kind == types_ResolvedTypeKind_rk_list) {
-            __auto_type _mv_1647 = (*t).inner_type;
-            if (_mv_1647.has_value) {
-                __auto_type inner = _mv_1647.value;
+            __auto_type _mv_1648 = (*t).inner_type;
+            if (_mv_1648.has_value) {
+                __auto_type inner = _mv_1648.value;
                 {
                     __auto_type new_inner = infer_substitute_type_vars(arena, inner, bind_names, bind_types);
                     __auto_type new_list = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_list, SLOP_STR("List"), ((slop_option_string){.has_value = false}), SLOP_STR("slop_list_t*"));
                     types_resolved_type_set_inner(new_list, new_inner);
                     return new_list;
                 }
-            } else if (!_mv_1647.has_value) {
+            } else if (!_mv_1648.has_value) {
                 return t;
             }
         } else if (kind == types_ResolvedTypeKind_rk_option) {
-            __auto_type _mv_1648 = (*t).inner_type;
-            if (_mv_1648.has_value) {
-                __auto_type inner = _mv_1648.value;
+            __auto_type _mv_1649 = (*t).inner_type;
+            if (_mv_1649.has_value) {
+                __auto_type inner = _mv_1649.value;
                 {
                     __auto_type new_inner = infer_substitute_type_vars(arena, inner, bind_names, bind_types);
                     __auto_type inner_name = (*new_inner).name;
@@ -445,7 +445,7 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
                     types_resolved_type_set_inner(new_opt, new_inner);
                     return new_opt;
                 }
-            } else if (!_mv_1648.has_value) {
+            } else if (!_mv_1649.has_value) {
                 return t;
             }
         } else if (kind == types_ResolvedTypeKind_rk_result) {
@@ -496,22 +496,22 @@ types_ResolvedType* infer_infer_generic_call(env_TypeEnv* env, types_FnSignature
                 {
                     __auto_type limit = (((num_args < num_params)) ? num_args : num_params);
                     for (int64_t i = 0; i < limit; i++) {
-                        __auto_type _mv_1649 = parser_sexpr_list_get(expr, (i + 1));
-                        if (_mv_1649.has_value) {
-                            __auto_type arg_expr = _mv_1649.value;
+                        __auto_type _mv_1650 = parser_sexpr_list_get(expr, (i + 1));
+                        if (_mv_1650.has_value) {
+                            __auto_type arg_expr = _mv_1650.value;
                             {
                                 __auto_type actual_type = infer_infer_expr(env, arg_expr);
-                                __auto_type _mv_1650 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_ParamInfo _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1650.has_value) {
-                                    __auto_type param_info = _mv_1650.value;
+                                __auto_type _mv_1651 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_ParamInfo _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1651.has_value) {
+                                    __auto_type param_info = _mv_1651.value;
                                     {
                                         __auto_type formal_type = param_info.param_type;
                                         infer_unify_types(arena, formal_type, actual_type, bind_names, bind_types);
                                     }
-                                } else if (!_mv_1650.has_value) {
+                                } else if (!_mv_1651.has_value) {
                                 }
                             }
-                        } else if (!_mv_1649.has_value) {
+                        } else if (!_mv_1650.has_value) {
                         }
                     }
                 }
@@ -561,19 +561,19 @@ uint8_t infer_types_compatible_with_range(types_ResolvedType* a, types_ResolvedT
         __auto_type a_kind = (*a).kind;
         __auto_type b_kind = (*b).kind;
         if (a_kind == types_ResolvedTypeKind_rk_range) {
-            __auto_type _mv_1651 = (*a).inner_type;
-            if (_mv_1651.has_value) {
-                __auto_type base = _mv_1651.value;
+            __auto_type _mv_1652 = (*a).inner_type;
+            if (_mv_1652.has_value) {
+                __auto_type base = _mv_1652.value;
                 return string_eq((*base).name, (*b).name);
-            } else if (!_mv_1651.has_value) {
+            } else if (!_mv_1652.has_value) {
                 return 0;
             }
         } else if (b_kind == types_ResolvedTypeKind_rk_range) {
-            __auto_type _mv_1652 = (*b).inner_type;
-            if (_mv_1652.has_value) {
-                __auto_type base = _mv_1652.value;
+            __auto_type _mv_1653 = (*b).inner_type;
+            if (_mv_1653.has_value) {
+                __auto_type base = _mv_1653.value;
                 return string_eq((*a).name, (*base).name);
-            } else if (!_mv_1652.has_value) {
+            } else if (!_mv_1653.has_value) {
                 return 0;
             }
         } else {
@@ -608,29 +608,29 @@ types_ResolvedType* infer_unify_branch_types(env_TypeEnv* env, types_ResolvedTyp
 
 void infer_sexpr_set_resolved_type(types_SExpr* expr, types_ResolvedType* t) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1653 = (*expr);
-    switch (_mv_1653.tag) {
+    __auto_type _mv_1654 = (*expr);
+    switch (_mv_1654.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1653.data.sym;
+            __auto_type sym = _mv_1654.data.sym;
             (*expr) = ((types_SExpr){ .tag = types_SExpr_sym, .data.sym = (types_SExprSymbol){sym.name, sym.line, sym.col, (slop_option_types_ResolvedType_ptr){.has_value = 1, .value = t}} });
             break;
         }
         case types_SExpr_str:
         {
-            __auto_type str = _mv_1653.data.str;
+            __auto_type str = _mv_1654.data.str;
             (*expr) = ((types_SExpr){ .tag = types_SExpr_str, .data.str = (types_SExprString){str.value, str.line, str.col, (slop_option_types_ResolvedType_ptr){.has_value = 1, .value = t}} });
             break;
         }
         case types_SExpr_num:
         {
-            __auto_type num = _mv_1653.data.num;
+            __auto_type num = _mv_1654.data.num;
             (*expr) = ((types_SExpr){ .tag = types_SExpr_num, .data.num = (types_SExprNumber){num.int_value, num.float_value, num.is_float, num.raw, num.line, num.col, (slop_option_types_ResolvedType_ptr){.has_value = 1, .value = t}} });
             break;
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1653.data.lst;
+            __auto_type lst = _mv_1654.data.lst;
             (*expr) = ((types_SExpr){ .tag = types_SExpr_lst, .data.lst = (types_SExprList){lst.items, lst.line, lst.col, (slop_option_types_ResolvedType_ptr){.has_value = 1, .value = t}} });
             break;
         }
@@ -655,11 +655,11 @@ types_ResolvedType* infer_infer_expr_inner(env_TypeEnv* env, types_SExpr* expr) 
     {
         __auto_type line = parser_sexpr_line(expr);
         __auto_type col = parser_sexpr_col(expr);
-        __auto_type _mv_1654 = (*expr);
-        switch (_mv_1654.tag) {
+        __auto_type _mv_1655 = (*expr);
+        switch (_mv_1655.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1654.data.sym;
+                __auto_type sym = _mv_1655.data.sym;
                 {
                     __auto_type name = sym.name;
                     if (string_eq(name, SLOP_STR("true")) || string_eq(name, SLOP_STR("false"))) {
@@ -669,37 +669,37 @@ types_ResolvedType* infer_infer_expr_inner(env_TypeEnv* env, types_SExpr* expr) 
                     } else if (string_eq(name, SLOP_STR("none"))) {
                         return env_env_make_option_type(env, NULL);
                     } else {
-                        __auto_type _mv_1655 = env_env_lookup_var(env, name);
-                        if (_mv_1655.has_value) {
-                            __auto_type t = _mv_1655.value;
+                        __auto_type _mv_1656 = env_env_lookup_var(env, name);
+                        if (_mv_1656.has_value) {
+                            __auto_type t = _mv_1656.value;
                             return t;
-                        } else if (!_mv_1655.has_value) {
-                            __auto_type _mv_1656 = env_env_lookup_constant(env, name);
-                            if (_mv_1656.has_value) {
-                                __auto_type t = _mv_1656.value;
+                        } else if (!_mv_1656.has_value) {
+                            __auto_type _mv_1657 = env_env_lookup_constant(env, name);
+                            if (_mv_1657.has_value) {
+                                __auto_type t = _mv_1657.value;
                                 return t;
-                            } else if (!_mv_1656.has_value) {
-                                __auto_type _mv_1657 = env_env_lookup_function(env, name);
-                                if (_mv_1657.has_value) {
-                                    __auto_type sig = _mv_1657.value;
+                            } else if (!_mv_1657.has_value) {
+                                __auto_type _mv_1658 = env_env_lookup_function(env, name);
+                                if (_mv_1658.has_value) {
+                                    __auto_type sig = _mv_1658.value;
                                     return env_env_make_fn_type(env, sig);
-                                } else if (!_mv_1657.has_value) {
+                                } else if (!_mv_1658.has_value) {
                                     if (infer_string_contains_char(name, 46)) {
                                         {
                                             __auto_type dot_pos = infer_string_index_of(name, 46);
                                             __auto_type arena = env_env_arena(env);
                                             __auto_type base_name = infer_string_substring(arena, name, 0, dot_pos);
                                             __auto_type field_name = infer_string_substring(arena, name, (dot_pos + 1), ((int64_t)(name.len)));
-                                            __auto_type _mv_1658 = env_env_lookup_var(env, base_name);
-                                            if (_mv_1658.has_value) {
-                                                __auto_type obj_type = _mv_1658.value;
+                                            __auto_type _mv_1659 = env_env_lookup_var(env, base_name);
+                                            if (_mv_1659.has_value) {
+                                                __auto_type obj_type = _mv_1659.value;
                                                 return infer_check_field_exists(env, obj_type, field_name, line, col);
-                                            } else if (!_mv_1658.has_value) {
-                                                __auto_type _mv_1659 = env_env_lookup_type(env, base_name);
-                                                if (_mv_1659.has_value) {
-                                                    __auto_type type_info = _mv_1659.value;
+                                            } else if (!_mv_1659.has_value) {
+                                                __auto_type _mv_1660 = env_env_lookup_type(env, base_name);
+                                                if (_mv_1660.has_value) {
+                                                    __auto_type type_info = _mv_1660.value;
                                                     return type_info;
-                                                } else if (!_mv_1659.has_value) {
+                                                } else if (!_mv_1660.has_value) {
                                                     {
                                                         __auto_type msg = string_concat(arena, SLOP_STR("Undefined variable: "), name);
                                                         env_env_add_error(env, msg, line, col);
@@ -709,22 +709,22 @@ types_ResolvedType* infer_infer_expr_inner(env_TypeEnv* env, types_SExpr* expr) 
                                             }
                                         }
                                     } else {
-                                        __auto_type _mv_1660 = env_env_lookup_type(env, name);
-                                        if (_mv_1660.has_value) {
-                                            __auto_type type_info = _mv_1660.value;
+                                        __auto_type _mv_1661 = env_env_lookup_type(env, name);
+                                        if (_mv_1661.has_value) {
+                                            __auto_type type_info = _mv_1661.value;
                                             return type_info;
-                                        } else if (!_mv_1660.has_value) {
-                                            __auto_type _mv_1661 = env_env_lookup_variant(env, name);
-                                            if (_mv_1661.has_value) {
-                                                __auto_type enum_name = _mv_1661.value;
-                                                __auto_type _mv_1662 = env_env_lookup_type(env, enum_name);
-                                                if (_mv_1662.has_value) {
-                                                    __auto_type t = _mv_1662.value;
+                                        } else if (!_mv_1661.has_value) {
+                                            __auto_type _mv_1662 = env_env_lookup_variant(env, name);
+                                            if (_mv_1662.has_value) {
+                                                __auto_type enum_name = _mv_1662.value;
+                                                __auto_type _mv_1663 = env_env_lookup_type(env, enum_name);
+                                                if (_mv_1663.has_value) {
+                                                    __auto_type t = _mv_1663.value;
                                                     return t;
-                                                } else if (!_mv_1662.has_value) {
+                                                } else if (!_mv_1663.has_value) {
                                                     return env_env_get_int_type(env);
                                                 }
-                                            } else if (!_mv_1661.has_value) {
+                                            } else if (!_mv_1662.has_value) {
                                                 {
                                                     __auto_type arena = env_env_arena(env);
                                                     __auto_type msg = string_concat(arena, SLOP_STR("Undefined variable: "), name);
@@ -742,17 +742,17 @@ types_ResolvedType* infer_infer_expr_inner(env_TypeEnv* env, types_SExpr* expr) 
             }
             case types_SExpr_num:
             {
-                __auto_type num = _mv_1654.data.num;
+                __auto_type num = _mv_1655.data.num;
                 return env_env_get_int_type(env);
             }
             case types_SExpr_str:
             {
-                __auto_type str = _mv_1654.data.str;
+                __auto_type str = _mv_1655.data.str;
                 return env_env_get_string_type(env);
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1654.data.lst;
+                __auto_type lst = _mv_1655.data.lst;
                 return infer_infer_list_expr(env, expr, lst);
             }
         }
@@ -768,16 +768,16 @@ types_ResolvedType* infer_infer_list_expr(env_TypeEnv* env, types_SExpr* expr, t
         if (len == 0) {
             return env_env_get_unit_type(env);
         } else {
-            __auto_type _mv_1663 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (!_mv_1663.has_value) {
+            __auto_type _mv_1664 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (!_mv_1664.has_value) {
                 return env_env_get_unit_type(env);
-            } else if (_mv_1663.has_value) {
-                __auto_type head = _mv_1663.value;
-                __auto_type _mv_1664 = (*head);
-                switch (_mv_1664.tag) {
+            } else if (_mv_1664.has_value) {
+                __auto_type head = _mv_1664.value;
+                __auto_type _mv_1665 = (*head);
+                switch (_mv_1665.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_1664.data.sym;
+                        __auto_type sym = _mv_1665.data.sym;
                         {
                             __auto_type op = sym.name;
                             return infer_infer_special_form(env, expr, lst, op);
@@ -801,31 +801,31 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
         __auto_type col = parser_sexpr_col(expr);
         if (string_eq(op, SLOP_STR("if"))) {
             if (len >= 4) {
-                __auto_type _mv_1665 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1665.has_value) {
-                    __auto_type cond_expr = _mv_1665.value;
+                __auto_type _mv_1666 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1666.has_value) {
+                    __auto_type cond_expr = _mv_1666.value;
                     {
                         __auto_type _ = infer_infer_expr(env, cond_expr);
                     }
-                } else if (!_mv_1665.has_value) {
+                } else if (!_mv_1666.has_value) {
                 }
-                __auto_type _mv_1666 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1666.has_value) {
-                    __auto_type then_expr = _mv_1666.value;
+                __auto_type _mv_1667 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1667.has_value) {
+                    __auto_type then_expr = _mv_1667.value;
                     {
                         __auto_type then_type = infer_infer_expr(env, then_expr);
-                        __auto_type _mv_1667 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1667.has_value) {
-                            __auto_type else_expr = _mv_1667.value;
+                        __auto_type _mv_1668 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1668.has_value) {
+                            __auto_type else_expr = _mv_1668.value;
                             {
                                 __auto_type else_type = infer_infer_expr(env, else_expr);
                                 return infer_unify_branch_types(env, then_type, else_type, line, col);
                             }
-                        } else if (!_mv_1667.has_value) {
+                        } else if (!_mv_1668.has_value) {
                             return then_type;
                         }
                     }
-                } else if (!_mv_1666.has_value) {
+                } else if (!_mv_1667.has_value) {
                     return env_env_get_unit_type(env);
                 }
             } else {
@@ -838,11 +838,11 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
         } else if (string_eq(op, SLOP_STR("do"))) {
             infer_infer_body_exprs(env, expr, 1);
             if (len > 1) {
-                __auto_type _mv_1668 = ({ __auto_type _lst = items; size_t _idx = (size_t)(len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1668.has_value) {
-                    __auto_type last = _mv_1668.value;
+                __auto_type _mv_1669 = ({ __auto_type _lst = items; size_t _idx = (size_t)(len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1669.has_value) {
+                    __auto_type last = _mv_1669.value;
                     return infer_infer_expr(env, last);
-                } else if (!_mv_1668.has_value) {
+                } else if (!_mv_1669.has_value) {
                     return env_env_get_unit_type(env);
                 }
             } else {
@@ -855,56 +855,56 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             return env_env_get_unit_type(env);
         } else if (string_eq(op, SLOP_STR("for"))) {
             if (len >= 2) {
-                __auto_type _mv_1669 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1669.has_value) {
-                    __auto_type binding_form = _mv_1669.value;
+                __auto_type _mv_1670 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1670.has_value) {
+                    __auto_type binding_form = _mv_1670.value;
                     if (parser_sexpr_is_list(binding_form)) {
                         {
                             __auto_type bind_len = parser_sexpr_list_len(binding_form);
                             if (bind_len >= 3) {
-                                __auto_type _mv_1670 = parser_sexpr_list_get(binding_form, 0);
-                                if (_mv_1670.has_value) {
-                                    __auto_type var_expr = _mv_1670.value;
+                                __auto_type _mv_1671 = parser_sexpr_list_get(binding_form, 0);
+                                if (_mv_1671.has_value) {
+                                    __auto_type var_expr = _mv_1671.value;
                                     {
                                         __auto_type var_name = parser_sexpr_get_symbol_name(var_expr);
                                         if (!(string_eq(var_name, SLOP_STR("")))) {
                                             env_env_push_scope(env);
                                             env_env_bind_var(env, var_name, env_env_get_int_type(env));
-                                            __auto_type _mv_1671 = parser_sexpr_list_get(binding_form, 1);
-                                            if (_mv_1671.has_value) {
-                                                __auto_type start_expr = _mv_1671.value;
+                                            __auto_type _mv_1672 = parser_sexpr_list_get(binding_form, 1);
+                                            if (_mv_1672.has_value) {
+                                                __auto_type start_expr = _mv_1672.value;
                                                 {
                                                     __auto_type _ = infer_infer_expr(env, start_expr);
                                                 }
-                                            } else if (!_mv_1671.has_value) {
+                                            } else if (!_mv_1672.has_value) {
                                             }
-                                            __auto_type _mv_1672 = parser_sexpr_list_get(binding_form, 2);
-                                            if (_mv_1672.has_value) {
-                                                __auto_type end_expr = _mv_1672.value;
+                                            __auto_type _mv_1673 = parser_sexpr_list_get(binding_form, 2);
+                                            if (_mv_1673.has_value) {
+                                                __auto_type end_expr = _mv_1673.value;
                                                 {
                                                     __auto_type _ = infer_infer_expr(env, end_expr);
                                                 }
-                                            } else if (!_mv_1672.has_value) {
+                                            } else if (!_mv_1673.has_value) {
                                             }
                                             for (int64_t body_idx = 2; body_idx < len; body_idx++) {
-                                                __auto_type _mv_1673 = ({ __auto_type _lst = items; size_t _idx = (size_t)body_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1673.has_value) {
-                                                    __auto_type body_expr = _mv_1673.value;
+                                                __auto_type _mv_1674 = ({ __auto_type _lst = items; size_t _idx = (size_t)body_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1674.has_value) {
+                                                    __auto_type body_expr = _mv_1674.value;
                                                     {
                                                         __auto_type _ = infer_infer_expr(env, body_expr);
                                                     }
-                                                } else if (!_mv_1673.has_value) {
+                                                } else if (!_mv_1674.has_value) {
                                                 }
                                             }
                                             env_env_pop_scope(env);
                                         }
                                     }
-                                } else if (!_mv_1670.has_value) {
+                                } else if (!_mv_1671.has_value) {
                                 }
                             }
                         }
                     }
-                } else if (!_mv_1669.has_value) {
+                } else if (!_mv_1670.has_value) {
                 }
                 return env_env_get_unit_type(env);
             } else {
@@ -912,24 +912,24 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             }
         } else if (string_eq(op, SLOP_STR("for-each"))) {
             if (len >= 3) {
-                __auto_type _mv_1674 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1674.has_value) {
-                    __auto_type binding_form = _mv_1674.value;
+                __auto_type _mv_1675 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1675.has_value) {
+                    __auto_type binding_form = _mv_1675.value;
                     if (parser_sexpr_is_list(binding_form)) {
                         {
                             __auto_type bind_len = parser_sexpr_list_len(binding_form);
                             if (bind_len >= 2) {
-                                __auto_type _mv_1675 = parser_sexpr_list_get(binding_form, 0);
-                                if (_mv_1675.has_value) {
-                                    __auto_type var_expr = _mv_1675.value;
+                                __auto_type _mv_1676 = parser_sexpr_list_get(binding_form, 0);
+                                if (_mv_1676.has_value) {
+                                    __auto_type var_expr = _mv_1676.value;
                                     {
                                         __auto_type var_name = parser_sexpr_get_symbol_name(var_expr);
                                         if (string_eq(var_name, SLOP_STR(""))) {
                                             return env_env_get_unit_type(env);
                                         } else {
-                                            __auto_type _mv_1676 = parser_sexpr_list_get(binding_form, 1);
-                                            if (_mv_1676.has_value) {
-                                                __auto_type coll_expr = _mv_1676.value;
+                                            __auto_type _mv_1677 = parser_sexpr_list_get(binding_form, 1);
+                                            if (_mv_1677.has_value) {
+                                                __auto_type coll_expr = _mv_1677.value;
                                                 {
                                                     __auto_type coll_type = infer_infer_expr(env, coll_expr);
                                                     __auto_type coll_line = parser_sexpr_line(coll_expr);
@@ -939,25 +939,25 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                                         env_env_push_scope(env);
                                                         env_env_bind_var(env, var_name, elem_type);
                                                         for (int64_t body_idx = 2; body_idx < len; body_idx++) {
-                                                            __auto_type _mv_1677 = ({ __auto_type _lst = items; size_t _idx = (size_t)body_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                            if (_mv_1677.has_value) {
-                                                                __auto_type body_expr = _mv_1677.value;
+                                                            __auto_type _mv_1678 = ({ __auto_type _lst = items; size_t _idx = (size_t)body_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                            if (_mv_1678.has_value) {
+                                                                __auto_type body_expr = _mv_1678.value;
                                                                 {
                                                                     __auto_type _ = infer_infer_expr(env, body_expr);
                                                                 }
-                                                            } else if (!_mv_1677.has_value) {
+                                                            } else if (!_mv_1678.has_value) {
                                                             }
                                                         }
                                                         env_env_pop_scope(env);
                                                         return env_env_get_unit_type(env);
                                                     }
                                                 }
-                                            } else if (!_mv_1676.has_value) {
+                                            } else if (!_mv_1677.has_value) {
                                                 return env_env_get_unit_type(env);
                                             }
                                         }
                                     }
-                                } else if (!_mv_1675.has_value) {
+                                } else if (!_mv_1676.has_value) {
                                     return env_env_get_unit_type(env);
                                 }
                             } else {
@@ -967,7 +967,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                     } else {
                         return env_env_get_unit_type(env);
                     }
-                } else if (!_mv_1674.has_value) {
+                } else if (!_mv_1675.has_value) {
                     return env_env_get_unit_type(env);
                 }
             } else {
@@ -982,23 +982,23 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
         } else if (string_eq(op, SLOP_STR("fn"))) {
             env_env_push_scope(env);
             if (len >= 2) {
-                __auto_type _mv_1678 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1678.has_value) {
-                    __auto_type params_expr = _mv_1678.value;
+                __auto_type _mv_1679 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1679.has_value) {
+                    __auto_type params_expr = _mv_1679.value;
                     if (parser_sexpr_is_list(params_expr)) {
                         {
                             __auto_type num_params = parser_sexpr_list_len(params_expr);
                             for (int64_t k = 0; k < num_params; k++) {
-                                __auto_type _mv_1679 = parser_sexpr_list_get(params_expr, k);
-                                if (_mv_1679.has_value) {
-                                    __auto_type param_form = _mv_1679.value;
+                                __auto_type _mv_1680 = parser_sexpr_list_get(params_expr, k);
+                                if (_mv_1680.has_value) {
+                                    __auto_type param_form = _mv_1680.value;
                                     infer_bind_param_from_form(env, param_form);
-                                } else if (!_mv_1679.has_value) {
+                                } else if (!_mv_1680.has_value) {
                                 }
                             }
                         }
                     }
-                } else if (!_mv_1678.has_value) {
+                } else if (!_mv_1679.has_value) {
                 }
             }
             {
@@ -1013,16 +1013,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             return infer_infer_with_arena_expr(env, expr);
         } else if (string_eq(op, SLOP_STR("set!"))) {
             if (len >= 4) {
-                __auto_type _mv_1680 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1680.has_value) {
-                    __auto_type val_expr = _mv_1680.value;
-                    {
-                        __auto_type _ = infer_infer_expr(env, val_expr);
-                    }
-                } else if (!_mv_1680.has_value) {
-                }
-            } else if (len >= 3) {
-                __auto_type _mv_1681 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                __auto_type _mv_1681 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                 if (_mv_1681.has_value) {
                     __auto_type val_expr = _mv_1681.value;
                     {
@@ -1030,18 +1021,27 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                     }
                 } else if (!_mv_1681.has_value) {
                 }
+            } else if (len >= 3) {
+                __auto_type _mv_1682 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1682.has_value) {
+                    __auto_type val_expr = _mv_1682.value;
+                    {
+                        __auto_type _ = infer_infer_expr(env, val_expr);
+                    }
+                } else if (!_mv_1682.has_value) {
+                }
             } else {
             }
             return env_env_get_unit_type(env);
         } else if (string_eq(op, SLOP_STR("return"))) {
             if (len >= 2) {
-                __auto_type _mv_1682 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1682.has_value) {
-                    __auto_type ret_expr = _mv_1682.value;
+                __auto_type _mv_1683 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1683.has_value) {
+                    __auto_type ret_expr = _mv_1683.value;
                     {
                         __auto_type _ = infer_infer_expr(env, ret_expr);
                     }
-                } else if (!_mv_1682.has_value) {
+                } else if (!_mv_1683.has_value) {
                 }
             }
             return env_env_get_never_type(env);
@@ -1055,24 +1055,24 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             return env_env_get_int_type(env);
         } else if (string_eq(op, SLOP_STR("deref"))) {
             if (len >= 2) {
-                __auto_type _mv_1683 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1683.has_value) {
-                    __auto_type ptr_expr = _mv_1683.value;
+                __auto_type _mv_1684 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1684.has_value) {
+                    __auto_type ptr_expr = _mv_1684.value;
                     {
                         __auto_type ptr_type = infer_infer_expr(env, ptr_expr);
                         if (types_resolved_type_is_pointer(ptr_type)) {
-                            __auto_type _mv_1684 = (*ptr_type).inner_type;
-                            if (_mv_1684.has_value) {
-                                __auto_type inner = _mv_1684.value;
+                            __auto_type _mv_1685 = (*ptr_type).inner_type;
+                            if (_mv_1685.has_value) {
+                                __auto_type inner = _mv_1685.value;
                                 return inner;
-                            } else if (!_mv_1684.has_value) {
+                            } else if (!_mv_1685.has_value) {
                                 return env_env_get_unit_type(env);
                             }
                         } else {
                             return ptr_type;
                         }
                     }
-                } else if (!_mv_1683.has_value) {
+                } else if (!_mv_1684.has_value) {
                     return env_env_get_unit_type(env);
                 }
             } else {
@@ -1080,14 +1080,14 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             }
         } else if (string_eq(op, SLOP_STR("addr"))) {
             if (len >= 2) {
-                __auto_type _mv_1685 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1685.has_value) {
-                    __auto_type inner_expr = _mv_1685.value;
+                __auto_type _mv_1686 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1686.has_value) {
+                    __auto_type inner_expr = _mv_1686.value;
                     {
                         __auto_type inner_type = infer_infer_expr(env, inner_expr);
                         return env_env_make_ptr_type(env, inner_type);
                     }
-                } else if (!_mv_1685.has_value) {
+                } else if (!_mv_1686.has_value) {
                     return env_env_get_unit_type(env);
                 }
             } else {
@@ -1095,16 +1095,16 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             }
         } else if (string_eq(op, SLOP_STR("cast"))) {
             if (len >= 2) {
-                __auto_type _mv_1686 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1686.has_value) {
-                    __auto_type type_expr = _mv_1686.value;
+                __auto_type _mv_1687 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1687.has_value) {
+                    __auto_type type_expr = _mv_1687.value;
                     {
                         __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                         if (string_eq(type_name, SLOP_STR(""))) {
                             if (parser_sexpr_is_list(type_expr)) {
-                                __auto_type _mv_1687 = parser_sexpr_list_get(type_expr, 0);
-                                if (_mv_1687.has_value) {
-                                    __auto_type head_expr = _mv_1687.value;
+                                __auto_type _mv_1688 = parser_sexpr_list_get(type_expr, 0);
+                                if (_mv_1688.has_value) {
+                                    __auto_type head_expr = _mv_1688.value;
                                     {
                                         __auto_type head_name = parser_sexpr_get_symbol_name(head_expr);
                                         if (string_eq(head_name, SLOP_STR("Int"))) {
@@ -1134,18 +1134,18 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                             return env_env_get_unknown_type(env);
                                         }
                                     }
-                                } else if (!_mv_1687.has_value) {
+                                } else if (!_mv_1688.has_value) {
                                     return env_env_get_unknown_type(env);
                                 }
                             } else {
                                 return env_env_get_unknown_type(env);
                             }
                         } else {
-                            __auto_type _mv_1688 = env_env_lookup_type(env, type_name);
-                            if (_mv_1688.has_value) {
-                                __auto_type t = _mv_1688.value;
+                            __auto_type _mv_1689 = env_env_lookup_type(env, type_name);
+                            if (_mv_1689.has_value) {
+                                __auto_type t = _mv_1689.value;
                                 return t;
-                            } else if (!_mv_1688.has_value) {
+                            } else if (!_mv_1689.has_value) {
                                 if (string_eq(type_name, SLOP_STR("Int"))) {
                                     return env_env_get_int_type(env);
                                 } else if (string_eq(type_name, SLOP_STR("Bool"))) {
@@ -1160,7 +1160,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             }
                         }
                     }
-                } else if (!_mv_1686.has_value) {
+                } else if (!_mv_1687.has_value) {
                     return env_env_get_unknown_type(env);
                 }
             } else {
@@ -1168,30 +1168,30 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             }
         } else if (string_eq(op, SLOP_STR("quote"))) {
             if (len >= 2) {
-                __auto_type _mv_1689 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1689.has_value) {
-                    __auto_type variant_expr = _mv_1689.value;
+                __auto_type _mv_1690 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1690.has_value) {
+                    __auto_type variant_expr = _mv_1690.value;
                     {
                         __auto_type variant_name = parser_sexpr_get_symbol_name(variant_expr);
                         if (string_eq(variant_name, SLOP_STR(""))) {
                             return env_env_get_unknown_type(env);
                         } else {
-                            __auto_type _mv_1690 = env_env_lookup_variant(env, variant_name);
-                            if (_mv_1690.has_value) {
-                                __auto_type enum_name = _mv_1690.value;
-                                __auto_type _mv_1691 = env_env_lookup_type(env, enum_name);
-                                if (_mv_1691.has_value) {
-                                    __auto_type enum_type = _mv_1691.value;
+                            __auto_type _mv_1691 = env_env_lookup_variant(env, variant_name);
+                            if (_mv_1691.has_value) {
+                                __auto_type enum_name = _mv_1691.value;
+                                __auto_type _mv_1692 = env_env_lookup_type(env, enum_name);
+                                if (_mv_1692.has_value) {
+                                    __auto_type enum_type = _mv_1692.value;
                                     return enum_type;
-                                } else if (!_mv_1691.has_value) {
+                                } else if (!_mv_1692.has_value) {
                                     return env_env_get_unknown_type(env);
                                 }
-                            } else if (!_mv_1690.has_value) {
+                            } else if (!_mv_1691.has_value) {
                                 return env_env_get_unknown_type(env);
                             }
                         }
                     }
-                } else if (!_mv_1689.has_value) {
+                } else if (!_mv_1690.has_value) {
                     return env_env_get_unknown_type(env);
                 }
             } else {
@@ -1201,14 +1201,14 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             return infer_infer_field_access(env, expr, lst, line, col);
         } else if (string_eq(op, SLOP_STR("some"))) {
             if (len >= 2) {
-                __auto_type _mv_1692 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1692.has_value) {
-                    __auto_type inner_expr = _mv_1692.value;
+                __auto_type _mv_1693 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1693.has_value) {
+                    __auto_type inner_expr = _mv_1693.value;
                     {
                         __auto_type inner_type = infer_infer_expr(env, inner_expr);
                         return env_env_make_option_type(env, inner_type);
                     }
-                } else if (!_mv_1692.has_value) {
+                } else if (!_mv_1693.has_value) {
                     return env_env_make_option_type(env, NULL);
                 }
             } else {
@@ -1218,41 +1218,41 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             return env_env_make_option_type(env, NULL);
         } else if (string_eq(op, SLOP_STR("record-new"))) {
             for (int64_t fi = 2; fi < len; fi++) {
-                __auto_type _mv_1693 = ({ __auto_type _lst = items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1693.has_value) {
-                    __auto_type field_pair = _mv_1693.value;
+                __auto_type _mv_1694 = ({ __auto_type _lst = items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1694.has_value) {
+                    __auto_type field_pair = _mv_1694.value;
                     if (parser_sexpr_is_list(field_pair) && (parser_sexpr_list_len(field_pair) >= 2)) {
-                        __auto_type _mv_1694 = parser_sexpr_list_get(field_pair, 1);
-                        if (_mv_1694.has_value) {
-                            __auto_type val_expr = _mv_1694.value;
+                        __auto_type _mv_1695 = parser_sexpr_list_get(field_pair, 1);
+                        if (_mv_1695.has_value) {
+                            __auto_type val_expr = _mv_1695.value;
                             {
                                 __auto_type _ = infer_infer_expr(env, val_expr);
                             }
-                        } else if (!_mv_1694.has_value) {
+                        } else if (!_mv_1695.has_value) {
                         }
                     }
-                } else if (!_mv_1693.has_value) {
+                } else if (!_mv_1694.has_value) {
                 }
             }
             if (len >= 2) {
-                __auto_type _mv_1695 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1695.has_value) {
-                    __auto_type type_expr = _mv_1695.value;
+                __auto_type _mv_1696 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1696.has_value) {
+                    __auto_type type_expr = _mv_1696.value;
                     {
                         __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                         if (string_eq(type_name, SLOP_STR(""))) {
                             return env_env_get_unit_type(env);
                         } else {
-                            __auto_type _mv_1696 = env_env_lookup_type(env, type_name);
-                            if (_mv_1696.has_value) {
-                                __auto_type t = _mv_1696.value;
+                            __auto_type _mv_1697 = env_env_lookup_type(env, type_name);
+                            if (_mv_1697.has_value) {
+                                __auto_type t = _mv_1697.value;
                                 return t;
-                            } else if (!_mv_1696.has_value) {
+                            } else if (!_mv_1697.has_value) {
                                 return env_env_get_unit_type(env);
                             }
                         }
                     }
-                } else if (!_mv_1695.has_value) {
+                } else if (!_mv_1696.has_value) {
                     return env_env_get_unit_type(env);
                 }
             } else {
@@ -1260,34 +1260,34 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             }
         } else if (string_eq(op, SLOP_STR("union-new"))) {
             if (len >= 4) {
-                __auto_type _mv_1697 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1697.has_value) {
-                    __auto_type val_expr = _mv_1697.value;
+                __auto_type _mv_1698 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1698.has_value) {
+                    __auto_type val_expr = _mv_1698.value;
                     {
                         __auto_type _ = infer_infer_expr(env, val_expr);
                     }
-                } else if (!_mv_1697.has_value) {
+                } else if (!_mv_1698.has_value) {
                 }
             }
             if (len >= 2) {
-                __auto_type _mv_1698 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1698.has_value) {
-                    __auto_type type_expr = _mv_1698.value;
+                __auto_type _mv_1699 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1699.has_value) {
+                    __auto_type type_expr = _mv_1699.value;
                     {
                         __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                         if (string_eq(type_name, SLOP_STR(""))) {
                             return env_env_get_unit_type(env);
                         } else {
-                            __auto_type _mv_1699 = env_env_lookup_type(env, type_name);
-                            if (_mv_1699.has_value) {
-                                __auto_type t = _mv_1699.value;
+                            __auto_type _mv_1700 = env_env_lookup_type(env, type_name);
+                            if (_mv_1700.has_value) {
+                                __auto_type t = _mv_1700.value;
                                 return t;
-                            } else if (!_mv_1699.has_value) {
+                            } else if (!_mv_1700.has_value) {
                                 return env_env_get_unit_type(env);
                             }
                         }
                     }
-                } else if (!_mv_1698.has_value) {
+                } else if (!_mv_1699.has_value) {
                     return env_env_get_unit_type(env);
                 }
             } else {
@@ -1305,42 +1305,42 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
         } else if (infer_is_chan_buffered_op(op) || infer_is_chan_op(op)) {
             return infer_infer_threading_builtin(env, op, expr, items, len, line, col);
         } else {
-            __auto_type _mv_1700 = env_env_lookup_function(env, op);
-            if (_mv_1700.has_value) {
-                __auto_type sig = _mv_1700.value;
+            __auto_type _mv_1701 = env_env_lookup_function(env, op);
+            if (_mv_1701.has_value) {
+                __auto_type sig = _mv_1701.value;
                 if (infer_has_type_params(sig)) {
                     return infer_infer_generic_call(env, sig, expr, line, col);
                 } else {
                     infer_check_fn_call_args(env, sig, expr, line, col);
                     return (*sig).return_type;
                 }
-            } else if (!_mv_1700.has_value) {
-                __auto_type _mv_1701 = env_env_lookup_type(env, op);
-                if (_mv_1701.has_value) {
-                    __auto_type the_type = _mv_1701.value;
+            } else if (!_mv_1701.has_value) {
+                __auto_type _mv_1702 = env_env_lookup_type(env, op);
+                if (_mv_1702.has_value) {
+                    __auto_type the_type = _mv_1702.value;
                     return the_type;
-                } else if (!_mv_1701.has_value) {
+                } else if (!_mv_1702.has_value) {
                     if (string_eq(op, SLOP_STR("list-get"))) {
                         infer_check_builtin_args(env, SLOP_STR("list-get"), 2, (len - 1), line, col);
                         infer_infer_builtin_args(env, expr);
                         {
                             types_ResolvedType* elem_type = NULL;
                             if (len >= 2) {
-                                __auto_type _mv_1702 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1702.has_value) {
-                                    __auto_type list_arg = _mv_1702.value;
+                                __auto_type _mv_1703 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1703.has_value) {
+                                    __auto_type list_arg = _mv_1703.value;
                                     {
                                         __auto_type list_type = infer_infer_expr(env, list_arg);
                                         if ((*list_type).kind == types_ResolvedTypeKind_rk_list) {
-                                            __auto_type _mv_1703 = (*list_type).inner_type;
-                                            if (_mv_1703.has_value) {
-                                                __auto_type inner = _mv_1703.value;
+                                            __auto_type _mv_1704 = (*list_type).inner_type;
+                                            if (_mv_1704.has_value) {
+                                                __auto_type inner = _mv_1704.value;
                                                 elem_type = inner;
-                                            } else if (!_mv_1703.has_value) {
+                                            } else if (!_mv_1704.has_value) {
                                             }
                                         }
                                     }
-                                } else if (!_mv_1702.has_value) {
+                                } else if (!_mv_1703.has_value) {
                                 }
                             }
                             return env_env_make_option_type(env, elem_type);
@@ -1353,52 +1353,52 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             env_env_add_error(env, SLOP_STR("arena-alloc requires arena and type/size arguments"), line, col);
                             return env_env_get_int_type(env);
                         } else {
-                            __auto_type _mv_1704 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1704.has_value) {
-                                __auto_type type_expr = _mv_1704.value;
+                            __auto_type _mv_1705 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1705.has_value) {
+                                __auto_type type_expr = _mv_1705.value;
                                 {
                                     __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                                     if (string_eq(type_name, SLOP_STR(""))) {
                                         if (parser_sexpr_is_list(type_expr)) {
-                                            __auto_type _mv_1705 = parser_sexpr_list_get(type_expr, 0);
-                                            if (_mv_1705.has_value) {
-                                                __auto_type head_expr = _mv_1705.value;
+                                            __auto_type _mv_1706 = parser_sexpr_list_get(type_expr, 0);
+                                            if (_mv_1706.has_value) {
+                                                __auto_type head_expr = _mv_1706.value;
                                                 if (string_eq(parser_sexpr_get_symbol_name(head_expr), SLOP_STR("sizeof"))) {
-                                                    __auto_type _mv_1706 = parser_sexpr_list_get(type_expr, 1);
-                                                    if (_mv_1706.has_value) {
-                                                        __auto_type sizeof_type_expr = _mv_1706.value;
+                                                    __auto_type _mv_1707 = parser_sexpr_list_get(type_expr, 1);
+                                                    if (_mv_1707.has_value) {
+                                                        __auto_type sizeof_type_expr = _mv_1707.value;
                                                         {
                                                             __auto_type sizeof_type_name = parser_sexpr_get_symbol_name(sizeof_type_expr);
                                                             if (string_eq(sizeof_type_name, SLOP_STR(""))) {
                                                                 return env_env_get_int_type(env);
                                                             } else {
-                                                                __auto_type _mv_1707 = env_env_lookup_type(env, sizeof_type_name);
-                                                                if (_mv_1707.has_value) {
-                                                                    __auto_type resolved = _mv_1707.value;
+                                                                __auto_type _mv_1708 = env_env_lookup_type(env, sizeof_type_name);
+                                                                if (_mv_1708.has_value) {
+                                                                    __auto_type resolved = _mv_1708.value;
                                                                     return env_env_make_ptr_type(env, resolved);
-                                                                } else if (!_mv_1707.has_value) {
+                                                                } else if (!_mv_1708.has_value) {
                                                                     return env_env_get_int_type(env);
                                                                 }
                                                             }
                                                         }
-                                                    } else if (!_mv_1706.has_value) {
+                                                    } else if (!_mv_1707.has_value) {
                                                         return env_env_get_int_type(env);
                                                     }
                                                 } else {
                                                     return env_env_get_int_type(env);
                                                 }
-                                            } else if (!_mv_1705.has_value) {
+                                            } else if (!_mv_1706.has_value) {
                                                 return env_env_get_int_type(env);
                                             }
                                         } else {
                                             return env_env_get_int_type(env);
                                         }
                                     } else {
-                                        __auto_type _mv_1708 = env_env_lookup_type(env, type_name);
-                                        if (_mv_1708.has_value) {
-                                            __auto_type resolved = _mv_1708.value;
+                                        __auto_type _mv_1709 = env_env_lookup_type(env, type_name);
+                                        if (_mv_1709.has_value) {
+                                            __auto_type resolved = _mv_1709.value;
                                             return env_env_make_ptr_type(env, resolved);
-                                        } else if (!_mv_1708.has_value) {
+                                        } else if (!_mv_1709.has_value) {
                                             {
                                                 __auto_type arena = env_env_arena(env);
                                                 env_env_add_warning(env, string_concat(arena, SLOP_STR("arena-alloc: unknown type: "), type_name), line, col);
@@ -1407,7 +1407,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                         }
                                     }
                                 }
-                            } else if (!_mv_1704.has_value) {
+                            } else if (!_mv_1705.has_value) {
                                 return env_env_get_int_type(env);
                             }
                         }
@@ -1432,16 +1432,16 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             __auto_type arena = env_env_arena(env);
                             __auto_type list_type = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_list, SLOP_STR("List"), ((slop_option_string){.has_value = false}), SLOP_STR("slop_list_t*"));
                             if (len >= 3) {
-                                __auto_type _mv_1709 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1709.has_value) {
-                                    __auto_type type_expr = _mv_1709.value;
+                                __auto_type _mv_1710 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1710.has_value) {
+                                    __auto_type type_expr = _mv_1710.value;
                                     {
                                         __auto_type elem_type = ((parser_sexpr_is_list(type_expr)) ? infer_resolve_complex_type_expr(env, type_expr) : ({ __auto_type tname = parser_sexpr_get_symbol_name(type_expr); ((string_eq(tname, SLOP_STR(""))) ? NULL : infer_resolve_simple_type(env, tname)); }));
                                         if (elem_type != NULL) {
                                             types_resolved_type_set_inner(list_type, elem_type);
                                         }
                                     }
-                                } else if (!_mv_1709.has_value) {
+                                } else if (!_mv_1710.has_value) {
                                 }
                             }
                             return list_type;
@@ -1469,14 +1469,14 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             __auto_type arena = env_env_arena(env);
                             __auto_type result_type = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_result, SLOP_STR("Result"), ((slop_option_string){.has_value = false}), SLOP_STR("Result"));
                             if (len >= 2) {
-                                __auto_type _mv_1710 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1710.has_value) {
-                                    __auto_type val_expr = _mv_1710.value;
+                                __auto_type _mv_1711 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1711.has_value) {
+                                    __auto_type val_expr = _mv_1711.value;
                                     {
                                         __auto_type val_type = infer_infer_expr(env, val_expr);
                                         types_resolved_type_set_inner(result_type, val_type);
                                     }
-                                } else if (!_mv_1710.has_value) {
+                                } else if (!_mv_1711.has_value) {
                                 }
                             }
                             return result_type;
@@ -1486,38 +1486,38 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             __auto_type arena = env_env_arena(env);
                             __auto_type result_type = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_result, SLOP_STR("Result"), ((slop_option_string){.has_value = false}), SLOP_STR("Result"));
                             if (len >= 2) {
-                                __auto_type _mv_1711 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1711.has_value) {
-                                    __auto_type val_expr = _mv_1711.value;
+                                __auto_type _mv_1712 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1712.has_value) {
+                                    __auto_type val_expr = _mv_1712.value;
                                     {
                                         __auto_type val_type = infer_infer_expr(env, val_expr);
                                         types_resolved_type_set_inner2(result_type, val_type);
                                     }
-                                } else if (!_mv_1711.has_value) {
+                                } else if (!_mv_1712.has_value) {
                                 }
                             }
                             return result_type;
                         }
                     } else if (string_eq(op, SLOP_STR("@"))) {
                         if (len >= 2) {
-                            __auto_type _mv_1712 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1712.has_value) {
-                                __auto_type ptr_expr = _mv_1712.value;
+                            __auto_type _mv_1713 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1713.has_value) {
+                                __auto_type ptr_expr = _mv_1713.value;
                                 {
                                     __auto_type ptr_type = infer_infer_expr(env, ptr_expr);
                                     if (types_resolved_type_is_pointer(ptr_type)) {
-                                        __auto_type _mv_1713 = (*ptr_type).inner_type;
-                                        if (_mv_1713.has_value) {
-                                            __auto_type inner = _mv_1713.value;
+                                        __auto_type _mv_1714 = (*ptr_type).inner_type;
+                                        if (_mv_1714.has_value) {
+                                            __auto_type inner = _mv_1714.value;
                                             return inner;
-                                        } else if (!_mv_1713.has_value) {
+                                        } else if (!_mv_1714.has_value) {
                                             return env_env_get_int_type(env);
                                         }
                                     } else {
                                         return env_env_get_int_type(env);
                                     }
                                 }
-                            } else if (!_mv_1712.has_value) {
+                            } else if (!_mv_1713.has_value) {
                                 return env_env_get_int_type(env);
                             }
                         } else {
@@ -1534,39 +1534,39 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             types_ResolvedType* key_type = NULL;
                             types_ResolvedType* val_type = NULL;
                             if (len >= 3) {
-                                __auto_type _mv_1714 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1714.has_value) {
-                                    __auto_type type_expr = _mv_1714.value;
+                                __auto_type _mv_1715 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1715.has_value) {
+                                    __auto_type type_expr = _mv_1715.value;
                                     {
                                         __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                                         if (!(string_eq(type_name, SLOP_STR("")))) {
-                                            __auto_type _mv_1715 = env_env_lookup_type(env, type_name);
-                                            if (_mv_1715.has_value) {
-                                                __auto_type t = _mv_1715.value;
+                                            __auto_type _mv_1716 = env_env_lookup_type(env, type_name);
+                                            if (_mv_1716.has_value) {
+                                                __auto_type t = _mv_1716.value;
                                                 key_type = t;
-                                            } else if (!_mv_1715.has_value) {
+                                            } else if (!_mv_1716.has_value) {
                                             }
                                         }
                                     }
-                                } else if (!_mv_1714.has_value) {
+                                } else if (!_mv_1715.has_value) {
                                 }
                             }
                             if (len >= 4) {
-                                __auto_type _mv_1716 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1716.has_value) {
-                                    __auto_type type_expr = _mv_1716.value;
+                                __auto_type _mv_1717 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1717.has_value) {
+                                    __auto_type type_expr = _mv_1717.value;
                                     {
                                         __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                                         if (!(string_eq(type_name, SLOP_STR("")))) {
-                                            __auto_type _mv_1717 = env_env_lookup_type(env, type_name);
-                                            if (_mv_1717.has_value) {
-                                                __auto_type t = _mv_1717.value;
+                                            __auto_type _mv_1718 = env_env_lookup_type(env, type_name);
+                                            if (_mv_1718.has_value) {
+                                                __auto_type t = _mv_1718.value;
                                                 val_type = t;
-                                            } else if (!_mv_1717.has_value) {
+                                            } else if (!_mv_1718.has_value) {
                                             }
                                         }
                                     }
-                                } else if (!_mv_1716.has_value) {
+                                } else if (!_mv_1717.has_value) {
                                 }
                             }
                             {
@@ -1585,19 +1585,19 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                         {
                             types_ResolvedType* val_type = NULL;
                             if (len >= 2) {
-                                __auto_type _mv_1718 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1718.has_value) {
-                                    __auto_type map_expr = _mv_1718.value;
+                                __auto_type _mv_1719 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1719.has_value) {
+                                    __auto_type map_expr = _mv_1719.value;
                                     {
                                         __auto_type map_type = infer_infer_expr(env, map_expr);
-                                        __auto_type _mv_1719 = (*map_type).inner_type2;
-                                        if (_mv_1719.has_value) {
-                                            __auto_type inner = _mv_1719.value;
+                                        __auto_type _mv_1720 = (*map_type).inner_type2;
+                                        if (_mv_1720.has_value) {
+                                            __auto_type inner = _mv_1720.value;
                                             val_type = inner;
-                                        } else if (!_mv_1719.has_value) {
+                                        } else if (!_mv_1720.has_value) {
                                         }
                                     }
-                                } else if (!_mv_1718.has_value) {
+                                } else if (!_mv_1719.has_value) {
                                 }
                             }
                             return env_env_make_option_type(env, val_type);
@@ -1608,9 +1608,9 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                     } else if (string_eq(op, SLOP_STR("map-has"))) {
                         infer_check_builtin_args(env, SLOP_STR("map-has"), 2, (len - 1), line, col);
                         if (len >= 2) {
-                            __auto_type _mv_1720 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1720.has_value) {
-                                __auto_type map_expr = _mv_1720.value;
+                            __auto_type _mv_1721 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1721.has_value) {
+                                __auto_type map_expr = _mv_1721.value;
                                 {
                                     __auto_type map_type = infer_infer_expr(env, map_expr);
                                     __auto_type type_name = (*map_type).name;
@@ -1622,7 +1622,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                         }
                                     }
                                 }
-                            } else if (!_mv_1720.has_value) {
+                            } else if (!_mv_1721.has_value) {
                             }
                         }
                         return env_env_get_bool_type(env);
@@ -1632,19 +1632,19 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             __auto_type arena = env_env_arena(env);
                             types_ResolvedType* key_type = NULL;
                             if (len >= 2) {
-                                __auto_type _mv_1721 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1721.has_value) {
-                                    __auto_type map_expr = _mv_1721.value;
+                                __auto_type _mv_1722 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1722.has_value) {
+                                    __auto_type map_expr = _mv_1722.value;
                                     {
                                         __auto_type map_type = infer_infer_expr(env, map_expr);
-                                        __auto_type _mv_1722 = (*map_type).inner_type;
-                                        if (_mv_1722.has_value) {
-                                            __auto_type inner = _mv_1722.value;
+                                        __auto_type _mv_1723 = (*map_type).inner_type;
+                                        if (_mv_1723.has_value) {
+                                            __auto_type inner = _mv_1723.value;
                                             key_type = inner;
-                                        } else if (!_mv_1722.has_value) {
+                                        } else if (!_mv_1723.has_value) {
                                         }
                                     }
-                                } else if (!_mv_1721.has_value) {
+                                } else if (!_mv_1722.has_value) {
                                 }
                             }
                             {
@@ -1669,21 +1669,21 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             __auto_type arena = env_env_arena(env);
                             types_ResolvedType* elem_type = NULL;
                             if (len >= 3) {
-                                __auto_type _mv_1723 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1723.has_value) {
-                                    __auto_type type_expr = _mv_1723.value;
+                                __auto_type _mv_1724 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1724.has_value) {
+                                    __auto_type type_expr = _mv_1724.value;
                                     {
                                         __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                                         if (!(string_eq(type_name, SLOP_STR("")))) {
-                                            __auto_type _mv_1724 = env_env_lookup_type(env, type_name);
-                                            if (_mv_1724.has_value) {
-                                                __auto_type t = _mv_1724.value;
+                                            __auto_type _mv_1725 = env_env_lookup_type(env, type_name);
+                                            if (_mv_1725.has_value) {
+                                                __auto_type t = _mv_1725.value;
                                                 elem_type = t;
-                                            } else if (!_mv_1724.has_value) {
+                                            } else if (!_mv_1725.has_value) {
                                             }
                                         }
                                     }
-                                } else if (!_mv_1723.has_value) {
+                                } else if (!_mv_1724.has_value) {
                                 }
                             }
                             {
@@ -1709,19 +1709,19 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             __auto_type arena = env_env_arena(env);
                             types_ResolvedType* elem_type = NULL;
                             if (len >= 2) {
-                                __auto_type _mv_1725 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1725.has_value) {
-                                    __auto_type set_expr = _mv_1725.value;
+                                __auto_type _mv_1726 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1726.has_value) {
+                                    __auto_type set_expr = _mv_1726.value;
                                     {
                                         __auto_type set_type = infer_infer_expr(env, set_expr);
-                                        __auto_type _mv_1726 = (*set_type).inner_type;
-                                        if (_mv_1726.has_value) {
-                                            __auto_type inner = _mv_1726.value;
+                                        __auto_type _mv_1727 = (*set_type).inner_type;
+                                        if (_mv_1727.has_value) {
+                                            __auto_type inner = _mv_1727.value;
                                             elem_type = inner;
-                                        } else if (!_mv_1726.has_value) {
+                                        } else if (!_mv_1727.has_value) {
                                         }
                                     }
-                                } else if (!_mv_1725.has_value) {
+                                } else if (!_mv_1726.has_value) {
                                 }
                             }
                             {
@@ -1737,15 +1737,15 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                     } else {
                         {
                             __auto_type arena = env_env_arena(env);
-                            __auto_type _mv_1727 = env_env_lookup_variant(env, op);
-                            if (_mv_1727.has_value) {
-                                __auto_type parent_type = _mv_1727.value;
+                            __auto_type _mv_1728 = env_env_lookup_variant(env, op);
+                            if (_mv_1728.has_value) {
+                                __auto_type parent_type = _mv_1728.value;
                                 {
                                     __auto_type msg = string_concat(arena, SLOP_STR("'"), string_concat(arena, op, string_concat(arena, SLOP_STR("' is a variant of '"), string_concat(arena, parent_type, SLOP_STR("'. Use (union-new Type variant value) syntax")))));
                                     env_env_add_error(env, msg, line, col);
                                     return env_env_get_unknown_type(env);
                                 }
-                            } else if (!_mv_1727.has_value) {
+                            } else if (!_mv_1728.has_value) {
                                 if (strlib_starts_with(op, SLOP_STR("set-")) || (strlib_starts_with(op, SLOP_STR("map-")) || (strlib_starts_with(op, SLOP_STR("list-")) || strlib_starts_with(op, SLOP_STR("arena-"))))) {
                                     {
                                         __auto_type msg = string_concat(arena, SLOP_STR("Unknown builtin: '"), string_concat(arena, op, SLOP_STR("'")));
@@ -1753,12 +1753,12 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                         return env_env_get_unknown_type(env);
                                     }
                                 } else {
-                                    __auto_type _mv_1728 = env_env_lookup_var(env, op);
-                                    if (_mv_1728.has_value) {
-                                        __auto_type var_type = _mv_1728.value;
+                                    __auto_type _mv_1729 = env_env_lookup_var(env, op);
+                                    if (_mv_1729.has_value) {
+                                        __auto_type var_type = _mv_1729.value;
                                         infer_infer_builtin_args(env, expr);
                                         return var_type;
-                                    } else if (!_mv_1728.has_value) {
+                                    } else if (!_mv_1729.has_value) {
                                         if (infer_string_contains_char(op, 45)) {
                                             {
                                                 __auto_type msg = string_concat(arena, SLOP_STR("Unknown function: '"), string_concat(arena, op, SLOP_STR("' - did you forget to import it?")));
@@ -1820,14 +1820,14 @@ void infer_check_single_arg(env_TypeEnv* env, types_FnSignature* sig, types_SExp
         __auto_type params = (*sig).params;
         __auto_type fn_name = (*sig).name;
         __auto_type arena = env_env_arena(env);
-        __auto_type _mv_1729 = ({ __auto_type _lst = params; size_t _idx = (size_t)arg_idx; slop_option_types_ParamInfo _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1729.has_value) {
-            __auto_type param_info = _mv_1729.value;
+        __auto_type _mv_1730 = ({ __auto_type _lst = params; size_t _idx = (size_t)arg_idx; slop_option_types_ParamInfo _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1730.has_value) {
+            __auto_type param_info = _mv_1730.value;
             {
                 __auto_type expected_type = param_info.param_type;
-                __auto_type _mv_1730 = parser_sexpr_list_get(expr, (arg_idx + 1));
-                if (_mv_1730.has_value) {
-                    __auto_type arg_expr = _mv_1730.value;
+                __auto_type _mv_1731 = parser_sexpr_list_get(expr, (arg_idx + 1));
+                if (_mv_1731.has_value) {
+                    __auto_type arg_expr = _mv_1731.value;
                     {
                         __auto_type actual_type = infer_infer_expr(env, arg_expr);
                         __auto_type expected_name = (*expected_type).name;
@@ -1854,10 +1854,10 @@ void infer_check_single_arg(env_TypeEnv* env, types_FnSignature* sig, types_SExp
                             }
                         }
                     }
-                } else if (!_mv_1730.has_value) {
+                } else if (!_mv_1731.has_value) {
                 }
             }
-        } else if (!_mv_1729.has_value) {
+        } else if (!_mv_1730.has_value) {
         }
     }
 }
@@ -1880,13 +1880,13 @@ void infer_infer_builtin_args(env_TypeEnv* env, types_SExpr* expr) {
         {
             __auto_type len = parser_sexpr_list_len(expr);
             for (int64_t i = 1; i < len; i++) {
-                __auto_type _mv_1731 = parser_sexpr_list_get(expr, i);
-                if (_mv_1731.has_value) {
-                    __auto_type arg_expr = _mv_1731.value;
+                __auto_type _mv_1732 = parser_sexpr_list_get(expr, i);
+                if (_mv_1732.has_value) {
+                    __auto_type arg_expr = _mv_1732.value;
                     {
                         __auto_type _ = infer_infer_expr(env, arg_expr);
                     }
-                } else if (!_mv_1731.has_value) {
+                } else if (!_mv_1732.has_value) {
                 }
             }
         }
@@ -1900,13 +1900,13 @@ void infer_infer_body_exprs(env_TypeEnv* env, types_SExpr* expr, int64_t start_i
         {
             __auto_type len = parser_sexpr_list_len(expr);
             for (int64_t i = start_idx; i < len; i++) {
-                __auto_type _mv_1732 = parser_sexpr_list_get(expr, i);
-                if (_mv_1732.has_value) {
-                    __auto_type body_expr = _mv_1732.value;
+                __auto_type _mv_1733 = parser_sexpr_list_get(expr, i);
+                if (_mv_1733.has_value) {
+                    __auto_type body_expr = _mv_1733.value;
                     {
                         __auto_type _ = infer_infer_expr(env, body_expr);
                     }
-                } else if (!_mv_1732.has_value) {
+                } else if (!_mv_1733.has_value) {
                 }
             }
         }
@@ -1921,23 +1921,23 @@ types_ResolvedType* infer_infer_field_access(env_TypeEnv* env, types_SExpr* expr
         if (len < 3) {
             return env_env_get_unit_type(env);
         } else {
-            __auto_type _mv_1733 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (!_mv_1733.has_value) {
+            __auto_type _mv_1734 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (!_mv_1734.has_value) {
                 return env_env_get_unit_type(env);
-            } else if (_mv_1733.has_value) {
-                __auto_type obj_expr = _mv_1733.value;
+            } else if (_mv_1734.has_value) {
+                __auto_type obj_expr = _mv_1734.value;
                 {
                     __auto_type obj_type = infer_infer_expr(env, obj_expr);
-                    __auto_type _mv_1734 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (!_mv_1734.has_value) {
+                    __auto_type _mv_1735 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (!_mv_1735.has_value) {
                         return env_env_get_unit_type(env);
-                    } else if (_mv_1734.has_value) {
-                        __auto_type field_expr = _mv_1734.value;
-                        __auto_type _mv_1735 = (*field_expr);
-                        switch (_mv_1735.tag) {
+                    } else if (_mv_1735.has_value) {
+                        __auto_type field_expr = _mv_1735.value;
+                        __auto_type _mv_1736 = (*field_expr);
+                        switch (_mv_1736.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type field_sym = _mv_1735.data.sym;
+                                __auto_type field_sym = _mv_1736.data.sym;
                                 {
                                     __auto_type field_name = field_sym.name;
                                     return infer_check_field_exists(env, obj_type, field_name, line, col);
@@ -1961,11 +1961,11 @@ types_ResolvedType* infer_check_field_exists(env_TypeEnv* env, types_ResolvedTyp
         __auto_type type_name = (*obj_type).name;
         __auto_type arena = env_env_arena(env);
         if (types_resolved_type_is_record(obj_type)) {
-            __auto_type _mv_1736 = types_resolved_type_get_field_type(obj_type, field_name);
-            if (_mv_1736.has_value) {
-                __auto_type field_type = _mv_1736.value;
+            __auto_type _mv_1737 = types_resolved_type_get_field_type(obj_type, field_name);
+            if (_mv_1737.has_value) {
+                __auto_type field_type = _mv_1737.value;
                 return field_type;
-            } else if (!_mv_1736.has_value) {
+            } else if (!_mv_1737.has_value) {
                 {
                     __auto_type msg = string_concat(arena, SLOP_STR("Record '"), string_concat(arena, type_name, string_concat(arena, SLOP_STR("' has no field '"), string_concat(arena, field_name, SLOP_STR("'")))));
                     env_env_add_error(env, msg, line, col);
@@ -1989,11 +1989,11 @@ types_ResolvedType* infer_check_field_exists(env_TypeEnv* env, types_ResolvedTyp
                         return env_env_get_unknown_type(env);
                     } else {
                         if (types_resolved_type_is_pointer(obj_type)) {
-                            __auto_type _mv_1737 = (*obj_type).inner_type;
-                            if (_mv_1737.has_value) {
-                                __auto_type inner_type = _mv_1737.value;
+                            __auto_type _mv_1738 = (*obj_type).inner_type;
+                            if (_mv_1738.has_value) {
+                                __auto_type inner_type = _mv_1738.value;
                                 return infer_check_field_exists(env, inner_type, field_name, line, col);
-                            } else if (!_mv_1737.has_value) {
+                            } else if (!_mv_1738.has_value) {
                                 return env_env_get_unknown_type(env);
                             }
                         } else {
@@ -2025,22 +2025,22 @@ types_ResolvedType* infer_infer_cond_expr(env_TypeEnv* env, types_SExpr* expr, t
         types_ResolvedType* result_type = env_env_get_unit_type(env);
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1738 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1738.has_value) {
-                __auto_type clause = _mv_1738.value;
-                __auto_type _mv_1739 = (*clause);
-                switch (_mv_1739.tag) {
+            __auto_type _mv_1739 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1739.has_value) {
+                __auto_type clause = _mv_1739.value;
+                __auto_type _mv_1740 = (*clause);
+                switch (_mv_1740.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type clause_lst = _mv_1739.data.lst;
+                        __auto_type clause_lst = _mv_1740.data.lst;
                         {
                             __auto_type clause_items = clause_lst.items;
                             __auto_type clause_len = ((int64_t)((clause_items).len));
                             if (clause_len > 1) {
                                 for (int64_t ci = 0; ci < (clause_len - 1); ci++) {
-                                    __auto_type _mv_1740 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)ci; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_1740.has_value) {
-                                        __auto_type clause_elem = _mv_1740.value;
+                                    __auto_type _mv_1741 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)ci; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_1741.has_value) {
+                                        __auto_type clause_elem = _mv_1741.value;
                                         {
                                             __auto_type elem_name = parser_sexpr_get_symbol_name(clause_elem);
                                             if (!(string_eq(elem_name, SLOP_STR("else")))) {
@@ -2049,12 +2049,12 @@ types_ResolvedType* infer_infer_cond_expr(env_TypeEnv* env, types_SExpr* expr, t
                                                 }
                                             }
                                         }
-                                    } else if (!_mv_1740.has_value) {
+                                    } else if (!_mv_1741.has_value) {
                                     }
                                 }
-                                __auto_type _mv_1741 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)(clause_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1741.has_value) {
-                                    __auto_type body = _mv_1741.value;
+                                __auto_type _mv_1742 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)(clause_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1742.has_value) {
+                                    __auto_type body = _mv_1742.value;
                                     {
                                         __auto_type body_type = infer_infer_expr(env, body);
                                         if (!(has_result)) {
@@ -2064,7 +2064,7 @@ types_ResolvedType* infer_infer_cond_expr(env_TypeEnv* env, types_SExpr* expr, t
                                             result_type = infer_unify_branch_types(env, result_type, body_type, line, col);
                                         }
                                     }
-                                } else if (!_mv_1741.has_value) {
+                                } else if (!_mv_1742.has_value) {
                                 }
                             }
                         }
@@ -2074,7 +2074,7 @@ types_ResolvedType* infer_infer_cond_expr(env_TypeEnv* env, types_SExpr* expr, t
                         break;
                     }
                 }
-            } else if (!_mv_1738.has_value) {
+            } else if (!_mv_1739.has_value) {
             }
             i = (i + 1);
         }
@@ -2087,16 +2087,16 @@ void infer_bind_match_pattern(env_TypeEnv* env, types_ResolvedType* scrutinee_ty
     SLOP_PRE(((pattern != NULL)), "(!= pattern nil)");
     if (parser_sexpr_is_list(pattern)) {
         if (parser_sexpr_list_len(pattern) > 0) {
-            __auto_type _mv_1742 = parser_sexpr_list_get(pattern, 0);
-            if (_mv_1742.has_value) {
-                __auto_type variant_expr = _mv_1742.value;
+            __auto_type _mv_1743 = parser_sexpr_list_get(pattern, 0);
+            if (_mv_1743.has_value) {
+                __auto_type variant_expr = _mv_1743.value;
                 {
                     __auto_type variant_name = parser_sexpr_get_symbol_name(variant_expr);
                     if (!(string_eq(variant_name, SLOP_STR("")))) {
                         if (parser_sexpr_list_len(pattern) > 1) {
-                            __auto_type _mv_1743 = parser_sexpr_list_get(pattern, 1);
-                            if (_mv_1743.has_value) {
-                                __auto_type binding_expr = _mv_1743.value;
+                            __auto_type _mv_1744 = parser_sexpr_list_get(pattern, 1);
+                            if (_mv_1744.has_value) {
+                                __auto_type binding_expr = _mv_1744.value;
                                 {
                                     __auto_type binding_name = parser_sexpr_get_symbol_name(binding_expr);
                                     if (!(string_eq(binding_name, SLOP_STR("")))) {
@@ -2107,29 +2107,29 @@ void infer_bind_match_pattern(env_TypeEnv* env, types_ResolvedType* scrutinee_ty
                                                 env_env_bind_var(env, binding_name, env_env_get_generic_type(env));
                                             } else {
                                                 if ((scrutinee_kind == types_ResolvedTypeKind_rk_option) && string_eq(variant_name, SLOP_STR("some"))) {
-                                                    __auto_type _mv_1744 = (*scrutinee_type).inner_type;
-                                                    if (_mv_1744.has_value) {
-                                                        __auto_type inner = _mv_1744.value;
+                                                    __auto_type _mv_1745 = (*scrutinee_type).inner_type;
+                                                    if (_mv_1745.has_value) {
+                                                        __auto_type inner = _mv_1745.value;
                                                         env_env_bind_var(env, binding_name, inner);
-                                                    } else if (!_mv_1744.has_value) {
+                                                    } else if (!_mv_1745.has_value) {
                                                         env_env_bind_var(env, binding_name, env_env_get_generic_type(env));
                                                     }
                                                 } else {
                                                     if (scrutinee_kind == types_ResolvedTypeKind_rk_result) {
                                                         if (string_eq(variant_name, SLOP_STR("ok"))) {
-                                                            __auto_type _mv_1745 = (*scrutinee_type).inner_type;
-                                                            if (_mv_1745.has_value) {
-                                                                __auto_type inner = _mv_1745.value;
+                                                            __auto_type _mv_1746 = (*scrutinee_type).inner_type;
+                                                            if (_mv_1746.has_value) {
+                                                                __auto_type inner = _mv_1746.value;
                                                                 env_env_bind_var(env, binding_name, inner);
-                                                            } else if (!_mv_1745.has_value) {
+                                                            } else if (!_mv_1746.has_value) {
                                                                 env_env_bind_var(env, binding_name, env_env_get_generic_type(env));
                                                             }
                                                         } else if (string_eq(variant_name, SLOP_STR("error"))) {
-                                                            __auto_type _mv_1746 = (*scrutinee_type).inner_type2;
-                                                            if (_mv_1746.has_value) {
-                                                                __auto_type inner2 = _mv_1746.value;
+                                                            __auto_type _mv_1747 = (*scrutinee_type).inner_type2;
+                                                            if (_mv_1747.has_value) {
+                                                                __auto_type inner2 = _mv_1747.value;
                                                                 env_env_bind_var(env, binding_name, inner2);
-                                                            } else if (!_mv_1746.has_value) {
+                                                            } else if (!_mv_1747.has_value) {
                                                                 env_env_bind_var(env, binding_name, env_env_get_generic_type(env));
                                                             }
                                                         } else {
@@ -2140,11 +2140,11 @@ void infer_bind_match_pattern(env_TypeEnv* env, types_ResolvedType* scrutinee_ty
                                                             __auto_type payload_types = types_resolved_type_get_variant_payloads(env_env_arena(env), scrutinee_type, variant_name);
                                                             if (((int64_t)((payload_types).len)) > 0) {
                                                                 if (!(string_eq(binding_name, SLOP_STR("true"))) && !(string_eq(binding_name, SLOP_STR("false")))) {
-                                                                    __auto_type _mv_1747 = ({ __auto_type _lst = payload_types; size_t _idx = (size_t)0; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                    if (_mv_1747.has_value) {
-                                                                        __auto_type first_type = _mv_1747.value;
+                                                                    __auto_type _mv_1748 = ({ __auto_type _lst = payload_types; size_t _idx = (size_t)0; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                    if (_mv_1748.has_value) {
+                                                                        __auto_type first_type = _mv_1748.value;
                                                                         env_env_bind_var(env, binding_name, first_type);
-                                                                    } else if (!_mv_1747.has_value) {
+                                                                    } else if (!_mv_1748.has_value) {
                                                                         env_env_bind_var(env, binding_name, env_env_get_generic_type(env));
                                                                     }
                                                                 }
@@ -2152,20 +2152,20 @@ void infer_bind_match_pattern(env_TypeEnv* env, types_ResolvedType* scrutinee_ty
                                                                     __auto_type pat_len = parser_sexpr_list_len(pattern);
                                                                     __auto_type num_types = ((int64_t)((payload_types).len));
                                                                     for (int64_t pi = 2; pi < pat_len; pi++) {
-                                                                        __auto_type _mv_1748 = parser_sexpr_list_get(pattern, pi);
-                                                                        if (_mv_1748.has_value) {
-                                                                            __auto_type extra_binding = _mv_1748.value;
+                                                                        __auto_type _mv_1749 = parser_sexpr_list_get(pattern, pi);
+                                                                        if (_mv_1749.has_value) {
+                                                                            __auto_type extra_binding = _mv_1749.value;
                                                                             {
                                                                                 __auto_type extra_name = parser_sexpr_get_symbol_name(extra_binding);
                                                                                 if ((!(string_eq(extra_name, SLOP_STR("")))) && (!(string_eq(extra_name, SLOP_STR("_")))) && (!(string_eq(extra_name, SLOP_STR("true")))) && (!(string_eq(extra_name, SLOP_STR("false"))))) {
                                                                                     {
                                                                                         __auto_type type_idx = (pi - 1);
                                                                                         if (type_idx < num_types) {
-                                                                                            __auto_type _mv_1749 = ({ __auto_type _lst = payload_types; size_t _idx = (size_t)type_idx; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                                            if (_mv_1749.has_value) {
-                                                                                                __auto_type pt = _mv_1749.value;
+                                                                                            __auto_type _mv_1750 = ({ __auto_type _lst = payload_types; size_t _idx = (size_t)type_idx; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                                            if (_mv_1750.has_value) {
+                                                                                                __auto_type pt = _mv_1750.value;
                                                                                                 env_env_bind_var(env, extra_name, pt);
-                                                                                            } else if (!_mv_1749.has_value) {
+                                                                                            } else if (!_mv_1750.has_value) {
                                                                                                 env_env_bind_var(env, extra_name, env_env_get_generic_type(env));
                                                                                             }
                                                                                         } else {
@@ -2174,7 +2174,7 @@ void infer_bind_match_pattern(env_TypeEnv* env, types_ResolvedType* scrutinee_ty
                                                                                     }
                                                                                 }
                                                                             }
-                                                                        } else if (!_mv_1748.has_value) {
+                                                                        } else if (!_mv_1749.has_value) {
                                                                         }
                                                                     }
                                                                 }
@@ -2188,12 +2188,12 @@ void infer_bind_match_pattern(env_TypeEnv* env, types_ResolvedType* scrutinee_ty
                                         }
                                     }
                                 }
-                            } else if (!_mv_1743.has_value) {
+                            } else if (!_mv_1744.has_value) {
                             }
                         }
                     }
                 }
-            } else if (!_mv_1742.has_value) {
+            } else if (!_mv_1743.has_value) {
             }
         }
     }
@@ -2211,38 +2211,38 @@ types_ResolvedType* infer_infer_match_expr(env_TypeEnv* env, types_SExpr* expr, 
         __auto_type scrutinee_type = (((len >= 2)) ? ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type scrutinee = _mv.value; infer_infer_expr(env, scrutinee); }) : (env_env_get_unit_type(env)); }) : env_env_get_unit_type(env));
         int64_t i = 2;
         while (i < len) {
-            __auto_type _mv_1750 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1750.has_value) {
-                __auto_type clause = _mv_1750.value;
-                __auto_type _mv_1751 = (*clause);
-                switch (_mv_1751.tag) {
+            __auto_type _mv_1751 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1751.has_value) {
+                __auto_type clause = _mv_1751.value;
+                __auto_type _mv_1752 = (*clause);
+                switch (_mv_1752.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type clause_lst = _mv_1751.data.lst;
+                        __auto_type clause_lst = _mv_1752.data.lst;
                         {
                             __auto_type clause_items = clause_lst.items;
                             __auto_type clause_len = ((int64_t)((clause_items).len));
                             if (clause_len > 1) {
                                 env_env_push_scope(env);
-                                __auto_type _mv_1752 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1752.has_value) {
-                                    __auto_type pattern = _mv_1752.value;
+                                __auto_type _mv_1753 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1753.has_value) {
+                                    __auto_type pattern = _mv_1753.value;
                                     infer_bind_match_pattern(env, scrutinee_type, pattern);
-                                } else if (!_mv_1752.has_value) {
+                                } else if (!_mv_1753.has_value) {
                                 }
                                 for (int64_t bi = 1; bi < (clause_len - 1); bi++) {
-                                    __auto_type _mv_1753 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_1753.has_value) {
-                                        __auto_type body_expr = _mv_1753.value;
+                                    __auto_type _mv_1754 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_1754.has_value) {
+                                        __auto_type body_expr = _mv_1754.value;
                                         {
                                             __auto_type _ = infer_infer_expr(env, body_expr);
                                         }
-                                    } else if (!_mv_1753.has_value) {
+                                    } else if (!_mv_1754.has_value) {
                                     }
                                 }
-                                __auto_type _mv_1754 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)(clause_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1754.has_value) {
-                                    __auto_type body = _mv_1754.value;
+                                __auto_type _mv_1755 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)(clause_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1755.has_value) {
+                                    __auto_type body = _mv_1755.value;
                                     {
                                         __auto_type body_type = infer_infer_expr(env, body);
                                         if (!(has_result)) {
@@ -2252,7 +2252,7 @@ types_ResolvedType* infer_infer_match_expr(env_TypeEnv* env, types_SExpr* expr, 
                                             result_type = infer_unify_branch_types(env, result_type, body_type, line, col);
                                         }
                                     }
-                                } else if (!_mv_1754.has_value) {
+                                } else if (!_mv_1755.has_value) {
                                 }
                                 env_env_pop_scope(env);
                             }
@@ -2263,7 +2263,7 @@ types_ResolvedType* infer_infer_match_expr(env_TypeEnv* env, types_SExpr* expr, 
                         break;
                     }
                 }
-            } else if (!_mv_1750.has_value) {
+            } else if (!_mv_1751.has_value) {
             }
             i = (i + 1);
         }
@@ -2275,22 +2275,22 @@ void infer_check_return_type(env_TypeEnv* env, types_SExpr* fn_form, slop_string
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((fn_form != NULL)), "(!= fn-form nil)");
     SLOP_PRE(((inferred_type != NULL)), "(!= inferred-type nil)");
-    __auto_type _mv_1755 = (*fn_form);
-    switch (_mv_1755.tag) {
+    __auto_type _mv_1756 = (*fn_form);
+    switch (_mv_1756.tag) {
         case types_SExpr_lst:
         {
-            __auto_type fn_lst = _mv_1755.data.lst;
+            __auto_type fn_lst = _mv_1756.data.lst;
             {
                 __auto_type items = fn_lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 for (int64_t i = 3; i < len; i++) {
-                    __auto_type _mv_1756 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1756.has_value) {
-                        __auto_type item = _mv_1756.value;
+                    __auto_type _mv_1757 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1757.has_value) {
+                        __auto_type item = _mv_1757.value;
                         if (parser_is_form(item, SLOP_STR("@spec"))) {
                             infer_check_spec_return_type(env, item, fn_name, inferred_type, fn_line, fn_col);
                         }
-                    } else if (!_mv_1756.has_value) {
+                    } else if (!_mv_1757.has_value) {
                     }
                 }
             }
@@ -2305,18 +2305,18 @@ void infer_check_return_type(env_TypeEnv* env, types_SExpr* fn_form, slop_string
 void infer_check_spec_return_type(env_TypeEnv* env, types_SExpr* spec_form, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((spec_form != NULL)), "(!= spec-form nil)");
-    __auto_type _mv_1757 = (*spec_form);
-    switch (_mv_1757.tag) {
+    __auto_type _mv_1758 = (*spec_form);
+    switch (_mv_1758.tag) {
         case types_SExpr_lst:
         {
-            __auto_type spec_lst = _mv_1757.data.lst;
+            __auto_type spec_lst = _mv_1758.data.lst;
             {
                 __auto_type spec_items = spec_lst.items;
-                __auto_type _mv_1758 = ({ __auto_type _lst = spec_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1758.has_value) {
-                    __auto_type spec_body = _mv_1758.value;
+                __auto_type _mv_1759 = ({ __auto_type _lst = spec_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1759.has_value) {
+                    __auto_type spec_body = _mv_1759.value;
                     infer_check_spec_body_return(env, spec_body, fn_name, inferred_type, fn_line, fn_col);
-                } else if (!_mv_1758.has_value) {
+                } else if (!_mv_1759.has_value) {
                 }
             }
             break;
@@ -2330,19 +2330,19 @@ void infer_check_spec_return_type(env_TypeEnv* env, types_SExpr* spec_form, slop
 void infer_check_spec_body_return(env_TypeEnv* env, types_SExpr* spec_body, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((spec_body != NULL)), "(!= spec-body nil)");
-    __auto_type _mv_1759 = (*spec_body);
-    switch (_mv_1759.tag) {
+    __auto_type _mv_1760 = (*spec_body);
+    switch (_mv_1760.tag) {
         case types_SExpr_lst:
         {
-            __auto_type body_lst = _mv_1759.data.lst;
+            __auto_type body_lst = _mv_1760.data.lst;
             {
                 __auto_type body_items = body_lst.items;
                 __auto_type body_len = ((int64_t)((body_items).len));
-                __auto_type _mv_1760 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1760.has_value) {
-                    __auto_type ret_expr = _mv_1760.value;
+                __auto_type _mv_1761 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1761.has_value) {
+                    __auto_type ret_expr = _mv_1761.value;
                     infer_check_return_expr(env, ret_expr, fn_name, inferred_type, fn_line, fn_col);
-                } else if (!_mv_1760.has_value) {
+                } else if (!_mv_1761.has_value) {
                 }
             }
             break;
@@ -2364,11 +2364,11 @@ uint8_t infer_is_integer_type(slop_string name) {
 void infer_check_return_expr(env_TypeEnv* env, types_SExpr* ret_expr, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((ret_expr != NULL)), "(!= ret-expr nil)");
-    __auto_type _mv_1761 = (*ret_expr);
-    switch (_mv_1761.tag) {
+    __auto_type _mv_1762 = (*ret_expr);
+    switch (_mv_1762.tag) {
         case types_SExpr_sym:
         {
-            __auto_type ret_sym = _mv_1761.data.sym;
+            __auto_type ret_sym = _mv_1762.data.sym;
             {
                 __auto_type declared_name = ret_sym.name;
                 __auto_type inferred_name = (*inferred_type).name;
@@ -2392,16 +2392,16 @@ void infer_bind_param_from_form(env_TypeEnv* env, types_SExpr* param_form) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((param_form != NULL)), "(!= param-form nil)");
     if (parser_sexpr_is_list(param_form) && (parser_sexpr_list_len(param_form) >= 2)) {
-        __auto_type _mv_1762 = parser_sexpr_list_get(param_form, 0);
-        if (_mv_1762.has_value) {
-            __auto_type first_expr = _mv_1762.value;
+        __auto_type _mv_1763 = parser_sexpr_list_get(param_form, 0);
+        if (_mv_1763.has_value) {
+            __auto_type first_expr = _mv_1763.value;
             {
                 __auto_type first_name = parser_sexpr_get_symbol_name(first_expr);
                 if ((string_eq(first_name, SLOP_STR("in"))) || (string_eq(first_name, SLOP_STR("out"))) || (string_eq(first_name, SLOP_STR("mut")))) {
                     if (parser_sexpr_list_len(param_form) >= 3) {
-                        __auto_type _mv_1763 = parser_sexpr_list_get(param_form, 1);
-                        if (_mv_1763.has_value) {
-                            __auto_type name_expr = _mv_1763.value;
+                        __auto_type _mv_1764 = parser_sexpr_list_get(param_form, 1);
+                        if (_mv_1764.has_value) {
+                            __auto_type name_expr = _mv_1764.value;
                             {
                                 __auto_type param_name = parser_sexpr_get_symbol_name(name_expr);
                                 if (!(string_eq(param_name, SLOP_STR("")))) {
@@ -2411,7 +2411,7 @@ void infer_bind_param_from_form(env_TypeEnv* env, types_SExpr* param_form) {
                                     }
                                 }
                             }
-                        } else if (!_mv_1763.has_value) {
+                        } else if (!_mv_1764.has_value) {
                         }
                     }
                 } else {
@@ -2423,7 +2423,7 @@ void infer_bind_param_from_form(env_TypeEnv* env, types_SExpr* param_form) {
                     }
                 }
             }
-        } else if (!_mv_1762.has_value) {
+        } else if (!_mv_1763.has_value) {
         }
     }
 }
@@ -2433,9 +2433,9 @@ types_ResolvedType* infer_get_param_type_from_form(env_TypeEnv* env, types_SExpr
     SLOP_PRE(((param_form != NULL)), "(!= param-form nil)");
     {
         __auto_type type_pos = ({ __auto_type _mv = parser_sexpr_list_get(param_form, 0); _mv.has_value ? ({ __auto_type first_expr = _mv.value; ({ __auto_type first_name = parser_sexpr_get_symbol_name(first_expr); ((((string_eq(first_name, SLOP_STR("in"))) || (string_eq(first_name, SLOP_STR("out"))) || (string_eq(first_name, SLOP_STR("mut"))))) ? 2 : 1); }); }) : (1); });
-        __auto_type _mv_1764 = parser_sexpr_list_get(param_form, type_pos);
-        if (_mv_1764.has_value) {
-            __auto_type type_expr = _mv_1764.value;
+        __auto_type _mv_1765 = parser_sexpr_list_get(param_form, type_pos);
+        if (_mv_1765.has_value) {
+            __auto_type type_expr = _mv_1765.value;
             {
                 __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                 if (string_eq(type_name, SLOP_STR(""))) {
@@ -2448,7 +2448,7 @@ types_ResolvedType* infer_get_param_type_from_form(env_TypeEnv* env, types_SExpr
                     return infer_resolve_simple_type(env, type_name);
                 }
             }
-        } else if (!_mv_1764.has_value) {
+        } else if (!_mv_1765.has_value) {
             return env_env_get_unknown_type(env);
         }
     }
@@ -2457,9 +2457,9 @@ types_ResolvedType* infer_get_param_type_from_form(env_TypeEnv* env, types_SExpr
 types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExpr* type_expr) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_1765 = parser_sexpr_list_get(type_expr, 0);
-    if (_mv_1765.has_value) {
-        __auto_type head_expr = _mv_1765.value;
+    __auto_type _mv_1766 = parser_sexpr_list_get(type_expr, 0);
+    if (_mv_1766.has_value) {
+        __auto_type head_expr = _mv_1766.value;
         {
             __auto_type head_name = parser_sexpr_get_symbol_name(head_expr);
             if (string_eq(head_name, SLOP_STR("Option"))) {
@@ -2487,16 +2487,16 @@ types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExp
                     __auto_type map_type = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_map, SLOP_STR("Map"), ((slop_option_string){.has_value = false}), SLOP_STR("slop_map*"));
                     types_resolved_type_set_inner(map_type, key_type);
                     if (parser_sexpr_list_len(type_expr) >= 3) {
-                        __auto_type _mv_1766 = parser_sexpr_list_get(type_expr, 2);
-                        if (_mv_1766.has_value) {
-                            __auto_type val_expr = _mv_1766.value;
+                        __auto_type _mv_1767 = parser_sexpr_list_get(type_expr, 2);
+                        if (_mv_1767.has_value) {
+                            __auto_type val_expr = _mv_1767.value;
                             {
                                 __auto_type val_type = infer_resolve_simple_type(env, parser_sexpr_get_symbol_name(val_expr));
                                 if (val_type != NULL) {
                                     types_resolved_type_set_inner2(map_type, val_type);
                                 }
                             }
-                        } else if (!_mv_1766.has_value) {
+                        } else if (!_mv_1767.has_value) {
                         }
                     }
                     return map_type;
@@ -2530,9 +2530,9 @@ types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExp
                     __auto_type arena = env_env_arena(env);
                     __auto_type result_type = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_result, SLOP_STR("Result"), ((slop_option_string){.has_value = false}), SLOP_STR("Result"));
                     if (parser_sexpr_list_len(type_expr) >= 2) {
-                        __auto_type _mv_1767 = parser_sexpr_list_get(type_expr, 1);
-                        if (_mv_1767.has_value) {
-                            __auto_type ok_expr = _mv_1767.value;
+                        __auto_type _mv_1768 = parser_sexpr_list_get(type_expr, 1);
+                        if (_mv_1768.has_value) {
+                            __auto_type ok_expr = _mv_1768.value;
                             {
                                 __auto_type ok_name = parser_sexpr_get_symbol_name(ok_expr);
                                 {
@@ -2540,13 +2540,13 @@ types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExp
                                     types_resolved_type_set_inner(result_type, ok_type);
                                 }
                             }
-                        } else if (!_mv_1767.has_value) {
+                        } else if (!_mv_1768.has_value) {
                         }
                     }
                     if (parser_sexpr_list_len(type_expr) >= 3) {
-                        __auto_type _mv_1768 = parser_sexpr_list_get(type_expr, 2);
-                        if (_mv_1768.has_value) {
-                            __auto_type err_expr = _mv_1768.value;
+                        __auto_type _mv_1769 = parser_sexpr_list_get(type_expr, 2);
+                        if (_mv_1769.has_value) {
+                            __auto_type err_expr = _mv_1769.value;
                             {
                                 __auto_type err_name = parser_sexpr_get_symbol_name(err_expr);
                                 {
@@ -2554,22 +2554,22 @@ types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExp
                                     types_resolved_type_set_inner2(result_type, err_type);
                                 }
                             }
-                        } else if (!_mv_1768.has_value) {
+                        } else if (!_mv_1769.has_value) {
                         }
                     }
                     return result_type;
                 }
             } else {
-                __auto_type _mv_1769 = env_env_lookup_type(env, head_name);
-                if (_mv_1769.has_value) {
-                    __auto_type t = _mv_1769.value;
+                __auto_type _mv_1770 = env_env_lookup_type(env, head_name);
+                if (_mv_1770.has_value) {
+                    __auto_type t = _mv_1770.value;
                     return t;
-                } else if (!_mv_1769.has_value) {
+                } else if (!_mv_1770.has_value) {
                     return env_env_get_unknown_type(env);
                 }
             }
         }
-    } else if (!_mv_1765.has_value) {
+    } else if (!_mv_1766.has_value) {
         return env_env_get_unknown_type(env);
     }
 }
@@ -2579,9 +2579,9 @@ types_ResolvedType* infer_resolve_option_inner_type(env_TypeEnv* env, types_SExp
     if (parser_sexpr_list_len(type_expr) < 2) {
         return env_env_get_unknown_type(env);
     } else {
-        __auto_type _mv_1770 = parser_sexpr_list_get(type_expr, 1);
-        if (_mv_1770.has_value) {
-            __auto_type inner_expr = _mv_1770.value;
+        __auto_type _mv_1771 = parser_sexpr_list_get(type_expr, 1);
+        if (_mv_1771.has_value) {
+            __auto_type inner_expr = _mv_1771.value;
             {
                 __auto_type inner_name = parser_sexpr_get_symbol_name(inner_expr);
                 if (string_eq(inner_name, SLOP_STR(""))) {
@@ -2590,7 +2590,7 @@ types_ResolvedType* infer_resolve_option_inner_type(env_TypeEnv* env, types_SExp
                     return infer_resolve_simple_type(env, inner_name);
                 }
             }
-        } else if (!_mv_1770.has_value) {
+        } else if (!_mv_1771.has_value) {
             return env_env_get_unknown_type(env);
         }
     }
@@ -2601,9 +2601,9 @@ types_ResolvedType* infer_resolve_ptr_inner_type(env_TypeEnv* env, types_SExpr* 
     if (parser_sexpr_list_len(type_expr) < 2) {
         return env_env_get_unit_type(env);
     } else {
-        __auto_type _mv_1771 = parser_sexpr_list_get(type_expr, 1);
-        if (_mv_1771.has_value) {
-            __auto_type inner_expr = _mv_1771.value;
+        __auto_type _mv_1772 = parser_sexpr_list_get(type_expr, 1);
+        if (_mv_1772.has_value) {
+            __auto_type inner_expr = _mv_1772.value;
             {
                 __auto_type inner_name = parser_sexpr_get_symbol_name(inner_expr);
                 if (string_eq(inner_name, SLOP_STR(""))) {
@@ -2616,7 +2616,7 @@ types_ResolvedType* infer_resolve_ptr_inner_type(env_TypeEnv* env, types_SExpr* 
                     return infer_resolve_simple_type(env, inner_name);
                 }
             }
-        } else if (!_mv_1771.has_value) {
+        } else if (!_mv_1772.has_value) {
             return env_env_get_unit_type(env);
         }
     }
@@ -2624,11 +2624,11 @@ types_ResolvedType* infer_resolve_ptr_inner_type(env_TypeEnv* env, types_SExpr* 
 
 types_ResolvedType* infer_resolve_type_lenient(env_TypeEnv* env, slop_string type_name) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_1772 = env_env_lookup_type(env, type_name);
-    if (_mv_1772.has_value) {
-        __auto_type t = _mv_1772.value;
+    __auto_type _mv_1773 = env_env_lookup_type(env, type_name);
+    if (_mv_1773.has_value) {
+        __auto_type t = _mv_1773.value;
         return t;
-    } else if (!_mv_1772.has_value) {
+    } else if (!_mv_1773.has_value) {
         {
             __auto_type arena = env_env_arena(env);
             if (string_eq(type_name, SLOP_STR("Int"))) {
@@ -2650,11 +2650,11 @@ types_ResolvedType* infer_resolve_type_lenient(env_TypeEnv* env, slop_string typ
 
 types_ResolvedType* infer_resolve_simple_type(env_TypeEnv* env, slop_string type_name) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_1773 = env_env_lookup_type(env, type_name);
-    if (_mv_1773.has_value) {
-        __auto_type t = _mv_1773.value;
+    __auto_type _mv_1774 = env_env_lookup_type(env, type_name);
+    if (_mv_1774.has_value) {
+        __auto_type t = _mv_1774.value;
         return t;
-    } else if (!_mv_1773.has_value) {
+    } else if (!_mv_1774.has_value) {
         {
             __auto_type arena = env_env_arena(env);
             if (string_eq(type_name, SLOP_STR("Int"))) {
@@ -2711,24 +2711,24 @@ void infer_bind_let_binding(env_TypeEnv* env, types_SExpr* binding_form) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((binding_form != NULL)), "(!= binding-form nil)");
     if (parser_sexpr_is_list(binding_form) && (parser_sexpr_list_len(binding_form) >= 2)) {
-        __auto_type _mv_1774 = parser_sexpr_list_get(binding_form, 0);
-        if (_mv_1774.has_value) {
-            __auto_type first_expr = _mv_1774.value;
+        __auto_type _mv_1775 = parser_sexpr_list_get(binding_form, 0);
+        if (_mv_1775.has_value) {
+            __auto_type first_expr = _mv_1775.value;
             {
                 __auto_type first_name = parser_sexpr_get_symbol_name(first_expr);
                 if (string_eq(first_name, SLOP_STR("mut"))) {
                     if (parser_sexpr_list_len(binding_form) >= 3) {
-                        __auto_type _mv_1775 = parser_sexpr_list_get(binding_form, 1);
-                        if (_mv_1775.has_value) {
-                            __auto_type name_expr = _mv_1775.value;
+                        __auto_type _mv_1776 = parser_sexpr_list_get(binding_form, 1);
+                        if (_mv_1776.has_value) {
+                            __auto_type name_expr = _mv_1776.value;
                             {
                                 __auto_type var_name = parser_sexpr_get_symbol_name(name_expr);
                                 if (!(string_eq(var_name, SLOP_STR("")))) {
                                     {
                                         __auto_type binding_len = parser_sexpr_list_len(binding_form);
-                                        __auto_type _mv_1776 = parser_sexpr_list_get(binding_form, (binding_len - 1));
-                                        if (_mv_1776.has_value) {
-                                            __auto_type val_expr = _mv_1776.value;
+                                        __auto_type _mv_1777 = parser_sexpr_list_get(binding_form, (binding_len - 1));
+                                        if (_mv_1777.has_value) {
+                                            __auto_type val_expr = _mv_1777.value;
                                             {
                                                 __auto_type val_type = infer_infer_expr(env, val_expr);
                                                 __auto_type val_type_name = (*val_type).name;
@@ -2750,12 +2750,12 @@ void infer_bind_let_binding(env_TypeEnv* env, types_SExpr* binding_form) {
                                                     env_env_bind_var(env, var_name, val_type);
                                                 }
                                             }
-                                        } else if (!_mv_1776.has_value) {
+                                        } else if (!_mv_1777.has_value) {
                                         }
                                     }
                                 }
                             }
-                        } else if (!_mv_1775.has_value) {
+                        } else if (!_mv_1776.has_value) {
                         }
                     }
                 } else {
@@ -2763,17 +2763,7 @@ void infer_bind_let_binding(env_TypeEnv* env, types_SExpr* binding_form) {
                         {
                             __auto_type binding_len = parser_sexpr_list_len(binding_form);
                             if (binding_len == 3) {
-                                __auto_type _mv_1777 = parser_sexpr_list_get(binding_form, 2);
-                                if (_mv_1777.has_value) {
-                                    __auto_type val_expr = _mv_1777.value;
-                                    {
-                                        __auto_type val_type = infer_infer_expr(env, val_expr);
-                                        env_env_bind_var(env, first_name, val_type);
-                                    }
-                                } else if (!_mv_1777.has_value) {
-                                }
-                            } else {
-                                __auto_type _mv_1778 = parser_sexpr_list_get(binding_form, 1);
+                                __auto_type _mv_1778 = parser_sexpr_list_get(binding_form, 2);
                                 if (_mv_1778.has_value) {
                                     __auto_type val_expr = _mv_1778.value;
                                     {
@@ -2782,12 +2772,22 @@ void infer_bind_let_binding(env_TypeEnv* env, types_SExpr* binding_form) {
                                     }
                                 } else if (!_mv_1778.has_value) {
                                 }
+                            } else {
+                                __auto_type _mv_1779 = parser_sexpr_list_get(binding_form, 1);
+                                if (_mv_1779.has_value) {
+                                    __auto_type val_expr = _mv_1779.value;
+                                    {
+                                        __auto_type val_type = infer_infer_expr(env, val_expr);
+                                        env_env_bind_var(env, first_name, val_type);
+                                    }
+                                } else if (!_mv_1779.has_value) {
+                                }
                             }
                         }
                     }
                 }
             }
-        } else if (!_mv_1774.has_value) {
+        } else if (!_mv_1775.has_value) {
         }
     }
 }
@@ -2797,23 +2797,23 @@ types_ResolvedType* infer_infer_let_expr(env_TypeEnv* env, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     env_env_push_scope(env);
     if (parser_sexpr_is_list(expr)) {
-        __auto_type _mv_1779 = parser_sexpr_list_get(expr, 1);
-        if (_mv_1779.has_value) {
-            __auto_type bindings_expr = _mv_1779.value;
+        __auto_type _mv_1780 = parser_sexpr_list_get(expr, 1);
+        if (_mv_1780.has_value) {
+            __auto_type bindings_expr = _mv_1780.value;
             if (parser_sexpr_is_list(bindings_expr)) {
                 {
                     __auto_type num_bindings = parser_sexpr_list_len(bindings_expr);
                     for (int64_t i = 0; i < num_bindings; i++) {
-                        __auto_type _mv_1780 = parser_sexpr_list_get(bindings_expr, i);
-                        if (_mv_1780.has_value) {
-                            __auto_type binding = _mv_1780.value;
+                        __auto_type _mv_1781 = parser_sexpr_list_get(bindings_expr, i);
+                        if (_mv_1781.has_value) {
+                            __auto_type binding = _mv_1781.value;
                             infer_bind_let_binding(env, binding);
-                        } else if (!_mv_1780.has_value) {
+                        } else if (!_mv_1781.has_value) {
                         }
                     }
                 }
             }
-        } else if (!_mv_1779.has_value) {
+        } else if (!_mv_1780.has_value) {
         }
     }
     {
@@ -2841,14 +2841,14 @@ types_ResolvedType* infer_infer_with_arena_expr(env_TypeEnv* env, types_SExpr* e
                     env_env_add_error(env, SLOP_STR("with-arena :as requires name and size"), parser_sexpr_line(expr), parser_sexpr_col(expr));
                     return env_env_get_unit_type(env);
                 } else {
-                    __auto_type _mv_1781 = parser_sexpr_list_get(expr, size_idx);
-                    if (_mv_1781.has_value) {
-                        __auto_type size_expr = _mv_1781.value;
-                        __auto_type _mv_1782 = (*size_expr);
-                        switch (_mv_1782.tag) {
+                    __auto_type _mv_1782 = parser_sexpr_list_get(expr, size_idx);
+                    if (_mv_1782.has_value) {
+                        __auto_type size_expr = _mv_1782.value;
+                        __auto_type _mv_1783 = (*size_expr);
+                        switch (_mv_1783.tag) {
                             case types_SExpr_num:
                             {
-                                __auto_type num = _mv_1782.data.num;
+                                __auto_type num = _mv_1783.data.num;
                                 if (num.int_value <= 0) {
                                     env_env_add_error(env, SLOP_STR("with-arena size must be positive"), num.line, num.col);
                                 } else {
@@ -2859,18 +2859,18 @@ types_ResolvedType* infer_infer_with_arena_expr(env_TypeEnv* env, types_SExpr* e
                                 break;
                             }
                         }
-                    } else if (!_mv_1781.has_value) {
+                    } else if (!_mv_1782.has_value) {
                     }
                     env_env_push_scope(env);
                     env_env_bind_var(env, arena_name, env_env_get_arena_type(env));
                     {
                         types_ResolvedType* result_type = env_env_get_unit_type(env);
                         for (int64_t i = body_start; i < len; i++) {
-                            __auto_type _mv_1783 = parser_sexpr_list_get(expr, i);
-                            if (_mv_1783.has_value) {
-                                __auto_type body_expr = _mv_1783.value;
+                            __auto_type _mv_1784 = parser_sexpr_list_get(expr, i);
+                            if (_mv_1784.has_value) {
+                                __auto_type body_expr = _mv_1784.value;
                                 result_type = infer_infer_expr(env, body_expr);
-                            } else if (!_mv_1783.has_value) {
+                            } else if (!_mv_1784.has_value) {
                             }
                         }
                         env_env_pop_scope(env);
@@ -2890,9 +2890,9 @@ slop_string infer_get_fn_name(types_SExpr* fn_form) {
         if (parser_sexpr_list_len(fn_form) < 2) {
             return SLOP_STR("unknown");
         } else {
-            __auto_type _mv_1784 = parser_sexpr_list_get(fn_form, 1);
-            if (_mv_1784.has_value) {
-                __auto_type name_expr = _mv_1784.value;
+            __auto_type _mv_1785 = parser_sexpr_list_get(fn_form, 1);
+            if (_mv_1785.has_value) {
+                __auto_type name_expr = _mv_1785.value;
                 {
                     __auto_type name = parser_sexpr_get_symbol_name(name_expr);
                     if (string_eq(name, SLOP_STR(""))) {
@@ -2901,7 +2901,7 @@ slop_string infer_get_fn_name(types_SExpr* fn_form) {
                         return name;
                     }
                 }
-            } else if (!_mv_1784.has_value) {
+            } else if (!_mv_1785.has_value) {
                 return SLOP_STR("unknown");
             }
         }
@@ -2913,19 +2913,19 @@ types_ResolvedType* infer_resolve_hole_type(env_TypeEnv* env, slop_list_types_SE
     if (len < 2) {
         return env_env_get_unit_type(env);
     } else {
-        __auto_type _mv_1785 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1785.has_value) {
-            __auto_type type_expr = _mv_1785.value;
+        __auto_type _mv_1786 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1786.has_value) {
+            __auto_type type_expr = _mv_1786.value;
             {
                 __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                 if (string_eq(type_name, SLOP_STR(""))) {
                     return env_env_get_unit_type(env);
                 } else {
-                    __auto_type _mv_1786 = env_env_lookup_type(env, type_name);
-                    if (_mv_1786.has_value) {
-                        __auto_type t = _mv_1786.value;
+                    __auto_type _mv_1787 = env_env_lookup_type(env, type_name);
+                    if (_mv_1787.has_value) {
+                        __auto_type t = _mv_1787.value;
                         return t;
-                    } else if (!_mv_1786.has_value) {
+                    } else if (!_mv_1787.has_value) {
                         if (string_eq(type_name, SLOP_STR("Int"))) {
                             return env_env_get_int_type(env);
                         } else if (string_eq(type_name, SLOP_STR("Bool"))) {
@@ -2940,7 +2940,7 @@ types_ResolvedType* infer_resolve_hole_type(env_TypeEnv* env, slop_list_types_SE
                     }
                 }
             }
-        } else if (!_mv_1785.has_value) {
+        } else if (!_mv_1786.has_value) {
             return env_env_get_unit_type(env);
         }
     }
@@ -2950,21 +2950,21 @@ slop_string infer_get_hole_prompt(slop_list_types_SExpr_ptr items, int64_t len) 
     if (len < 3) {
         return SLOP_STR("(no description)");
     } else {
-        __auto_type _mv_1787 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1787.has_value) {
-            __auto_type prompt_expr = _mv_1787.value;
-            __auto_type _mv_1788 = (*prompt_expr);
-            switch (_mv_1788.tag) {
+        __auto_type _mv_1788 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1788.has_value) {
+            __auto_type prompt_expr = _mv_1788.value;
+            __auto_type _mv_1789 = (*prompt_expr);
+            switch (_mv_1789.tag) {
                 case types_SExpr_str:
                 {
-                    __auto_type str = _mv_1788.data.str;
+                    __auto_type str = _mv_1789.data.str;
                     return str.value;
                 }
                 default: {
                     return SLOP_STR("(no description)");
                 }
             }
-        } else if (!_mv_1787.has_value) {
+        } else if (!_mv_1788.has_value) {
             return SLOP_STR("(no description)");
         }
     }
@@ -2982,35 +2982,35 @@ int64_t infer_find_last_body_idx(slop_list_types_SExpr_ptr items) {
 }
 
 uint8_t infer_is_c_name_related(slop_list_types_SExpr_ptr items, int64_t idx) {
-    __auto_type _mv_1789 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-    if (_mv_1789.has_value) {
-        __auto_type item = _mv_1789.value;
-        __auto_type _mv_1790 = (*item);
-        switch (_mv_1790.tag) {
+    __auto_type _mv_1790 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+    if (_mv_1790.has_value) {
+        __auto_type item = _mv_1790.value;
+        __auto_type _mv_1791 = (*item);
+        switch (_mv_1791.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1790.data.sym;
+                __auto_type sym = _mv_1791.data.sym;
                 return string_eq(sym.name, SLOP_STR(":c-name"));
             }
             case types_SExpr_str:
             {
-                __auto_type _ = _mv_1790.data.str;
+                __auto_type _ = _mv_1791.data.str;
                 if (idx > 0) {
-                    __auto_type _mv_1791 = ({ __auto_type _lst = items; size_t _idx = (size_t)(idx - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1791.has_value) {
-                        __auto_type prev = _mv_1791.value;
-                        __auto_type _mv_1792 = (*prev);
-                        switch (_mv_1792.tag) {
+                    __auto_type _mv_1792 = ({ __auto_type _lst = items; size_t _idx = (size_t)(idx - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1792.has_value) {
+                        __auto_type prev = _mv_1792.value;
+                        __auto_type _mv_1793 = (*prev);
+                        switch (_mv_1793.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1792.data.sym;
+                                __auto_type sym = _mv_1793.data.sym;
                                 return string_eq(sym.name, SLOP_STR(":c-name"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1791.has_value) {
+                    } else if (!_mv_1792.has_value) {
                         return 0;
                     }
                 } else {
@@ -3021,7 +3021,7 @@ uint8_t infer_is_c_name_related(slop_list_types_SExpr_ptr items, int64_t idx) {
                 return 0;
             }
         }
-    } else if (!_mv_1789.has_value) {
+    } else if (!_mv_1790.has_value) {
         return 0;
     }
 }
@@ -3029,21 +3029,21 @@ uint8_t infer_is_c_name_related(slop_list_types_SExpr_ptr items, int64_t idx) {
 uint8_t infer_is_annotation_expr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     if (parser_sexpr_is_list(expr)) {
-        __auto_type _mv_1793 = parser_sexpr_list_get(expr, 0);
-        if (_mv_1793.has_value) {
-            __auto_type head = _mv_1793.value;
-            __auto_type _mv_1794 = (*head);
-            switch (_mv_1794.tag) {
+        __auto_type _mv_1794 = parser_sexpr_list_get(expr, 0);
+        if (_mv_1794.has_value) {
+            __auto_type head = _mv_1794.value;
+            __auto_type _mv_1795 = (*head);
+            switch (_mv_1795.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_1794.data.sym;
+                    __auto_type sym = _mv_1795.data.sym;
                     return strlib_starts_with(sym.name, SLOP_STR("@"));
                 }
                 default: {
                     return 0;
                 }
             }
-        } else if (!_mv_1793.has_value) {
+        } else if (!_mv_1794.has_value) {
             return 0;
         }
     } else {
@@ -3053,14 +3053,14 @@ uint8_t infer_is_annotation_expr(types_SExpr* expr) {
 
 uint8_t infer_is_checkable_annotation(types_SExpr* expr) {
     if (parser_sexpr_is_list(expr)) {
-        __auto_type _mv_1795 = parser_sexpr_list_get(expr, 0);
-        if (_mv_1795.has_value) {
-            __auto_type head = _mv_1795.value;
-            __auto_type _mv_1796 = (*head);
-            switch (_mv_1796.tag) {
+        __auto_type _mv_1796 = parser_sexpr_list_get(expr, 0);
+        if (_mv_1796.has_value) {
+            __auto_type head = _mv_1796.value;
+            __auto_type _mv_1797 = (*head);
+            switch (_mv_1797.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_1796.data.sym;
+                    __auto_type sym = _mv_1797.data.sym;
                     {
                         __auto_type name = sym.name;
                         return ((string_eq(name, SLOP_STR("@pre"))) || (string_eq(name, SLOP_STR("@post"))) || (string_eq(name, SLOP_STR("@assume"))) || (string_eq(name, SLOP_STR("@assert"))));
@@ -3070,7 +3070,7 @@ uint8_t infer_is_checkable_annotation(types_SExpr* expr) {
                     return 0;
                 }
             }
-        } else if (!_mv_1795.has_value) {
+        } else if (!_mv_1796.has_value) {
             return 0;
         }
     } else {
@@ -3093,23 +3093,23 @@ types_ResolvedType* infer_infer_fn_body(env_TypeEnv* env, types_SExpr* fn_form) 
             {
                 __auto_type params_len = parser_sexpr_list_len(fn_form);
                 if (params_len > 2) {
-                    __auto_type _mv_1797 = parser_sexpr_list_get(fn_form, 2);
-                    if (_mv_1797.has_value) {
-                        __auto_type params_expr = _mv_1797.value;
+                    __auto_type _mv_1798 = parser_sexpr_list_get(fn_form, 2);
+                    if (_mv_1798.has_value) {
+                        __auto_type params_expr = _mv_1798.value;
                         if (parser_sexpr_is_list(params_expr)) {
                             {
                                 __auto_type num_params = parser_sexpr_list_len(params_expr);
                                 for (int64_t k = 0; k < num_params; k++) {
-                                    __auto_type _mv_1798 = parser_sexpr_list_get(params_expr, k);
-                                    if (_mv_1798.has_value) {
-                                        __auto_type param_form = _mv_1798.value;
+                                    __auto_type _mv_1799 = parser_sexpr_list_get(params_expr, k);
+                                    if (_mv_1799.has_value) {
+                                        __auto_type param_form = _mv_1799.value;
                                         infer_bind_param_from_form(env, param_form);
-                                    } else if (!_mv_1798.has_value) {
+                                    } else if (!_mv_1799.has_value) {
                                     }
                                 }
                             }
                         }
-                    } else if (!_mv_1797.has_value) {
+                    } else if (!_mv_1798.has_value) {
                     }
                 }
             }
@@ -3131,34 +3131,34 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
         {
             __auto_type num_patterns = ((int64_t)((patterns).len));
             for (int64_t i = 0; i < num_patterns; i++) {
-                __auto_type _mv_1799 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1799.has_value) {
-                    __auto_type pattern_case = _mv_1799.value;
-                    __auto_type _mv_1800 = (*pattern_case);
-                    switch (_mv_1800.tag) {
+                __auto_type _mv_1800 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1800.has_value) {
+                    __auto_type pattern_case = _mv_1800.value;
+                    __auto_type _mv_1801 = (*pattern_case);
+                    switch (_mv_1801.tag) {
                         case types_SExpr_lst:
                         {
-                            __auto_type pattern_list = _mv_1800.data.lst;
+                            __auto_type pattern_list = _mv_1801.data.lst;
                             if (((int64_t)((pattern_list.items).len)) > 0) {
-                                __auto_type _mv_1801 = ({ __auto_type _lst = pattern_list.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1801.has_value) {
-                                    __auto_type pattern_expr = _mv_1801.value;
-                                    __auto_type _mv_1802 = (*pattern_expr);
-                                    switch (_mv_1802.tag) {
+                                __auto_type _mv_1802 = ({ __auto_type _lst = pattern_list.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1802.has_value) {
+                                    __auto_type pattern_expr = _mv_1802.value;
+                                    __auto_type _mv_1803 = (*pattern_expr);
+                                    switch (_mv_1803.tag) {
                                         case types_SExpr_lst:
                                         {
-                                            __auto_type variant_list = _mv_1802.data.lst;
+                                            __auto_type variant_list = _mv_1803.data.lst;
                                             {
                                                 __auto_type variant_items = variant_list.items;
                                                 if (((int64_t)((variant_items).len)) > 0) {
-                                                    __auto_type _mv_1803 = ({ __auto_type _lst = variant_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1803.has_value) {
-                                                        __auto_type variant_name_expr = _mv_1803.value;
-                                                        __auto_type _mv_1804 = (*variant_name_expr);
-                                                        switch (_mv_1804.tag) {
+                                                    __auto_type _mv_1804 = ({ __auto_type _lst = variant_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1804.has_value) {
+                                                        __auto_type variant_name_expr = _mv_1804.value;
+                                                        __auto_type _mv_1805 = (*variant_name_expr);
+                                                        switch (_mv_1805.tag) {
                                                             case types_SExpr_sym:
                                                             {
-                                                                __auto_type variant_sym = _mv_1804.data.sym;
+                                                                __auto_type variant_sym = _mv_1805.data.sym;
                                                                 {
                                                                     __auto_type variant_name = variant_sym.name;
                                                                     {
@@ -3168,24 +3168,24 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                                                                             {
                                                                                 __auto_type num_vt = ((int64_t)((variant_items).len));
                                                                                 for (int64_t vi = 1; vi < num_vt; vi++) {
-                                                                                    __auto_type _mv_1805 = ({ __auto_type _lst = variant_items; size_t _idx = (size_t)vi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                                    if (_mv_1805.has_value) {
-                                                                                        __auto_type binding_expr = _mv_1805.value;
-                                                                                        __auto_type _mv_1806 = (*binding_expr);
-                                                                                        switch (_mv_1806.tag) {
+                                                                                    __auto_type _mv_1806 = ({ __auto_type _lst = variant_items; size_t _idx = (size_t)vi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                                    if (_mv_1806.has_value) {
+                                                                                        __auto_type binding_expr = _mv_1806.value;
+                                                                                        __auto_type _mv_1807 = (*binding_expr);
+                                                                                        switch (_mv_1807.tag) {
                                                                                             case types_SExpr_sym:
                                                                                             {
-                                                                                                __auto_type binding_sym = _mv_1806.data.sym;
+                                                                                                __auto_type binding_sym = _mv_1807.data.sym;
                                                                                                 {
                                                                                                     __auto_type bname = binding_sym.name;
                                                                                                     __auto_type type_idx = (vi - 1);
                                                                                                     if (!(string_eq(bname, SLOP_STR("_"))) && !(string_eq(bname, SLOP_STR("")))) {
                                                                                                         if (type_idx < num_pt) {
-                                                                                                            __auto_type _mv_1807 = ({ __auto_type _lst = payload_types; size_t _idx = (size_t)type_idx; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                                                            if (_mv_1807.has_value) {
-                                                                                                                __auto_type pt = _mv_1807.value;
+                                                                                                            __auto_type _mv_1808 = ({ __auto_type _lst = payload_types; size_t _idx = (size_t)type_idx; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                                                            if (_mv_1808.has_value) {
+                                                                                                                __auto_type pt = _mv_1808.value;
                                                                                                                 env_env_bind_var(env, bname, pt);
-                                                                                                            } else if (!_mv_1807.has_value) {
+                                                                                                            } else if (!_mv_1808.has_value) {
                                                                                                                 env_env_bind_var(env, bname, env_env_get_generic_type(env));
                                                                                                             }
                                                                                                         } else {
@@ -3199,15 +3199,15 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                                                                                                 break;
                                                                                             }
                                                                                         }
-                                                                                    } else if (!_mv_1805.has_value) {
+                                                                                    } else if (!_mv_1806.has_value) {
                                                                                     }
                                                                                 }
                                                                             }
                                                                         } else {
-                                                                            __auto_type _mv_1808 = types_resolved_type_get_variant_index(scrutinee_type, variant_name);
-                                                                            if (_mv_1808.has_value) {
-                                                                                __auto_type _ = _mv_1808.value;
-                                                                            } else if (!_mv_1808.has_value) {
+                                                                            __auto_type _mv_1809 = types_resolved_type_get_variant_index(scrutinee_type, variant_name);
+                                                                            if (_mv_1809.has_value) {
+                                                                                __auto_type _ = _mv_1809.value;
+                                                                            } else if (!_mv_1809.has_value) {
                                                                             }
                                                                         }
                                                                     }
@@ -3218,7 +3218,7 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                                                                 break;
                                                             }
                                                         }
-                                                    } else if (!_mv_1803.has_value) {
+                                                    } else if (!_mv_1804.has_value) {
                                                     }
                                                 }
                                             }
@@ -3228,7 +3228,7 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1801.has_value) {
+                                } else if (!_mv_1802.has_value) {
                                 }
                             }
                             break;
@@ -3237,7 +3237,7 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                             break;
                         }
                     }
-                } else if (!_mv_1799.has_value) {
+                } else if (!_mv_1800.has_value) {
                 }
             }
         }

--- a/bootstrap/compiler/slop_match.c
+++ b/bootstrap/compiler/slop_match.c
@@ -2233,7 +2233,7 @@ void match_emit_inline_for_each_set(context_TranspileContext* ctx, slop_string v
         __auto_type elem_c_type = expr_slop_value_type_to_c_type(ctx, elem_slop_type);
         context_ctx_emit(ctx, SLOP_STR("{"));
         context_ctx_indent(ctx);
-        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), coll_c, SLOP_STR(";")));
+        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, coll_c, resolved_type), SLOP_STR(";")));
         context_ctx_emit(ctx, SLOP_STR("for (size_t _i = 0; _i < _coll->cap; _i++) {"));
         context_ctx_indent(ctx);
         context_ctx_emit(ctx, SLOP_STR("if (_coll->entries[_i].occupied) {"));
@@ -2265,7 +2265,7 @@ void match_emit_inline_for_each_map_keys(context_TranspileContext* ctx, slop_str
         __auto_type key_c_type = expr_slop_value_type_to_c_type(ctx, key_slop_type);
         context_ctx_emit(ctx, SLOP_STR("{"));
         context_ctx_indent(ctx);
-        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), coll_c, SLOP_STR(";")));
+        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, coll_c, resolved_type), SLOP_STR(";")));
         context_ctx_emit(ctx, SLOP_STR("for (size_t _i = 0; _i < _coll->cap; _i++) {"));
         context_ctx_indent(ctx);
         context_ctx_emit(ctx, SLOP_STR("if (_coll->entries[_i].occupied) {"));
@@ -2337,7 +2337,7 @@ void match_emit_inline_for_each_map_kv(context_TranspileContext* ctx, slop_list_
                                                             __auto_type val_c_type = expr_slop_value_type_to_c_type(ctx, val_slop_type);
                                                             context_ctx_emit(ctx, SLOP_STR("{"));
                                                             context_ctx_indent(ctx);
-                                                            context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), map_c, SLOP_STR(";")));
+                                                            context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, map_c, resolved_type), SLOP_STR(";")));
                                                             context_ctx_emit(ctx, SLOP_STR("for (size_t _i = 0; _i < _coll->cap; _i++) {"));
                                                             context_ctx_indent(ctx);
                                                             context_ctx_emit(ctx, SLOP_STR("if (_coll->entries[_i].occupied) {"));

--- a/bootstrap/compiler/slop_resolve.c
+++ b/bootstrap/compiler/slop_resolve.c
@@ -12,16 +12,16 @@ void resolve_resolve_imports(env_TypeEnv* env, slop_list_types_SExpr_ptr ast) {
     {
         __auto_type len = ((int64_t)((ast).len));
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_1809 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1809.has_value) {
-                __auto_type expr = _mv_1809.value;
+            __auto_type _mv_1810 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1810.has_value) {
+                __auto_type expr = _mv_1810.value;
                 if (parser_is_form(expr, SLOP_STR("import"))) {
                     resolve_resolve_import_stmt(env, expr);
                 } else if (parser_is_form(expr, SLOP_STR("module"))) {
                     resolve_resolve_module_imports(env, expr);
                 } else {
                 }
-            } else if (!_mv_1809.has_value) {
+            } else if (!_mv_1810.has_value) {
             }
         }
     }
@@ -34,13 +34,13 @@ void resolve_resolve_module_imports(env_TypeEnv* env, types_SExpr* module_form) 
         {
             __auto_type len = parser_sexpr_list_len(module_form);
             for (int64_t i = 2; i < len; i++) {
-                __auto_type _mv_1810 = parser_sexpr_list_get(module_form, i);
-                if (_mv_1810.has_value) {
-                    __auto_type item = _mv_1810.value;
+                __auto_type _mv_1811 = parser_sexpr_list_get(module_form, i);
+                if (_mv_1811.has_value) {
+                    __auto_type item = _mv_1811.value;
                     if (parser_is_form(item, SLOP_STR("import"))) {
                         resolve_resolve_import_stmt(env, item);
                     }
-                } else if (!_mv_1810.has_value) {
+                } else if (!_mv_1811.has_value) {
                 }
             }
         }
@@ -53,41 +53,41 @@ void resolve_resolve_import_stmt(env_TypeEnv* env, types_SExpr* import_form) {
     SLOP_PRE((parser_is_form(import_form, SLOP_STR("import"))), "(is-form import-form \"import\")");
     {
         __auto_type arena = env_env_arena(env);
-        __auto_type _mv_1811 = (*import_form);
-        switch (_mv_1811.tag) {
+        __auto_type _mv_1812 = (*import_form);
+        switch (_mv_1812.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1811.data.lst;
+                __auto_type lst = _mv_1812.data.lst;
                 {
                     __auto_type items = lst.items;
-                    __auto_type _mv_1812 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1812.has_value) {
-                        __auto_type mod_name_expr = _mv_1812.value;
-                        __auto_type _mv_1813 = (*mod_name_expr);
-                        switch (_mv_1813.tag) {
+                    __auto_type _mv_1813 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1813.has_value) {
+                        __auto_type mod_name_expr = _mv_1813.value;
+                        __auto_type _mv_1814 = (*mod_name_expr);
+                        switch (_mv_1814.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type mod_sym = _mv_1813.data.sym;
-                                __auto_type _mv_1814 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1814.has_value) {
-                                    __auto_type names_expr = _mv_1814.value;
-                                    __auto_type _mv_1815 = (*names_expr);
-                                    switch (_mv_1815.tag) {
+                                __auto_type mod_sym = _mv_1814.data.sym;
+                                __auto_type _mv_1815 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1815.has_value) {
+                                    __auto_type names_expr = _mv_1815.value;
+                                    __auto_type _mv_1816 = (*names_expr);
+                                    switch (_mv_1816.tag) {
                                         case types_SExpr_lst:
                                         {
-                                            __auto_type names_lst = _mv_1815.data.lst;
+                                            __auto_type names_lst = _mv_1816.data.lst;
                                             {
                                                 __auto_type name_items = names_lst.items;
                                                 __auto_type name_len = ((int64_t)((name_items).len));
                                                 for (int64_t j = 0; j < name_len; j++) {
-                                                    __auto_type _mv_1816 = ({ __auto_type _lst = name_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1816.has_value) {
-                                                        __auto_type name_expr = _mv_1816.value;
-                                                        __auto_type _mv_1817 = (*name_expr);
-                                                        switch (_mv_1817.tag) {
+                                                    __auto_type _mv_1817 = ({ __auto_type _lst = name_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1817.has_value) {
+                                                        __auto_type name_expr = _mv_1817.value;
+                                                        __auto_type _mv_1818 = (*name_expr);
+                                                        switch (_mv_1818.tag) {
                                                             case types_SExpr_sym:
                                                             {
-                                                                __auto_type name_sym = _mv_1817.data.sym;
+                                                                __auto_type name_sym = _mv_1818.data.sym;
                                                                 {
                                                                     __auto_type local_name = name_sym.name;
                                                                     __auto_type actual_module = ({ __auto_type _mv = env_env_lookup_type_direct(env, local_name); _mv.has_value ? ({ __auto_type t = _mv.value; ({ __auto_type _mv = (*t).module_name; _mv.has_value ? ({ __auto_type mod = _mv.value; mod; }) : (mod_sym.name); }); }) : (mod_sym.name); });
@@ -103,7 +103,7 @@ void resolve_resolve_import_stmt(env_TypeEnv* env, types_SExpr* import_form) {
                                                                 break;
                                                             }
                                                         }
-                                                    } else if (!_mv_1816.has_value) {
+                                                    } else if (!_mv_1817.has_value) {
                                                     }
                                                 }
                                             }
@@ -113,7 +113,7 @@ void resolve_resolve_import_stmt(env_TypeEnv* env, types_SExpr* import_form) {
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1814.has_value) {
+                                } else if (!_mv_1815.has_value) {
                                 }
                                 break;
                             }
@@ -121,7 +121,7 @@ void resolve_resolve_import_stmt(env_TypeEnv* env, types_SExpr* import_form) {
                                 break;
                             }
                         }
-                    } else if (!_mv_1812.has_value) {
+                    } else if (!_mv_1813.has_value) {
                     }
                 }
                 break;
@@ -150,9 +150,9 @@ slop_option_string resolve_resolve_module_file(slop_arena* arena, slop_string mo
     if (!(resolve_contains_slash(module_name))) {
         return (slop_option_string){.has_value = false};
     } else {
-        __auto_type _mv_1818 = from_file;
-        if (_mv_1818.has_value) {
-            __auto_type current_path = _mv_1818.value;
+        __auto_type _mv_1819 = from_file;
+        if (_mv_1819.has_value) {
+            __auto_type current_path = _mv_1819.value;
             {
                 __auto_type dir = path_path_dirname(arena, current_path);
                 __auto_type rel_path = string_concat(arena, module_name, SLOP_STR(".slop"));
@@ -163,7 +163,7 @@ slop_option_string resolve_resolve_module_file(slop_arena* arena, slop_string mo
                     return (slop_option_string){.has_value = false};
                 }
             }
-        } else if (!_mv_1818.has_value) {
+        } else if (!_mv_1819.has_value) {
             return (slop_option_string){.has_value = false};
         }
     }

--- a/bootstrap/compiler/slop_stmt.c
+++ b/bootstrap/compiler/slop_stmt.c
@@ -28,8 +28,6 @@ void stmt_transpile_with_arena(context_TranspileContext* ctx, types_SExpr* expr,
 void stmt_transpile_cond(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return);
 void stmt_transpile_cond_body(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items, int64_t start, uint8_t is_return);
 void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr);
-uint8_t stmt_is_set_type(slop_string slop_type);
-uint8_t stmt_is_map_type(slop_string slop_type);
 void stmt_transpile_for_each_set(context_TranspileContext* ctx, slop_string var_name, types_SExprSymbol var_sym, slop_string coll_c, slop_string resolved_type, slop_list_types_SExpr_ptr items, int64_t len);
 void stmt_transpile_for_each_map_keys(context_TranspileContext* ctx, slop_string var_name, types_SExprSymbol var_sym, slop_string coll_c, slop_string resolved_type, slop_list_types_SExpr_ptr items, int64_t len);
 void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_types_SExpr_ptr binding_items, slop_list_types_SExpr_ptr items, int64_t len);
@@ -1449,14 +1447,6 @@ void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr) {
     }
 }
 
-uint8_t stmt_is_set_type(slop_string slop_type) {
-    return (strlib_starts_with(slop_type, SLOP_STR("(Set ")) || strlib_starts_with(slop_type, SLOP_STR("(Ptr (Set ")));
-}
-
-uint8_t stmt_is_map_type(slop_string slop_type) {
-    return (strlib_starts_with(slop_type, SLOP_STR("(Map ")) || strlib_starts_with(slop_type, SLOP_STR("(Ptr (Map ")));
-}
-
 void stmt_transpile_for_each_set(context_TranspileContext* ctx, slop_string var_name, types_SExprSymbol var_sym, slop_string coll_c, slop_string resolved_type, slop_list_types_SExpr_ptr items, int64_t len) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
@@ -1465,7 +1455,7 @@ void stmt_transpile_for_each_set(context_TranspileContext* ctx, slop_string var_
         __auto_type elem_c_type = expr_slop_value_type_to_c_type(ctx, elem_slop_type);
         context_ctx_emit(ctx, SLOP_STR("{"));
         context_ctx_indent(ctx);
-        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), coll_c, SLOP_STR(";")));
+        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, coll_c, resolved_type), SLOP_STR(";")));
         context_ctx_emit(ctx, SLOP_STR("for (size_t _i = 0; _i < _coll->cap; _i++) {"));
         context_ctx_indent(ctx);
         context_ctx_emit(ctx, SLOP_STR("if (_coll->entries[_i].occupied) {"));
@@ -1508,7 +1498,7 @@ void stmt_transpile_for_each_map_keys(context_TranspileContext* ctx, slop_string
         __auto_type key_c_type = expr_slop_value_type_to_c_type(ctx, key_slop_type);
         context_ctx_emit(ctx, SLOP_STR("{"));
         context_ctx_indent(ctx);
-        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), coll_c, SLOP_STR(";")));
+        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, coll_c, resolved_type), SLOP_STR(";")));
         context_ctx_emit(ctx, SLOP_STR("for (size_t _i = 0; _i < _coll->cap; _i++) {"));
         context_ctx_indent(ctx);
         context_ctx_emit(ctx, SLOP_STR("if (_coll->entries[_i].occupied) {"));
@@ -1591,7 +1581,7 @@ void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_typ
                                                             __auto_type val_c_type = expr_slop_value_type_to_c_type(ctx, val_slop_type);
                                                             context_ctx_emit(ctx, SLOP_STR("{"));
                                                             context_ctx_indent(ctx);
-                                                            context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), map_c, SLOP_STR(";")));
+                                                            context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, map_c, resolved_type), SLOP_STR(";")));
                                                             context_ctx_emit(ctx, SLOP_STR("for (size_t _i = 0; _i < _coll->cap; _i++) {"));
                                                             context_ctx_indent(ctx);
                                                             context_ctx_emit(ctx, SLOP_STR("if (_coll->entries[_i].occupied) {"));
@@ -1721,12 +1711,12 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
                                                                 {
                                                                     __auto_type coll_slop_type = expr_infer_expr_slop_type(ctx, coll_expr);
                                                                     __auto_type resolved_type = expr_resolve_type_alias(ctx, coll_slop_type);
-                                                                    if (stmt_is_set_type(resolved_type)) {
+                                                                    if (expr_is_set_type(resolved_type)) {
                                                                         {
                                                                             __auto_type coll_c = expr_transpile_expr(ctx, coll_expr);
                                                                             stmt_transpile_for_each_set(ctx, var_name, var_sym, coll_c, resolved_type, items, len);
                                                                         }
-                                                                    } else if (stmt_is_map_type(resolved_type)) {
+                                                                    } else if (expr_is_map_type(resolved_type)) {
                                                                         {
                                                                             __auto_type coll_c = expr_transpile_expr(ctx, coll_expr);
                                                                             stmt_transpile_for_each_map_keys(ctx, var_name, var_sym, coll_c, resolved_type, items, len);

--- a/bootstrap/compiler/slop_stmt.h
+++ b/bootstrap/compiler/slop_stmt.h
@@ -49,8 +49,6 @@ void stmt_transpile_with_arena(context_TranspileContext* ctx, types_SExpr* expr,
 void stmt_transpile_cond(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return);
 void stmt_transpile_cond_body(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items, int64_t start, uint8_t is_return);
 void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr);
-uint8_t stmt_is_set_type(slop_string slop_type);
-uint8_t stmt_is_map_type(slop_string slop_type);
 void stmt_transpile_for_each_set(context_TranspileContext* ctx, slop_string var_name, types_SExprSymbol var_sym, slop_string coll_c, slop_string resolved_type, slop_list_types_SExpr_ptr items, int64_t len);
 void stmt_transpile_for_each_map_keys(context_TranspileContext* ctx, slop_string var_name, types_SExprSymbol var_sym, slop_string coll_c, slop_string resolved_type, slop_list_types_SExpr_ptr items, int64_t len);
 void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_types_SExpr_ptr binding_items, slop_list_types_SExpr_ptr items, int64_t len);

--- a/bootstrap/compiler/slop_transpiler.c
+++ b/bootstrap/compiler/slop_transpiler.c
@@ -101,6 +101,7 @@ void transpiler_emit_primitive_option_types_header(context_TranspileContext* ctx
 uint8_t transpiler_is_primitive_or_runtime_type(slop_string type_name);
 void transpiler_emit_imported_list_types_header(context_TranspileContext* ctx);
 void transpiler_emit_imported_option_types_header(context_TranspileContext* ctx);
+void transpiler_emit_late_registered_list_types_header(context_TranspileContext* ctx);
 void transpiler_emit_late_registered_option_types_header(context_TranspileContext* ctx);
 void transpiler_emit_value_list_types_header(context_TranspileContext* ctx);
 void transpiler_emit_complex_value_list_types_header(context_TranspileContext* ctx);
@@ -2474,6 +2475,7 @@ void transpiler_transpile_module(context_TranspileContext* ctx, types_SExpr* mod
                             transpiler_emit_fn_forward_decls(ctx, items, body_start);
                             transpiler_emit_module_functions(ctx, items, body_start);
                             transpiler_emit_late_registered_option_types_header(ctx);
+                            transpiler_emit_late_registered_list_types_header(ctx);
                             transpiler_emit_header_guard_close(ctx);
                         }
                     }
@@ -4169,6 +4171,24 @@ void transpiler_emit_imported_option_types_header(context_TranspileContext* ctx)
     }
 }
 
+void transpiler_emit_late_registered_list_types_header(context_TranspileContext* ctx) {
+    SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
+    {
+        __auto_type list_types = context_ctx_get_list_types(ctx);
+        __auto_type len = ((int64_t)((list_types).len));
+        int64_t i = 0;
+        while (i < len) {
+            __auto_type _mv_1507 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1507.has_value) {
+                __auto_type lt = _mv_1507.value;
+                transpiler_emit_single_list_type_header(ctx, lt);
+            } else if (!_mv_1507.has_value) {
+            }
+            i = (i + 1);
+        }
+    }
+}
+
 void transpiler_emit_late_registered_option_types_header(context_TranspileContext* ctx) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
@@ -4176,11 +4196,11 @@ void transpiler_emit_late_registered_option_types_header(context_TranspileContex
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1507 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1507.has_value) {
-                __auto_type ot = _mv_1507.value;
+            __auto_type _mv_1508 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1508.has_value) {
+                __auto_type ot = _mv_1508.value;
                 transpiler_emit_single_option_type_header(ctx, ot);
-            } else if (!_mv_1507.has_value) {
+            } else if (!_mv_1508.has_value) {
             }
             i = (i + 1);
         }
@@ -4194,13 +4214,13 @@ void transpiler_emit_value_list_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1508 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1508.has_value) {
-                __auto_type lt = _mv_1508.value;
+            __auto_type _mv_1509 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1509.has_value) {
+                __auto_type lt = _mv_1509.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_is_type_emitted_or_primitive(ctx, lt.elem_type)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1508.has_value) {
+            } else if (!_mv_1509.has_value) {
             }
             i = (i + 1);
         }
@@ -4214,13 +4234,13 @@ void transpiler_emit_complex_value_list_types_header(context_TranspileContext* c
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1509 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1509.has_value) {
-                __auto_type lt = _mv_1509.value;
+            __auto_type _mv_1510 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1510.has_value) {
+                __auto_type lt = _mv_1510.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && !(context_ctx_is_type_emitted(ctx, lt.c_name))) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1509.has_value) {
+            } else if (!_mv_1510.has_value) {
             }
             i = (i + 1);
         }
@@ -4256,9 +4276,9 @@ void transpiler_emit_union_payload_hash_eq(context_TranspileContext* ctx, slop_l
         __auto_type len = ((int64_t)((variants).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1510 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1510.has_value) {
-                __auto_type variant = _mv_1510.value;
+            __auto_type _mv_1511 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1511.has_value) {
+                __auto_type variant = _mv_1511.value;
                 {
                     __auto_type slop_type = variant.slop_type;
                     __auto_type c_payload_type = variant.c_type;
@@ -4278,7 +4298,7 @@ void transpiler_emit_union_payload_hash_eq(context_TranspileContext* ctx, slop_l
                         }
                     }
                 }
-            } else if (!_mv_1510.has_value) {
+            } else if (!_mv_1511.has_value) {
             }
             i = (i + 1);
         }
@@ -4291,9 +4311,9 @@ void transpiler_emit_record_field_dependencies(context_TranspileContext* ctx, sl
         __auto_type len = ((int64_t)((fields).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1511 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1511.has_value) {
-                __auto_type field = _mv_1511.value;
+            __auto_type _mv_1512 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1512.has_value) {
+                __auto_type field = _mv_1512.value;
                 {
                     __auto_type slop_type = field.slop_type;
                     __auto_type c_type = field.c_type;
@@ -4329,7 +4349,7 @@ void transpiler_emit_record_field_dependencies(context_TranspileContext* ctx, sl
                         }
                     }
                 }
-            } else if (!_mv_1511.has_value) {
+            } else if (!_mv_1512.has_value) {
             }
             i = (i + 1);
         }
@@ -4386,9 +4406,9 @@ uint8_t transpiler_is_primitive_slop_type(slop_string slop_type) {
 
 uint8_t transpiler_is_range_type_alias(context_TranspileContext* ctx, slop_string slop_type) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
-    __auto_type _mv_1512 = context_ctx_lookup_type_alias(ctx, slop_type);
-    if (_mv_1512.has_value) {
-        __auto_type underlying = _mv_1512.value;
+    __auto_type _mv_1513 = context_ctx_lookup_type_alias(ctx, slop_type);
+    if (_mv_1513.has_value) {
+        __auto_type underlying = _mv_1513.value;
         if (strlib_starts_with(underlying, SLOP_STR("(Int"))) {
             return 1;
         } else if (strlib_starts_with(underlying, SLOP_STR("(I64"))) {
@@ -4410,7 +4430,7 @@ uint8_t transpiler_is_range_type_alias(context_TranspileContext* ctx, slop_strin
         } else {
             return 0;
         }
-    } else if (!_mv_1512.has_value) {
+    } else if (!_mv_1513.has_value) {
         return 0;
     }
 }
@@ -4424,11 +4444,11 @@ void transpiler_emit_union_hash_fn(context_TranspileContext* ctx, slop_string c_
         __auto_type len = ((int64_t)((variants).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1513 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1513.has_value) {
-                __auto_type variant = _mv_1513.value;
+            __auto_type _mv_1514 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1514.has_value) {
+                __auto_type variant = _mv_1514.value;
                 transpiler_emit_union_variant_hash(ctx, c_type, variant);
-            } else if (!_mv_1513.has_value) {
+            } else if (!_mv_1514.has_value) {
             }
             i = (i + 1);
         }
@@ -4485,11 +4505,11 @@ void transpiler_emit_union_eq_fn(context_TranspileContext* ctx, slop_string c_ty
         __auto_type len = ((int64_t)((variants).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1514 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1514.has_value) {
-                __auto_type variant = _mv_1514.value;
+            __auto_type _mv_1515 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1515.has_value) {
+                __auto_type variant = _mv_1515.value;
                 transpiler_emit_union_variant_eq(ctx, c_type, variant);
-            } else if (!_mv_1514.has_value) {
+            } else if (!_mv_1515.has_value) {
             }
             i = (i + 1);
         }
@@ -4536,11 +4556,11 @@ void transpiler_emit_struct_hash_fn(context_TranspileContext* ctx, slop_string c
         __auto_type len = ((int64_t)((fields).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1515 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1515.has_value) {
-                __auto_type field = _mv_1515.value;
+            __auto_type _mv_1516 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1516.has_value) {
+                __auto_type field = _mv_1516.value;
                 transpiler_emit_field_hash(ctx, field);
-            } else if (!_mv_1515.has_value) {
+            } else if (!_mv_1516.has_value) {
             }
             i = (i + 1);
         }
@@ -4607,11 +4627,11 @@ void transpiler_emit_struct_eq_fn(context_TranspileContext* ctx, slop_string c_t
             {
                 int64_t i = 0;
                 while (i < len) {
-                    __auto_type _mv_1516 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1516.has_value) {
-                        __auto_type field = _mv_1516.value;
+                    __auto_type _mv_1517 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1517.has_value) {
+                        __auto_type field = _mv_1517.value;
                         transpiler_emit_field_eq(ctx, field);
-                    } else if (!_mv_1516.has_value) {
+                    } else if (!_mv_1517.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -4672,12 +4692,12 @@ void transpiler_emit_struct_key_types_header(context_TranspileContext* ctx) {
             context_ctx_emit_header(ctx, SLOP_STR("/* Hash/eq functions and list types for struct map/set keys */"));
         }
         while (i < ((int64_t)((struct_key_types).len))) {
-            __auto_type _mv_1517 = ({ __auto_type _lst = struct_key_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1517.has_value) {
-                __auto_type c_type = _mv_1517.value;
+            __auto_type _mv_1518 = ({ __auto_type _lst = struct_key_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1518.has_value) {
+                __auto_type c_type = _mv_1518.value;
                 {
                     __auto_type guard_name = context_ctx_str3(ctx, transpiler_uppercase_name(ctx, c_type), SLOP_STR("_HASH_EQ_DEFINED"), SLOP_STR(""));
-                    __auto_type list_c_name = context_ctx_str(ctx, SLOP_STR("slop_list_"), c_type);
+                    __auto_type list_c_name = context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier((*ctx).arena, c_type));
                     context_ctx_emit_header(ctx, context_ctx_str(ctx, SLOP_STR("#ifndef "), guard_name));
                     context_ctx_emit_header(ctx, context_ctx_str(ctx, SLOP_STR("#define "), guard_name));
                     transpiler_emit_struct_hash_eq(ctx, c_type);
@@ -4688,7 +4708,7 @@ void transpiler_emit_struct_key_types_header(context_TranspileContext* ctx) {
                     context_ctx_emit_header(ctx, SLOP_STR("#endif"));
                     context_ctx_emit_header(ctx, SLOP_STR(""));
                 }
-            } else if (!_mv_1517.has_value) {
+            } else if (!_mv_1518.has_value) {
             }
             i = (i + 1);
         }
@@ -4784,9 +4804,9 @@ void transpiler_emit_chan_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((chan_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1518 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1518.has_value) {
-                __auto_type ct = _mv_1518.value;
+            __auto_type _mv_1519 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1519.has_value) {
+                __auto_type ct = _mv_1519.value;
                 {
                     __auto_type elem_type = ct.elem_type;
                     __auto_type c_name = ct.c_name;
@@ -4811,7 +4831,7 @@ void transpiler_emit_chan_types_header(context_TranspileContext* ctx) {
                         }
                     }
                 }
-            } else if (!_mv_1518.has_value) {
+            } else if (!_mv_1519.has_value) {
             }
             i = (i + 1);
         }
@@ -4825,9 +4845,9 @@ void transpiler_emit_chan_funcs_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((chan_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1519 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1519.has_value) {
-                __auto_type ct = _mv_1519.value;
+            __auto_type _mv_1520 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1520.has_value) {
+                __auto_type ct = _mv_1520.value;
                 {
                     __auto_type elem_type = ct.elem_type;
                     __auto_type c_name = ct.c_name;
@@ -4835,7 +4855,7 @@ void transpiler_emit_chan_funcs_header(context_TranspileContext* ctx) {
                         transpiler_emit_chan_send_recv_funcs(ctx, c_name, elem_type);
                     }
                 }
-            } else if (!_mv_1519.has_value) {
+            } else if (!_mv_1520.has_value) {
             }
             i = (i + 1);
         }
@@ -4971,9 +4991,9 @@ void transpiler_emit_thread_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((thread_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1520 = ({ __auto_type _lst = thread_types; size_t _idx = (size_t)i; slop_option_context_ThreadType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1520.has_value) {
-                __auto_type tt = _mv_1520.value;
+            __auto_type _mv_1521 = ({ __auto_type _lst = thread_types; size_t _idx = (size_t)i; slop_option_context_ThreadType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1521.has_value) {
+                __auto_type tt = _mv_1521.value;
                 {
                     __auto_type result_type = tt.result_type;
                     __auto_type c_name = tt.c_name;
@@ -5005,7 +5025,7 @@ void transpiler_emit_thread_types_header(context_TranspileContext* ctx) {
                         }
                     }
                 }
-            } else if (!_mv_1520.has_value) {
+            } else if (!_mv_1521.has_value) {
             }
             i = (i + 1);
         }
@@ -5050,44 +5070,44 @@ slop_string transpiler_uppercase_name(context_TranspileContext* ctx, slop_string
 
 uint8_t transpiler_is_simple_enum_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1521 = (*item);
-    switch (_mv_1521.tag) {
+    __auto_type _mv_1522 = (*item);
+    switch (_mv_1522.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1521.data.lst;
+            __auto_type lst = _mv_1522.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 3) {
                     return 0;
                 } else {
-                    __auto_type _mv_1522 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1522.has_value) {
-                        __auto_type def_expr = _mv_1522.value;
-                        __auto_type _mv_1523 = (*def_expr);
-                        switch (_mv_1523.tag) {
+                    __auto_type _mv_1523 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1523.has_value) {
+                        __auto_type def_expr = _mv_1523.value;
+                        __auto_type _mv_1524 = (*def_expr);
+                        switch (_mv_1524.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type def_lst = _mv_1523.data.lst;
+                                __auto_type def_lst = _mv_1524.data.lst;
                                 {
                                     __auto_type def_items = def_lst.items;
                                     if (((int64_t)((def_items).len)) < 1) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1524 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1524.has_value) {
-                                            __auto_type head = _mv_1524.value;
-                                            __auto_type _mv_1525 = (*head);
-                                            switch (_mv_1525.tag) {
+                                        __auto_type _mv_1525 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1525.has_value) {
+                                            __auto_type head = _mv_1525.value;
+                                            __auto_type _mv_1526 = (*head);
+                                            switch (_mv_1526.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_1525.data.sym;
+                                                    __auto_type sym = _mv_1526.data.sym;
                                                     return (string_eq(sym.name, SLOP_STR("enum")) && !(transpiler_has_enum_payload_variants(def_items)));
                                                 }
                                                 default: {
                                                     return 0;
                                                 }
                                             }
-                                        } else if (!_mv_1524.has_value) {
+                                        } else if (!_mv_1525.has_value) {
                                             return 0;
                                         }
                                     }
@@ -5097,7 +5117,7 @@ uint8_t transpiler_is_simple_enum_def(types_SExpr* item) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1522.has_value) {
+                    } else if (!_mv_1523.has_value) {
                         return 0;
                     }
                 }
@@ -5116,23 +5136,11 @@ void transpiler_emit_module_types_header(context_TranspileContext* ctx, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1526 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1526.has_value) {
-                __auto_type item = _mv_1526.value;
-                if (transpiler_is_type_def(item) && transpiler_is_type_alias_def(item)) {
-                    transpiler_emit_type_alias_to_header(ctx, item);
-                }
-            } else if (!_mv_1526.has_value) {
-            }
-            i = (i + 1);
-        }
-        i = start;
-        while (i < len) {
             __auto_type _mv_1527 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_1527.has_value) {
                 __auto_type item = _mv_1527.value;
-                if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
-                    transpiler_emit_type_to_header(ctx, item);
+                if (transpiler_is_type_def(item) && transpiler_is_type_alias_def(item)) {
+                    transpiler_emit_type_alias_to_header(ctx, item);
                 }
             } else if (!_mv_1527.has_value) {
             }
@@ -5143,10 +5151,22 @@ void transpiler_emit_module_types_header(context_TranspileContext* ctx, slop_lis
             __auto_type _mv_1528 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_1528.has_value) {
                 __auto_type item = _mv_1528.value;
-                if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
+                if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
                     transpiler_emit_type_to_header(ctx, item);
                 }
             } else if (!_mv_1528.has_value) {
+            }
+            i = (i + 1);
+        }
+        i = start;
+        while (i < len) {
+            __auto_type _mv_1529 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1529.has_value) {
+                __auto_type item = _mv_1529.value;
+                if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
+                    transpiler_emit_type_to_header(ctx, item);
+                }
+            } else if (!_mv_1529.has_value) {
             }
             i = (i + 1);
         }
@@ -5159,13 +5179,13 @@ void transpiler_emit_simple_type_aliases_header(context_TranspileContext* ctx, s
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1529 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1529.has_value) {
-                __auto_type item = _mv_1529.value;
+            __auto_type _mv_1530 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1530.has_value) {
+                __auto_type item = _mv_1530.value;
                 if ((transpiler_is_type_def(item)) && (transpiler_is_type_alias_def(item)) && (!(transpiler_is_result_type_alias_def(item)))) {
                     transpiler_emit_type_alias_to_header(ctx, item);
                 }
-            } else if (!_mv_1529.has_value) {
+            } else if (!_mv_1530.has_value) {
             }
             i = (i + 1);
         }
@@ -5178,13 +5198,13 @@ void transpiler_emit_type_aliases_header(context_TranspileContext* ctx, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1530 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1530.has_value) {
-                __auto_type item = _mv_1530.value;
+            __auto_type _mv_1531 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1531.has_value) {
+                __auto_type item = _mv_1531.value;
                 if ((transpiler_is_type_def(item)) && (transpiler_is_type_alias_def(item)) && (transpiler_is_result_type_alias_def(item))) {
                     transpiler_emit_type_alias_to_header(ctx, item);
                 }
-            } else if (!_mv_1530.has_value) {
+            } else if (!_mv_1531.has_value) {
             }
             i = (i + 1);
         }
@@ -5197,13 +5217,13 @@ void transpiler_emit_simple_enums_header(context_TranspileContext* ctx, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1531 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1531.has_value) {
-                __auto_type item = _mv_1531.value;
+            __auto_type _mv_1532 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1532.has_value) {
+                __auto_type item = _mv_1532.value;
                 if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
                     transpiler_emit_type_to_header(ctx, item);
                 }
-            } else if (!_mv_1531.has_value) {
+            } else if (!_mv_1532.has_value) {
             }
             i = (i + 1);
         }
@@ -5218,9 +5238,9 @@ void transpiler_emit_pending_container_deps(context_TranspileContext* ctx, types
         __auto_type len = ((int64_t)((field_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1532 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1532.has_value) {
-                __auto_type field_type = _mv_1532.value;
+            __auto_type _mv_1533 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1533.has_value) {
+                __auto_type field_type = _mv_1533.value;
                 if (!(context_ctx_is_type_emitted(ctx, field_type)) && transpiler_is_emittable_container_type(ctx, field_type)) {
                     if (strlib_starts_with(field_type, SLOP_STR("slop_option_"))) {
                         transpiler_emit_option_by_c_name(ctx, field_type);
@@ -5229,7 +5249,7 @@ void transpiler_emit_pending_container_deps(context_TranspileContext* ctx, types
                         transpiler_emit_list_by_c_name(ctx, field_type);
                     }
                 }
-            } else if (!_mv_1532.has_value) {
+            } else if (!_mv_1533.has_value) {
             }
             i = (i + 1);
         }
@@ -5243,13 +5263,13 @@ void transpiler_emit_option_by_c_name(context_TranspileContext* ctx, slop_string
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1533 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1533.has_value) {
-                __auto_type ot = _mv_1533.value;
+            __auto_type _mv_1534 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1534.has_value) {
+                __auto_type ot = _mv_1534.value;
                 if (string_eq(ot.c_name, c_name)) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1533.has_value) {
+            } else if (!_mv_1534.has_value) {
             }
             i = (i + 1);
         }
@@ -5263,13 +5283,13 @@ void transpiler_emit_list_by_c_name(context_TranspileContext* ctx, slop_string c
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1534 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1534.has_value) {
-                __auto_type lt = _mv_1534.value;
+            __auto_type _mv_1535 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1535.has_value) {
+                __auto_type lt = _mv_1535.value;
                 if (string_eq(lt.c_name, c_name)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1534.has_value) {
+            } else if (!_mv_1535.has_value) {
             }
             i = (i + 1);
         }
@@ -5290,9 +5310,9 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                 int64_t i = start;
                 while (i < len) {
                     if (!(transpiler_index_in_list(emitted, i))) {
-                        __auto_type _mv_1535 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1535.has_value) {
-                            __auto_type item = _mv_1535.value;
+                        __auto_type _mv_1536 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1536.has_value) {
+                            __auto_type item = _mv_1536.value;
                             if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                                 if (transpiler_type_deps_satisfied(ctx, item)) {
                                     transpiler_emit_pending_container_deps(ctx, item);
@@ -5302,7 +5322,7 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                                     transpiler_emit_option_list_for_type(ctx, item);
                                 }
                             }
-                        } else if (!_mv_1535.has_value) {
+                        } else if (!_mv_1536.has_value) {
                         }
                     }
                     i = (i + 1);
@@ -5319,9 +5339,9 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                     int64_t i = start;
                     while (i < len) {
                         if (!(transpiler_index_in_list(emitted, i))) {
-                            __auto_type _mv_1536 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1536.has_value) {
-                                __auto_type item = _mv_1536.value;
+                            __auto_type _mv_1537 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1537.has_value) {
+                                __auto_type item = _mv_1537.value;
                                 if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                                     if (transpiler_type_deps_satisfied(ctx, item)) {
                                         transpiler_emit_pending_container_deps(ctx, item);
@@ -5331,7 +5351,7 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                                         transpiler_emit_option_list_for_type(ctx, item);
                                     }
                                 }
-                            } else if (!_mv_1536.has_value) {
+                            } else if (!_mv_1537.has_value) {
                             }
                         }
                         i = (i + 1);
@@ -5348,13 +5368,13 @@ uint8_t transpiler_has_unemitted_struct_types(slop_list_types_SExpr_ptr items, i
         uint8_t found = 0;
         while ((i < len) && !(found)) {
             if (!(transpiler_index_in_list(emitted, i))) {
-                __auto_type _mv_1537 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1537.has_value) {
-                    __auto_type item = _mv_1537.value;
+                __auto_type _mv_1538 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1538.has_value) {
+                    __auto_type item = _mv_1538.value;
                     if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                         found = 1;
                     }
-                } else if (!_mv_1537.has_value) {
+                } else if (!_mv_1538.has_value) {
                 }
             }
             i = (i + 1);
@@ -5369,26 +5389,26 @@ void transpiler_break_list_cycles(context_TranspileContext* ctx, slop_list_types
         int64_t i = start;
         while (i < len) {
             if (!(transpiler_index_in_list(emitted, i))) {
-                __auto_type _mv_1538 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1538.has_value) {
-                    __auto_type item = _mv_1538.value;
+                __auto_type _mv_1539 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1539.has_value) {
+                    __auto_type item = _mv_1539.value;
                     if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                         {
                             __auto_type blocking_deps = transpiler_find_blocking_list_deps(ctx, item);
                             __auto_type dep_len = ((int64_t)((blocking_deps).len));
                             __auto_type j = 0;
                             while (j < dep_len) {
-                                __auto_type _mv_1539 = ({ __auto_type _lst = blocking_deps; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1539.has_value) {
-                                    __auto_type dep_name = _mv_1539.value;
+                                __auto_type _mv_1540 = ({ __auto_type _lst = blocking_deps; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1540.has_value) {
+                                    __auto_type dep_name = _mv_1540.value;
                                     transpiler_emit_list_declare_by_c_name(ctx, dep_name);
-                                } else if (!_mv_1539.has_value) {
+                                } else if (!_mv_1540.has_value) {
                                 }
                                 j = (j + 1);
                             }
                         }
                     }
-                } else if (!_mv_1538.has_value) {
+                } else if (!_mv_1539.has_value) {
                 }
             }
             i = (i + 1);
@@ -5406,13 +5426,13 @@ slop_list_string transpiler_find_blocking_list_deps(context_TranspileContext* ct
         __auto_type result = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1540 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1540.has_value) {
-                __auto_type field_type = _mv_1540.value;
+            __auto_type _mv_1541 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1541.has_value) {
+                __auto_type field_type = _mv_1541.value;
                 if ((strlib_starts_with(field_type, SLOP_STR("slop_list_"))) && (!(context_ctx_is_type_emitted(ctx, field_type))) && (!(transpiler_is_runtime_list_type(field_type)))) {
                     ({ __auto_type _lst_p = &(result); __auto_type _item = (field_type); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                 }
-            } else if (!_mv_1540.has_value) {
+            } else if (!_mv_1541.has_value) {
             }
             i = (i + 1);
         }
@@ -5427,13 +5447,13 @@ void transpiler_emit_list_declare_by_c_name(context_TranspileContext* ctx, slop_
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1541 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1541.has_value) {
-                __auto_type lt = _mv_1541.value;
+            __auto_type _mv_1542 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1542.has_value) {
+                __auto_type lt = _mv_1542.value;
                 if (string_eq(lt.c_name, c_name)) {
                     transpiler_emit_list_type_declare_only(ctx, lt);
                 }
-            } else if (!_mv_1541.has_value) {
+            } else if (!_mv_1542.has_value) {
             }
             i = (i + 1);
         }
@@ -5446,13 +5466,13 @@ uint8_t transpiler_index_in_list(slop_list_int lst, int64_t idx) {
         int64_t i = 0;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1542 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_int _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1542.has_value) {
-                __auto_type v = _mv_1542.value;
+            __auto_type _mv_1543 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_int _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1543.has_value) {
+                __auto_type v = _mv_1543.value;
                 if (v == idx) {
                     found = 1;
                 }
-            } else if (!_mv_1542.has_value) {
+            } else if (!_mv_1543.has_value) {
             }
             i = (i + 1);
         }
@@ -5469,13 +5489,13 @@ uint8_t transpiler_type_deps_satisfied(context_TranspileContext* ctx, types_SExp
         int64_t i = 0;
         uint8_t all_satisfied = 1;
         while ((i < len) && all_satisfied) {
-            __auto_type _mv_1543 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1543.has_value) {
-                __auto_type field_type = _mv_1543.value;
+            __auto_type _mv_1544 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1544.has_value) {
+                __auto_type field_type = _mv_1544.value;
                 if (!(transpiler_type_is_available(ctx, field_type))) {
                     all_satisfied = 0;
                 }
-            } else if (!_mv_1543.has_value) {
+            } else if (!_mv_1544.has_value) {
             }
             i = (i + 1);
         }
@@ -5522,34 +5542,34 @@ slop_list_string transpiler_get_type_field_types(context_TranspileContext* ctx, 
     {
         __auto_type arena = (*ctx).arena;
         __auto_type result = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
-        __auto_type _mv_1544 = (*type_def);
-        switch (_mv_1544.tag) {
+        __auto_type _mv_1545 = (*type_def);
+        switch (_mv_1545.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1544.data.lst;
+                __auto_type lst = _mv_1545.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_1545 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1545.has_value) {
-                            __auto_type def_expr = _mv_1545.value;
-                            __auto_type _mv_1546 = (*def_expr);
-                            switch (_mv_1546.tag) {
+                        __auto_type _mv_1546 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1546.has_value) {
+                            __auto_type def_expr = _mv_1546.value;
+                            __auto_type _mv_1547 = (*def_expr);
+                            switch (_mv_1547.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type def_lst = _mv_1546.data.lst;
+                                    __auto_type def_lst = _mv_1547.data.lst;
                                     {
                                         __auto_type def_items = def_lst.items;
                                         __auto_type def_len = ((int64_t)((def_items).len));
                                         if (def_len > 0) {
-                                            __auto_type _mv_1547 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1547.has_value) {
-                                                __auto_type head = _mv_1547.value;
-                                                __auto_type _mv_1548 = (*head);
-                                                switch (_mv_1548.tag) {
+                                            __auto_type _mv_1548 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1548.has_value) {
+                                                __auto_type head = _mv_1548.value;
+                                                __auto_type _mv_1549 = (*head);
+                                                switch (_mv_1549.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type sym = _mv_1548.data.sym;
+                                                        __auto_type sym = _mv_1549.data.sym;
                                                         {
                                                             __auto_type kind = sym.name;
                                                             if (string_eq(kind, SLOP_STR("record"))) {
@@ -5565,7 +5585,7 @@ slop_list_string transpiler_get_type_field_types(context_TranspileContext* ctx, 
                                                         break;
                                                     }
                                                 }
-                                            } else if (!_mv_1547.has_value) {
+                                            } else if (!_mv_1548.has_value) {
                                             }
                                         }
                                     }
@@ -5575,7 +5595,7 @@ slop_list_string transpiler_get_type_field_types(context_TranspileContext* ctx, 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1545.has_value) {
+                        } else if (!_mv_1546.has_value) {
                         }
                     }
                 }
@@ -5597,25 +5617,25 @@ slop_list_string transpiler_extract_record_field_types(context_TranspileContext*
         __auto_type len = ((int64_t)((def_items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1549 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1549.has_value) {
-                __auto_type field_expr = _mv_1549.value;
-                __auto_type _mv_1550 = (*field_expr);
-                switch (_mv_1550.tag) {
+            __auto_type _mv_1550 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1550.has_value) {
+                __auto_type field_expr = _mv_1550.value;
+                __auto_type _mv_1551 = (*field_expr);
+                switch (_mv_1551.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type field_lst = _mv_1550.data.lst;
+                        __auto_type field_lst = _mv_1551.data.lst;
                         if (((int64_t)((field_lst.items).len)) >= 2) {
-                            __auto_type _mv_1551 = ({ __auto_type _lst = field_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1551.has_value) {
-                                __auto_type type_expr = _mv_1551.value;
+                            __auto_type _mv_1552 = ({ __auto_type _lst = field_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1552.has_value) {
+                                __auto_type type_expr = _mv_1552.value;
                                 {
                                     __auto_type type_str = transpiler_get_field_type_string(ctx, type_expr);
                                     if (!(string_eq(type_str, SLOP_STR("")))) {
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (type_str); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
                                 }
-                            } else if (!_mv_1551.has_value) {
+                            } else if (!_mv_1552.has_value) {
                             }
                         }
                         break;
@@ -5624,7 +5644,7 @@ slop_list_string transpiler_extract_record_field_types(context_TranspileContext*
                         break;
                     }
                 }
-            } else if (!_mv_1549.has_value) {
+            } else if (!_mv_1550.has_value) {
             }
             i = (i + 1);
         }
@@ -5640,25 +5660,25 @@ slop_list_string transpiler_extract_union_variant_types(context_TranspileContext
         __auto_type len = ((int64_t)((def_items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1552 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1552.has_value) {
-                __auto_type variant_expr = _mv_1552.value;
-                __auto_type _mv_1553 = (*variant_expr);
-                switch (_mv_1553.tag) {
+            __auto_type _mv_1553 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1553.has_value) {
+                __auto_type variant_expr = _mv_1553.value;
+                __auto_type _mv_1554 = (*variant_expr);
+                switch (_mv_1554.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type variant_lst = _mv_1553.data.lst;
+                        __auto_type variant_lst = _mv_1554.data.lst;
                         if (((int64_t)((variant_lst.items).len)) >= 2) {
-                            __auto_type _mv_1554 = ({ __auto_type _lst = variant_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1554.has_value) {
-                                __auto_type type_expr = _mv_1554.value;
+                            __auto_type _mv_1555 = ({ __auto_type _lst = variant_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1555.has_value) {
+                                __auto_type type_expr = _mv_1555.value;
                                 {
                                     __auto_type type_str = transpiler_get_field_type_string(ctx, type_expr);
                                     if (!(string_eq(type_str, SLOP_STR("")))) {
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (type_str); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
                                 }
-                            } else if (!_mv_1554.has_value) {
+                            } else if (!_mv_1555.has_value) {
                             }
                         }
                         break;
@@ -5667,7 +5687,7 @@ slop_list_string transpiler_extract_union_variant_types(context_TranspileContext
                         break;
                     }
                 }
-            } else if (!_mv_1552.has_value) {
+            } else if (!_mv_1553.has_value) {
             }
             i = (i + 1);
         }
@@ -5680,62 +5700,43 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1555 = (*type_expr);
-        switch (_mv_1555.tag) {
+        __auto_type _mv_1556 = (*type_expr);
+        switch (_mv_1556.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1555.data.sym;
+                __auto_type sym = _mv_1556.data.sym;
                 {
                     __auto_type name = sym.name;
-                    __auto_type _mv_1556 = context_ctx_lookup_type(ctx, name);
-                    if (_mv_1556.has_value) {
-                        __auto_type entry = _mv_1556.value;
+                    __auto_type _mv_1557 = context_ctx_lookup_type(ctx, name);
+                    if (_mv_1557.has_value) {
+                        __auto_type entry = _mv_1557.value;
                         return entry.c_name;
-                    } else if (!_mv_1556.has_value) {
+                    } else if (!_mv_1557.has_value) {
                         return ctype_to_c_type(arena, type_expr);
                     }
                 }
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1555.data.lst;
+                __auto_type lst = _mv_1556.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 1) {
                         return SLOP_STR("");
                     } else {
-                        __auto_type _mv_1557 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1557.has_value) {
-                            __auto_type head = _mv_1557.value;
-                            __auto_type _mv_1558 = (*head);
-                            switch (_mv_1558.tag) {
+                        __auto_type _mv_1558 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1558.has_value) {
+                            __auto_type head = _mv_1558.value;
+                            __auto_type _mv_1559 = (*head);
+                            switch (_mv_1559.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1558.data.sym;
+                                    __auto_type sym = _mv_1559.data.sym;
                                     {
                                         __auto_type kind = sym.name;
                                         if (string_eq(kind, SLOP_STR("Ptr"))) {
                                             return SLOP_STR("");
                                         } else if (string_eq(kind, SLOP_STR("Option"))) {
-                                            if (((int64_t)((items).len)) >= 2) {
-                                                __auto_type _mv_1559 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1559.has_value) {
-                                                    __auto_type inner = _mv_1559.value;
-                                                    {
-                                                        __auto_type inner_str = transpiler_get_field_type_string(ctx, inner);
-                                                        if (string_eq(inner_str, SLOP_STR(""))) {
-                                                            return SLOP_STR("");
-                                                        } else {
-                                                            return context_ctx_str(ctx, SLOP_STR("slop_option_"), ctype_type_to_identifier(arena, inner_str));
-                                                        }
-                                                    }
-                                                } else if (!_mv_1559.has_value) {
-                                                    return SLOP_STR("");
-                                                }
-                                            } else {
-                                                return SLOP_STR("");
-                                            }
-                                        } else if (string_eq(kind, SLOP_STR("List"))) {
                                             if (((int64_t)((items).len)) >= 2) {
                                                 __auto_type _mv_1560 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                                 if (_mv_1560.has_value) {
@@ -5745,10 +5746,29 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                                                         if (string_eq(inner_str, SLOP_STR(""))) {
                                                             return SLOP_STR("");
                                                         } else {
-                                                            return context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, inner_str));
+                                                            return context_ctx_str(ctx, SLOP_STR("slop_option_"), ctype_type_to_identifier(arena, inner_str));
                                                         }
                                                     }
                                                 } else if (!_mv_1560.has_value) {
+                                                    return SLOP_STR("");
+                                                }
+                                            } else {
+                                                return SLOP_STR("");
+                                            }
+                                        } else if (string_eq(kind, SLOP_STR("List"))) {
+                                            if (((int64_t)((items).len)) >= 2) {
+                                                __auto_type _mv_1561 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1561.has_value) {
+                                                    __auto_type inner = _mv_1561.value;
+                                                    {
+                                                        __auto_type inner_str = transpiler_get_field_type_string(ctx, inner);
+                                                        if (string_eq(inner_str, SLOP_STR(""))) {
+                                                            return SLOP_STR("");
+                                                        } else {
+                                                            return context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, inner_str));
+                                                        }
+                                                    }
+                                                } else if (!_mv_1561.has_value) {
                                                     return SLOP_STR("");
                                                 }
                                             } else {
@@ -5763,7 +5783,7 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                                     return SLOP_STR("");
                                 }
                             }
-                        } else if (!_mv_1557.has_value) {
+                        } else if (!_mv_1558.has_value) {
                             return SLOP_STR("");
                         }
                     }
@@ -5791,31 +5811,31 @@ void transpiler_emit_option_list_for_type(context_TranspileContext* ctx, types_S
 slop_string transpiler_get_type_c_name(context_TranspileContext* ctx, types_SExpr* type_def) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
-    __auto_type _mv_1561 = (*type_def);
-    switch (_mv_1561.tag) {
+    __auto_type _mv_1562 = (*type_def);
+    switch (_mv_1562.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1561.data.lst;
+            __auto_type lst = _mv_1562.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return SLOP_STR("");
                 } else {
-                    __auto_type _mv_1562 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1562.has_value) {
-                        __auto_type name_expr = _mv_1562.value;
-                        __auto_type _mv_1563 = (*name_expr);
-                        switch (_mv_1563.tag) {
+                    __auto_type _mv_1563 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1563.has_value) {
+                        __auto_type name_expr = _mv_1563.value;
+                        __auto_type _mv_1564 = (*name_expr);
+                        switch (_mv_1564.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1563.data.sym;
+                                __auto_type sym = _mv_1564.data.sym;
                                 {
                                     __auto_type name = sym.name;
-                                    __auto_type _mv_1564 = context_ctx_lookup_type(ctx, name);
-                                    if (_mv_1564.has_value) {
-                                        __auto_type entry = _mv_1564.value;
+                                    __auto_type _mv_1565 = context_ctx_lookup_type(ctx, name);
+                                    if (_mv_1565.has_value) {
+                                        __auto_type entry = _mv_1565.value;
                                         return entry.c_name;
-                                    } else if (!_mv_1564.has_value) {
+                                    } else if (!_mv_1565.has_value) {
                                         return SLOP_STR("");
                                     }
                                 }
@@ -5824,7 +5844,7 @@ slop_string transpiler_get_type_c_name(context_TranspileContext* ctx, types_SExp
                                 return SLOP_STR("");
                             }
                         }
-                    } else if (!_mv_1562.has_value) {
+                    } else if (!_mv_1563.has_value) {
                         return SLOP_STR("");
                     }
                 }
@@ -5843,13 +5863,13 @@ void transpiler_emit_option_for_inner_type(context_TranspileContext* ctx, slop_s
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1565 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1565.has_value) {
-                __auto_type ot = _mv_1565.value;
+            __auto_type _mv_1566 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1566.has_value) {
+                __auto_type ot = _mv_1566.value;
                 if (string_eq(ot.inner_type, inner_c_name) && !(transpiler_is_pointer_elem_type(ot.inner_type))) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1565.has_value) {
+            } else if (!_mv_1566.has_value) {
             }
             i = (i + 1);
         }
@@ -5863,14 +5883,14 @@ void transpiler_emit_list_for_elem_type(context_TranspileContext* ctx, slop_stri
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1566 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1566.has_value) {
-                __auto_type lt = _mv_1566.value;
+            __auto_type _mv_1567 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1567.has_value) {
+                __auto_type lt = _mv_1567.value;
                 if (string_eq(lt.elem_type, elem_c_name) && !(transpiler_is_pointer_elem_type(lt.elem_type))) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                     transpiler_emit_option_for_inner_type(ctx, lt.c_name);
                 }
-            } else if (!_mv_1566.has_value) {
+            } else if (!_mv_1567.has_value) {
             }
             i = (i + 1);
         }
@@ -5888,13 +5908,13 @@ uint8_t transpiler_struct_uses_value_list_or_option(context_TranspileContext* ct
             __auto_type len = ((int64_t)((list_types).len));
             int64_t i = 0;
             while ((i < len) && !(found)) {
-                __auto_type _mv_1567 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1567.has_value) {
-                    __auto_type lt = _mv_1567.value;
+                __auto_type _mv_1568 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1568.has_value) {
+                    __auto_type lt = _mv_1568.value;
                     if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_struct_uses_list_type(ctx, type_def, lt.c_name)) {
                         found = 1;
                     }
-                } else if (!_mv_1567.has_value) {
+                } else if (!_mv_1568.has_value) {
                 }
                 i = (i + 1);
             }
@@ -5904,13 +5924,13 @@ uint8_t transpiler_struct_uses_value_list_or_option(context_TranspileContext* ct
                 __auto_type len2 = ((int64_t)((option_types).len));
                 int64_t j = 0;
                 while ((j < len2) && !(found)) {
-                    __auto_type _mv_1568 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)j; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1568.has_value) {
-                        __auto_type ot = _mv_1568.value;
+                    __auto_type _mv_1569 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)j; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1569.has_value) {
+                        __auto_type ot = _mv_1569.value;
                         if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_struct_uses_option_type(ctx, type_def, ot.c_name)) {
                             found = 1;
                         }
-                    } else if (!_mv_1568.has_value) {
+                    } else if (!_mv_1569.has_value) {
                     }
                     j = (j + 1);
                 }
@@ -5928,13 +5948,13 @@ void transpiler_emit_struct_dependent_list_types(context_TranspileContext* ctx, 
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1569 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1569.has_value) {
-                __auto_type lt = _mv_1569.value;
+            __auto_type _mv_1570 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1570.has_value) {
+                __auto_type lt = _mv_1570.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_struct_uses_list_type(ctx, type_def, lt.c_name)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1569.has_value) {
+            } else if (!_mv_1570.has_value) {
             }
             i = (i + 1);
         }
@@ -5949,14 +5969,14 @@ void transpiler_emit_struct_dependent_option_types(context_TranspileContext* ctx
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1570 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1570.has_value) {
-                __auto_type ot = _mv_1570.value;
+            __auto_type _mv_1571 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1571.has_value) {
+                __auto_type ot = _mv_1571.value;
                 if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_struct_uses_option_type(ctx, type_def, ot.c_name)) {
                     transpiler_emit_list_type_if_needed(ctx, ot.inner_type);
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1570.has_value) {
+            } else if (!_mv_1571.has_value) {
             }
             i = (i + 1);
         }
@@ -5971,15 +5991,15 @@ void transpiler_emit_struct_dependent_list_types_safe(context_TranspileContext* 
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1571 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1571.has_value) {
-                __auto_type lt = _mv_1571.value;
+            __auto_type _mv_1572 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1572.has_value) {
+                __auto_type lt = _mv_1572.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_struct_uses_list_type(ctx, type_def, lt.c_name)) {
                     if (transpiler_is_type_emitted_or_primitive(ctx, lt.elem_type)) {
                         transpiler_emit_single_list_type_header(ctx, lt);
                     }
                 }
-            } else if (!_mv_1571.has_value) {
+            } else if (!_mv_1572.has_value) {
             }
             i = (i + 1);
         }
@@ -5994,16 +6014,16 @@ void transpiler_emit_struct_dependent_option_types_safe(context_TranspileContext
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1572 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1572.has_value) {
-                __auto_type ot = _mv_1572.value;
+            __auto_type _mv_1573 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1573.has_value) {
+                __auto_type ot = _mv_1573.value;
                 if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_struct_uses_option_type(ctx, type_def, ot.c_name)) {
                     if (transpiler_is_type_emitted_or_primitive(ctx, ot.inner_type)) {
                         transpiler_emit_list_type_if_needed_safe(ctx, ot.inner_type);
                         transpiler_emit_single_option_type_header(ctx, ot);
                     }
                 }
-            } else if (!_mv_1572.has_value) {
+            } else if (!_mv_1573.has_value) {
             }
             i = (i + 1);
         }
@@ -6028,9 +6048,9 @@ uint8_t transpiler_is_imported_type(context_TranspileContext* ctx, slop_string t
     if (strlib_starts_with(type_name, SLOP_STR("slop_list_")) || strlib_starts_with(type_name, SLOP_STR("slop_option_"))) {
         return 0;
     } else {
-        __auto_type _mv_1573 = context_ctx_get_module(ctx);
-        if (_mv_1573.has_value) {
-            __auto_type current_mod = _mv_1573.value;
+        __auto_type _mv_1574 = context_ctx_get_module(ctx);
+        if (_mv_1574.has_value) {
+            __auto_type current_mod = _mv_1574.value;
             {
                 __auto_type arena = (*ctx).arena;
                 __auto_type c_mod = ctype_to_c_name(arena, current_mod);
@@ -6044,7 +6064,7 @@ uint8_t transpiler_is_imported_type(context_TranspileContext* ctx, slop_string t
                     }
                 }
             }
-        } else if (!_mv_1573.has_value) {
+        } else if (!_mv_1574.has_value) {
             return 0;
         }
     }
@@ -6075,13 +6095,13 @@ void transpiler_emit_list_type_if_needed_safe(context_TranspileContext* ctx, slo
             __auto_type len = ((int64_t)((list_types).len));
             int64_t i = 0;
             while (i < len) {
-                __auto_type _mv_1574 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1574.has_value) {
-                    __auto_type lt = _mv_1574.value;
+                __auto_type _mv_1575 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1575.has_value) {
+                    __auto_type lt = _mv_1575.value;
                     if (string_eq(lt.c_name, inner_type) && transpiler_is_type_emitted_or_primitive(ctx, lt.elem_type)) {
                         transpiler_emit_single_list_type_header(ctx, lt);
                     }
-                } else if (!_mv_1574.has_value) {
+                } else if (!_mv_1575.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6097,13 +6117,13 @@ void transpiler_emit_list_type_if_needed(context_TranspileContext* ctx, slop_str
             __auto_type len = ((int64_t)((list_types).len));
             int64_t i = 0;
             while (i < len) {
-                __auto_type _mv_1575 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1575.has_value) {
-                    __auto_type lt = _mv_1575.value;
+                __auto_type _mv_1576 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1576.has_value) {
+                    __auto_type lt = _mv_1576.value;
                     if (string_eq(lt.c_name, inner_type)) {
                         transpiler_emit_single_list_type_header(ctx, lt);
                     }
-                } else if (!_mv_1575.has_value) {
+                } else if (!_mv_1576.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6116,21 +6136,21 @@ uint8_t transpiler_struct_uses_list_type(context_TranspileContext* ctx, types_SE
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1576 = (*type_def);
-        switch (_mv_1576.tag) {
+        __auto_type _mv_1577 = (*type_def);
+        switch (_mv_1577.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1576.data.lst;
+                __auto_type lst = _mv_1577.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 3) {
                         return 0;
                     } else {
-                        __auto_type _mv_1577 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1577.has_value) {
-                            __auto_type body_expr = _mv_1577.value;
+                        __auto_type _mv_1578 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1578.has_value) {
+                            __auto_type body_expr = _mv_1578.value;
                             return transpiler_type_body_uses_typename(ctx, body_expr, list_type_name);
-                        } else if (!_mv_1577.has_value) {
+                        } else if (!_mv_1578.has_value) {
                             return 0;
                         }
                     }
@@ -6154,24 +6174,24 @@ uint8_t transpiler_type_body_uses_typename(context_TranspileContext* ctx, types_
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1578 = (*body_expr);
-        switch (_mv_1578.tag) {
+        __auto_type _mv_1579 = (*body_expr);
+        switch (_mv_1579.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1578.data.lst;
+                __auto_type lst = _mv_1579.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type found = 0;
                     __auto_type i = 1;
                     while ((i < len) && !(found)) {
-                        __auto_type _mv_1579 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1579.has_value) {
-                            __auto_type field_expr = _mv_1579.value;
+                        __auto_type _mv_1580 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1580.has_value) {
+                            __auto_type field_expr = _mv_1580.value;
                             if (transpiler_field_uses_typename(ctx, field_expr, typename)) {
                                 found = 1;
                             }
-                        } else if (!_mv_1579.has_value) {
+                        } else if (!_mv_1580.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -6188,24 +6208,24 @@ uint8_t transpiler_type_body_uses_typename(context_TranspileContext* ctx, types_
 uint8_t transpiler_field_uses_typename(context_TranspileContext* ctx, types_SExpr* field_expr, slop_string typename) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((field_expr != NULL)), "(!= field-expr nil)");
-    __auto_type _mv_1580 = (*field_expr);
-    switch (_mv_1580.tag) {
+    __auto_type _mv_1581 = (*field_expr);
+    switch (_mv_1581.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1580.data.lst;
+            __auto_type lst = _mv_1581.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return 0;
                 } else {
-                    __auto_type _mv_1581 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1581.has_value) {
-                        __auto_type type_expr = _mv_1581.value;
+                    __auto_type _mv_1582 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1582.has_value) {
+                        __auto_type type_expr = _mv_1582.value;
                         {
                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                             return string_eq(c_type, typename);
                         }
-                    } else if (!_mv_1581.has_value) {
+                    } else if (!_mv_1582.has_value) {
                         return 0;
                     }
                 }
@@ -6222,33 +6242,33 @@ void transpiler_emit_type_to_header(context_TranspileContext* ctx, types_SExpr* 
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1582 = (*type_def);
-        switch (_mv_1582.tag) {
+        __auto_type _mv_1583 = (*type_def);
+        switch (_mv_1583.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1582.data.lst;
+                __auto_type lst = _mv_1583.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 3) {
-                        __auto_type _mv_1583 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1583.has_value) {
-                            __auto_type name_expr = _mv_1583.value;
-                            __auto_type _mv_1584 = (*name_expr);
-                            switch (_mv_1584.tag) {
+                        __auto_type _mv_1584 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1584.has_value) {
+                            __auto_type name_expr = _mv_1584.value;
+                            __auto_type _mv_1585 = (*name_expr);
+                            switch (_mv_1585.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1584.data.sym;
+                                    __auto_type name_sym = _mv_1585.data.sym;
                                     {
                                         __auto_type type_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, type_name);
                                         __auto_type c_name = ((context_ctx_prefixing_enabled(ctx)) ? ({ __auto_type _mv = context_ctx_get_module(ctx); _mv.has_value ? ({ __auto_type mod_name = _mv.value; context_ctx_str(ctx, ctype_to_c_name(arena, mod_name), context_ctx_str(ctx, SLOP_STR("_"), base_name)); }) : (base_name); }) : base_name);
-                                        __auto_type _mv_1585 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1585.has_value) {
-                                            __auto_type body_expr = _mv_1585.value;
+                                        __auto_type _mv_1586 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1586.has_value) {
+                                            __auto_type body_expr = _mv_1586.value;
                                             transpiler_emit_type_body_to_header(ctx, type_name, c_name, body_expr);
                                             context_ctx_mark_type_emitted(ctx, c_name);
-                                        } else if (!_mv_1585.has_value) {
+                                        } else if (!_mv_1586.has_value) {
                                         }
                                     }
                                     break;
@@ -6257,7 +6277,7 @@ void transpiler_emit_type_to_header(context_TranspileContext* ctx, types_SExpr* 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1583.has_value) {
+                        } else if (!_mv_1584.has_value) {
                         }
                     }
                 }
@@ -6275,23 +6295,23 @@ void transpiler_emit_type_body_to_header(context_TranspileContext* ctx, slop_str
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1586 = (*body_expr);
-        switch (_mv_1586.tag) {
+        __auto_type _mv_1587 = (*body_expr);
+        switch (_mv_1587.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1586.data.lst;
+                __auto_type lst = _mv_1587.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 1) {
                     } else {
-                        __auto_type _mv_1587 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1587.has_value) {
-                            __auto_type kind_expr = _mv_1587.value;
-                            __auto_type _mv_1588 = (*kind_expr);
-                            switch (_mv_1588.tag) {
+                        __auto_type _mv_1588 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1588.has_value) {
+                            __auto_type kind_expr = _mv_1588.value;
+                            __auto_type _mv_1589 = (*kind_expr);
+                            switch (_mv_1589.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type kind_sym = _mv_1588.data.sym;
+                                    __auto_type kind_sym = _mv_1589.data.sym;
                                     {
                                         __auto_type kind = kind_sym.name;
                                         if (string_eq(kind, SLOP_STR("enum"))) {
@@ -6309,7 +6329,7 @@ void transpiler_emit_type_body_to_header(context_TranspileContext* ctx, slop_str
                                     break;
                                 }
                             }
-                        } else if (!_mv_1587.has_value) {
+                        } else if (!_mv_1588.has_value) {
                         }
                     }
                 }
@@ -6330,14 +6350,14 @@ void transpiler_emit_enum_to_header(context_TranspileContext* ctx, slop_string c
         int64_t i = 1;
         context_ctx_emit_header(ctx, SLOP_STR("typedef enum {"));
         while (i < len) {
-            __auto_type _mv_1589 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1589.has_value) {
-                __auto_type variant_expr = _mv_1589.value;
-                __auto_type _mv_1590 = (*variant_expr);
-                switch (_mv_1590.tag) {
+            __auto_type _mv_1590 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1590.has_value) {
+                __auto_type variant_expr = _mv_1590.value;
+                __auto_type _mv_1591 = (*variant_expr);
+                switch (_mv_1591.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type variant_sym = _mv_1590.data.sym;
+                        __auto_type variant_sym = _mv_1591.data.sym;
                         {
                             __auto_type variant_name = variant_sym.name;
                             __auto_type c_variant = context_ctx_str3(ctx, c_name, SLOP_STR("_"), ctype_to_c_name(arena, variant_name));
@@ -6354,7 +6374,7 @@ void transpiler_emit_enum_to_header(context_TranspileContext* ctx, slop_string c
                         break;
                     }
                 }
-            } else if (!_mv_1589.has_value) {
+            } else if (!_mv_1590.has_value) {
             }
             i = (i + 1);
         }
@@ -6372,11 +6392,11 @@ void transpiler_emit_struct_to_header(context_TranspileContext* ctx, slop_string
         int64_t i = 1;
         context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("struct "), c_name, SLOP_STR(" {")));
         while (i < len) {
-            __auto_type _mv_1591 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1591.has_value) {
-                __auto_type field_expr = _mv_1591.value;
+            __auto_type _mv_1592 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1592.has_value) {
+                __auto_type field_expr = _mv_1592.value;
                 transpiler_emit_field_to_header(ctx, raw_type_name, c_name, field_expr);
-            } else if (!_mv_1591.has_value) {
+            } else if (!_mv_1592.has_value) {
             }
             i = (i + 1);
         }
@@ -6391,28 +6411,28 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
     SLOP_PRE(((field_expr != NULL)), "(!= field-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1592 = (*field_expr);
-        switch (_mv_1592.tag) {
+        __auto_type _mv_1593 = (*field_expr);
+        switch (_mv_1593.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1592.data.lst;
+                __auto_type lst = _mv_1593.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_1593 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1593.has_value) {
-                            __auto_type name_expr = _mv_1593.value;
-                            __auto_type _mv_1594 = (*name_expr);
-                            switch (_mv_1594.tag) {
+                        __auto_type _mv_1594 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1594.has_value) {
+                            __auto_type name_expr = _mv_1594.value;
+                            __auto_type _mv_1595 = (*name_expr);
+                            switch (_mv_1595.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1594.data.sym;
+                                    __auto_type name_sym = _mv_1595.data.sym;
                                     {
                                         __auto_type field_name = name_sym.name;
                                         __auto_type c_field_name = ctype_to_c_name(arena, field_name);
-                                        __auto_type _mv_1595 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1595.has_value) {
-                                            __auto_type type_expr = _mv_1595.value;
+                                        __auto_type _mv_1596 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1596.has_value) {
+                                            __auto_type type_expr = _mv_1596.value;
                                             {
                                                 __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                 __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
@@ -6421,7 +6441,7 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
                                                 context_ctx_register_field_type(ctx, raw_type_name, field_name, c_type, slop_type_str, is_ptr);
                                                 context_ctx_register_field_type(ctx, c_type_name, field_name, c_type, slop_type_str, is_ptr);
                                             }
-                                        } else if (!_mv_1595.has_value) {
+                                        } else if (!_mv_1596.has_value) {
                                         }
                                     }
                                     break;
@@ -6430,7 +6450,7 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1593.has_value) {
+                        } else if (!_mv_1594.has_value) {
                         }
                     }
                 }
@@ -6445,31 +6465,31 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
 
 uint8_t transpiler_is_pointer_type_expr_header(types_SExpr* type_expr) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_1596 = (*type_expr);
-    switch (_mv_1596.tag) {
+    __auto_type _mv_1597 = (*type_expr);
+    switch (_mv_1597.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1596.data.lst;
+            __auto_type lst = _mv_1597.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1597 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1597.has_value) {
-                        __auto_type head = _mv_1597.value;
-                        __auto_type _mv_1598 = (*head);
-                        switch (_mv_1598.tag) {
+                    __auto_type _mv_1598 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1598.has_value) {
+                        __auto_type head = _mv_1598.value;
+                        __auto_type _mv_1599 = (*head);
+                        switch (_mv_1599.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1598.data.sym;
+                                __auto_type sym = _mv_1599.data.sym;
                                 return string_eq(sym.name, SLOP_STR("Ptr"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1597.has_value) {
+                    } else if (!_mv_1598.has_value) {
                         return 0;
                     }
                 }
@@ -6491,9 +6511,9 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
         {
             int64_t i = 1;
             while (i < len) {
-                __auto_type _mv_1599 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1599.has_value) {
-                    __auto_type variant_expr = _mv_1599.value;
+                __auto_type _mv_1600 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1600.has_value) {
+                    __auto_type variant_expr = _mv_1600.value;
                     {
                         __auto_type variant_name = transpiler_get_variant_name(variant_expr);
                         __auto_type c_variant = context_ctx_str3(ctx, c_name, SLOP_STR("_"), ctype_to_c_name(arena, variant_name));
@@ -6504,7 +6524,7 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
                             context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("    "), c_variant, SLOP_STR(",")));
                         }
                     }
-                } else if (!_mv_1599.has_value) {
+                } else if (!_mv_1600.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6517,11 +6537,11 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
         {
             int64_t i = 1;
             while (i < len) {
-                __auto_type _mv_1600 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1600.has_value) {
-                    __auto_type variant_expr = _mv_1600.value;
+                __auto_type _mv_1601 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1601.has_value) {
+                    __auto_type variant_expr = _mv_1601.value;
                     transpiler_emit_union_variant_to_header(ctx, variant_expr);
-                } else if (!_mv_1600.has_value) {
+                } else if (!_mv_1601.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6535,36 +6555,36 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
 
 slop_string transpiler_get_variant_name(types_SExpr* variant_expr) {
     SLOP_PRE(((variant_expr != NULL)), "(!= variant-expr nil)");
-    __auto_type _mv_1601 = (*variant_expr);
-    switch (_mv_1601.tag) {
+    __auto_type _mv_1602 = (*variant_expr);
+    switch (_mv_1602.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1601.data.sym;
+            __auto_type sym = _mv_1602.data.sym;
             return sym.name;
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1601.data.lst;
+            __auto_type lst = _mv_1602.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return SLOP_STR("unknown");
                 } else {
-                    __auto_type _mv_1602 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1602.has_value) {
-                        __auto_type name_expr = _mv_1602.value;
-                        __auto_type _mv_1603 = (*name_expr);
-                        switch (_mv_1603.tag) {
+                    __auto_type _mv_1603 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1603.has_value) {
+                        __auto_type name_expr = _mv_1603.value;
+                        __auto_type _mv_1604 = (*name_expr);
+                        switch (_mv_1604.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type name_sym = _mv_1603.data.sym;
+                                __auto_type name_sym = _mv_1604.data.sym;
                                 return name_sym.name;
                             }
                             default: {
                                 return SLOP_STR("unknown");
                             }
                         }
-                    } else if (!_mv_1602.has_value) {
+                    } else if (!_mv_1603.has_value) {
                         return SLOP_STR("unknown");
                     }
                 }
@@ -6581,35 +6601,35 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
     SLOP_PRE(((variant_expr != NULL)), "(!= variant-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1604 = (*variant_expr);
-        switch (_mv_1604.tag) {
+        __auto_type _mv_1605 = (*variant_expr);
+        switch (_mv_1605.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1604.data.sym;
+                __auto_type sym = _mv_1605.data.sym;
                 break;
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1604.data.lst;
+                __auto_type lst = _mv_1605.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type num_items = ((int64_t)((items).len));
                     if (num_items >= 2) {
-                        __auto_type _mv_1605 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1605.has_value) {
-                            __auto_type name_expr = _mv_1605.value;
-                            __auto_type _mv_1606 = (*name_expr);
-                            switch (_mv_1606.tag) {
+                        __auto_type _mv_1606 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1606.has_value) {
+                            __auto_type name_expr = _mv_1606.value;
+                            __auto_type _mv_1607 = (*name_expr);
+                            switch (_mv_1607.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1606.data.sym;
+                                    __auto_type name_sym = _mv_1607.data.sym;
                                     {
                                         __auto_type variant_name = name_sym.name;
                                         __auto_type c_field = ctype_to_c_name(arena, variant_name);
                                         if (num_items == 2) {
-                                            __auto_type _mv_1607 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1607.has_value) {
-                                                __auto_type type_expr = _mv_1607.value;
+                                            __auto_type _mv_1608 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1608.has_value) {
+                                                __auto_type type_expr = _mv_1608.value;
                                                 {
                                                     __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                     {
@@ -6617,14 +6637,14 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
                                                         context_ctx_emit_header(ctx, context_ctx_str4(ctx, SLOP_STR("        "), actual_type, SLOP_STR(" "), context_ctx_str(ctx, c_field, SLOP_STR(";"))));
                                                     }
                                                 }
-                                            } else if (!_mv_1607.has_value) {
+                                            } else if (!_mv_1608.has_value) {
                                             }
                                         } else if (num_items >= 3) {
                                             context_ctx_emit_header(ctx, SLOP_STR("        struct {"));
                                             for (int64_t fi = 1; fi < num_items; fi++) {
-                                                __auto_type _mv_1608 = ({ __auto_type _lst = items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1608.has_value) {
-                                                    __auto_type type_expr = _mv_1608.value;
+                                                __auto_type _mv_1609 = ({ __auto_type _lst = items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1609.has_value) {
+                                                    __auto_type type_expr = _mv_1609.value;
                                                     {
                                                         __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                         {
@@ -6633,7 +6653,7 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
                                                             context_ctx_emit_header(ctx, context_ctx_str5(ctx, SLOP_STR("            "), actual_type, SLOP_STR(" "), field_name, SLOP_STR(";")));
                                                         }
                                                     }
-                                                } else if (!_mv_1608.has_value) {
+                                                } else if (!_mv_1609.has_value) {
                                                 }
                                             }
                                             context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("        } "), c_field, SLOP_STR(";")));
@@ -6646,7 +6666,7 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
                                     break;
                                 }
                             }
-                        } else if (!_mv_1605.has_value) {
+                        } else if (!_mv_1606.has_value) {
                         }
                     }
                 }
@@ -6666,9 +6686,9 @@ void transpiler_emit_module_consts(context_TranspileContext* ctx, slop_list_type
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1609 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1609.has_value) {
-                __auto_type item = _mv_1609.value;
+            __auto_type _mv_1610 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1610.has_value) {
+                __auto_type item = _mv_1610.value;
                 if (transpiler_is_const_def(item)) {
                     {
                         __auto_type const_name = transpiler_get_const_name(item);
@@ -6677,7 +6697,7 @@ void transpiler_emit_module_consts(context_TranspileContext* ctx, slop_list_type
                     }
                     emitted_any = 1;
                 }
-            } else if (!_mv_1609.has_value) {
+            } else if (!_mv_1610.has_value) {
             }
             i = (i + 1);
         }
@@ -6689,31 +6709,31 @@ void transpiler_emit_module_consts(context_TranspileContext* ctx, slop_list_type
 
 slop_string transpiler_get_const_name(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1610 = (*item);
-    switch (_mv_1610.tag) {
+    __auto_type _mv_1611 = (*item);
+    switch (_mv_1611.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1610.data.lst;
+            __auto_type lst = _mv_1611.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return SLOP_STR("");
                 } else {
-                    __auto_type _mv_1611 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1611.has_value) {
-                        __auto_type name_expr = _mv_1611.value;
-                        __auto_type _mv_1612 = (*name_expr);
-                        switch (_mv_1612.tag) {
+                    __auto_type _mv_1612 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1612.has_value) {
+                        __auto_type name_expr = _mv_1612.value;
+                        __auto_type _mv_1613 = (*name_expr);
+                        switch (_mv_1613.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1612.data.sym;
+                                __auto_type sym = _mv_1613.data.sym;
                                 return sym.name;
                             }
                             default: {
                                 return SLOP_STR("");
                             }
                         }
-                    } else if (!_mv_1611.has_value) {
+                    } else if (!_mv_1612.has_value) {
                         return SLOP_STR("");
                     }
                 }
@@ -6732,15 +6752,15 @@ void transpiler_emit_module_consts_header(context_TranspileContext* ctx, slop_li
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1613 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1613.has_value) {
-                __auto_type item = _mv_1613.value;
+            __auto_type _mv_1614 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1614.has_value) {
+                __auto_type item = _mv_1614.value;
                 if (transpiler_is_const_def(item)) {
                     if (transpiler_emit_const_header_if_exported(ctx, item, exports)) {
                         emitted_any = 1;
                     }
                 }
-            } else if (!_mv_1613.has_value) {
+            } else if (!_mv_1614.has_value) {
             }
             i = (i + 1);
         }
@@ -6753,35 +6773,35 @@ void transpiler_emit_module_consts_header(context_TranspileContext* ctx, slop_li
 uint8_t transpiler_emit_const_header_if_exported(context_TranspileContext* ctx, types_SExpr* item, slop_list_string exports) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1614 = (*item);
-    switch (_mv_1614.tag) {
+    __auto_type _mv_1615 = (*item);
+    switch (_mv_1615.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1614.data.lst;
+            __auto_type lst = _mv_1615.data.lst;
             {
                 __auto_type const_items = lst.items;
                 if (((int64_t)((const_items).len)) < 4) {
                     return 0;
                 } else {
-                    __auto_type _mv_1615 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1615.has_value) {
-                        __auto_type name_expr = _mv_1615.value;
-                        __auto_type _mv_1616 = (*name_expr);
-                        switch (_mv_1616.tag) {
+                    __auto_type _mv_1616 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1616.has_value) {
+                        __auto_type name_expr = _mv_1616.value;
+                        __auto_type _mv_1617 = (*name_expr);
+                        switch (_mv_1617.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type name_sym = _mv_1616.data.sym;
+                                __auto_type name_sym = _mv_1617.data.sym;
                                 {
                                     __auto_type raw_name = name_sym.name;
                                     if (!(transpiler_list_contains_str(exports, raw_name))) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1617 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1617.has_value) {
-                                            __auto_type type_expr = _mv_1617.value;
+                                        __auto_type _mv_1618 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1618.has_value) {
+                                            __auto_type type_expr = _mv_1618.value;
                                             transpiler_emit_const_header_decl(ctx, raw_name, type_expr, ({ __auto_type _mv = ({ __auto_type _lst = const_items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type v = _mv.value; v; }) : (NULL); }));
                                             return 1;
-                                        } else if (!_mv_1617.has_value) {
+                                        } else if (!_mv_1618.has_value) {
                                             return 0;
                                         }
                                     }
@@ -6791,7 +6811,7 @@ uint8_t transpiler_emit_const_header_if_exported(context_TranspileContext* ctx, 
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1615.has_value) {
+                    } else if (!_mv_1616.has_value) {
                         return 0;
                     }
                 }
@@ -6841,13 +6861,13 @@ void transpiler_emit_module_functions(context_TranspileContext* ctx, slop_list_t
         int64_t i = start;
         context_ctx_start_function_buffer(ctx);
         while (i < len) {
-            __auto_type _mv_1618 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1618.has_value) {
-                __auto_type item = _mv_1618.value;
+            __auto_type _mv_1619 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1619.has_value) {
+                __auto_type item = _mv_1619.value;
                 if (transpiler_is_fn_def(item)) {
                     defn_transpile_function(ctx, item);
                 }
-            } else if (!_mv_1618.has_value) {
+            } else if (!_mv_1619.has_value) {
             }
             i = (i + 1);
         }
@@ -6865,12 +6885,12 @@ void transpiler_emit_all_lambdas(context_TranspileContext* ctx) {
         int64_t i = 0;
         if (count > 0) {
             while (i < count) {
-                __auto_type _mv_1619 = ({ __auto_type _lst = lambdas; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1619.has_value) {
-                    __auto_type lambda_code = _mv_1619.value;
+                __auto_type _mv_1620 = ({ __auto_type _lst = lambdas; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1620.has_value) {
+                    __auto_type lambda_code = _mv_1620.value;
                     context_ctx_emit(ctx, lambda_code);
                     context_ctx_emit(ctx, SLOP_STR(""));
-                } else if (!_mv_1619.has_value) {
+                } else if (!_mv_1620.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6888,11 +6908,11 @@ slop_string transpiler_generate_c_output(context_TranspileContext* ctx) {
         __auto_type result = SLOP_STR("");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1620 = ({ __auto_type _lst = output_lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1620.has_value) {
-                __auto_type line = _mv_1620.value;
+            __auto_type _mv_1621 = ({ __auto_type _lst = output_lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1621.has_value) {
+                __auto_type line = _mv_1621.value;
                 result = context_ctx_str3(ctx, result, line, SLOP_STR("\n"));
-            } else if (!_mv_1620.has_value) {
+            } else if (!_mv_1621.has_value) {
             }
             i = (i + 1);
         }
@@ -6906,11 +6926,11 @@ void transpiler_transpile_file(context_TranspileContext* ctx, slop_list_types_SE
         __auto_type len = ((int64_t)((exprs).len));
         int64_t i = 0;
         if ((len > 0) && transpiler_is_module_expr(exprs)) {
-            __auto_type _mv_1621 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1621.has_value) {
-                __auto_type module_expr = _mv_1621.value;
+            __auto_type _mv_1622 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1622.has_value) {
+                __auto_type module_expr = _mv_1622.value;
                 transpiler_transpile_module(ctx, module_expr);
-            } else if (!_mv_1621.has_value) {
+            } else if (!_mv_1622.has_value) {
             }
         } else {
             emit_emit_standard_includes(ctx);
@@ -6926,34 +6946,34 @@ uint8_t transpiler_is_module_expr(slop_list_types_SExpr_ptr exprs) {
     if (((int64_t)((exprs).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_1622 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1622.has_value) {
-            __auto_type first = _mv_1622.value;
-            __auto_type _mv_1623 = (*first);
-            switch (_mv_1623.tag) {
+        __auto_type _mv_1623 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1623.has_value) {
+            __auto_type first = _mv_1623.value;
+            __auto_type _mv_1624 = (*first);
+            switch (_mv_1624.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type lst = _mv_1623.data.lst;
+                    __auto_type lst = _mv_1624.data.lst;
                     {
                         __auto_type items = lst.items;
                         if (((int64_t)((items).len)) < 1) {
                             return 0;
                         } else {
-                            __auto_type _mv_1624 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1624.has_value) {
-                                __auto_type head = _mv_1624.value;
-                                __auto_type _mv_1625 = (*head);
-                                switch (_mv_1625.tag) {
+                            __auto_type _mv_1625 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1625.has_value) {
+                                __auto_type head = _mv_1625.value;
+                                __auto_type _mv_1626 = (*head);
+                                switch (_mv_1626.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1625.data.sym;
+                                        __auto_type sym = _mv_1626.data.sym;
                                         return string_eq(sym.name, SLOP_STR("module"));
                                     }
                                     default: {
                                         return 0;
                                     }
                                 }
-                            } else if (!_mv_1624.has_value) {
+                            } else if (!_mv_1625.has_value) {
                                 return 0;
                             }
                         }
@@ -6963,7 +6983,7 @@ uint8_t transpiler_is_module_expr(slop_list_types_SExpr_ptr exprs) {
                     return 0;
                 }
             }
-        } else if (!_mv_1622.has_value) {
+        } else if (!_mv_1623.has_value) {
             return 0;
         }
     }

--- a/bootstrap/compiler/slop_transpiler.h
+++ b/bootstrap/compiler/slop_transpiler.h
@@ -182,6 +182,7 @@ void transpiler_emit_primitive_option_types_header(context_TranspileContext* ctx
 uint8_t transpiler_is_primitive_or_runtime_type(slop_string type_name);
 void transpiler_emit_imported_list_types_header(context_TranspileContext* ctx);
 void transpiler_emit_imported_option_types_header(context_TranspileContext* ctx);
+void transpiler_emit_late_registered_list_types_header(context_TranspileContext* ctx);
 void transpiler_emit_late_registered_option_types_header(context_TranspileContext* ctx);
 void transpiler_emit_value_list_types_header(context_TranspileContext* ctx);
 void transpiler_emit_complex_value_list_types_header(context_TranspileContext* ctx);

--- a/bootstrap/tester/slop_ctype.c
+++ b/bootstrap/tester/slop_ctype.c
@@ -11,6 +11,7 @@ uint8_t ctype_is_numeric_type(slop_string name);
 slop_option_string ctype_builtin_type_c(slop_arena* arena, slop_string name);
 slop_string ctype_to_c_name(slop_arena* arena, slop_string name);
 slop_string ctype_type_to_identifier(slop_arena* arena, slop_string c_type);
+slop_string ctype_unwrap_ptr_container_type(slop_arena* arena, slop_string slop_type);
 uint8_t ctype_is_type_variable(slop_string name);
 slop_string ctype_to_c_type(slop_arena* arena, types_SExpr* expr);
 slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_ptr items);
@@ -148,6 +149,20 @@ slop_string ctype_type_to_identifier(slop_arena* arena, slop_string c_type) {
         }
         return result;
     }
+}
+
+slop_string ctype_unwrap_ptr_container_type(slop_arena* arena, slop_string slop_type) {
+    slop_string _retval = {0};
+    if (strlib_starts_with(slop_type, SLOP_STR("(Ptr (Map ")) || strlib_starts_with(slop_type, SLOP_STR("(Ptr (Set "))) {
+        {
+            __auto_type inner_len = ((int64_t)((string_len(slop_type) - 6)));
+            _retval = strlib_substring(arena, slop_type, 5, inner_len);
+        }
+    } else {
+        _retval = slop_type;
+    }
+    SLOP_POST(((string_len(_retval) <= string_len(slop_type))), "(<= (string-len $result) (string-len slop-type))");
+    return _retval;
 }
 
 uint8_t ctype_is_type_variable(slop_string name) {

--- a/bootstrap/tester/slop_ctype.h
+++ b/bootstrap/tester/slop_ctype.h
@@ -32,6 +32,7 @@ uint8_t ctype_is_numeric_type(slop_string name);
 slop_option_string ctype_builtin_type_c(slop_arena* arena, slop_string name);
 slop_string ctype_to_c_name(slop_arena* arena, slop_string name);
 slop_string ctype_type_to_identifier(slop_arena* arena, slop_string c_type);
+slop_string ctype_unwrap_ptr_container_type(slop_arena* arena, slop_string slop_type);
 uint8_t ctype_is_type_variable(slop_string name);
 slop_string ctype_to_c_type(slop_arena* arena, types_SExpr* expr);
 slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_ptr items);

--- a/bootstrap/tester/slop_expr.c
+++ b/bootstrap/tester/slop_expr.c
@@ -47,10 +47,10 @@ slop_string expr_infer_field_access_list_type(context_TranspileContext* ctx, typ
 slop_string expr_list_type_to_option_type(context_TranspileContext* ctx, slop_string c_type);
 slop_string expr_prefix_list_element_type(context_TranspileContext* ctx, slop_string elem_type);
 slop_string expr_substring_after_prefix(slop_arena* arena, slop_string s, slop_string prefix);
-slop_string expr_extract_map_value_from_slop_type(slop_arena* arena, slop_string slop_type);
+slop_string expr_extract_map_value_from_slop_type(slop_arena* arena, slop_string raw_slop_type);
 slop_string expr_slop_value_type_to_c_type(context_TranspileContext* ctx, slop_string slop_type);
 slop_string expr_get_var_name_from_expr(types_SExpr* expr);
-slop_string expr_extract_map_key_from_slop_type(slop_arena* arena, slop_string slop_type);
+slop_string expr_extract_map_key_from_slop_type(slop_arena* arena, slop_string raw_slop_type);
 slop_string expr_resolve_type_alias(context_TranspileContext* ctx, slop_string slop_type);
 slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr* expr);
 slop_string expr_infer_map_key_c_type_from_slop_type(context_TranspileContext* ctx, slop_string slop_type);
@@ -60,7 +60,7 @@ slop_string expr_extract_list_elem_from_inferred(context_TranspileContext* ctx, 
 slop_string expr_infer_map_key_c_type(context_TranspileContext* ctx, types_SExpr* map_expr);
 uint8_t expr_is_set_type(slop_string slop_type);
 uint8_t expr_is_map_type(slop_string slop_type);
-slop_string expr_extract_set_elem_from_slop_type(slop_arena* arena, slop_string slop_type);
+slop_string expr_extract_set_elem_from_slop_type(slop_arena* arena, slop_string raw_slop_type);
 slop_string expr_infer_set_elem_c_type(context_TranspileContext* ctx, types_SExpr* set_expr);
 slop_string expr_compound_slop_type_to_id(slop_arena* arena, slop_string slop_type);
 slop_string expr_slop_value_type_to_option_id(slop_arena* arena, slop_string slop_type);
@@ -129,6 +129,8 @@ slop_string expr_get_arena_from_field_access(context_TranspileContext* ctx, type
 slop_string expr_get_arena_from_base(context_TranspileContext* ctx, types_SExpr* base_expr);
 slop_string expr_get_arena_for_list_push(context_TranspileContext* ctx, slop_string list_c);
 uint8_t expr_is_ptr_to_ptr_map(context_TranspileContext* ctx, types_SExpr* expr);
+slop_string expr_deref_container_c(context_TranspileContext* ctx, slop_string container_c, slop_string slop_type);
+slop_string expr_resolve_container_c(context_TranspileContext* ctx, types_SExpr* container_expr);
 slop_string expr_transpile_record_new(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items);
 slop_string expr_transpile_record_fields(context_TranspileContext* ctx, slop_string type_name, slop_list_types_SExpr_ptr items, int64_t start_idx);
 slop_string expr_build_inline_struct_type(context_TranspileContext* ctx, slop_list_types_SExpr_ptr type_items);
@@ -1756,46 +1758,49 @@ slop_string expr_substring_after_prefix(slop_arena* arena, slop_string s, slop_s
     }
 }
 
-slop_string expr_extract_map_value_from_slop_type(slop_arena* arena, slop_string slop_type) {
+slop_string expr_extract_map_value_from_slop_type(slop_arena* arena, slop_string raw_slop_type) {
     {
-        __auto_type len = string_len(slop_type);
-        if (len < 10) {
-            return SLOP_STR("");
-        } else {
-            if (!(strlib_starts_with(slop_type, SLOP_STR("(Map ")))) {
+        __auto_type slop_type = ctype_unwrap_ptr_container_type(arena, raw_slop_type);
+        {
+            __auto_type len = string_len(slop_type);
+            if (len < 10) {
                 return SLOP_STR("");
             } else {
-                {
-                    int64_t i = 5;
-                    int64_t nesting = 1;
-                    int64_t key_space = 0;
-                    uint8_t found_key = 0;
-                    __auto_type end_idx = (len - 1);
-                    while ((i < end_idx) && !(found_key)) {
-                        {
-                            __auto_type c = strlib_char_at(slop_type, ((int64_t)(i)));
-                            if (c == 40) {
-                                nesting = (nesting + 1);
-                            } else if (c == 41) {
-                                nesting = (nesting - 1);
-                            } else if ((c == 32) && (nesting == 1)) {
-                                key_space = i;
-                                found_key = 1;
-                            } else {
+                if (!(strlib_starts_with(slop_type, SLOP_STR("(Map ")))) {
+                    return SLOP_STR("");
+                } else {
+                    {
+                        int64_t i = 5;
+                        int64_t nesting = 1;
+                        int64_t key_space = 0;
+                        uint8_t found_key = 0;
+                        __auto_type end_idx = (len - 1);
+                        while ((i < end_idx) && !(found_key)) {
+                            {
+                                __auto_type c = strlib_char_at(slop_type, ((int64_t)(i)));
+                                if (c == 40) {
+                                    nesting = (nesting + 1);
+                                } else if (c == 41) {
+                                    nesting = (nesting - 1);
+                                } else if ((c == 32) && (nesting == 1)) {
+                                    key_space = i;
+                                    found_key = 1;
+                                } else {
+                                }
                             }
+                            i = (i + 1);
                         }
-                        i = (i + 1);
-                    }
-                    if (!(found_key)) {
-                        return SLOP_STR("");
-                    } else {
-                        {
-                            __auto_type value_start = (key_space + 1);
-                            __auto_type value_len = (end_idx - value_start);
-                            if (value_len > 0) {
-                                return strlib_substring(arena, slop_type, ((int64_t)(value_start)), ((int64_t)(value_len)));
-                            } else {
-                                return SLOP_STR("");
+                        if (!(found_key)) {
+                            return SLOP_STR("");
+                        } else {
+                            {
+                                __auto_type value_start = (key_space + 1);
+                                __auto_type value_len = (end_idx - value_start);
+                                if (value_len > 0) {
+                                    return strlib_substring(arena, slop_type, ((int64_t)(value_start)), ((int64_t)(value_len)));
+                                } else {
+                                    return SLOP_STR("");
+                                }
                             }
                         }
                     }
@@ -1851,46 +1856,49 @@ slop_string expr_get_var_name_from_expr(types_SExpr* expr) {
     }
 }
 
-slop_string expr_extract_map_key_from_slop_type(slop_arena* arena, slop_string slop_type) {
+slop_string expr_extract_map_key_from_slop_type(slop_arena* arena, slop_string raw_slop_type) {
     {
-        __auto_type len = string_len(slop_type);
-        if (len < 10) {
-            return SLOP_STR("");
-        } else {
-            if (!(strlib_starts_with(slop_type, SLOP_STR("(Map ")))) {
+        __auto_type slop_type = ctype_unwrap_ptr_container_type(arena, raw_slop_type);
+        {
+            __auto_type len = string_len(slop_type);
+            if (len < 10) {
                 return SLOP_STR("");
             } else {
-                {
-                    int64_t i = 5;
-                    int64_t nesting = 1;
-                    int64_t key_space = 0;
-                    uint8_t found_key = 0;
-                    __auto_type end_idx = (len - 1);
-                    while ((i < end_idx) && !(found_key)) {
-                        {
-                            __auto_type c = strlib_char_at(slop_type, ((int64_t)(i)));
-                            if (c == 40) {
-                                nesting = (nesting + 1);
-                            } else if (c == 41) {
-                                nesting = (nesting - 1);
-                            } else if ((c == 32) && (nesting == 1)) {
-                                key_space = i;
-                                found_key = 1;
-                            } else {
+                if (!(strlib_starts_with(slop_type, SLOP_STR("(Map ")))) {
+                    return SLOP_STR("");
+                } else {
+                    {
+                        int64_t i = 5;
+                        int64_t nesting = 1;
+                        int64_t key_space = 0;
+                        uint8_t found_key = 0;
+                        __auto_type end_idx = (len - 1);
+                        while ((i < end_idx) && !(found_key)) {
+                            {
+                                __auto_type c = strlib_char_at(slop_type, ((int64_t)(i)));
+                                if (c == 40) {
+                                    nesting = (nesting + 1);
+                                } else if (c == 41) {
+                                    nesting = (nesting - 1);
+                                } else if ((c == 32) && (nesting == 1)) {
+                                    key_space = i;
+                                    found_key = 1;
+                                } else {
+                                }
                             }
+                            i = (i + 1);
                         }
-                        i = (i + 1);
-                    }
-                    if (!(found_key)) {
-                        return SLOP_STR("");
-                    } else {
-                        {
-                            __auto_type key_start = 5;
-                            __auto_type key_len = (key_space - key_start);
-                            if (key_len > 0) {
-                                return strlib_substring(arena, slop_type, ((int64_t)(key_start)), ((int64_t)(key_len)));
-                            } else {
-                                return SLOP_STR("");
+                        if (!(found_key)) {
+                            return SLOP_STR("");
+                        } else {
+                            {
+                                __auto_type key_start = 5;
+                                __auto_type key_len = (key_space - key_start);
+                                if (key_len > 0) {
+                                    return strlib_substring(arena, slop_type, ((int64_t)(key_start)), ((int64_t)(key_len)));
+                                } else {
+                                    return SLOP_STR("");
+                                }
                             }
                         }
                     }
@@ -2293,22 +2301,25 @@ uint8_t expr_is_map_type(slop_string slop_type) {
     return (strlib_starts_with(slop_type, SLOP_STR("(Map ")) || strlib_starts_with(slop_type, SLOP_STR("(Ptr (Map ")));
 }
 
-slop_string expr_extract_set_elem_from_slop_type(slop_arena* arena, slop_string slop_type) {
+slop_string expr_extract_set_elem_from_slop_type(slop_arena* arena, slop_string raw_slop_type) {
     {
-        __auto_type len = string_len(slop_type);
-        if (len < 7) {
-            return SLOP_STR("");
-        } else {
-            if (!(strlib_starts_with(slop_type, SLOP_STR("(Set ")))) {
+        __auto_type slop_type = ctype_unwrap_ptr_container_type(arena, raw_slop_type);
+        {
+            __auto_type len = string_len(slop_type);
+            if (len < 7) {
                 return SLOP_STR("");
             } else {
-                {
-                    __auto_type elem_start = 5;
-                    __auto_type elem_len = ((len - 1) - elem_start);
-                    if (elem_len > 0) {
-                        return strlib_substring(arena, slop_type, ((int64_t)(elem_start)), ((int64_t)(elem_len)));
-                    } else {
-                        return SLOP_STR("");
+                if (!(strlib_starts_with(slop_type, SLOP_STR("(Set ")))) {
+                    return SLOP_STR("");
+                } else {
+                    {
+                        __auto_type elem_start = 5;
+                        __auto_type elem_len = ((len - 1) - elem_start);
+                        if (elem_len > 0) {
+                            return strlib_substring(arena, slop_type, ((int64_t)(elem_start)), ((int64_t)(elem_len)));
+                        } else {
+                            return SLOP_STR("");
+                        }
                     }
                 }
             }
@@ -5171,12 +5182,12 @@ slop_string expr_slop_type_to_c_type(context_TranspileContext* ctx, slop_string 
             } else if (strlib_starts_with(slop_type, SLOP_STR("(List "))) {
                 {
                     __auto_type inner = strlib_substring(arena, slop_type, 6, ((0) > ((((int64_t)(string_len(slop_type))) - 7)) ? (0) : ((((int64_t)(string_len(slop_type))) - 7))));
-                    return context_ctx_str(ctx, SLOP_STR("slop_list_"), expr_slop_type_to_c_type(ctx, inner));
+                    return context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, expr_slop_type_to_c_type(ctx, inner)));
                 }
             } else if (strlib_starts_with(slop_type, SLOP_STR("(Option "))) {
                 {
                     __auto_type inner = strlib_substring(arena, slop_type, 8, ((0) > ((((int64_t)(string_len(slop_type))) - 9)) ? (0) : ((((int64_t)(string_len(slop_type))) - 9))));
-                    return context_ctx_str(ctx, SLOP_STR("slop_option_"), expr_slop_type_to_c_type(ctx, inner));
+                    return context_ctx_str(ctx, SLOP_STR("slop_option_"), ctype_type_to_identifier(arena, expr_slop_type_to_c_type(ctx, inner)));
                 }
             } else if (strlib_starts_with(slop_type, SLOP_STR("(Chan "))) {
                 {
@@ -6853,7 +6864,32 @@ uint8_t expr_is_ptr_to_ptr_map(context_TranspileContext* ctx, types_SExpr* expr)
             }
         }
         default: {
-            return 0;
+            {
+                __auto_type slop_type = expr_resolve_type_alias(ctx, expr_infer_expr_slop_type(ctx, expr));
+                return (strlib_starts_with(slop_type, SLOP_STR("(Ptr (Map ")) || strlib_starts_with(slop_type, SLOP_STR("(Ptr (Set ")));
+            }
+        }
+    }
+}
+
+slop_string expr_deref_container_c(context_TranspileContext* ctx, slop_string container_c, slop_string slop_type) {
+    SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
+    if (strlib_starts_with(slop_type, SLOP_STR("(Ptr (Map ")) || strlib_starts_with(slop_type, SLOP_STR("(Ptr (Set "))) {
+        return context_ctx_str3(ctx, SLOP_STR("(*"), container_c, SLOP_STR(")"));
+    } else {
+        return container_c;
+    }
+}
+
+slop_string expr_resolve_container_c(context_TranspileContext* ctx, types_SExpr* container_expr) {
+    SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
+    SLOP_PRE(((container_expr != NULL)), "(!= container-expr nil)");
+    {
+        __auto_type c = expr_transpile_expr(ctx, container_expr);
+        if (expr_is_ptr_to_ptr_map(ctx, container_expr)) {
+            return context_ctx_str3(ctx, SLOP_STR("(*"), c, SLOP_STR(")"));
+        } else {
+            return c;
         }
     }
 }
@@ -7471,33 +7507,20 @@ slop_string expr_transpile_map_put(context_TranspileContext* ctx, slop_list_type
                     if (_mv_489.has_value) {
                         __auto_type val_expr = _mv_489.value;
                         {
-                            __auto_type map_c = expr_transpile_expr(ctx, map_expr);
+                            __auto_type map_c = expr_resolve_container_c(ctx, map_expr);
                             __auto_type key_c = expr_transpile_expr(ctx, key_expr);
                             __auto_type val_c = expr_transpile_expr(ctx, val_expr);
                             __auto_type key_ptr = expr_wrap_map_key_as_ptr(ctx, key_c, key_expr, map_expr);
-                            __auto_type needs_deref = expr_is_ptr_to_ptr_map(ctx, map_expr);
                             __auto_type val_decl_type = expr_map_put_value_decl_type(ctx, map_expr);
                             __auto_type arena_c = expr_resolve_arena_c_name(ctx, SLOP_STR("map-put"), items);
-                            if (needs_deref) {
-                                {
-                                    __auto_type s1 = context_ctx_str4(ctx, SLOP_STR("({ "), val_decl_type, SLOP_STR(" _val = "), val_c);
-                                    __auto_type s2 = context_ctx_str(ctx, s1, context_ctx_str5(ctx, SLOP_STR("; void* _vptr = slop_arena_alloc("), arena_c, SLOP_STR(", sizeof(_val)); memcpy(_vptr, &_val, sizeof(_val)); slop_map_put("), arena_c, SLOP_STR(", (*")));
-                                    __auto_type s3 = context_ctx_str(ctx, s2, map_c);
-                                    __auto_type s4 = context_ctx_str(ctx, s3, SLOP_STR("), "));
-                                    __auto_type s5 = context_ctx_str(ctx, s4, key_ptr);
-                                    __auto_type s6 = context_ctx_str(ctx, s5, SLOP_STR(", _vptr); })"));
-                                    return s6;
-                                }
-                            } else {
-                                {
-                                    __auto_type s1 = context_ctx_str4(ctx, SLOP_STR("({ "), val_decl_type, SLOP_STR(" _val = "), val_c);
-                                    __auto_type s2 = context_ctx_str(ctx, s1, context_ctx_str5(ctx, SLOP_STR("; void* _vptr = slop_arena_alloc("), arena_c, SLOP_STR(", sizeof(_val)); memcpy(_vptr, &_val, sizeof(_val)); slop_map_put("), arena_c, SLOP_STR(", ")));
-                                    __auto_type s3 = context_ctx_str(ctx, s2, map_c);
-                                    __auto_type s4 = context_ctx_str(ctx, s3, SLOP_STR(", "));
-                                    __auto_type s5 = context_ctx_str(ctx, s4, key_ptr);
-                                    __auto_type s6 = context_ctx_str(ctx, s5, SLOP_STR(", _vptr); })"));
-                                    return s6;
-                                }
+                            {
+                                __auto_type s1 = context_ctx_str4(ctx, SLOP_STR("({ "), val_decl_type, SLOP_STR(" _val = "), val_c);
+                                __auto_type s2 = context_ctx_str(ctx, s1, context_ctx_str5(ctx, SLOP_STR("; void* _vptr = slop_arena_alloc("), arena_c, SLOP_STR(", sizeof(_val)); memcpy(_vptr, &_val, sizeof(_val)); slop_map_put("), arena_c, SLOP_STR(", ")));
+                                __auto_type s3 = context_ctx_str(ctx, s2, map_c);
+                                __auto_type s4 = context_ctx_str(ctx, s3, SLOP_STR(", "));
+                                __auto_type s5 = context_ctx_str(ctx, s4, key_ptr);
+                                __auto_type s6 = context_ctx_str(ctx, s5, SLOP_STR(", _vptr); })"));
+                                return s6;
                             }
                         }
                     } else if (!_mv_489.has_value) {
@@ -7532,7 +7555,7 @@ slop_string expr_transpile_map_get(context_TranspileContext* ctx, slop_list_type
                 if (_mv_491.has_value) {
                     __auto_type key_expr = _mv_491.value;
                     {
-                        __auto_type map_c = expr_transpile_expr(ctx, map_expr);
+                        __auto_type map_c = expr_resolve_container_c(ctx, map_expr);
                         __auto_type key_c = expr_transpile_expr(ctx, key_expr);
                         __auto_type key_ptr = expr_wrap_map_key_as_ptr(ctx, key_c, key_expr, map_expr);
                         __auto_type option_type = expr_infer_map_value_option_type(ctx, map_expr);
@@ -7574,7 +7597,7 @@ slop_string expr_transpile_map_has(context_TranspileContext* ctx, slop_list_type
                 if (_mv_493.has_value) {
                     __auto_type key_expr = _mv_493.value;
                     {
-                        __auto_type map_c = expr_transpile_expr(ctx, map_expr);
+                        __auto_type map_c = expr_resolve_container_c(ctx, map_expr);
                         __auto_type key_c = expr_transpile_expr(ctx, key_expr);
                         __auto_type key_ptr = expr_wrap_map_key_as_ptr(ctx, key_c, key_expr, map_expr);
                         return context_ctx_str(ctx, SLOP_STR("(slop_map_get("), context_ctx_str(ctx, map_c, context_ctx_str(ctx, SLOP_STR(", "), context_ctx_str(ctx, key_ptr, SLOP_STR(") != NULL)")))));
@@ -7606,15 +7629,10 @@ slop_string expr_transpile_map_remove(context_TranspileContext* ctx, slop_list_t
                 if (_mv_495.has_value) {
                     __auto_type key_expr = _mv_495.value;
                     {
-                        __auto_type map_c = expr_transpile_expr(ctx, map_expr);
+                        __auto_type map_c = expr_resolve_container_c(ctx, map_expr);
                         __auto_type key_c = expr_transpile_expr(ctx, key_expr);
                         __auto_type key_ptr = expr_wrap_map_key_as_ptr(ctx, key_c, key_expr, map_expr);
-                        __auto_type needs_deref = expr_is_ptr_to_ptr_map(ctx, map_expr);
-                        if (needs_deref) {
-                            return context_ctx_str(ctx, SLOP_STR("slop_map_remove((*"), context_ctx_str(ctx, map_c, context_ctx_str(ctx, SLOP_STR("), "), context_ctx_str(ctx, key_ptr, SLOP_STR(")")))));
-                        } else {
-                            return context_ctx_str(ctx, SLOP_STR("slop_map_remove("), context_ctx_str(ctx, map_c, context_ctx_str(ctx, SLOP_STR(", "), context_ctx_str(ctx, key_ptr, SLOP_STR(")")))));
-                        }
+                        return context_ctx_str(ctx, SLOP_STR("slop_map_remove("), context_ctx_str(ctx, map_c, context_ctx_str(ctx, SLOP_STR(", "), context_ctx_str(ctx, key_ptr, SLOP_STR(")")))));
                     }
                 } else if (!_mv_495.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("map-remove: missing key"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
@@ -7641,16 +7659,20 @@ slop_string expr_transpile_map_keys(context_TranspileContext* ctx, slop_list_typ
             if (_mv_496.has_value) {
                 __auto_type map_expr = _mv_496.value;
                 {
-                    __auto_type map_c = expr_transpile_expr(ctx, map_expr);
+                    __auto_type map_c = expr_resolve_container_c(ctx, map_expr);
                     __auto_type key_c_type = expr_infer_map_key_c_type(ctx, map_expr);
-                    __auto_type debug_var_name = expr_get_var_name_from_expr(map_expr);
-                    __auto_type debug_slop_type = ({ __auto_type _mv = context_ctx_lookup_var(ctx, debug_var_name); _mv.has_value ? ({ __auto_type entry = _mv.value; entry.slop_type; }) : (SLOP_STR("VAR_NOT_FOUND")); });
                     __auto_type arena_c = expr_resolve_arena_c_name(ctx, SLOP_STR("map-keys"), items);
-                    if (string_eq(key_c_type, SLOP_STR("slop_string")) || (string_len(key_c_type) == 0)) {
-                        return context_ctx_str(ctx, SLOP_STR("/* DEBUG: var="), context_ctx_str(ctx, debug_var_name, context_ctx_str(ctx, SLOP_STR(" slop="), context_ctx_str(ctx, debug_slop_type, context_ctx_str(ctx, SLOP_STR(" key="), context_ctx_str(ctx, key_c_type, context_ctx_str(ctx, context_ctx_str3(ctx, SLOP_STR(" */ slop_map_keys("), arena_c, SLOP_STR(", ")), context_ctx_str(ctx, map_c, SLOP_STR(")")))))))));
+                    if (string_eq(key_c_type, SLOP_STR("slop_string"))) {
+                        return context_ctx_str(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map_keys("), arena_c, SLOP_STR(", ")), context_ctx_str(ctx, map_c, SLOP_STR(")")));
+                    } else if (string_len(key_c_type) == 0) {
+                        context_ctx_add_error_at(ctx, SLOP_STR("map-keys: cannot infer key type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
+                        return SLOP_STR("NULL");
                     } else {
                         {
-                            __auto_type list_type = context_ctx_str(ctx, SLOP_STR("slop_list_"), key_c_type);
+                            __auto_type key_id = ctype_type_to_identifier(arena, key_c_type);
+                            __auto_type list_type = context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, key_c_type));
+                            context_ctx_register_list_type(ctx, key_c_type, list_type);
+                            context_ctx_register_option_type(ctx, key_c_type, context_ctx_str(ctx, SLOP_STR("slop_option_"), key_id));
                             return context_ctx_str(ctx, context_ctx_str3(ctx, SLOP_STR("({ slop_set_elements_result _r = slop_set_elements_raw("), arena_c, SLOP_STR(", ")), context_ctx_str(ctx, map_c, context_ctx_str(ctx, SLOP_STR("); ("), context_ctx_str(ctx, list_type, context_ctx_str(ctx, SLOP_STR("){.data = ("), context_ctx_str(ctx, key_c_type, context_ctx_str(ctx, SLOP_STR("*)_r.data, .len = _r.len, .cap = _r.cap}; })"), SLOP_STR(""))))))));
                         }
                     }
@@ -7709,7 +7731,7 @@ slop_string expr_transpile_set_put(context_TranspileContext* ctx, slop_list_type
                 if (_mv_500.has_value) {
                     __auto_type elem_expr = _mv_500.value;
                     {
-                        __auto_type set_c = expr_transpile_expr(ctx, set_expr);
+                        __auto_type set_c = expr_resolve_container_c(ctx, set_expr);
                         __auto_type elem_c = expr_transpile_expr(ctx, elem_expr);
                         __auto_type elem_ptr = expr_wrap_map_key_as_ptr(ctx, elem_c, elem_expr, set_expr);
                         __auto_type arena_c = expr_resolve_arena_c_name(ctx, SLOP_STR("set-put"), items);
@@ -7742,7 +7764,7 @@ slop_string expr_transpile_set_has(context_TranspileContext* ctx, slop_list_type
                 if (_mv_502.has_value) {
                     __auto_type elem_expr = _mv_502.value;
                     {
-                        __auto_type set_c = expr_transpile_expr(ctx, set_expr);
+                        __auto_type set_c = expr_resolve_container_c(ctx, set_expr);
                         __auto_type elem_c = expr_transpile_expr(ctx, elem_expr);
                         __auto_type elem_ptr = expr_wrap_map_key_as_ptr(ctx, elem_c, elem_expr, set_expr);
                         return context_ctx_str(ctx, SLOP_STR("(slop_map_get("), context_ctx_str(ctx, set_c, context_ctx_str(ctx, SLOP_STR(", "), context_ctx_str(ctx, elem_ptr, SLOP_STR(") != NULL)")))));
@@ -7774,7 +7796,7 @@ slop_string expr_transpile_set_remove(context_TranspileContext* ctx, slop_list_t
                 if (_mv_504.has_value) {
                     __auto_type elem_expr = _mv_504.value;
                     {
-                        __auto_type set_c = expr_transpile_expr(ctx, set_expr);
+                        __auto_type set_c = expr_resolve_container_c(ctx, set_expr);
                         __auto_type elem_c = expr_transpile_expr(ctx, elem_expr);
                         __auto_type elem_ptr = expr_wrap_map_key_as_ptr(ctx, elem_c, elem_expr, set_expr);
                         return context_ctx_str(ctx, SLOP_STR("slop_map_remove("), context_ctx_str(ctx, set_c, context_ctx_str(ctx, SLOP_STR(", "), context_ctx_str(ctx, elem_ptr, SLOP_STR(")")))));
@@ -7795,6 +7817,7 @@ slop_string expr_transpile_set_elements(context_TranspileContext* ctx, slop_list
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type len = ((int64_t)((items).len));
+        __auto_type arena = (*ctx).arena;
         if (len < 2) {
             context_ctx_add_error_at(ctx, SLOP_STR("set-elements: needs set"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             return SLOP_STR("NULL");
@@ -7803,14 +7826,20 @@ slop_string expr_transpile_set_elements(context_TranspileContext* ctx, slop_list
             if (_mv_505.has_value) {
                 __auto_type set_expr = _mv_505.value;
                 {
-                    __auto_type set_c = expr_transpile_expr(ctx, set_expr);
+                    __auto_type set_c = expr_resolve_container_c(ctx, set_expr);
                     __auto_type elem_c_type = expr_infer_set_elem_c_type(ctx, set_expr);
                     __auto_type arena_c = expr_resolve_arena_c_name(ctx, SLOP_STR("set-elements"), items);
-                    if (string_eq(elem_c_type, SLOP_STR("slop_string")) || (string_len(elem_c_type) == 0)) {
+                    if (string_eq(elem_c_type, SLOP_STR("slop_string"))) {
                         return context_ctx_str(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map_keys("), arena_c, SLOP_STR(", ")), context_ctx_str(ctx, set_c, SLOP_STR(")")));
+                    } else if (string_len(elem_c_type) == 0) {
+                        context_ctx_add_error_at(ctx, SLOP_STR("set-elements: cannot infer element type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
+                        return SLOP_STR("NULL");
                     } else {
                         {
-                            __auto_type list_type = context_ctx_str(ctx, SLOP_STR("slop_list_"), elem_c_type);
+                            __auto_type elem_id = ctype_type_to_identifier(arena, elem_c_type);
+                            __auto_type list_type = context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, elem_c_type));
+                            context_ctx_register_list_type(ctx, elem_c_type, list_type);
+                            context_ctx_register_option_type(ctx, elem_c_type, context_ctx_str(ctx, SLOP_STR("slop_option_"), elem_id));
                             return context_ctx_str(ctx, context_ctx_str3(ctx, SLOP_STR("({ slop_set_elements_result _r = slop_set_elements_raw("), arena_c, SLOP_STR(", ")), context_ctx_str(ctx, set_c, context_ctx_str(ctx, SLOP_STR("); ("), context_ctx_str(ctx, list_type, context_ctx_str(ctx, SLOP_STR("){.data = ("), context_ctx_str(ctx, elem_c_type, context_ctx_str(ctx, SLOP_STR("*)_r.data, .len = _r.len, .cap = _r.cap}; })"), SLOP_STR(""))))))));
                         }
                     }
@@ -8077,7 +8106,7 @@ slop_string expr_transpile_for_each_set_as_expr(context_TranspileContext* ctx, s
         __auto_type elem_slop_type = expr_extract_set_elem_from_slop_type(arena, resolved_type);
         __auto_type elem_c_type = expr_slop_value_type_to_c_type(ctx, elem_slop_type);
         {
-            __auto_type result = context_ctx_str3(ctx, SLOP_STR("({ slop_map* _coll = (slop_map*)"), coll_c, SLOP_STR("; for (size_t _i = 0; _i < _coll->cap; _i++) { "));
+            __auto_type result = context_ctx_str3(ctx, SLOP_STR("({ slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, coll_c, resolved_type), SLOP_STR("; for (size_t _i = 0; _i < _coll->cap; _i++) { "));
             __auto_type if_part = SLOP_STR("if (_coll->entries[_i].occupied) { ");
             __auto_type cast_part = context_ctx_str(ctx, elem_c_type, SLOP_STR("*)_coll->entries[_i].key"));
             __auto_type assign_prefix = context_ctx_str4(ctx, elem_c_type, SLOP_STR(" "), var_name, SLOP_STR(" = *("));
@@ -8115,7 +8144,7 @@ slop_string expr_transpile_for_each_map_keys_as_expr(context_TranspileContext* c
         __auto_type key_slop_type = expr_extract_map_key_from_slop_type(arena, resolved_type);
         __auto_type key_c_type = expr_slop_value_type_to_c_type(ctx, key_slop_type);
         {
-            __auto_type result = context_ctx_str3(ctx, SLOP_STR("({ slop_map* _coll = (slop_map*)"), coll_c, SLOP_STR("; for (size_t _i = 0; _i < _coll->cap; _i++) { "));
+            __auto_type result = context_ctx_str3(ctx, SLOP_STR("({ slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, coll_c, resolved_type), SLOP_STR("; for (size_t _i = 0; _i < _coll->cap; _i++) { "));
             __auto_type if_part = SLOP_STR("if (_coll->entries[_i].occupied) { ");
             __auto_type cast_part = context_ctx_str(ctx, key_c_type, SLOP_STR("*)_coll->entries[_i].key"));
             __auto_type assign_prefix = context_ctx_str4(ctx, key_c_type, SLOP_STR(" "), var_name, SLOP_STR(" = *("));
@@ -8191,7 +8220,7 @@ slop_string expr_transpile_for_each_map_kv_as_expr(context_TranspileContext* ctx
                                                             __auto_type key_c_type = expr_slop_value_type_to_c_type(ctx, key_slop_type);
                                                             __auto_type val_c_type = expr_slop_value_type_to_c_type(ctx, val_slop_type);
                                                             {
-                                                                __auto_type result = context_ctx_str3(ctx, SLOP_STR("({ slop_map* _coll = (slop_map*)"), map_c, SLOP_STR("; for (size_t _i = 0; _i < _coll->cap; _i++) { "));
+                                                                __auto_type result = context_ctx_str3(ctx, SLOP_STR("({ slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, map_c, resolved_type), SLOP_STR("; for (size_t _i = 0; _i < _coll->cap; _i++) { "));
                                                                 __auto_type if_part = SLOP_STR("if (_coll->entries[_i].occupied) { ");
                                                                 __auto_type k_cast = context_ctx_str(ctx, key_c_type, SLOP_STR("*)_coll->entries[_i].key"));
                                                                 __auto_type k_prefix = context_ctx_str4(ctx, key_c_type, SLOP_STR(" "), k_name, SLOP_STR(" = *("));
@@ -9926,9 +9955,9 @@ slop_string expr_infer_elem_from_type(context_TranspileContext* ctx, types_SExpr
                             return SLOP_STR("");
                         }
                     }
-                } else if (strlib_starts_with(resolved_type, SLOP_STR("(Set "))) {
+                } else if (expr_is_set_type(resolved_type)) {
                     return expr_extract_set_elem_from_slop_type(arena, resolved_type);
-                } else if (strlib_starts_with(resolved_type, SLOP_STR("(Map "))) {
+                } else if (expr_is_map_type(resolved_type)) {
                     return expr_extract_map_key_from_slop_type(arena, resolved_type);
                 } else {
                     return SLOP_STR("");

--- a/bootstrap/tester/slop_expr.h
+++ b/bootstrap/tester/slop_expr.h
@@ -65,10 +65,10 @@ slop_string expr_infer_field_access_list_type(context_TranspileContext* ctx, typ
 slop_string expr_list_type_to_option_type(context_TranspileContext* ctx, slop_string c_type);
 slop_string expr_prefix_list_element_type(context_TranspileContext* ctx, slop_string elem_type);
 slop_string expr_substring_after_prefix(slop_arena* arena, slop_string s, slop_string prefix);
-slop_string expr_extract_map_value_from_slop_type(slop_arena* arena, slop_string slop_type);
+slop_string expr_extract_map_value_from_slop_type(slop_arena* arena, slop_string raw_slop_type);
 slop_string expr_slop_value_type_to_c_type(context_TranspileContext* ctx, slop_string slop_type);
 slop_string expr_get_var_name_from_expr(types_SExpr* expr);
-slop_string expr_extract_map_key_from_slop_type(slop_arena* arena, slop_string slop_type);
+slop_string expr_extract_map_key_from_slop_type(slop_arena* arena, slop_string raw_slop_type);
 slop_string expr_resolve_type_alias(context_TranspileContext* ctx, slop_string slop_type);
 slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr* expr);
 slop_string expr_infer_map_key_c_type_from_slop_type(context_TranspileContext* ctx, slop_string slop_type);
@@ -78,7 +78,7 @@ slop_string expr_extract_list_elem_from_inferred(context_TranspileContext* ctx, 
 slop_string expr_infer_map_key_c_type(context_TranspileContext* ctx, types_SExpr* map_expr);
 uint8_t expr_is_set_type(slop_string slop_type);
 uint8_t expr_is_map_type(slop_string slop_type);
-slop_string expr_extract_set_elem_from_slop_type(slop_arena* arena, slop_string slop_type);
+slop_string expr_extract_set_elem_from_slop_type(slop_arena* arena, slop_string raw_slop_type);
 slop_string expr_infer_set_elem_c_type(context_TranspileContext* ctx, types_SExpr* set_expr);
 slop_string expr_compound_slop_type_to_id(slop_arena* arena, slop_string slop_type);
 slop_string expr_slop_value_type_to_option_id(slop_arena* arena, slop_string slop_type);
@@ -147,6 +147,8 @@ slop_string expr_get_arena_from_field_access(context_TranspileContext* ctx, type
 slop_string expr_get_arena_from_base(context_TranspileContext* ctx, types_SExpr* base_expr);
 slop_string expr_get_arena_for_list_push(context_TranspileContext* ctx, slop_string list_c);
 uint8_t expr_is_ptr_to_ptr_map(context_TranspileContext* ctx, types_SExpr* expr);
+slop_string expr_deref_container_c(context_TranspileContext* ctx, slop_string container_c, slop_string slop_type);
+slop_string expr_resolve_container_c(context_TranspileContext* ctx, types_SExpr* container_expr);
 slop_string expr_transpile_record_new(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items);
 slop_string expr_transpile_record_fields(context_TranspileContext* ctx, slop_string type_name, slop_list_types_SExpr_ptr items, int64_t start_idx);
 slop_string expr_build_inline_struct_type(context_TranspileContext* ctx, slop_list_types_SExpr_ptr type_items);

--- a/bootstrap/tester/slop_extract.c
+++ b/bootstrap/tester/slop_extract.c
@@ -27,28 +27,6 @@ int64_t extract_find_arrow_separator(slop_list_types_SExpr_ptr items) {
         int64_t i = 0;
         int64_t found = -1;
         while ((i < len) && (found == -1)) {
-            __auto_type _mv_1502 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1502.has_value) {
-                __auto_type item = _mv_1502.value;
-                if (parser_sexpr_is_symbol(item)) {
-                    if (string_eq(parser_sexpr_get_symbol_name(item), SLOP_STR("->"))) {
-                        found = i;
-                    }
-                }
-            } else if (!_mv_1502.has_value) {
-            }
-            i = (i + 1);
-        }
-        return found;
-    }
-}
-
-int64_t extract_find_arrow_separator_from(slop_list_types_SExpr_ptr items, int64_t start) {
-    {
-        __auto_type len = ((int64_t)((items).len));
-        int64_t i = start;
-        int64_t found = -1;
-        while ((i < len) && (found == -1)) {
             __auto_type _mv_1503 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_1503.has_value) {
                 __auto_type item = _mv_1503.value;
@@ -65,6 +43,28 @@ int64_t extract_find_arrow_separator_from(slop_list_types_SExpr_ptr items, int64
     }
 }
 
+int64_t extract_find_arrow_separator_from(slop_list_types_SExpr_ptr items, int64_t start) {
+    {
+        __auto_type len = ((int64_t)((items).len));
+        int64_t i = start;
+        int64_t found = -1;
+        while ((i < len) && (found == -1)) {
+            __auto_type _mv_1504 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1504.has_value) {
+                __auto_type item = _mv_1504.value;
+                if (parser_sexpr_is_symbol(item)) {
+                    if (string_eq(parser_sexpr_get_symbol_name(item), SLOP_STR("->"))) {
+                        found = i;
+                    }
+                }
+            } else if (!_mv_1504.has_value) {
+            }
+            i = (i + 1);
+        }
+        return found;
+    }
+}
+
 int64_t extract_detect_arena_param(types_SExpr* params) {
     if (!(parser_sexpr_is_symbol(params))) {
         {
@@ -72,38 +72,38 @@ int64_t extract_detect_arena_param(types_SExpr* params) {
             int64_t i = 0;
             int64_t found = -1;
             while ((i < len) && (found == -1)) {
-                __auto_type _mv_1504 = parser_sexpr_list_get(params, i);
-                if (_mv_1504.has_value) {
-                    __auto_type param = _mv_1504.value;
+                __auto_type _mv_1505 = parser_sexpr_list_get(params, i);
+                if (_mv_1505.has_value) {
+                    __auto_type param = _mv_1505.value;
                     {
                         __auto_type plen = parser_sexpr_list_len(param);
                         if (plen >= 2) {
                             {
                                 __auto_type type_pos = (((plen == 2)) ? 1 : 2);
                                 __auto_type name_pos = (((plen == 2)) ? 0 : 1);
-                                __auto_type _mv_1505 = parser_sexpr_list_get(param, name_pos);
-                                if (_mv_1505.has_value) {
-                                    __auto_type name_expr = _mv_1505.value;
+                                __auto_type _mv_1506 = parser_sexpr_list_get(param, name_pos);
+                                if (_mv_1506.has_value) {
+                                    __auto_type name_expr = _mv_1506.value;
                                     if (parser_sexpr_is_symbol(name_expr)) {
                                         if (string_eq(parser_sexpr_get_symbol_name(name_expr), SLOP_STR("arena"))) {
-                                            __auto_type _mv_1506 = parser_sexpr_list_get(param, type_pos);
-                                            if (_mv_1506.has_value) {
-                                                __auto_type type_expr = _mv_1506.value;
+                                            __auto_type _mv_1507 = parser_sexpr_list_get(param, type_pos);
+                                            if (_mv_1507.has_value) {
+                                                __auto_type type_expr = _mv_1507.value;
                                                 if (parser_sexpr_is_symbol(type_expr)) {
                                                     if (string_eq(parser_sexpr_get_symbol_name(type_expr), SLOP_STR("Arena"))) {
                                                         found = i;
                                                     }
                                                 }
-                                            } else if (!_mv_1506.has_value) {
+                                            } else if (!_mv_1507.has_value) {
                                             }
                                         }
                                     }
-                                } else if (!_mv_1505.has_value) {
+                                } else if (!_mv_1506.has_value) {
                                 }
                             }
                         }
                     }
-                } else if (!_mv_1504.has_value) {
+                } else if (!_mv_1505.has_value) {
                 }
                 i = (i + 1);
             }
@@ -118,24 +118,24 @@ slop_option_string extract_extract_return_type(slop_arena* arena, types_SExpr* s
     if (parser_sexpr_list_len(spec_form) < 2) {
         return (slop_option_string){.has_value = false};
     } else {
-        __auto_type _mv_1507 = parser_sexpr_list_get(spec_form, 1);
-        if (_mv_1507.has_value) {
-            __auto_type sig = _mv_1507.value;
+        __auto_type _mv_1508 = parser_sexpr_list_get(spec_form, 1);
+        if (_mv_1508.has_value) {
+            __auto_type sig = _mv_1508.value;
             {
                 __auto_type sig_len = parser_sexpr_list_len(sig);
                 if (sig_len < 3) {
                     return (slop_option_string){.has_value = false};
                 } else {
-                    __auto_type _mv_1508 = parser_sexpr_list_get(sig, (sig_len - 1));
-                    if (_mv_1508.has_value) {
-                        __auto_type ret_type = _mv_1508.value;
+                    __auto_type _mv_1509 = parser_sexpr_list_get(sig, (sig_len - 1));
+                    if (_mv_1509.has_value) {
+                        __auto_type ret_type = _mv_1509.value;
                         return (slop_option_string){.has_value = 1, .value = parser_pretty_print(arena, ret_type)};
-                    } else if (!_mv_1508.has_value) {
+                    } else if (!_mv_1509.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
                 }
             }
-        } else if (!_mv_1507.has_value) {
+        } else if (!_mv_1508.has_value) {
             return (slop_option_string){.has_value = false};
         }
     }
@@ -148,20 +148,20 @@ slop_list_types_SExpr_ptr extract_collect_preconditions(slop_arena* arena, types
         __auto_type form_len = parser_sexpr_list_len(fn_form);
         int64_t i = 3;
         while (i < form_len) {
-            __auto_type _mv_1509 = parser_sexpr_list_get(fn_form, i);
-            if (_mv_1509.has_value) {
-                __auto_type item = _mv_1509.value;
+            __auto_type _mv_1510 = parser_sexpr_list_get(fn_form, i);
+            if (_mv_1510.has_value) {
+                __auto_type item = _mv_1510.value;
                 if (parser_is_form(item, SLOP_STR("@pre"))) {
                     if (parser_sexpr_list_len(item) >= 2) {
-                        __auto_type _mv_1510 = parser_sexpr_list_get(item, 1);
-                        if (_mv_1510.has_value) {
-                            __auto_type cond_expr = _mv_1510.value;
+                        __auto_type _mv_1511 = parser_sexpr_list_get(item, 1);
+                        if (_mv_1511.has_value) {
+                            __auto_type cond_expr = _mv_1511.value;
                             ({ __auto_type _lst_p = &(result); __auto_type _item = (cond_expr); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                        } else if (!_mv_1510.has_value) {
+                        } else if (!_mv_1511.has_value) {
                         }
                     }
                 }
-            } else if (!_mv_1509.has_value) {
+            } else if (!_mv_1510.has_value) {
             }
             i = (i + 1);
         }
@@ -177,11 +177,11 @@ slop_list_extract_TestCase_ptr extract_extract_fn_examples(slop_arena* arena, ty
         } else {
             {
                 __auto_type fn_name_opt = parser_sexpr_list_get(fn_form, 1);
-                __auto_type _mv_1511 = fn_name_opt;
-                if (!_mv_1511.has_value) {
+                __auto_type _mv_1512 = fn_name_opt;
+                if (!_mv_1512.has_value) {
                     return result;
-                } else if (_mv_1511.has_value) {
-                    __auto_type fn_name_expr = _mv_1511.value;
+                } else if (_mv_1512.has_value) {
+                    __auto_type fn_name_expr = _mv_1512.value;
                     if (!(parser_sexpr_is_symbol(fn_name_expr))) {
                         return result;
                     } else {
@@ -189,11 +189,11 @@ slop_list_extract_TestCase_ptr extract_extract_fn_examples(slop_arena* arena, ty
                             __auto_type fn_name = parser_sexpr_get_symbol_name(fn_name_expr);
                             {
                                 __auto_type params_opt = parser_sexpr_list_get(fn_form, 2);
-                                __auto_type _mv_1512 = params_opt;
-                                if (!_mv_1512.has_value) {
+                                __auto_type _mv_1513 = params_opt;
+                                if (!_mv_1513.has_value) {
                                     return result;
-                                } else if (_mv_1512.has_value) {
-                                    __auto_type params = _mv_1512.value;
+                                } else if (_mv_1513.has_value) {
+                                    __auto_type params = _mv_1513.value;
                                     {
                                         __auto_type arena_pos = extract_detect_arena_param(params);
                                         __auto_type needs_arena = (arena_pos >= 0);
@@ -203,24 +203,24 @@ slop_list_extract_TestCase_ptr extract_extract_fn_examples(slop_arena* arena, ty
                                             __auto_type form_len = parser_sexpr_list_len(fn_form);
                                             __auto_type i = 3;
                                             while (i < form_len) {
-                                                __auto_type _mv_1513 = parser_sexpr_list_get(fn_form, i);
-                                                if (_mv_1513.has_value) {
-                                                    __auto_type item = _mv_1513.value;
+                                                __auto_type _mv_1514 = parser_sexpr_list_get(fn_form, i);
+                                                if (_mv_1514.has_value) {
+                                                    __auto_type item = _mv_1514.value;
                                                     if (parser_is_form(item, SLOP_STR("@spec"))) {
                                                         return_type = extract_extract_return_type(arena, item);
                                                     }
                                                     if (parser_is_form(item, SLOP_STR("@example"))) {
                                                         {
                                                             __auto_type example_tc = extract_parse_example(arena, item, fn_name, module_name, return_type, needs_arena, arena_pos, params, preconditions);
-                                                            __auto_type _mv_1514 = example_tc;
-                                                            if (_mv_1514.has_value) {
-                                                                __auto_type tc = _mv_1514.value;
+                                                            __auto_type _mv_1515 = example_tc;
+                                                            if (_mv_1515.has_value) {
+                                                                __auto_type tc = _mv_1515.value;
                                                                 ({ __auto_type _lst_p = &(result); __auto_type _item = (tc); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                                                            } else if (!_mv_1514.has_value) {
+                                                            } else if (!_mv_1515.has_value) {
                                                             }
                                                         }
                                                     }
-                                                } else if (!_mv_1513.has_value) {
+                                                } else if (!_mv_1514.has_value) {
                                                 }
                                                 i = (i + 1);
                                             }
@@ -247,11 +247,11 @@ slop_option_extract_TestCase_ptr extract_parse_example(slop_arena* arena, types_
                 __auto_type items = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
                 int64_t i = 1;
                 while (i < example_len) {
-                    __auto_type _mv_1515 = parser_sexpr_list_get(example_form, i);
-                    if (_mv_1515.has_value) {
-                        __auto_type item = _mv_1515.value;
+                    __auto_type _mv_1516 = parser_sexpr_list_get(example_form, i);
+                    if (_mv_1516.has_value) {
+                        __auto_type item = _mv_1516.value;
                         ({ __auto_type _lst_p = &(items); __auto_type _item = (item); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                    } else if (!_mv_1515.has_value) {
+                    } else if (!_mv_1516.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -259,23 +259,23 @@ slop_option_extract_TestCase_ptr extract_parse_example(slop_arena* arena, types_
                     slop_option_string eq_fn = (slop_option_string){.has_value = false};
                     int64_t args_start = 0;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_1516 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1516.has_value) {
-                            __auto_type first_item = _mv_1516.value;
+                        __auto_type _mv_1517 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1517.has_value) {
+                            __auto_type first_item = _mv_1517.value;
                             if (parser_sexpr_is_symbol(first_item)) {
                                 if (string_eq(parser_sexpr_get_symbol_name(first_item), SLOP_STR(":eq"))) {
-                                    __auto_type _mv_1517 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_1517.has_value) {
-                                        __auto_type eq_name_expr = _mv_1517.value;
+                                    __auto_type _mv_1518 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_1518.has_value) {
+                                        __auto_type eq_name_expr = _mv_1518.value;
                                         if (parser_sexpr_is_symbol(eq_name_expr)) {
                                             eq_fn = (slop_option_string){.has_value = 1, .value = parser_sexpr_get_symbol_name(eq_name_expr)};
                                             args_start = 2;
                                         }
-                                    } else if (!_mv_1517.has_value) {
+                                    } else if (!_mv_1518.has_value) {
                                     }
                                 }
                             }
-                        } else if (!_mv_1516.has_value) {
+                        } else if (!_mv_1517.has_value) {
                         }
                     }
                     {
@@ -290,21 +290,21 @@ slop_option_extract_TestCase_ptr extract_parse_example(slop_arena* arena, types_
                                     __auto_type args = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
                                     int64_t j = args_start;
                                     while (j < arrow_idx) {
-                                        __auto_type _mv_1518 = ({ __auto_type _lst = items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1518.has_value) {
-                                            __auto_type arg = _mv_1518.value;
+                                        __auto_type _mv_1519 = ({ __auto_type _lst = items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1519.has_value) {
+                                            __auto_type arg = _mv_1519.value;
                                             ({ __auto_type _lst_p = &(args); __auto_type _item = (arg); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                                        } else if (!_mv_1518.has_value) {
+                                        } else if (!_mv_1519.has_value) {
                                         }
                                         j = (j + 1);
                                     }
                                     {
                                         __auto_type final_args = extract_unpack_grouped_args(arena, args);
-                                        __auto_type _mv_1519 = ({ __auto_type _lst = items; size_t _idx = (size_t)(arrow_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1519.has_value) {
-                                            __auto_type expected = _mv_1519.value;
+                                        __auto_type _mv_1520 = ({ __auto_type _lst = items; size_t _idx = (size_t)(arrow_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1520.has_value) {
+                                            __auto_type expected = _mv_1520.value;
                                             return (slop_option_extract_TestCase_ptr){.has_value = 1, .value = extract_test_case_new(arena, fn_name, module_name, final_args, expected, return_type, needs_arena, arena_pos, eq_fn, params, preconditions)};
-                                        } else if (!_mv_1519.has_value) {
+                                        } else if (!_mv_1520.has_value) {
                                             return (slop_option_extract_TestCase_ptr){.has_value = false};
                                         }
                                     }
@@ -322,28 +322,28 @@ slop_list_types_SExpr_ptr extract_unpack_grouped_args(slop_arena* arena, slop_li
     {
         slop_list_types_SExpr_ptr result = args;
         if (((int64_t)((args).len)) == 1) {
-            __auto_type _mv_1520 = ({ __auto_type _lst = args; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1520.has_value) {
-                __auto_type first_arg = _mv_1520.value;
+            __auto_type _mv_1521 = ({ __auto_type _lst = args; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1521.has_value) {
+                __auto_type first_arg = _mv_1521.value;
                 if (!(parser_sexpr_is_symbol(first_arg))) {
                     {
                         __auto_type inner_len = parser_sexpr_list_len(first_arg);
                         if (inner_len == 0) {
                             result = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
                         } else {
-                            __auto_type _mv_1521 = parser_sexpr_list_get(first_arg, 0);
-                            if (_mv_1521.has_value) {
-                                __auto_type first_inner = _mv_1521.value;
+                            __auto_type _mv_1522 = parser_sexpr_list_get(first_arg, 0);
+                            if (_mv_1522.has_value) {
+                                __auto_type first_inner = _mv_1522.value;
                                 if (parser_sexpr_is_symbol(first_inner) && string_eq(parser_sexpr_get_symbol_name(first_inner), SLOP_STR("arena"))) {
                                     {
                                         __auto_type unpacked = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
                                         __auto_type i = 1;
                                         while (i < inner_len) {
-                                            __auto_type _mv_1522 = parser_sexpr_list_get(first_arg, i);
-                                            if (_mv_1522.has_value) {
-                                                __auto_type item = _mv_1522.value;
+                                            __auto_type _mv_1523 = parser_sexpr_list_get(first_arg, i);
+                                            if (_mv_1523.has_value) {
+                                                __auto_type item = _mv_1523.value;
                                                 ({ __auto_type _lst_p = &(unpacked); __auto_type _item = (item); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                                            } else if (!_mv_1522.has_value) {
+                                            } else if (!_mv_1523.has_value) {
                                             }
                                             i = (i + 1);
                                         }
@@ -355,11 +355,11 @@ slop_list_types_SExpr_ptr extract_unpack_grouped_args(slop_arena* arena, slop_li
                                             __auto_type unpacked = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
                                             __auto_type i = 0;
                                             while (i < inner_len) {
-                                                __auto_type _mv_1523 = parser_sexpr_list_get(first_arg, i);
-                                                if (_mv_1523.has_value) {
-                                                    __auto_type item = _mv_1523.value;
+                                                __auto_type _mv_1524 = parser_sexpr_list_get(first_arg, i);
+                                                if (_mv_1524.has_value) {
+                                                    __auto_type item = _mv_1524.value;
                                                     ({ __auto_type _lst_p = &(unpacked); __auto_type _item = (item); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                                                } else if (!_mv_1523.has_value) {
+                                                } else if (!_mv_1524.has_value) {
                                                 }
                                                 i = (i + 1);
                                             }
@@ -367,12 +367,12 @@ slop_list_types_SExpr_ptr extract_unpack_grouped_args(slop_arena* arena, slop_li
                                         }
                                     }
                                 }
-                            } else if (!_mv_1521.has_value) {
+                            } else if (!_mv_1522.has_value) {
                             }
                         }
                     }
                 }
-            } else if (!_mv_1520.has_value) {
+            } else if (!_mv_1521.has_value) {
             }
         }
         return result;
@@ -387,11 +387,11 @@ slop_list_extract_TestCase_ptr extract_extract_examples_from_module(slop_arena* 
         } else {
             {
                 __auto_type mod_name_opt = parser_sexpr_list_get(module_form, 1);
-                __auto_type _mv_1524 = mod_name_opt;
-                if (!_mv_1524.has_value) {
+                __auto_type _mv_1525 = mod_name_opt;
+                if (!_mv_1525.has_value) {
                     return result;
-                } else if (_mv_1524.has_value) {
-                    __auto_type mod_name_expr = _mv_1524.value;
+                } else if (_mv_1525.has_value) {
+                    __auto_type mod_name_expr = _mv_1525.value;
                     {
                         slop_option_string mod_name = (slop_option_string){.has_value = false};
                         if (parser_sexpr_is_symbol(mod_name_expr)) {
@@ -401,26 +401,26 @@ slop_list_extract_TestCase_ptr extract_extract_examples_from_module(slop_arena* 
                             __auto_type form_len = parser_sexpr_list_len(module_form);
                             __auto_type i = 2;
                             while (i < form_len) {
-                                __auto_type _mv_1525 = parser_sexpr_list_get(module_form, i);
-                                if (_mv_1525.has_value) {
-                                    __auto_type item = _mv_1525.value;
+                                __auto_type _mv_1526 = parser_sexpr_list_get(module_form, i);
+                                if (_mv_1526.has_value) {
+                                    __auto_type item = _mv_1526.value;
                                     if (parser_is_form(item, SLOP_STR("fn"))) {
                                         {
                                             __auto_type fn_tests = extract_extract_fn_examples(arena, item, mod_name);
                                             __auto_type fn_tests_len = ((int64_t)((fn_tests).len));
                                             __auto_type j = 0;
                                             while (j < fn_tests_len) {
-                                                __auto_type _mv_1526 = ({ __auto_type _lst = fn_tests; size_t _idx = (size_t)j; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1526.has_value) {
-                                                    __auto_type tc = _mv_1526.value;
+                                                __auto_type _mv_1527 = ({ __auto_type _lst = fn_tests; size_t _idx = (size_t)j; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1527.has_value) {
+                                                    __auto_type tc = _mv_1527.value;
                                                     ({ __auto_type _lst_p = &(result); __auto_type _item = (tc); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                                                } else if (!_mv_1526.has_value) {
+                                                } else if (!_mv_1527.has_value) {
                                                 }
                                                 j = (j + 1);
                                             }
                                         }
                                     }
-                                } else if (!_mv_1525.has_value) {
+                                } else if (!_mv_1526.has_value) {
                                 }
                                 i = (i + 1);
                             }
@@ -439,20 +439,20 @@ slop_list_extract_TestCase_ptr extract_extract_examples_from_ast(slop_arena* are
         __auto_type len = ((int64_t)((ast).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1527 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1527.has_value) {
-                __auto_type form = _mv_1527.value;
+            __auto_type _mv_1528 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1528.has_value) {
+                __auto_type form = _mv_1528.value;
                 if (parser_is_form(form, SLOP_STR("fn"))) {
                     {
                         __auto_type fn_tests = extract_extract_fn_examples(arena, form, ((slop_option_string){.has_value = false}));
                         __auto_type fn_tests_len = ((int64_t)((fn_tests).len));
                         __auto_type j = 0;
                         while (j < fn_tests_len) {
-                            __auto_type _mv_1528 = ({ __auto_type _lst = fn_tests; size_t _idx = (size_t)j; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1528.has_value) {
-                                __auto_type tc = _mv_1528.value;
+                            __auto_type _mv_1529 = ({ __auto_type _lst = fn_tests; size_t _idx = (size_t)j; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1529.has_value) {
+                                __auto_type tc = _mv_1529.value;
                                 ({ __auto_type _lst_p = &(result); __auto_type _item = (tc); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                            } else if (!_mv_1528.has_value) {
+                            } else if (!_mv_1529.has_value) {
                             }
                             j = (j + 1);
                         }
@@ -464,17 +464,17 @@ slop_list_extract_TestCase_ptr extract_extract_examples_from_ast(slop_arena* are
                         __auto_type mod_tests_len = ((int64_t)((mod_tests).len));
                         __auto_type k = 0;
                         while (k < mod_tests_len) {
-                            __auto_type _mv_1529 = ({ __auto_type _lst = mod_tests; size_t _idx = (size_t)k; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1529.has_value) {
-                                __auto_type tc = _mv_1529.value;
+                            __auto_type _mv_1530 = ({ __auto_type _lst = mod_tests; size_t _idx = (size_t)k; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1530.has_value) {
+                                __auto_type tc = _mv_1530.value;
                                 ({ __auto_type _lst_p = &(result); __auto_type _item = (tc); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                            } else if (!_mv_1529.has_value) {
+                            } else if (!_mv_1530.has_value) {
                             }
                             k = (k + 1);
                         }
                     }
                 }
-            } else if (!_mv_1527.has_value) {
+            } else if (!_mv_1528.has_value) {
             }
             i = (i + 1);
         }

--- a/bootstrap/tester/slop_match.c
+++ b/bootstrap/tester/slop_match.c
@@ -2233,7 +2233,7 @@ void match_emit_inline_for_each_set(context_TranspileContext* ctx, slop_string v
         __auto_type elem_c_type = expr_slop_value_type_to_c_type(ctx, elem_slop_type);
         context_ctx_emit(ctx, SLOP_STR("{"));
         context_ctx_indent(ctx);
-        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), coll_c, SLOP_STR(";")));
+        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, coll_c, resolved_type), SLOP_STR(";")));
         context_ctx_emit(ctx, SLOP_STR("for (size_t _i = 0; _i < _coll->cap; _i++) {"));
         context_ctx_indent(ctx);
         context_ctx_emit(ctx, SLOP_STR("if (_coll->entries[_i].occupied) {"));
@@ -2265,7 +2265,7 @@ void match_emit_inline_for_each_map_keys(context_TranspileContext* ctx, slop_str
         __auto_type key_c_type = expr_slop_value_type_to_c_type(ctx, key_slop_type);
         context_ctx_emit(ctx, SLOP_STR("{"));
         context_ctx_indent(ctx);
-        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), coll_c, SLOP_STR(";")));
+        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, coll_c, resolved_type), SLOP_STR(";")));
         context_ctx_emit(ctx, SLOP_STR("for (size_t _i = 0; _i < _coll->cap; _i++) {"));
         context_ctx_indent(ctx);
         context_ctx_emit(ctx, SLOP_STR("if (_coll->entries[_i].occupied) {"));
@@ -2337,7 +2337,7 @@ void match_emit_inline_for_each_map_kv(context_TranspileContext* ctx, slop_list_
                                                             __auto_type val_c_type = expr_slop_value_type_to_c_type(ctx, val_slop_type);
                                                             context_ctx_emit(ctx, SLOP_STR("{"));
                                                             context_ctx_indent(ctx);
-                                                            context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), map_c, SLOP_STR(";")));
+                                                            context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, map_c, resolved_type), SLOP_STR(";")));
                                                             context_ctx_emit(ctx, SLOP_STR("for (size_t _i = 0; _i < _coll->cap; _i++) {"));
                                                             context_ctx_indent(ctx);
                                                             context_ctx_emit(ctx, SLOP_STR("if (_coll->entries[_i].occupied) {"));

--- a/bootstrap/tester/slop_stmt.c
+++ b/bootstrap/tester/slop_stmt.c
@@ -28,8 +28,6 @@ void stmt_transpile_with_arena(context_TranspileContext* ctx, types_SExpr* expr,
 void stmt_transpile_cond(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return);
 void stmt_transpile_cond_body(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items, int64_t start, uint8_t is_return);
 void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr);
-uint8_t stmt_is_set_type(slop_string slop_type);
-uint8_t stmt_is_map_type(slop_string slop_type);
 void stmt_transpile_for_each_set(context_TranspileContext* ctx, slop_string var_name, types_SExprSymbol var_sym, slop_string coll_c, slop_string resolved_type, slop_list_types_SExpr_ptr items, int64_t len);
 void stmt_transpile_for_each_map_keys(context_TranspileContext* ctx, slop_string var_name, types_SExprSymbol var_sym, slop_string coll_c, slop_string resolved_type, slop_list_types_SExpr_ptr items, int64_t len);
 void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_types_SExpr_ptr binding_items, slop_list_types_SExpr_ptr items, int64_t len);
@@ -1449,14 +1447,6 @@ void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr) {
     }
 }
 
-uint8_t stmt_is_set_type(slop_string slop_type) {
-    return (strlib_starts_with(slop_type, SLOP_STR("(Set ")) || strlib_starts_with(slop_type, SLOP_STR("(Ptr (Set ")));
-}
-
-uint8_t stmt_is_map_type(slop_string slop_type) {
-    return (strlib_starts_with(slop_type, SLOP_STR("(Map ")) || strlib_starts_with(slop_type, SLOP_STR("(Ptr (Map ")));
-}
-
 void stmt_transpile_for_each_set(context_TranspileContext* ctx, slop_string var_name, types_SExprSymbol var_sym, slop_string coll_c, slop_string resolved_type, slop_list_types_SExpr_ptr items, int64_t len) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
@@ -1465,7 +1455,7 @@ void stmt_transpile_for_each_set(context_TranspileContext* ctx, slop_string var_
         __auto_type elem_c_type = expr_slop_value_type_to_c_type(ctx, elem_slop_type);
         context_ctx_emit(ctx, SLOP_STR("{"));
         context_ctx_indent(ctx);
-        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), coll_c, SLOP_STR(";")));
+        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, coll_c, resolved_type), SLOP_STR(";")));
         context_ctx_emit(ctx, SLOP_STR("for (size_t _i = 0; _i < _coll->cap; _i++) {"));
         context_ctx_indent(ctx);
         context_ctx_emit(ctx, SLOP_STR("if (_coll->entries[_i].occupied) {"));
@@ -1508,7 +1498,7 @@ void stmt_transpile_for_each_map_keys(context_TranspileContext* ctx, slop_string
         __auto_type key_c_type = expr_slop_value_type_to_c_type(ctx, key_slop_type);
         context_ctx_emit(ctx, SLOP_STR("{"));
         context_ctx_indent(ctx);
-        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), coll_c, SLOP_STR(";")));
+        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, coll_c, resolved_type), SLOP_STR(";")));
         context_ctx_emit(ctx, SLOP_STR("for (size_t _i = 0; _i < _coll->cap; _i++) {"));
         context_ctx_indent(ctx);
         context_ctx_emit(ctx, SLOP_STR("if (_coll->entries[_i].occupied) {"));
@@ -1591,7 +1581,7 @@ void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_typ
                                                             __auto_type val_c_type = expr_slop_value_type_to_c_type(ctx, val_slop_type);
                                                             context_ctx_emit(ctx, SLOP_STR("{"));
                                                             context_ctx_indent(ctx);
-                                                            context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), map_c, SLOP_STR(";")));
+                                                            context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, map_c, resolved_type), SLOP_STR(";")));
                                                             context_ctx_emit(ctx, SLOP_STR("for (size_t _i = 0; _i < _coll->cap; _i++) {"));
                                                             context_ctx_indent(ctx);
                                                             context_ctx_emit(ctx, SLOP_STR("if (_coll->entries[_i].occupied) {"));
@@ -1721,12 +1711,12 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
                                                                 {
                                                                     __auto_type coll_slop_type = expr_infer_expr_slop_type(ctx, coll_expr);
                                                                     __auto_type resolved_type = expr_resolve_type_alias(ctx, coll_slop_type);
-                                                                    if (stmt_is_set_type(resolved_type)) {
+                                                                    if (expr_is_set_type(resolved_type)) {
                                                                         {
                                                                             __auto_type coll_c = expr_transpile_expr(ctx, coll_expr);
                                                                             stmt_transpile_for_each_set(ctx, var_name, var_sym, coll_c, resolved_type, items, len);
                                                                         }
-                                                                    } else if (stmt_is_map_type(resolved_type)) {
+                                                                    } else if (expr_is_map_type(resolved_type)) {
                                                                         {
                                                                             __auto_type coll_c = expr_transpile_expr(ctx, coll_expr);
                                                                             stmt_transpile_for_each_map_keys(ctx, var_name, var_sym, coll_c, resolved_type, items, len);

--- a/bootstrap/tester/slop_stmt.h
+++ b/bootstrap/tester/slop_stmt.h
@@ -49,8 +49,6 @@ void stmt_transpile_with_arena(context_TranspileContext* ctx, types_SExpr* expr,
 void stmt_transpile_cond(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return);
 void stmt_transpile_cond_body(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items, int64_t start, uint8_t is_return);
 void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr);
-uint8_t stmt_is_set_type(slop_string slop_type);
-uint8_t stmt_is_map_type(slop_string slop_type);
 void stmt_transpile_for_each_set(context_TranspileContext* ctx, slop_string var_name, types_SExprSymbol var_sym, slop_string coll_c, slop_string resolved_type, slop_list_types_SExpr_ptr items, int64_t len);
 void stmt_transpile_for_each_map_keys(context_TranspileContext* ctx, slop_string var_name, types_SExprSymbol var_sym, slop_string coll_c, slop_string resolved_type, slop_list_types_SExpr_ptr items, int64_t len);
 void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_types_SExpr_ptr binding_items, slop_list_types_SExpr_ptr items, int64_t len);

--- a/bootstrap/tester/slop_test_emit.c
+++ b/bootstrap/tester/slop_test_emit.c
@@ -97,29 +97,29 @@ types_SExpr* test_emit_make_sexpr_list(slop_arena* arena, slop_list_types_SExpr_
 
 uint8_t test_emit_has_ellipsis(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1530 = (*expr);
-    switch (_mv_1530.tag) {
+    __auto_type _mv_1531 = (*expr);
+    switch (_mv_1531.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_1530.data.sym;
+            __auto_type s = _mv_1531.data.sym;
             return string_eq(s.name, SLOP_STR(".."));
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_1530.data.lst;
+            __auto_type l = _mv_1531.data.lst;
             {
                 __auto_type items = l.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type i = 0;
                 __auto_type found = 0;
                 while ((i < len) && !(found)) {
-                    __auto_type _mv_1531 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1531.has_value) {
-                        __auto_type item = _mv_1531.value;
+                    __auto_type _mv_1532 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1532.has_value) {
+                        __auto_type item = _mv_1532.value;
                         if (test_emit_has_ellipsis(item)) {
                             found = 1;
                         }
-                    } else if (!_mv_1531.has_value) {
+                    } else if (!_mv_1532.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -128,12 +128,12 @@ uint8_t test_emit_has_ellipsis(types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type _ = _mv_1530.data.num;
+            __auto_type _ = _mv_1531.data.num;
             return 0;
         }
         case types_SExpr_str:
         {
-            __auto_type _ = _mv_1530.data.str;
+            __auto_type _ = _mv_1531.data.str;
             return 0;
         }
     }
@@ -145,13 +145,13 @@ uint8_t test_emit_args_have_ellipsis(slop_list_types_SExpr_ptr args) {
         int64_t i = 0;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1532 = ({ __auto_type _lst = args; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1532.has_value) {
-                __auto_type arg = _mv_1532.value;
+            __auto_type _mv_1533 = ({ __auto_type _lst = args; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1533.has_value) {
+                __auto_type arg = _mv_1533.value;
                 if (test_emit_has_ellipsis(arg)) {
                     found = 1;
                 }
-            } else if (!_mv_1532.has_value) {
+            } else if (!_mv_1533.has_value) {
             }
             i = (i + 1);
         }
@@ -172,29 +172,29 @@ uint8_t test_emit_is_type_constructor_name(slop_string name) {
 
 uint8_t test_emit_contains_wildcard(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1533 = (*expr);
-    switch (_mv_1533.tag) {
+    __auto_type _mv_1534 = (*expr);
+    switch (_mv_1534.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_1533.data.sym;
+            __auto_type s = _mv_1534.data.sym;
             return ((string_eq(s.name, SLOP_STR("_"))) || (string_eq(s.name, SLOP_STR(".."))) || (string_eq(s.name, SLOP_STR("."))));
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_1533.data.lst;
+            __auto_type l = _mv_1534.data.lst;
             {
                 __auto_type items = l.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type i = 0;
                 __auto_type found = 0;
                 while ((i < len) && !(found)) {
-                    __auto_type _mv_1534 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1534.has_value) {
-                        __auto_type item = _mv_1534.value;
+                    __auto_type _mv_1535 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1535.has_value) {
+                        __auto_type item = _mv_1535.value;
                         if (test_emit_contains_wildcard(item)) {
                             found = 1;
                         }
-                    } else if (!_mv_1534.has_value) {
+                    } else if (!_mv_1535.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -203,12 +203,12 @@ uint8_t test_emit_contains_wildcard(types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type _ = _mv_1533.data.num;
+            __auto_type _ = _mv_1534.data.num;
             return 0;
         }
         case types_SExpr_str:
         {
-            __auto_type _ = _mv_1533.data.str;
+            __auto_type _ = _mv_1534.data.str;
             return 0;
         }
     }
@@ -216,11 +216,11 @@ uint8_t test_emit_contains_wildcard(types_SExpr* expr) {
 
 types_SExpr* test_emit_replace_wildcards(slop_arena* arena, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1535 = (*expr);
-    switch (_mv_1535.tag) {
+    __auto_type _mv_1536 = (*expr);
+    switch (_mv_1536.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_1535.data.sym;
+            __auto_type s = _mv_1536.data.sym;
             if ((string_eq(s.name, SLOP_STR("_"))) || (string_eq(s.name, SLOP_STR(".."))) || (string_eq(s.name, SLOP_STR(".")))) {
                 return test_emit_make_sexpr_sym(arena, SLOP_STR("__SLOP_WILDCARD__"));
             } else {
@@ -229,7 +229,7 @@ types_SExpr* test_emit_replace_wildcards(slop_arena* arena, types_SExpr* expr) {
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_1535.data.lst;
+            __auto_type l = _mv_1536.data.lst;
             {
                 __auto_type items = l.items;
                 __auto_type len = ((int64_t)((items).len));
@@ -237,15 +237,15 @@ types_SExpr* test_emit_replace_wildcards(slop_arena* arena, types_SExpr* expr) {
                 __auto_type i = 0;
                 __auto_type in_type_constructor = (((len > 0)) ? ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type first = _mv.value; ({ __auto_type _mv = (*first); uint8_t _mr = {0}; switch (_mv.tag) { case types_SExpr_sym: { __auto_type s = _mv.data.sym; _mr = test_emit_is_type_constructor_name(s.name); break; } default: { _mr = 0; break; }  } _mr; }); }) : (0); }) : 0);
                 while (i < len) {
-                    __auto_type _mv_1536 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1536.has_value) {
-                        __auto_type item = _mv_1536.value;
+                    __auto_type _mv_1537 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1537.has_value) {
+                        __auto_type item = _mv_1537.value;
                         if (in_type_constructor && (i > 0)) {
-                            __auto_type _mv_1537 = (*item);
-                            switch (_mv_1537.tag) {
+                            __auto_type _mv_1538 = (*item);
+                            switch (_mv_1538.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type s = _mv_1537.data.sym;
+                                    __auto_type s = _mv_1538.data.sym;
                                     if ((string_eq(s.name, SLOP_STR(".."))) && (((i + 1) < len)) && (({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)(i + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type next_item = _mv.value; ({ __auto_type _mv = (*next_item); uint8_t _mr = {0}; switch (_mv.tag) { case types_SExpr_sym: { __auto_type ns = _mv.data.sym; _mr = string_eq(ns.name, SLOP_STR(".")); break; } default: { _mr = 0; break; }  } _mr; }); }) : (0); }))) {
                                     } else if ((string_eq(s.name, SLOP_STR("_"))) || (string_eq(s.name, SLOP_STR(".."))) || (string_eq(s.name, SLOP_STR(".")))) {
                                         ({ __auto_type _lst_p = &(new_items); __auto_type _item = (test_emit_make_sexpr_sym(arena, SLOP_STR("__SLOP_WILDCARD__"))); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
@@ -262,7 +262,7 @@ types_SExpr* test_emit_replace_wildcards(slop_arena* arena, types_SExpr* expr) {
                         } else {
                             ({ __auto_type _lst_p = &(new_items); __auto_type _item = (test_emit_replace_wildcards(arena, item)); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                         }
-                    } else if (!_mv_1536.has_value) {
+                    } else if (!_mv_1537.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -271,12 +271,12 @@ types_SExpr* test_emit_replace_wildcards(slop_arena* arena, types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type _ = _mv_1535.data.num;
+            __auto_type _ = _mv_1536.data.num;
             return expr;
         }
         case types_SExpr_str:
         {
-            __auto_type _ = _mv_1535.data.str;
+            __auto_type _ = _mv_1536.data.str;
             return expr;
         }
     }
@@ -290,11 +290,11 @@ slop_string test_emit_prefix_symbol(slop_arena* arena, slop_string name, slop_st
     if (string_eq(name, SLOP_STR("arena"))) {
         return SLOP_STR("test_arena");
     } else {
-        __auto_type _mv_1538 = type_extract_registry_lookup_import(types, name);
-        if (_mv_1538.has_value) {
-            __auto_type mod_name = _mv_1538.value;
+        __auto_type _mv_1539 = type_extract_registry_lookup_import(types, name);
+        if (_mv_1539.has_value) {
+            __auto_type mod_name = _mv_1539.value;
             return string_concat(arena, ctype_to_c_name(arena, mod_name), string_concat(arena, SLOP_STR("_"), ctype_to_c_name(arena, name)));
-        } else if (!_mv_1538.has_value) {
+        } else if (!_mv_1539.has_value) {
             if (((int64_t)(prefix.len)) > 0) {
                 return string_concat(arena, prefix, string_concat(arena, SLOP_STR("_"), ctype_to_c_name(arena, name)));
             } else {
@@ -334,11 +334,11 @@ types_SExpr* test_emit_build_call_sexpr(slop_arena* arena, slop_string fn_name, 
                 ({ __auto_type _lst_p = &(call_items); __auto_type _item = (test_emit_make_sexpr_sym(arena, SLOP_STR("arena"))); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                 arg_idx = (arg_idx + 1);
             }
-            __auto_type _mv_1539 = ({ __auto_type _lst = args; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1539.has_value) {
-                __auto_type arg = _mv_1539.value;
+            __auto_type _mv_1540 = ({ __auto_type _lst = args; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1540.has_value) {
+                __auto_type arg = _mv_1540.value;
                 ({ __auto_type _lst_p = &(call_items); __auto_type _item = (arg); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-            } else if (!_mv_1539.has_value) {
+            } else if (!_mv_1540.has_value) {
             }
             i = (i + 1);
             arg_idx = (arg_idx + 1);
@@ -408,14 +408,14 @@ slop_list_string test_emit_emit_test_harness_typed(slop_arena* arena, slop_list_
             __auto_type import_count = ((int64_t)((imports).len));
             int64_t j = 0;
             while (j < import_count) {
-                __auto_type _mv_1540 = ({ __auto_type _lst = imports; size_t _idx = (size_t)j; slop_option_type_extract_ImportEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1540.has_value) {
-                    __auto_type entry = _mv_1540.value;
+                __auto_type _mv_1541 = ({ __auto_type _lst = imports; size_t _idx = (size_t)j; slop_option_type_extract_ImportEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1541.has_value) {
+                    __auto_type entry = _mv_1541.value;
                     {
                         __auto_type c_name = ctype_to_c_name(arena, entry.module_name);
                         test_emit_emit(ctx, string_concat(arena, SLOP_STR("#include \"slop_"), string_concat(arena, c_name, SLOP_STR(".h\""))));
                     }
-                } else if (!_mv_1540.has_value) {
+                } else if (!_mv_1541.has_value) {
                 }
                 j = (j + 1);
             }
@@ -438,11 +438,11 @@ slop_list_string test_emit_emit_test_harness_typed(slop_arena* arena, slop_list_
                 __auto_type test_count = ((int64_t)((tests).len));
                 int64_t i = 0;
                 while (i < test_count) {
-                    __auto_type _mv_1541 = ({ __auto_type _lst = tests; size_t _idx = (size_t)i; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1541.has_value) {
-                        __auto_type tc = _mv_1541.value;
+                    __auto_type _mv_1542 = ({ __auto_type _lst = tests; size_t _idx = (size_t)i; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1542.has_value) {
+                        __auto_type tc = _mv_1542.value;
                         test_emit_emit_test_function_typed(ctx, (*tc), i, module_prefix, types, tctx, file_name);
-                    } else if (!_mv_1541.has_value) {
+                    } else if (!_mv_1542.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -455,29 +455,29 @@ slop_list_string test_emit_emit_test_harness_typed(slop_arena* arena, slop_list_
 
 uint8_t test_emit_expr_mentions_arena(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1542 = (*expr);
-    switch (_mv_1542.tag) {
+    __auto_type _mv_1543 = (*expr);
+    switch (_mv_1543.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_1542.data.sym;
+            __auto_type s = _mv_1543.data.sym;
             return string_eq(s.name, SLOP_STR("arena"));
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_1542.data.lst;
+            __auto_type l = _mv_1543.data.lst;
             {
                 __auto_type items = l.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type i = 0;
                 __auto_type found = 0;
                 while ((i < len) && !(found)) {
-                    __auto_type _mv_1543 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1543.has_value) {
-                        __auto_type item = _mv_1543.value;
+                    __auto_type _mv_1544 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1544.has_value) {
+                        __auto_type item = _mv_1544.value;
                         if (test_emit_expr_mentions_arena(item)) {
                             found = 1;
                         }
-                    } else if (!_mv_1543.has_value) {
+                    } else if (!_mv_1544.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -486,12 +486,12 @@ uint8_t test_emit_expr_mentions_arena(types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type _ = _mv_1542.data.num;
+            __auto_type _ = _mv_1543.data.num;
             return 0;
         }
         case types_SExpr_str:
         {
-            __auto_type _ = _mv_1542.data.str;
+            __auto_type _ = _mv_1543.data.str;
             return 0;
         }
     }
@@ -508,13 +508,13 @@ uint8_t test_emit_test_mentions_arena(extract_TestCase tc) {
             int64_t i = 0;
             uint8_t found = test_emit_expr_mentions_arena(tc.expected);
             while ((i < len) && !(found)) {
-                __auto_type _mv_1544 = ({ __auto_type _lst = args; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1544.has_value) {
-                    __auto_type arg = _mv_1544.value;
+                __auto_type _mv_1545 = ({ __auto_type _lst = args; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1545.has_value) {
+                    __auto_type arg = _mv_1545.value;
                     if (test_emit_expr_mentions_arena(arg)) {
                         found = 1;
                     }
-                } else if (!_mv_1544.has_value) {
+                } else if (!_mv_1545.has_value) {
                 }
                 i = (i + 1);
             }
@@ -529,13 +529,13 @@ uint8_t test_emit_any_test_needs_arena(slop_list_extract_TestCase_ptr tests) {
         int64_t i = 0;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1545 = ({ __auto_type _lst = tests; size_t _idx = (size_t)i; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1545.has_value) {
-                __auto_type tc = _mv_1545.value;
+            __auto_type _mv_1546 = ({ __auto_type _lst = tests; size_t _idx = (size_t)i; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1546.has_value) {
+                __auto_type tc = _mv_1546.value;
                 if (test_emit_test_mentions_arena((*tc))) {
                     found = 1;
                 }
-            } else if (!_mv_1545.has_value) {
+            } else if (!_mv_1546.has_value) {
             }
             i = (i + 1);
         }
@@ -549,28 +549,28 @@ slop_string test_emit_format_error_position(slop_arena* arena, slop_string file_
 
 slop_string test_emit_param_name_at(types_SExpr* params, int64_t idx) {
     SLOP_PRE(((params != NULL)), "(!= params nil)");
-    __auto_type _mv_1546 = parser_sexpr_list_get(params, idx);
-    if (_mv_1546.has_value) {
-        __auto_type param = _mv_1546.value;
+    __auto_type _mv_1547 = parser_sexpr_list_get(params, idx);
+    if (_mv_1547.has_value) {
+        __auto_type param = _mv_1547.value;
         {
             __auto_type plen = parser_sexpr_list_len(param);
             if (plen < 2) {
                 return SLOP_STR("");
             } else {
-                __auto_type _mv_1547 = parser_sexpr_list_get(param, (((plen == 2)) ? 0 : 1));
-                if (_mv_1547.has_value) {
-                    __auto_type name_expr = _mv_1547.value;
+                __auto_type _mv_1548 = parser_sexpr_list_get(param, (((plen == 2)) ? 0 : 1));
+                if (_mv_1548.has_value) {
+                    __auto_type name_expr = _mv_1548.value;
                     if (parser_sexpr_is_symbol(name_expr)) {
                         return parser_sexpr_get_symbol_name(name_expr);
                     } else {
                         return SLOP_STR("");
                     }
-                } else if (!_mv_1547.has_value) {
+                } else if (!_mv_1548.has_value) {
                     return SLOP_STR("");
                 }
             }
         }
-    } else if (!_mv_1546.has_value) {
+    } else if (!_mv_1547.has_value) {
         return SLOP_STR("");
     }
 }
@@ -578,11 +578,11 @@ slop_string test_emit_param_name_at(types_SExpr* params, int64_t idx) {
 types_SExpr* test_emit_substitute_symbol(slop_arena* arena, types_SExpr* expr, slop_string name, types_SExpr* replacement) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     SLOP_PRE(((replacement != NULL)), "(!= replacement nil)");
-    __auto_type _mv_1548 = (*expr);
-    switch (_mv_1548.tag) {
+    __auto_type _mv_1549 = (*expr);
+    switch (_mv_1549.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_1548.data.sym;
+            __auto_type s = _mv_1549.data.sym;
             if (string_eq(s.name, name)) {
                 return replacement;
             } else {
@@ -591,7 +591,7 @@ types_SExpr* test_emit_substitute_symbol(slop_arena* arena, types_SExpr* expr, s
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_1548.data.lst;
+            __auto_type l = _mv_1549.data.lst;
             {
                 __auto_type items = l.items;
                 __auto_type len = ((int64_t)((items).len));
@@ -599,15 +599,15 @@ types_SExpr* test_emit_substitute_symbol(slop_arena* arena, types_SExpr* expr, s
                 __auto_type is_field_access = ((len >= 3) && ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type head = _mv.value; ({ __auto_type _mv = (*head); uint8_t _mr = {0}; switch (_mv.tag) { case types_SExpr_sym: { __auto_type hs = _mv.data.sym; _mr = string_eq(hs.name, SLOP_STR(".")); break; } default: { _mr = 0; break; }  } _mr; }); }) : (0); }));
                 __auto_type i = 0;
                 while (i < len) {
-                    __auto_type _mv_1549 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1549.has_value) {
-                        __auto_type item = _mv_1549.value;
+                    __auto_type _mv_1550 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1550.has_value) {
+                        __auto_type item = _mv_1550.value;
                         if (is_field_access && (i >= 2)) {
                             ({ __auto_type _lst_p = &(new_items); __auto_type _item = (item); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                         } else {
                             ({ __auto_type _lst_p = &(new_items); __auto_type _item = (test_emit_substitute_symbol(arena, item, name, replacement)); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                         }
-                    } else if (!_mv_1549.has_value) {
+                    } else if (!_mv_1550.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -616,12 +616,12 @@ types_SExpr* test_emit_substitute_symbol(slop_arena* arena, types_SExpr* expr, s
         }
         case types_SExpr_num:
         {
-            __auto_type _ = _mv_1548.data.num;
+            __auto_type _ = _mv_1549.data.num;
             return expr;
         }
         case types_SExpr_str:
         {
-            __auto_type _ = _mv_1548.data.str;
+            __auto_type _ = _mv_1549.data.str;
             return expr;
         }
     }
@@ -646,11 +646,11 @@ types_SExpr* test_emit_bind_precondition_args(slop_arena* arena, extract_TestCas
                     } else {
                         {
                             __auto_type arg_idx = (((needs_arena && (i > arena_pos))) ? (i - 1) : i);
-                            __auto_type _mv_1550 = ({ __auto_type _lst = args; size_t _idx = (size_t)arg_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1550.has_value) {
-                                __auto_type arg = _mv_1550.value;
+                            __auto_type _mv_1551 = ({ __auto_type _lst = args; size_t _idx = (size_t)arg_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1551.has_value) {
+                                __auto_type arg = _mv_1551.value;
                                 result = test_emit_substitute_symbol(arena, result, pname, arg);
-                            } else if (!_mv_1550.has_value) {
+                            } else if (!_mv_1551.has_value) {
                             }
                         }
                     }
@@ -669,9 +669,9 @@ slop_string test_emit_build_precondition_check(slop_arena* arena, context_Transp
         __auto_type result = SLOP_STR("");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1551 = ({ __auto_type _lst = pres; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1551.has_value) {
-                __auto_type cond_expr = _mv_1551.value;
+            __auto_type _mv_1552 = ({ __auto_type _lst = pres; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1552.has_value) {
+                __auto_type cond_expr = _mv_1552.value;
                 {
                     __auto_type c = expr_transpile_expr(tctx, test_emit_bind_precondition_args(arena, tc, cond_expr));
                     if (string_eq(result, SLOP_STR(""))) {
@@ -680,7 +680,7 @@ slop_string test_emit_build_precondition_check(slop_arena* arena, context_Transp
                         result = string_concat(arena, result, string_concat(arena, SLOP_STR(" && ("), string_concat(arena, c, SLOP_STR(")"))));
                     }
                 }
-            } else if (!_mv_1551.has_value) {
+            } else if (!_mv_1552.has_value) {
             }
             i = (i + 1);
         }
@@ -695,9 +695,9 @@ slop_string test_emit_describe_preconditions(slop_arena* arena, extract_TestCase
         __auto_type result = SLOP_STR("");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1552 = ({ __auto_type _lst = pres; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1552.has_value) {
-                __auto_type cond_expr = _mv_1552.value;
+            __auto_type _mv_1553 = ({ __auto_type _lst = pres; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1553.has_value) {
+                __auto_type cond_expr = _mv_1553.value;
                 {
                     __auto_type txt = parser_pretty_print(arena, cond_expr);
                     if (string_eq(result, SLOP_STR(""))) {
@@ -706,7 +706,7 @@ slop_string test_emit_describe_preconditions(slop_arena* arena, extract_TestCase
                         result = string_concat(arena, result, string_concat(arena, SLOP_STR(" and "), txt));
                     }
                 }
-            } else if (!_mv_1552.has_value) {
+            } else if (!_mv_1553.has_value) {
             }
             i = (i + 1);
         }
@@ -720,15 +720,15 @@ slop_option_string test_emit_first_error_since(slop_arena* arena, context_Transp
     {
         __auto_type errors = context_ctx_get_errors(tctx);
         if (((int64_t)((errors).len)) > before) {
-            __auto_type _mv_1553 = ({ __auto_type _lst = errors; size_t _idx = (size_t)((int64_t)(before)); slop_option_context_TranspileError _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1553.has_value) {
-                __auto_type e = _mv_1553.value;
+            __auto_type _mv_1554 = ({ __auto_type _lst = errors; size_t _idx = (size_t)((int64_t)(before)); slop_option_context_TranspileError _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1554.has_value) {
+                __auto_type e = _mv_1554.value;
                 {
                     __auto_type line = (((e.line > 0)) ? e.line : fallback_line);
                     __auto_type col = (((e.line > 0)) ? e.col : fallback_col);
                     return (slop_option_string){.has_value = 1, .value = string_concat(arena, e.message, string_concat(arena, SLOP_STR(" at "), test_emit_format_error_position(arena, file_name, line, col)))};
                 }
-            } else if (!_mv_1553.has_value) {
+            } else if (!_mv_1554.has_value) {
                 return (slop_option_string){.has_value = false};
             }
         } else {
@@ -740,11 +740,11 @@ slop_option_string test_emit_first_error_since(slop_arena* arena, context_Transp
 types_SExpr* test_emit_example_anchor(extract_TestCase tc) {
     SLOP_PRE(((tc.expected != NULL)), "(!= (. tc expected) nil)");
     types_SExpr* _retval = {0};
-    __auto_type _mv_1554 = ({ __auto_type _lst = tc.args; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-    if (_mv_1554.has_value) {
-        __auto_type a = _mv_1554.value;
+    __auto_type _mv_1555 = ({ __auto_type _lst = tc.args; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+    if (_mv_1555.has_value) {
+        __auto_type a = _mv_1555.value;
         return a;
-    } else if (!_mv_1554.has_value) {
+    } else if (!_mv_1555.has_value) {
         return tc.expected;
     }
     SLOP_POST(((_retval != NULL)), "(!= $result nil)");
@@ -771,14 +771,14 @@ void test_emit_emit_test_function_typed(test_emit_EmitContext* ctx, extract_Test
         __auto_type problem = ((test_emit_args_have_ellipsis(tc.args)) ? (slop_option_string){.has_value = 1, .value = string_concat(arena, SLOP_STR("'...' is not a value at "), test_emit_format_error_position(arena, file_name, anchor_line, anchor_col))} : test_emit_first_error_since(arena, tctx, errors_before, file_name, anchor_line, anchor_col));
         test_emit_emit(ctx, string_concat(arena, SLOP_STR("void test_"), string_concat(arena, int_to_string(arena, index), SLOP_STR("(void) {"))));
         test_emit_emit(ctx, string_concat(arena, SLOP_STR("    printf(\"  "), string_concat(arena, fn_name, string_concat(arena, SLOP_STR("("), string_concat(arena, test_emit_escape_string(arena, args_display), SLOP_STR(") -> \");"))))));
-        __auto_type _mv_1555 = problem;
-        if (_mv_1555.has_value) {
-            __auto_type reason = _mv_1555.value;
+        __auto_type _mv_1556 = problem;
+        if (_mv_1556.has_value) {
+            __auto_type reason = _mv_1556.value;
             test_emit_emit(ctx, string_concat(arena, SLOP_STR("    printf(\"ERROR: "), string_concat(arena, test_emit_escape_string(arena, reason), SLOP_STR("\\n\");"))));
             test_emit_emit(ctx, SLOP_STR("    tests_errored++;"));
             test_emit_emit(ctx, SLOP_STR("}"));
             test_emit_emit(ctx, SLOP_STR(""));
-        } else if (!_mv_1555.has_value) {
+        } else if (!_mv_1556.has_value) {
             if (string_len(pre_check) > 0) {
                 test_emit_emit(ctx, string_concat(arena, SLOP_STR("    if (!("), string_concat(arena, pre_check, SLOP_STR(")) {"))));
                 test_emit_emit(ctx, string_concat(arena, SLOP_STR("        printf(\"FAIL (precondition violated: "), string_concat(arena, test_emit_escape_string(arena, test_emit_describe_preconditions(arena, tc)), SLOP_STR(")\\n\");"))));
@@ -848,11 +848,11 @@ void test_emit_emit_main_function(test_emit_EmitContext* ctx, int64_t test_count
 slop_string test_emit_make_c_fn_name(slop_arena* arena, slop_string fn_name, slop_option_string module_name, slop_string prefix) {
     {
         __auto_type c_name = ctype_to_c_name(arena, fn_name);
-        __auto_type _mv_1556 = module_name;
-        if (_mv_1556.has_value) {
-            __auto_type mod = _mv_1556.value;
+        __auto_type _mv_1557 = module_name;
+        if (_mv_1557.has_value) {
+            __auto_type mod = _mv_1557.value;
             return string_concat(arena, ctype_to_c_name(arena, mod), string_concat(arena, SLOP_STR("_"), c_name));
-        } else if (!_mv_1556.has_value) {
+        } else if (!_mv_1557.has_value) {
             if (((int64_t)(prefix.len)) > 0) {
                 return string_concat(arena, prefix, string_concat(arena, SLOP_STR("_"), c_name));
             } else {
@@ -869,9 +869,9 @@ slop_string test_emit_build_args_display_typed(slop_arena* arena, slop_list_type
         uint8_t first = 1;
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1557 = ({ __auto_type _lst = args; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1557.has_value) {
-                __auto_type arg = _mv_1557.value;
+            __auto_type _mv_1558 = ({ __auto_type _lst = args; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1558.has_value) {
+                __auto_type arg = _mv_1558.value;
                 {
                     __auto_type arg_str = parser_pretty_print(arena, arg);
                     if (first) {
@@ -881,7 +881,7 @@ slop_string test_emit_build_args_display_typed(slop_arena* arena, slop_list_type
                         result = string_concat(arena, result, string_concat(arena, SLOP_STR(", "), arg_str));
                     }
                 }
-            } else if (!_mv_1557.has_value) {
+            } else if (!_mv_1558.has_value) {
             }
             i = (i + 1);
         }
@@ -914,15 +914,15 @@ test_emit_CompareInfo test_emit_build_comparison_typed(slop_arena* arena, types_
                                     {
                                         __auto_type record_name = test_emit_get_record_name_from_expr(inner_expr);
                                         __auto_type field_values = test_emit_get_record_field_values(arena, inner_expr);
-                                        __auto_type _mv_1558 = type_extract_registry_get_record_fields(types, record_name);
-                                        if (_mv_1558.has_value) {
-                                            __auto_type fields = _mv_1558.value;
+                                        __auto_type _mv_1559 = type_extract_registry_get_record_fields(types, record_name);
+                                        if (_mv_1559.has_value) {
+                                            __auto_type fields = _mv_1559.value;
                                             {
                                                 __auto_type expected_var_name = SLOP_STR("expected_value");
                                                 __auto_type compare_expr = test_emit_build_record_field_comparisons_with_values(arena, fields, field_values, SLOP_STR("result.value"), expected_var_name);
                                                 return (test_emit_CompareInfo){string_concat(arena, SLOP_STR("({ typeof(result.value) "), string_concat(arena, expected_var_name, string_concat(arena, SLOP_STR(" = "), string_concat(arena, inner_expected, string_concat(arena, SLOP_STR("; result.has_value && "), string_concat(arena, compare_expr, SLOP_STR("; })"))))))), SLOP_STR("%s"), SLOP_STR("result.has_value ? \"some(...)\" : \"none\""), SLOP_STR("%s"), SLOP_STR("\"some(...)\"")};
                                             }
-                                        } else if (!_mv_1558.has_value) {
+                                        } else if (!_mv_1559.has_value) {
                                             return (test_emit_CompareInfo){string_concat(arena, SLOP_STR("({ typeof(result.value) expected_value = "), string_concat(arena, inner_expected, SLOP_STR("; result.has_value && memcmp(&result.value, &expected_value, sizeof(result.value)) == 0; })"))), SLOP_STR("%s"), SLOP_STR("result.has_value ? \"some(...)\" : \"none\""), SLOP_STR("%s"), SLOP_STR("\"some(...)\"")};
                                         }
                                     }
@@ -960,15 +960,15 @@ test_emit_CompareInfo test_emit_build_comparison_typed(slop_arena* arena, types_
                                                 {
                                                     __auto_type record_name = test_emit_get_record_name_from_expr(inner_expr);
                                                     __auto_type field_values = test_emit_get_record_field_values(arena, inner_expr);
-                                                    __auto_type _mv_1559 = type_extract_registry_get_record_fields(types, record_name);
-                                                    if (_mv_1559.has_value) {
-                                                        __auto_type fields = _mv_1559.value;
+                                                    __auto_type _mv_1560 = type_extract_registry_get_record_fields(types, record_name);
+                                                    if (_mv_1560.has_value) {
+                                                        __auto_type fields = _mv_1560.value;
                                                         {
                                                             __auto_type expected_var_name = SLOP_STR("expected_ok");
                                                             __auto_type compare_expr = test_emit_build_record_field_comparisons_with_values(arena, fields, field_values, SLOP_STR("result.data.ok"), expected_var_name);
                                                             return (test_emit_CompareInfo){string_concat(arena, SLOP_STR("({ typeof(result.data.ok) "), string_concat(arena, expected_var_name, string_concat(arena, SLOP_STR(" = "), string_concat(arena, inner_expected, string_concat(arena, SLOP_STR("; result.is_ok && "), string_concat(arena, compare_expr, SLOP_STR("; })"))))))), SLOP_STR("%s"), SLOP_STR("result.is_ok ? \"ok(...)\" : \"error(...)\""), SLOP_STR("%s"), SLOP_STR("\"ok(...)\"")};
                                                         }
-                                                    } else if (!_mv_1559.has_value) {
+                                                    } else if (!_mv_1560.has_value) {
                                                         return (test_emit_CompareInfo){string_concat(arena, SLOP_STR("({ typeof(result.data.ok) expected_ok = "), string_concat(arena, inner_expected, SLOP_STR("; result.is_ok && memcmp(&result.data.ok, &expected_ok, sizeof(result.data.ok)) == 0; })"))), SLOP_STR("%s"), SLOP_STR("result.is_ok ? \"ok(...)\" : \"error(...)\""), SLOP_STR("%s"), SLOP_STR("\"ok(...)\"")};
                                                     }
                                                 }
@@ -1081,15 +1081,15 @@ test_emit_CompareInfo test_emit_build_record_comparison_typed(slop_arena* arena,
 }
 
 test_emit_CompareInfo test_emit_build_record_comparison_inner(slop_arena* arena, type_extract_TypeRegistry types, slop_string record_name, slop_list_types_SExpr_ptr field_values, slop_string c_expected, slop_string decl_type) {
-    __auto_type _mv_1560 = type_extract_registry_get_record_fields(types, record_name);
-    if (_mv_1560.has_value) {
-        __auto_type fields = _mv_1560.value;
+    __auto_type _mv_1561 = type_extract_registry_get_record_fields(types, record_name);
+    if (_mv_1561.has_value) {
+        __auto_type fields = _mv_1561.value;
         {
             __auto_type expected_var_name = SLOP_STR("expected_value");
             __auto_type compare_expr = test_emit_build_record_field_comparisons_with_values(arena, fields, field_values, SLOP_STR("result"), expected_var_name);
             return (test_emit_CompareInfo){string_concat(arena, SLOP_STR("({ typeof(result) "), string_concat(arena, expected_var_name, string_concat(arena, SLOP_STR(" = "), string_concat(arena, c_expected, string_concat(arena, SLOP_STR("; "), string_concat(arena, compare_expr, SLOP_STR("; })"))))))), SLOP_STR("%s"), SLOP_STR("\"<record>\""), SLOP_STR("%s"), SLOP_STR("\"<expected>\"")};
         }
-    } else if (!_mv_1560.has_value) {
+    } else if (!_mv_1561.has_value) {
         {
             __auto_type expected_var_name = SLOP_STR("expected_value");
             return (test_emit_CompareInfo){string_concat(arena, SLOP_STR("({ typeof(result) "), string_concat(arena, expected_var_name, string_concat(arena, SLOP_STR(" = "), string_concat(arena, c_expected, string_concat(arena, SLOP_STR("; memcmp(&result, &"), string_concat(arena, expected_var_name, SLOP_STR(", sizeof(result)) == 0; })"))))))), SLOP_STR("%s"), SLOP_STR("\"<record>\""), SLOP_STR("%s"), SLOP_STR("\"<expected>\"")};
@@ -1098,36 +1098,36 @@ test_emit_CompareInfo test_emit_build_record_comparison_inner(slop_arena* arena,
 }
 
 slop_string test_emit_get_record_decl_type(slop_arena* arena, type_extract_TypeRegistry types, slop_string record_name) {
-    __auto_type _mv_1561 = type_extract_registry_lookup(types, record_name);
-    if (_mv_1561.has_value) {
-        __auto_type entry = _mv_1561.value;
+    __auto_type _mv_1562 = type_extract_registry_lookup(types, record_name);
+    if (_mv_1562.has_value) {
+        __auto_type entry = _mv_1562.value;
         return (*entry).c_name;
-    } else if (!_mv_1561.has_value) {
+    } else if (!_mv_1562.has_value) {
         return SLOP_STR("");
     }
 }
 
 slop_string test_emit_get_record_name_from_expr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1562 = (*expr);
-    switch (_mv_1562.tag) {
+    __auto_type _mv_1563 = (*expr);
+    switch (_mv_1563.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1562.data.lst;
+            __auto_type lst = _mv_1563.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) == 0) {
                     return SLOP_STR("");
                 } else {
-                    __auto_type _mv_1563 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1563.has_value) {
-                        __auto_type first = _mv_1563.value;
+                    __auto_type _mv_1564 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1564.has_value) {
+                        __auto_type first = _mv_1564.value;
                         if (parser_sexpr_is_symbol(first)) {
                             return parser_sexpr_get_symbol_name(first);
                         } else {
                             return SLOP_STR("");
                         }
-                    } else if (!_mv_1563.has_value) {
+                    } else if (!_mv_1564.has_value) {
                         return SLOP_STR("");
                     }
                 }
@@ -1141,11 +1141,11 @@ slop_string test_emit_get_record_name_from_expr(types_SExpr* expr) {
 
 slop_list_types_SExpr_ptr test_emit_get_record_field_values(slop_arena* arena, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1564 = (*expr);
-    switch (_mv_1564.tag) {
+    __auto_type _mv_1565 = (*expr);
+    switch (_mv_1565.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1564.data.lst;
+            __auto_type lst = _mv_1565.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
@@ -1156,11 +1156,11 @@ slop_list_types_SExpr_ptr test_emit_get_record_field_values(slop_arena* arena, t
                         __auto_type result = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
                         __auto_type i = 1;
                         while (i < len) {
-                            __auto_type _mv_1565 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1565.has_value) {
-                                __auto_type val = _mv_1565.value;
+                            __auto_type _mv_1566 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1566.has_value) {
+                                __auto_type val = _mv_1566.value;
                                 ({ __auto_type _lst_p = &(result); __auto_type _item = (val); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                            } else if (!_mv_1565.has_value) {
+                            } else if (!_mv_1566.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -1177,11 +1177,11 @@ slop_list_types_SExpr_ptr test_emit_get_record_field_values(slop_arena* arena, t
 
 uint8_t test_emit_is_wildcard_expr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1566 = (*expr);
-    switch (_mv_1566.tag) {
+    __auto_type _mv_1567 = (*expr);
+    switch (_mv_1567.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1566.data.sym;
+            __auto_type sym = _mv_1567.data.sym;
             return ((string_eq(sym.name, SLOP_STR("_"))) || (string_eq(sym.name, SLOP_STR(".."))) || (string_eq(sym.name, SLOP_STR("."))));
         }
         default: {
@@ -1197,13 +1197,13 @@ int64_t test_emit_count_wildcard_values(slop_list_types_SExpr_ptr field_values) 
         int64_t i = 0;
         int64_t n = 0;
         while (i < len) {
-            __auto_type _mv_1567 = ({ __auto_type _lst = field_values; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1567.has_value) {
-                __auto_type v = _mv_1567.value;
+            __auto_type _mv_1568 = ({ __auto_type _lst = field_values; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1568.has_value) {
+                __auto_type v = _mv_1568.value;
                 if (test_emit_is_wildcard_expr(v)) {
                     n = (n + 1);
                 }
-            } else if (!_mv_1567.has_value) {
+            } else if (!_mv_1568.has_value) {
             }
             i = (i + 1);
         }
@@ -1219,9 +1219,9 @@ slop_string test_emit_build_record_field_comparisons_with_values(slop_arena* are
         __auto_type comp_result = SLOP_STR("1");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1568 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_type_extract_TstFieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1568.has_value) {
-                __auto_type field = _mv_1568.value;
+            __auto_type _mv_1569 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_type_extract_TstFieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1569.has_value) {
+                __auto_type field = _mv_1569.value;
                 {
                     __auto_type is_wildcard = ({ __auto_type _mv = ({ __auto_type _lst = field_values; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type val = _mv.value; test_emit_is_wildcard_expr(val); }) : (0); });
                     if (!(is_wildcard)) {
@@ -1233,7 +1233,7 @@ slop_string test_emit_build_record_field_comparisons_with_values(slop_arena* are
                         }
                     }
                 }
-            } else if (!_mv_1568.has_value) {
+            } else if (!_mv_1569.has_value) {
             }
             i = (i + 1);
         }
@@ -1320,44 +1320,44 @@ uint8_t test_emit_is_likely_struct_type(slop_string type_name) {
 
 slop_string test_emit_get_first_symbol_name(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1569 = (*expr);
-    switch (_mv_1569.tag) {
+    __auto_type _mv_1570 = (*expr);
+    switch (_mv_1570.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_1569.data.sym;
+            __auto_type s = _mv_1570.data.sym;
             return s.name;
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_1569.data.lst;
+            __auto_type l = _mv_1570.data.lst;
             if (((int64_t)((l.items).len)) > 0) {
-                __auto_type _mv_1570 = ({ __auto_type _lst = l.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1570.has_value) {
-                    __auto_type first = _mv_1570.value;
-                    __auto_type _mv_1571 = (*first);
-                    switch (_mv_1571.tag) {
+                __auto_type _mv_1571 = ({ __auto_type _lst = l.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1571.has_value) {
+                    __auto_type first = _mv_1571.value;
+                    __auto_type _mv_1572 = (*first);
+                    switch (_mv_1572.tag) {
                         case types_SExpr_sym:
                         {
-                            __auto_type s = _mv_1571.data.sym;
+                            __auto_type s = _mv_1572.data.sym;
                             return s.name;
                         }
                         case types_SExpr_lst:
                         {
-                            __auto_type _ = _mv_1571.data.lst;
+                            __auto_type _ = _mv_1572.data.lst;
                             return SLOP_STR("");
                         }
                         case types_SExpr_num:
                         {
-                            __auto_type _ = _mv_1571.data.num;
+                            __auto_type _ = _mv_1572.data.num;
                             return SLOP_STR("");
                         }
                         case types_SExpr_str:
                         {
-                            __auto_type _ = _mv_1571.data.str;
+                            __auto_type _ = _mv_1572.data.str;
                             return SLOP_STR("");
                         }
                     }
-                } else if (!_mv_1570.has_value) {
+                } else if (!_mv_1571.has_value) {
                     return SLOP_STR("");
                 }
             } else {
@@ -1366,12 +1366,12 @@ slop_string test_emit_get_first_symbol_name(types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type _ = _mv_1569.data.num;
+            __auto_type _ = _mv_1570.data.num;
             return SLOP_STR("");
         }
         case types_SExpr_str:
         {
-            __auto_type _ = _mv_1569.data.str;
+            __auto_type _ = _mv_1570.data.str;
             return SLOP_STR("");
         }
     }
@@ -1402,11 +1402,11 @@ slop_string test_emit_build_union_payload_comparison(slop_arena* arena, slop_str
         } else if (string_eq(payload_type, SLOP_STR("String"))) {
             return string_concat(arena, SLOP_STR("slop_string_eq(result.data."), string_concat(arena, c_variant, string_concat(arena, SLOP_STR(", "), string_concat(arena, expected_var, string_concat(arena, SLOP_STR(".data."), string_concat(arena, c_variant, SLOP_STR(")")))))));
         } else {
-            __auto_type _mv_1572 = type_extract_registry_get_record_fields(types, payload_type);
-            if (_mv_1572.has_value) {
-                __auto_type fields = _mv_1572.value;
+            __auto_type _mv_1573 = type_extract_registry_get_record_fields(types, payload_type);
+            if (_mv_1573.has_value) {
+                __auto_type fields = _mv_1573.value;
                 return test_emit_build_union_record_payload_comparison(arena, fields, field_values, c_variant, expected_var);
-            } else if (!_mv_1572.has_value) {
+            } else if (!_mv_1573.has_value) {
                 if (wildcard_count > 0) {
                     return SLOP_STR("1");
                 } else {
@@ -1423,9 +1423,9 @@ slop_string test_emit_build_union_record_payload_comparison(slop_arena* arena, s
         __auto_type result = SLOP_STR("1");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1573 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_type_extract_TstFieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1573.has_value) {
-                __auto_type field = _mv_1573.value;
+            __auto_type _mv_1574 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_type_extract_TstFieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1574.has_value) {
+                __auto_type field = _mv_1574.value;
                 {
                     __auto_type is_wildcard = ({ __auto_type _mv = ({ __auto_type _lst = field_values; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type val = _mv.value; test_emit_is_wildcard_expr(val); }) : (0); });
                     if (!(is_wildcard)) {
@@ -1437,7 +1437,7 @@ slop_string test_emit_build_union_record_payload_comparison(slop_arena* arena, s
                         }
                     }
                 }
-            } else if (!_mv_1573.has_value) {
+            } else if (!_mv_1574.has_value) {
             }
             i = (i + 1);
         }
@@ -1477,19 +1477,19 @@ slop_string test_emit_build_union_field_comparison(slop_arena* arena, slop_strin
 
 uint8_t test_emit_is_union_constructor_typed(types_SExpr* expr, type_extract_TypeRegistry types) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1574 = (*expr);
-    switch (_mv_1574.tag) {
+    __auto_type _mv_1575 = (*expr);
+    switch (_mv_1575.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1574.data.lst;
+            __auto_type lst = _mv_1575.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) == 0) {
                     return 0;
                 } else {
-                    __auto_type _mv_1575 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1575.has_value) {
-                        __auto_type first = _mv_1575.value;
+                    __auto_type _mv_1576 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1576.has_value) {
+                        __auto_type first = _mv_1576.value;
                         if (parser_sexpr_is_symbol(first)) {
                             {
                                 __auto_type name = parser_sexpr_get_symbol_name(first);
@@ -1499,11 +1499,11 @@ uint8_t test_emit_is_union_constructor_typed(types_SExpr* expr, type_extract_Typ
                                     if ((string_eq(name, SLOP_STR("none"))) || (string_eq(name, SLOP_STR("some"))) || (string_eq(name, SLOP_STR("ok"))) || (string_eq(name, SLOP_STR("error")))) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1576 = type_extract_registry_lookup_variant(types, name);
-                                        if (_mv_1576.has_value) {
-                                            __auto_type _ = _mv_1576.value;
+                                        __auto_type _mv_1577 = type_extract_registry_lookup_variant(types, name);
+                                        if (_mv_1577.has_value) {
+                                            __auto_type _ = _mv_1577.value;
                                             return 1;
-                                        } else if (!_mv_1576.has_value) {
+                                        } else if (!_mv_1577.has_value) {
                                             return 0;
                                         }
                                     }
@@ -1512,7 +1512,7 @@ uint8_t test_emit_is_union_constructor_typed(types_SExpr* expr, type_extract_Typ
                         } else {
                             return 0;
                         }
-                    } else if (!_mv_1575.has_value) {
+                    } else if (!_mv_1576.has_value) {
                         return 0;
                     }
                 }
@@ -1526,32 +1526,32 @@ uint8_t test_emit_is_union_constructor_typed(types_SExpr* expr, type_extract_Typ
 
 slop_string test_emit_get_union_variant_name(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1577 = (*expr);
-    switch (_mv_1577.tag) {
+    __auto_type _mv_1578 = (*expr);
+    switch (_mv_1578.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1577.data.lst;
+            __auto_type lst = _mv_1578.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) == 0) {
                     return SLOP_STR("");
                 } else {
-                    __auto_type _mv_1578 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1578.has_value) {
-                        __auto_type first = _mv_1578.value;
+                    __auto_type _mv_1579 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1579.has_value) {
+                        __auto_type first = _mv_1579.value;
                         if (parser_sexpr_is_symbol(first)) {
                             {
                                 __auto_type name = parser_sexpr_get_symbol_name(first);
                                 if (string_eq(name, SLOP_STR("union-new"))) {
-                                    __auto_type _mv_1579 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_1579.has_value) {
-                                        __auto_type variant_expr = _mv_1579.value;
+                                    __auto_type _mv_1580 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_1580.has_value) {
+                                        __auto_type variant_expr = _mv_1580.value;
                                         if (parser_sexpr_is_symbol(variant_expr)) {
                                             return parser_sexpr_get_symbol_name(variant_expr);
                                         } else {
                                             return SLOP_STR("");
                                         }
-                                    } else if (!_mv_1579.has_value) {
+                                    } else if (!_mv_1580.has_value) {
                                         return SLOP_STR("");
                                     }
                                 } else {
@@ -1561,7 +1561,7 @@ slop_string test_emit_get_union_variant_name(types_SExpr* expr) {
                         } else {
                             return SLOP_STR("");
                         }
-                    } else if (!_mv_1578.has_value) {
+                    } else if (!_mv_1579.has_value) {
                         return SLOP_STR("");
                     }
                 }
@@ -1575,21 +1575,21 @@ slop_string test_emit_get_union_variant_name(types_SExpr* expr) {
 
 uint8_t test_emit_is_enum_value_typed(types_SExpr* expr, type_extract_TypeRegistry types) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1580 = (*expr);
-    switch (_mv_1580.tag) {
+    __auto_type _mv_1581 = (*expr);
+    switch (_mv_1581.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1580.data.sym;
+            __auto_type sym = _mv_1581.data.sym;
             {
                 __auto_type name = sym.name;
                 if (strlib_starts_with(name, SLOP_STR("'"))) {
                     {
                         __auto_type variant_name = test_emit_emit_string_slice(name, 1);
-                        __auto_type _mv_1581 = type_extract_registry_lookup_enum_value(types, variant_name);
-                        if (_mv_1581.has_value) {
-                            __auto_type _ = _mv_1581.value;
+                        __auto_type _mv_1582 = type_extract_registry_lookup_enum_value(types, variant_name);
+                        if (_mv_1582.has_value) {
+                            __auto_type _ = _mv_1582.value;
                             return 1;
-                        } else if (!_mv_1581.has_value) {
+                        } else if (!_mv_1582.has_value) {
                             return 0;
                         }
                     }
@@ -1600,37 +1600,37 @@ uint8_t test_emit_is_enum_value_typed(types_SExpr* expr, type_extract_TypeRegist
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1580.data.lst;
+            __auto_type lst = _mv_1581.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return 0;
                 } else {
-                    __auto_type _mv_1582 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1582.has_value) {
-                        __auto_type first = _mv_1582.value;
+                    __auto_type _mv_1583 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1583.has_value) {
+                        __auto_type first = _mv_1583.value;
                         if (parser_sexpr_is_symbol(first) && string_eq(parser_sexpr_get_symbol_name(first), SLOP_STR("quote"))) {
-                            __auto_type _mv_1583 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1583.has_value) {
-                                __auto_type quoted = _mv_1583.value;
+                            __auto_type _mv_1584 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1584.has_value) {
+                                __auto_type quoted = _mv_1584.value;
                                 if (parser_sexpr_is_symbol(quoted)) {
-                                    __auto_type _mv_1584 = type_extract_registry_lookup_enum_value(types, parser_sexpr_get_symbol_name(quoted));
-                                    if (_mv_1584.has_value) {
-                                        __auto_type _ = _mv_1584.value;
+                                    __auto_type _mv_1585 = type_extract_registry_lookup_enum_value(types, parser_sexpr_get_symbol_name(quoted));
+                                    if (_mv_1585.has_value) {
+                                        __auto_type _ = _mv_1585.value;
                                         return 1;
-                                    } else if (!_mv_1584.has_value) {
+                                    } else if (!_mv_1585.has_value) {
                                         return 0;
                                     }
                                 } else {
                                     return 0;
                                 }
-                            } else if (!_mv_1583.has_value) {
+                            } else if (!_mv_1584.has_value) {
                                 return 0;
                             }
                         } else {
                             return 0;
                         }
-                    } else if (!_mv_1582.has_value) {
+                    } else if (!_mv_1583.has_value) {
                         return 0;
                     }
                 }
@@ -1644,30 +1644,30 @@ uint8_t test_emit_is_enum_value_typed(types_SExpr* expr, type_extract_TypeRegist
 
 uint8_t test_emit_is_record_constructor_typed(types_SExpr* expr, type_extract_TypeRegistry types) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1585 = (*expr);
-    switch (_mv_1585.tag) {
+    __auto_type _mv_1586 = (*expr);
+    switch (_mv_1586.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1585.data.lst;
+            __auto_type lst = _mv_1586.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) == 0) {
                     return 0;
                 } else {
-                    __auto_type _mv_1586 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1586.has_value) {
-                        __auto_type first = _mv_1586.value;
+                    __auto_type _mv_1587 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1587.has_value) {
+                        __auto_type first = _mv_1587.value;
                         if (parser_sexpr_is_symbol(first)) {
                             {
                                 __auto_type name = parser_sexpr_get_symbol_name(first);
                                 if (string_eq(name, SLOP_STR("none")) || (string_eq(name, SLOP_STR("some")) || (string_eq(name, SLOP_STR("ok")) || (string_eq(name, SLOP_STR("error")) || string_eq(name, SLOP_STR("list")))))) {
                                     return 0;
                                 } else {
-                                    __auto_type _mv_1587 = type_extract_registry_lookup(types, name);
-                                    if (_mv_1587.has_value) {
-                                        __auto_type entry = _mv_1587.value;
+                                    __auto_type _mv_1588 = type_extract_registry_lookup(types, name);
+                                    if (_mv_1588.has_value) {
+                                        __auto_type entry = _mv_1588.value;
                                         return type_extract_registry_is_record(types, name);
-                                    } else if (!_mv_1587.has_value) {
+                                    } else if (!_mv_1588.has_value) {
                                         return 0;
                                     }
                                 }
@@ -1675,7 +1675,7 @@ uint8_t test_emit_is_record_constructor_typed(types_SExpr* expr, type_extract_Ty
                         } else {
                             return 0;
                         }
-                    } else if (!_mv_1586.has_value) {
+                    } else if (!_mv_1587.has_value) {
                         return 0;
                     }
                 }
@@ -1697,11 +1697,11 @@ slop_string test_emit_emit_string_slice(slop_string s, int64_t start) {
 
 slop_string test_emit_get_some_inner_typed(slop_arena* arena, types_SExpr* expr, context_TranspileContext* tctx) {
     if (parser_sexpr_list_len(expr) > 1) {
-        __auto_type _mv_1588 = parser_sexpr_list_get(expr, 1);
-        if (_mv_1588.has_value) {
-            __auto_type inner = _mv_1588.value;
+        __auto_type _mv_1589 = parser_sexpr_list_get(expr, 1);
+        if (_mv_1589.has_value) {
+            __auto_type inner = _mv_1589.value;
             return test_emit_transpile_expr_safe(arena, tctx, inner);
-        } else if (!_mv_1588.has_value) {
+        } else if (!_mv_1589.has_value) {
             return SLOP_STR("0");
         }
     } else {
@@ -1719,19 +1719,19 @@ slop_string test_emit_get_error_inner_typed(slop_arena* arena, types_SExpr* expr
 
 types_SExpr* test_emit_get_some_inner_expr(types_SExpr* expected) {
     SLOP_PRE(((expected != NULL)), "(!= expected nil)");
-    __auto_type _mv_1589 = (*expected);
-    switch (_mv_1589.tag) {
+    __auto_type _mv_1590 = (*expected);
+    switch (_mv_1590.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1589.data.lst;
+            __auto_type lst = _mv_1590.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) > 1) {
-                    __auto_type _mv_1590 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1590.has_value) {
-                        __auto_type inner = _mv_1590.value;
+                    __auto_type _mv_1591 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1591.has_value) {
+                        __auto_type inner = _mv_1591.value;
                         return inner;
-                    } else if (!_mv_1590.has_value) {
+                    } else if (!_mv_1591.has_value) {
                         return expected;
                     }
                 } else {
@@ -1747,19 +1747,19 @@ types_SExpr* test_emit_get_some_inner_expr(types_SExpr* expected) {
 
 types_SExpr* test_emit_get_ok_inner_expr(types_SExpr* expected) {
     SLOP_PRE(((expected != NULL)), "(!= expected nil)");
-    __auto_type _mv_1591 = (*expected);
-    switch (_mv_1591.tag) {
+    __auto_type _mv_1592 = (*expected);
+    switch (_mv_1592.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1591.data.lst;
+            __auto_type lst = _mv_1592.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) > 1) {
-                    __auto_type _mv_1592 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1592.has_value) {
-                        __auto_type inner = _mv_1592.value;
+                    __auto_type _mv_1593 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1593.has_value) {
+                        __auto_type inner = _mv_1593.value;
                         return inner;
-                    } else if (!_mv_1592.has_value) {
+                    } else if (!_mv_1593.has_value) {
                         return expected;
                     }
                 } else {
@@ -1775,16 +1775,16 @@ types_SExpr* test_emit_get_ok_inner_expr(types_SExpr* expected) {
 
 uint8_t test_emit_is_none_value(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1593 = (*expr);
-    switch (_mv_1593.tag) {
+    __auto_type _mv_1594 = (*expr);
+    switch (_mv_1594.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1593.data.sym;
+            __auto_type sym = _mv_1594.data.sym;
             return string_eq(sym.name, SLOP_STR("none"));
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1593.data.lst;
+            __auto_type lst = _mv_1594.data.lst;
             {
                 __auto_type items = lst.items;
                 return ((((int64_t)((items).len)) == 1) && ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type first = _mv.value; (parser_sexpr_is_symbol(first) && string_eq(parser_sexpr_get_symbol_name(first), SLOP_STR("none"))); }) : (0); }));
@@ -1842,9 +1842,9 @@ slop_string test_emit_extract_list_element_type(slop_arena* arena, slop_string l
 slop_string test_emit_build_eq_function_name(slop_arena* arena, slop_string type_name, slop_string prefix, type_extract_TypeRegistry types) {
     {
         __auto_type type_c = strlib_to_lower(arena, ctype_to_c_name(arena, type_name));
-        __auto_type _mv_1594 = type_extract_registry_lookup_import(types, type_name);
-        if (_mv_1594.has_value) {
-            __auto_type mod_name = _mv_1594.value;
+        __auto_type _mv_1595 = type_extract_registry_lookup_import(types, type_name);
+        if (_mv_1595.has_value) {
+            __auto_type mod_name = _mv_1595.value;
             {
                 __auto_type parts = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
                 ({ __auto_type _lst_p = &(parts); __auto_type _item = (ctype_to_c_name(arena, mod_name)); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
@@ -1853,7 +1853,7 @@ slop_string test_emit_build_eq_function_name(slop_arena* arena, slop_string type
                 ({ __auto_type _lst_p = &(parts); __auto_type _item = (SLOP_STR("_eq")); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                 return strlib_string_build(arena, parts);
             }
-        } else if (!_mv_1594.has_value) {
+        } else if (!_mv_1595.has_value) {
             if (((int64_t)(prefix.len)) > 0) {
                 {
                     __auto_type parts = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
@@ -1877,11 +1877,11 @@ slop_string test_emit_build_eq_function_name(slop_arena* arena, slop_string type
 
 test_emit_CompareInfo test_emit_build_list_comparison_typed(slop_arena* arena, types_SExpr* expected, slop_string prefix, type_extract_TypeRegistry types, slop_string ret_type_str, slop_option_string eq_fn, context_TranspileContext* tctx) {
     SLOP_PRE(((expected != NULL)), "(!= expected nil)");
-    __auto_type _mv_1595 = (*expected);
-    switch (_mv_1595.tag) {
+    __auto_type _mv_1596 = (*expected);
+    switch (_mv_1596.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1595.data.lst;
+            __auto_type lst = _mv_1596.data.lst;
             {
                 __auto_type elements = lst.items;
                 __auto_type total_count = ((int64_t)((elements).len));
@@ -1895,13 +1895,13 @@ test_emit_CompareInfo test_emit_build_list_comparison_typed(slop_arena* arena, t
                             __auto_type has_wildcard = 0;
                             __auto_type j = start_idx;
                             while (j < total_count) {
-                                __auto_type _mv_1596 = ({ __auto_type _lst = elements; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1596.has_value) {
-                                    __auto_type elem = _mv_1596.value;
+                                __auto_type _mv_1597 = ({ __auto_type _lst = elements; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1597.has_value) {
+                                    __auto_type elem = _mv_1597.value;
                                     if (test_emit_is_wildcard_expr(elem)) {
                                         has_wildcard = 1;
                                     }
-                                } else if (!_mv_1596.has_value) {
+                                } else if (!_mv_1597.has_value) {
                                 }
                                 j = (j + 1);
                             }
@@ -1918,9 +1918,9 @@ test_emit_CompareInfo test_emit_build_list_comparison_typed(slop_arena* arena, t
                                             __auto_type i = start_idx;
                                             __auto_type first = 1;
                                             while (i < total_count) {
-                                                __auto_type _mv_1597 = ({ __auto_type _lst = elements; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1597.has_value) {
-                                                    __auto_type elem = _mv_1597.value;
+                                                __auto_type _mv_1598 = ({ __auto_type _lst = elements; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1598.has_value) {
+                                                    __auto_type elem = _mv_1598.value;
                                                     {
                                                         __auto_type elem_c = test_emit_transpile_expr_safe(arena, tctx, elem);
                                                         if (first) {
@@ -1930,7 +1930,7 @@ test_emit_CompareInfo test_emit_build_list_comparison_typed(slop_arena* arena, t
                                                             arr_init = string_concat(arena, arr_init, string_concat(arena, SLOP_STR(", "), elem_c));
                                                         }
                                                     }
-                                                } else if (!_mv_1597.has_value) {
+                                                } else if (!_mv_1598.has_value) {
                                                 }
                                                 i = (i + 1);
                                             }
@@ -2002,32 +2002,32 @@ context_TranspileContext* test_emit_init_transpile_context(slop_arena* arena, sl
         context_ctx_bind_var(tctx, (context_VarEntry){SLOP_STR("__SLOP_WILDCARD__"), SLOP_STR("{0}"), SLOP_STR("int64_t"), SLOP_STR("Int"), 0, 0, 0, SLOP_STR(""), SLOP_STR("")});
         context_ctx_set_strict_unknown_symbols(tctx, 1);
         if (((int64_t)((ast).len)) > 0) {
-            __auto_type _mv_1598 = ({ __auto_type _lst = ast; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1598.has_value) {
-                __auto_type first_expr = _mv_1598.value;
+            __auto_type _mv_1599 = ({ __auto_type _lst = ast; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1599.has_value) {
+                __auto_type first_expr = _mv_1599.value;
                 if (parser_is_form(first_expr, SLOP_STR("module"))) {
                     {
                         __auto_type mod_len = parser_sexpr_list_len(first_expr);
                         __auto_type body_forms = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
                         __auto_type i = 2;
                         if (i < mod_len) {
-                            __auto_type _mv_1599 = parser_sexpr_list_get(first_expr, i);
-                            if (_mv_1599.has_value) {
-                                __auto_type maybe_export = _mv_1599.value;
+                            __auto_type _mv_1600 = parser_sexpr_list_get(first_expr, i);
+                            if (_mv_1600.has_value) {
+                                __auto_type maybe_export = _mv_1600.value;
                                 if (parser_is_form(maybe_export, SLOP_STR("export"))) {
                                     i = (i + 1);
                                 }
-                            } else if (!_mv_1599.has_value) {
+                            } else if (!_mv_1600.has_value) {
                             }
                         }
                         while (i < mod_len) {
-                            __auto_type _mv_1600 = parser_sexpr_list_get(first_expr, i);
-                            if (_mv_1600.has_value) {
-                                __auto_type form = _mv_1600.value;
+                            __auto_type _mv_1601 = parser_sexpr_list_get(first_expr, i);
+                            if (_mv_1601.has_value) {
+                                __auto_type form = _mv_1601.value;
                                 if (!(parser_is_form(form, SLOP_STR("@doc")))) {
                                     ({ __auto_type _lst_p = &(body_forms); __auto_type _item = (form); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                 }
-                            } else if (!_mv_1600.has_value) {
+                            } else if (!_mv_1601.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -2035,7 +2035,7 @@ context_TranspileContext* test_emit_init_transpile_context(slop_arena* arena, sl
                         test_emit_register_all_field_types(tctx, body_forms);
                     }
                 }
-            } else if (!_mv_1598.has_value) {
+            } else if (!_mv_1599.has_value) {
             }
         }
         return tctx;
@@ -2049,30 +2049,30 @@ void test_emit_init_transpile_context_for_imports(slop_arena* arena, context_Tra
             context_ctx_set_module(tctx, (slop_option_string){.has_value = 1, .value = import_mod_name});
         }
         if (((int64_t)((import_ast).len)) > 0) {
-            __auto_type _mv_1601 = ({ __auto_type _lst = import_ast; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1601.has_value) {
-                __auto_type first_expr = _mv_1601.value;
+            __auto_type _mv_1602 = ({ __auto_type _lst = import_ast; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1602.has_value) {
+                __auto_type first_expr = _mv_1602.value;
                 if (parser_is_form(first_expr, SLOP_STR("module"))) {
                     {
                         __auto_type mod_len = parser_sexpr_list_len(first_expr);
                         __auto_type body_forms = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
                         __auto_type i = 2;
                         if (i < mod_len) {
-                            __auto_type _mv_1602 = parser_sexpr_list_get(first_expr, i);
-                            if (_mv_1602.has_value) {
-                                __auto_type maybe_export = _mv_1602.value;
+                            __auto_type _mv_1603 = parser_sexpr_list_get(first_expr, i);
+                            if (_mv_1603.has_value) {
+                                __auto_type maybe_export = _mv_1603.value;
                                 if (parser_is_form(maybe_export, SLOP_STR("export"))) {
                                     i = (i + 1);
                                 }
-                            } else if (!_mv_1602.has_value) {
+                            } else if (!_mv_1603.has_value) {
                             }
                         }
                         while (i < mod_len) {
-                            __auto_type _mv_1603 = parser_sexpr_list_get(first_expr, i);
-                            if (_mv_1603.has_value) {
-                                __auto_type form = _mv_1603.value;
+                            __auto_type _mv_1604 = parser_sexpr_list_get(first_expr, i);
+                            if (_mv_1604.has_value) {
+                                __auto_type form = _mv_1604.value;
                                 ({ __auto_type _lst_p = &(body_forms); __auto_type _item = (form); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                            } else if (!_mv_1603.has_value) {
+                            } else if (!_mv_1604.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -2080,7 +2080,7 @@ void test_emit_init_transpile_context_for_imports(slop_arena* arena, context_Tra
                         test_emit_register_all_field_types(tctx, body_forms);
                     }
                 }
-            } else if (!_mv_1601.has_value) {
+            } else if (!_mv_1602.has_value) {
             }
         }
         if (((int64_t)(saved_module.len)) > 0) {
@@ -2093,32 +2093,32 @@ void test_emit_init_transpile_context_for_imports(slop_arena* arena, context_Tra
 
 void test_emit_re_prescan_main_module(slop_arena* arena, context_TranspileContext* tctx, slop_list_types_SExpr_ptr ast) {
     if (((int64_t)((ast).len)) > 0) {
-        __auto_type _mv_1604 = ({ __auto_type _lst = ast; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1604.has_value) {
-            __auto_type first_expr = _mv_1604.value;
+        __auto_type _mv_1605 = ({ __auto_type _lst = ast; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1605.has_value) {
+            __auto_type first_expr = _mv_1605.value;
             if (parser_is_form(first_expr, SLOP_STR("module"))) {
                 {
                     __auto_type mod_len = parser_sexpr_list_len(first_expr);
                     __auto_type body_forms = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
                     __auto_type i = 2;
                     if (i < mod_len) {
-                        __auto_type _mv_1605 = parser_sexpr_list_get(first_expr, i);
-                        if (_mv_1605.has_value) {
-                            __auto_type maybe_export = _mv_1605.value;
+                        __auto_type _mv_1606 = parser_sexpr_list_get(first_expr, i);
+                        if (_mv_1606.has_value) {
+                            __auto_type maybe_export = _mv_1606.value;
                             if (parser_is_form(maybe_export, SLOP_STR("export"))) {
                                 i = (i + 1);
                             }
-                        } else if (!_mv_1605.has_value) {
+                        } else if (!_mv_1606.has_value) {
                         }
                     }
                     while (i < mod_len) {
-                        __auto_type _mv_1606 = parser_sexpr_list_get(first_expr, i);
-                        if (_mv_1606.has_value) {
-                            __auto_type form = _mv_1606.value;
+                        __auto_type _mv_1607 = parser_sexpr_list_get(first_expr, i);
+                        if (_mv_1607.has_value) {
+                            __auto_type form = _mv_1607.value;
                             if (!(parser_is_form(form, SLOP_STR("@doc")))) {
                                 ({ __auto_type _lst_p = &(body_forms); __auto_type _item = (form); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                             }
-                        } else if (!_mv_1606.has_value) {
+                        } else if (!_mv_1607.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -2126,7 +2126,7 @@ void test_emit_re_prescan_main_module(slop_arena* arena, context_TranspileContex
                     test_emit_register_all_field_types(tctx, body_forms);
                 }
             }
-        } else if (!_mv_1604.has_value) {
+        } else if (!_mv_1605.has_value) {
         }
     }
 }
@@ -2136,13 +2136,13 @@ void test_emit_register_all_field_types(context_TranspileContext* tctx, slop_lis
         __auto_type len = ((int64_t)((body_forms).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1607 = ({ __auto_type _lst = body_forms; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1607.has_value) {
-                __auto_type form = _mv_1607.value;
+            __auto_type _mv_1608 = ({ __auto_type _lst = body_forms; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1608.has_value) {
+                __auto_type form = _mv_1608.value;
                 if (parser_is_form(form, SLOP_STR("type"))) {
                     test_emit_register_type_fields(tctx, form);
                 }
-            } else if (!_mv_1607.has_value) {
+            } else if (!_mv_1608.has_value) {
             }
             i = (i + 1);
         }
@@ -2152,33 +2152,33 @@ void test_emit_register_all_field_types(context_TranspileContext* tctx, slop_lis
 void test_emit_register_type_fields(context_TranspileContext* tctx, types_SExpr* type_form) {
     SLOP_PRE(((tctx != NULL)), "(!= tctx nil)");
     if (parser_sexpr_list_len(type_form) >= 3) {
-        __auto_type _mv_1608 = parser_sexpr_list_get(type_form, 1);
-        if (_mv_1608.has_value) {
-            __auto_type name_expr = _mv_1608.value;
+        __auto_type _mv_1609 = parser_sexpr_list_get(type_form, 1);
+        if (_mv_1609.has_value) {
+            __auto_type name_expr = _mv_1609.value;
             if (parser_sexpr_is_symbol(name_expr)) {
                 {
                     __auto_type type_name = parser_sexpr_get_symbol_name(name_expr);
-                    __auto_type _mv_1609 = parser_sexpr_list_get(type_form, 2);
-                    if (_mv_1609.has_value) {
-                        __auto_type def_expr = _mv_1609.value;
+                    __auto_type _mv_1610 = parser_sexpr_list_get(type_form, 2);
+                    if (_mv_1610.has_value) {
+                        __auto_type def_expr = _mv_1610.value;
                         if (parser_is_form(def_expr, SLOP_STR("record"))) {
                             {
                                 __auto_type field_count = parser_sexpr_list_len(def_expr);
                                 __auto_type j = 1;
                                 while (j < field_count) {
-                                    __auto_type _mv_1610 = parser_sexpr_list_get(def_expr, j);
-                                    if (_mv_1610.has_value) {
-                                        __auto_type field_def = _mv_1610.value;
+                                    __auto_type _mv_1611 = parser_sexpr_list_get(def_expr, j);
+                                    if (_mv_1611.has_value) {
+                                        __auto_type field_def = _mv_1611.value;
                                         if (parser_sexpr_list_len(field_def) >= 2) {
-                                            __auto_type _mv_1611 = parser_sexpr_list_get(field_def, 0);
-                                            if (_mv_1611.has_value) {
-                                                __auto_type field_name_expr = _mv_1611.value;
+                                            __auto_type _mv_1612 = parser_sexpr_list_get(field_def, 0);
+                                            if (_mv_1612.has_value) {
+                                                __auto_type field_name_expr = _mv_1612.value;
                                                 if (parser_sexpr_is_symbol(field_name_expr)) {
                                                     {
                                                         __auto_type field_name = parser_sexpr_get_symbol_name(field_name_expr);
-                                                        __auto_type _mv_1612 = parser_sexpr_list_get(field_def, 1);
-                                                        if (_mv_1612.has_value) {
-                                                            __auto_type field_type_expr = _mv_1612.value;
+                                                        __auto_type _mv_1613 = parser_sexpr_list_get(field_def, 1);
+                                                        if (_mv_1613.has_value) {
+                                                            __auto_type field_type_expr = _mv_1613.value;
                                                             {
                                                                 __auto_type arena = (*tctx).arena;
                                                                 __auto_type c_type = context_to_c_type_prefixed(tctx, field_type_expr);
@@ -2192,24 +2192,24 @@ void test_emit_register_type_fields(context_TranspileContext* tctx, types_SExpr*
                                                                     }
                                                                 }
                                                             }
-                                                        } else if (!_mv_1612.has_value) {
+                                                        } else if (!_mv_1613.has_value) {
                                                         }
                                                     }
                                                 }
-                                            } else if (!_mv_1611.has_value) {
+                                            } else if (!_mv_1612.has_value) {
                                             }
                                         }
-                                    } else if (!_mv_1610.has_value) {
+                                    } else if (!_mv_1611.has_value) {
                                     }
                                     j = (j + 1);
                                 }
                             }
                         }
-                    } else if (!_mv_1609.has_value) {
+                    } else if (!_mv_1610.has_value) {
                     }
                 }
             }
-        } else if (!_mv_1608.has_value) {
+        } else if (!_mv_1609.has_value) {
         }
     }
 }

--- a/bootstrap/tester/slop_tester.c
+++ b/bootstrap/tester/slop_tester.c
@@ -20,20 +20,20 @@ slop_string tester_extract_module_name(slop_list_types_SExpr_ptr exprs) {
     if (((int64_t)((exprs).len)) < 1) {
         return SLOP_STR("");
     } else {
-        __auto_type _mv_1613 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1613.has_value) {
-            __auto_type first_expr = _mv_1613.value;
+        __auto_type _mv_1614 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1614.has_value) {
+            __auto_type first_expr = _mv_1614.value;
             if (parser_is_form(first_expr, SLOP_STR("module"))) {
                 if (parser_sexpr_list_len(first_expr) >= 2) {
-                    __auto_type _mv_1614 = parser_sexpr_list_get(first_expr, 1);
-                    if (_mv_1614.has_value) {
-                        __auto_type name_expr = _mv_1614.value;
+                    __auto_type _mv_1615 = parser_sexpr_list_get(first_expr, 1);
+                    if (_mv_1615.has_value) {
+                        __auto_type name_expr = _mv_1615.value;
                         if (parser_sexpr_is_symbol(name_expr)) {
                             return parser_sexpr_get_symbol_name(name_expr);
                         } else {
                             return SLOP_STR("");
                         }
-                    } else if (!_mv_1614.has_value) {
+                    } else if (!_mv_1615.has_value) {
                         return SLOP_STR("");
                     }
                 } else {
@@ -42,7 +42,7 @@ slop_string tester_extract_module_name(slop_list_types_SExpr_ptr exprs) {
             } else {
                 return SLOP_STR("");
             }
-        } else if (!_mv_1613.has_value) {
+        } else if (!_mv_1614.has_value) {
             return SLOP_STR("");
         }
     }
@@ -52,60 +52,60 @@ slop_list_type_extract_ImportEntry tester_extract_imports(slop_arena* arena, slo
     {
         __auto_type result = ((slop_list_type_extract_ImportEntry){ .data = (type_extract_ImportEntry*)slop_arena_alloc(arena, 16 * sizeof(type_extract_ImportEntry)), .len = 0, .cap = 16 });
         if (((int64_t)((exprs).len)) > 0) {
-            __auto_type _mv_1615 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1615.has_value) {
-                __auto_type module_expr = _mv_1615.value;
+            __auto_type _mv_1616 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1616.has_value) {
+                __auto_type module_expr = _mv_1616.value;
                 if (parser_is_form(module_expr, SLOP_STR("module"))) {
                     {
                         __auto_type mod_len = parser_sexpr_list_len(module_expr);
                         __auto_type i = 2;
                         while (i < mod_len) {
-                            __auto_type _mv_1616 = parser_sexpr_list_get(module_expr, i);
-                            if (_mv_1616.has_value) {
-                                __auto_type child = _mv_1616.value;
+                            __auto_type _mv_1617 = parser_sexpr_list_get(module_expr, i);
+                            if (_mv_1617.has_value) {
+                                __auto_type child = _mv_1617.value;
                                 if (parser_is_form(child, SLOP_STR("import"))) {
                                     if (parser_sexpr_list_len(child) >= 3) {
-                                        __auto_type _mv_1617 = parser_sexpr_list_get(child, 1);
-                                        if (_mv_1617.has_value) {
-                                            __auto_type name_expr = _mv_1617.value;
+                                        __auto_type _mv_1618 = parser_sexpr_list_get(child, 1);
+                                        if (_mv_1618.has_value) {
+                                            __auto_type name_expr = _mv_1618.value;
                                             if (parser_sexpr_is_symbol(name_expr)) {
                                                 {
                                                     __auto_type mod_name = parser_sexpr_get_symbol_name(name_expr);
                                                     __auto_type symbols = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
-                                                    __auto_type _mv_1618 = parser_sexpr_list_get(child, 2);
-                                                    if (_mv_1618.has_value) {
-                                                        __auto_type sym_list = _mv_1618.value;
+                                                    __auto_type _mv_1619 = parser_sexpr_list_get(child, 2);
+                                                    if (_mv_1619.has_value) {
+                                                        __auto_type sym_list = _mv_1619.value;
                                                         {
                                                             __auto_type sym_len = parser_sexpr_list_len(sym_list);
                                                             __auto_type j = 0;
                                                             while (j < sym_len) {
-                                                                __auto_type _mv_1619 = parser_sexpr_list_get(sym_list, j);
-                                                                if (_mv_1619.has_value) {
-                                                                    __auto_type sym_expr = _mv_1619.value;
+                                                                __auto_type _mv_1620 = parser_sexpr_list_get(sym_list, j);
+                                                                if (_mv_1620.has_value) {
+                                                                    __auto_type sym_expr = _mv_1620.value;
                                                                     if (parser_sexpr_is_symbol(sym_expr)) {
                                                                         ({ __auto_type _lst_p = &(symbols); __auto_type _item = (parser_sexpr_get_symbol_name(sym_expr)); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                                     }
-                                                                } else if (!_mv_1619.has_value) {
+                                                                } else if (!_mv_1620.has_value) {
                                                                 }
                                                                 j = (j + 1);
                                                             }
                                                         }
-                                                    } else if (!_mv_1618.has_value) {
+                                                    } else if (!_mv_1619.has_value) {
                                                     }
                                                     ({ __auto_type _lst_p = &(result); __auto_type _item = ((type_extract_ImportEntry){mod_name, symbols}); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                 }
                                             }
-                                        } else if (!_mv_1617.has_value) {
+                                        } else if (!_mv_1618.has_value) {
                                         }
                                     }
                                 }
-                            } else if (!_mv_1616.has_value) {
+                            } else if (!_mv_1617.has_value) {
                             }
                             i = (i + 1);
                         }
                     }
                 }
-            } else if (!_mv_1615.has_value) {
+            } else if (!_mv_1616.has_value) {
             }
         }
         return result;
@@ -113,40 +113,6 @@ slop_list_type_extract_ImportEntry tester_extract_imports(slop_arena* arena, slo
 }
 
 tester_TestResult tester_generate_tests(slop_arena* arena, slop_string source, slop_string file_name) {
-    __auto_type _mv_1620 = parser_parse(arena, source);
-    if (_mv_1620.is_ok) {
-        __auto_type exprs = _mv_1620.data.ok;
-        {
-            __auto_type mod_name = tester_extract_module_name(exprs);
-            __auto_type imports = tester_extract_imports(arena, exprs);
-            {
-                __auto_type test_cases = extract_extract_examples_from_ast(arena, exprs);
-                __auto_type test_count = ((int64_t)((test_cases).len));
-                if (test_count == 0) {
-                    return (tester_TestResult){1, ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 }), 0, mod_name, SLOP_STR("")};
-                } else {
-                    {
-                        __auto_type prefix = (((((int64_t)(mod_name.len)) > 0)) ? ctype_to_c_name(arena, mod_name) : SLOP_STR(""));
-                        __auto_type types = type_extract_extract_types_from_ast_with_imports(arena, exprs, mod_name, imports);
-                        __auto_type tctx = test_emit_init_transpile_context(arena, exprs, mod_name);
-                        {
-                            __auto_type harness_lines = test_emit_emit_test_harness_typed(arena, test_cases, prefix, types, imports, tctx, file_name);
-                            return (tester_TestResult){1, harness_lines, test_count, mod_name, SLOP_STR("")};
-                        }
-                    }
-                }
-            }
-        }
-    } else if (!_mv_1620.is_ok) {
-        __auto_type err = _mv_1620.data.err;
-        {
-            __auto_type error_msg = string_concat(arena, SLOP_STR("Parse error at line "), string_concat(arena, int_to_string(arena, err.line), string_concat(arena, SLOP_STR(", col "), string_concat(arena, int_to_string(arena, err.col), string_concat(arena, SLOP_STR(": "), err.message)))));
-            return (tester_TestResult){0, ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 }), 0, SLOP_STR(""), error_msg};
-        }
-    }
-}
-
-tester_TestResult tester_generate_tests_with_imports(slop_arena* arena, slop_string source, slop_list_string import_sources, slop_string file_name) {
     __auto_type _mv_1621 = parser_parse(arena, source);
     if (_mv_1621.is_ok) {
         __auto_type exprs = _mv_1621.data.ok;
@@ -164,33 +130,6 @@ tester_TestResult tester_generate_tests_with_imports(slop_arena* arena, slop_str
                         __auto_type types = type_extract_extract_types_from_ast_with_imports(arena, exprs, mod_name, imports);
                         __auto_type tctx = test_emit_init_transpile_context(arena, exprs, mod_name);
                         {
-                            __auto_type import_count = ((int64_t)((import_sources).len));
-                            __auto_type i = 0;
-                            while (i < import_count) {
-                                __auto_type _mv_1622 = ({ __auto_type _lst = import_sources; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1622.has_value) {
-                                    __auto_type import_src = _mv_1622.value;
-                                    __auto_type _mv_1623 = parser_parse(arena, import_src);
-                                    if (_mv_1623.is_ok) {
-                                        __auto_type import_exprs = _mv_1623.data.ok;
-                                        {
-                                            __auto_type import_mod_name = tester_extract_module_name(import_exprs);
-                                            __auto_type import_prefix = (((((int64_t)(import_mod_name.len)) > 0)) ? ctype_to_c_name(arena, import_mod_name) : SLOP_STR(""));
-                                            tester_extract_types_from_module_ast(arena, import_exprs, types, import_prefix);
-                                            test_emit_init_transpile_context_for_imports(arena, tctx, import_exprs, import_mod_name);
-                                            context_ctx_set_module(tctx, (slop_option_string){.has_value = 1, .value = mod_name});
-                                        }
-                                    } else if (!_mv_1623.is_ok) {
-                                        __auto_type _ = _mv_1623.data.err;
-                                    }
-                                } else if (!_mv_1622.has_value) {
-                                }
-                                i = (i + 1);
-                            }
-                        }
-                        context_ctx_set_module(tctx, (slop_option_string){.has_value = 1, .value = mod_name});
-                        test_emit_re_prescan_main_module(arena, tctx, exprs);
-                        {
                             __auto_type harness_lines = test_emit_emit_test_harness_typed(arena, test_cases, prefix, types, imports, tctx, file_name);
                             return (tester_TestResult){1, harness_lines, test_count, mod_name, SLOP_STR("")};
                         }
@@ -207,21 +146,82 @@ tester_TestResult tester_generate_tests_with_imports(slop_arena* arena, slop_str
     }
 }
 
+tester_TestResult tester_generate_tests_with_imports(slop_arena* arena, slop_string source, slop_list_string import_sources, slop_string file_name) {
+    __auto_type _mv_1622 = parser_parse(arena, source);
+    if (_mv_1622.is_ok) {
+        __auto_type exprs = _mv_1622.data.ok;
+        {
+            __auto_type mod_name = tester_extract_module_name(exprs);
+            __auto_type imports = tester_extract_imports(arena, exprs);
+            {
+                __auto_type test_cases = extract_extract_examples_from_ast(arena, exprs);
+                __auto_type test_count = ((int64_t)((test_cases).len));
+                if (test_count == 0) {
+                    return (tester_TestResult){1, ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 }), 0, mod_name, SLOP_STR("")};
+                } else {
+                    {
+                        __auto_type prefix = (((((int64_t)(mod_name.len)) > 0)) ? ctype_to_c_name(arena, mod_name) : SLOP_STR(""));
+                        __auto_type types = type_extract_extract_types_from_ast_with_imports(arena, exprs, mod_name, imports);
+                        __auto_type tctx = test_emit_init_transpile_context(arena, exprs, mod_name);
+                        {
+                            __auto_type import_count = ((int64_t)((import_sources).len));
+                            __auto_type i = 0;
+                            while (i < import_count) {
+                                __auto_type _mv_1623 = ({ __auto_type _lst = import_sources; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1623.has_value) {
+                                    __auto_type import_src = _mv_1623.value;
+                                    __auto_type _mv_1624 = parser_parse(arena, import_src);
+                                    if (_mv_1624.is_ok) {
+                                        __auto_type import_exprs = _mv_1624.data.ok;
+                                        {
+                                            __auto_type import_mod_name = tester_extract_module_name(import_exprs);
+                                            __auto_type import_prefix = (((((int64_t)(import_mod_name.len)) > 0)) ? ctype_to_c_name(arena, import_mod_name) : SLOP_STR(""));
+                                            tester_extract_types_from_module_ast(arena, import_exprs, types, import_prefix);
+                                            test_emit_init_transpile_context_for_imports(arena, tctx, import_exprs, import_mod_name);
+                                            context_ctx_set_module(tctx, (slop_option_string){.has_value = 1, .value = mod_name});
+                                        }
+                                    } else if (!_mv_1624.is_ok) {
+                                        __auto_type _ = _mv_1624.data.err;
+                                    }
+                                } else if (!_mv_1623.has_value) {
+                                }
+                                i = (i + 1);
+                            }
+                        }
+                        context_ctx_set_module(tctx, (slop_option_string){.has_value = 1, .value = mod_name});
+                        test_emit_re_prescan_main_module(arena, tctx, exprs);
+                        {
+                            __auto_type harness_lines = test_emit_emit_test_harness_typed(arena, test_cases, prefix, types, imports, tctx, file_name);
+                            return (tester_TestResult){1, harness_lines, test_count, mod_name, SLOP_STR("")};
+                        }
+                    }
+                }
+            }
+        }
+    } else if (!_mv_1622.is_ok) {
+        __auto_type err = _mv_1622.data.err;
+        {
+            __auto_type error_msg = string_concat(arena, SLOP_STR("Parse error at line "), string_concat(arena, int_to_string(arena, err.line), string_concat(arena, SLOP_STR(", col "), string_concat(arena, int_to_string(arena, err.col), string_concat(arena, SLOP_STR(": "), err.message)))));
+            return (tester_TestResult){0, ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 }), 0, SLOP_STR(""), error_msg};
+        }
+    }
+}
+
 void tester_extract_types_from_module_ast(slop_arena* arena, slop_list_types_SExpr_ptr ast, type_extract_TypeRegistry* types, slop_string prefix) {
     {
         __auto_type len = ((int64_t)((ast).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1624 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1624.has_value) {
-                __auto_type expr = _mv_1624.value;
+            __auto_type _mv_1625 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1625.has_value) {
+                __auto_type expr = _mv_1625.value;
                 if (parser_is_form(expr, SLOP_STR("module"))) {
                     tester_extract_types_from_module_form(arena, expr, types, prefix);
                 }
                 if (parser_is_form(expr, SLOP_STR("type"))) {
                     tester_extract_single_type_def(arena, expr, types, prefix);
                 }
-            } else if (!_mv_1624.has_value) {
+            } else if (!_mv_1625.has_value) {
             }
             i = (i + 1);
         }
@@ -233,13 +233,13 @@ void tester_extract_types_from_module_form(slop_arena* arena, types_SExpr* modul
         __auto_type len = parser_sexpr_list_len(module_form);
         int64_t i = 2;
         while (i < len) {
-            __auto_type _mv_1625 = parser_sexpr_list_get(module_form, i);
-            if (_mv_1625.has_value) {
-                __auto_type form = _mv_1625.value;
+            __auto_type _mv_1626 = parser_sexpr_list_get(module_form, i);
+            if (_mv_1626.has_value) {
+                __auto_type form = _mv_1626.value;
                 if (parser_is_form(form, SLOP_STR("type"))) {
                     tester_extract_single_type_def(arena, form, types, prefix);
                 }
-            } else if (!_mv_1625.has_value) {
+            } else if (!_mv_1626.has_value) {
             }
             i = (i + 1);
         }
@@ -248,16 +248,16 @@ void tester_extract_types_from_module_form(slop_arena* arena, types_SExpr* modul
 
 void tester_extract_single_type_def(slop_arena* arena, types_SExpr* type_form, type_extract_TypeRegistry* types, slop_string prefix) {
     if (parser_sexpr_list_len(type_form) >= 3) {
-        __auto_type _mv_1626 = parser_sexpr_list_get(type_form, 1);
-        if (_mv_1626.has_value) {
-            __auto_type name_expr = _mv_1626.value;
+        __auto_type _mv_1627 = parser_sexpr_list_get(type_form, 1);
+        if (_mv_1627.has_value) {
+            __auto_type name_expr = _mv_1627.value;
             if (parser_sexpr_is_symbol(name_expr)) {
                 {
                     __auto_type type_name = parser_sexpr_get_symbol_name(name_expr);
                     __auto_type c_name = tester_make_prefixed_c_name(arena, prefix, type_name);
-                    __auto_type _mv_1627 = parser_sexpr_list_get(type_form, 2);
-                    if (_mv_1627.has_value) {
-                        __auto_type def_expr = _mv_1627.value;
+                    __auto_type _mv_1628 = parser_sexpr_list_get(type_form, 2);
+                    if (_mv_1628.has_value) {
+                        __auto_type def_expr = _mv_1628.value;
                         if (parser_is_form(def_expr, SLOP_STR("record"))) {
                             {
                                 __auto_type entry = tester_extract_record_type_entry(arena, type_name, c_name, def_expr);
@@ -275,11 +275,11 @@ void tester_extract_single_type_def(slop_arena* arena, types_SExpr* type_form, t
                             }
                         } else {
                         }
-                    } else if (!_mv_1627.has_value) {
+                    } else if (!_mv_1628.has_value) {
                     }
                 }
             }
-        } else if (!_mv_1626.has_value) {
+        } else if (!_mv_1627.has_value) {
         }
     }
 }
@@ -333,32 +333,32 @@ type_extract_TstTypeEntry* tester_extract_record_type_entry(slop_arena* arena, s
         __auto_type len = parser_sexpr_list_len(def);
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1628 = parser_sexpr_list_get(def, i);
-            if (_mv_1628.has_value) {
-                __auto_type field_def = _mv_1628.value;
+            __auto_type _mv_1629 = parser_sexpr_list_get(def, i);
+            if (_mv_1629.has_value) {
+                __auto_type field_def = _mv_1629.value;
                 if (parser_sexpr_list_len(field_def) >= 2) {
-                    __auto_type _mv_1629 = parser_sexpr_list_get(field_def, 0);
-                    if (_mv_1629.has_value) {
-                        __auto_type field_name_expr = _mv_1629.value;
+                    __auto_type _mv_1630 = parser_sexpr_list_get(field_def, 0);
+                    if (_mv_1630.has_value) {
+                        __auto_type field_name_expr = _mv_1630.value;
                         if (parser_sexpr_is_symbol(field_name_expr)) {
                             {
                                 __auto_type field_name = parser_sexpr_get_symbol_name(field_name_expr);
-                                __auto_type _mv_1630 = parser_sexpr_list_get(field_def, 1);
-                                if (_mv_1630.has_value) {
-                                    __auto_type field_type_expr = _mv_1630.value;
+                                __auto_type _mv_1631 = parser_sexpr_list_get(field_def, 1);
+                                if (_mv_1631.has_value) {
+                                    __auto_type field_type_expr = _mv_1631.value;
                                     {
                                         __auto_type field_type = tester_sexpr_to_string_simple(arena, field_type_expr);
                                         __auto_type fe = (type_extract_TstFieldEntry){field_name, field_type};
                                         ({ __auto_type _lst_p = &((*entry).fields); __auto_type _item = (fe); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
-                                } else if (!_mv_1630.has_value) {
+                                } else if (!_mv_1631.has_value) {
                                 }
                             }
                         }
-                    } else if (!_mv_1629.has_value) {
+                    } else if (!_mv_1630.has_value) {
                     }
                 }
-            } else if (!_mv_1628.has_value) {
+            } else if (!_mv_1629.has_value) {
             }
             i = (i + 1);
         }
@@ -373,15 +373,15 @@ type_extract_TstTypeEntry* tester_extract_union_type_entry(slop_arena* arena, sl
         int64_t i = 1;
         int64_t idx = 0;
         while (i < len) {
-            __auto_type _mv_1631 = parser_sexpr_list_get(def, i);
-            if (_mv_1631.has_value) {
-                __auto_type variant_def = _mv_1631.value;
+            __auto_type _mv_1632 = parser_sexpr_list_get(def, i);
+            if (_mv_1632.has_value) {
+                __auto_type variant_def = _mv_1632.value;
                 {
                     __auto_type vlen = parser_sexpr_list_len(variant_def);
                     if (vlen >= 1) {
-                        __auto_type _mv_1632 = parser_sexpr_list_get(variant_def, 0);
-                        if (_mv_1632.has_value) {
-                            __auto_type variant_name_expr = _mv_1632.value;
+                        __auto_type _mv_1633 = parser_sexpr_list_get(variant_def, 0);
+                        if (_mv_1633.has_value) {
+                            __auto_type variant_name_expr = _mv_1633.value;
                             if (parser_sexpr_is_symbol(variant_name_expr)) {
                                 {
                                     __auto_type variant_name = parser_sexpr_get_symbol_name(variant_name_expr);
@@ -391,11 +391,11 @@ type_extract_TstTypeEntry* tester_extract_union_type_entry(slop_arena* arena, sl
                                     idx = (idx + 1);
                                 }
                             }
-                        } else if (!_mv_1632.has_value) {
+                        } else if (!_mv_1633.has_value) {
                         }
                     }
                 }
-            } else if (!_mv_1631.has_value) {
+            } else if (!_mv_1632.has_value) {
             }
             i = (i + 1);
         }
@@ -410,9 +410,9 @@ type_extract_TstTypeEntry* tester_extract_enum_type_entry(slop_arena* arena, slo
         int64_t i = 1;
         int64_t idx = 0;
         while (i < len) {
-            __auto_type _mv_1633 = parser_sexpr_list_get(def, i);
-            if (_mv_1633.has_value) {
-                __auto_type val_expr = _mv_1633.value;
+            __auto_type _mv_1634 = parser_sexpr_list_get(def, i);
+            if (_mv_1634.has_value) {
+                __auto_type val_expr = _mv_1634.value;
                 if (parser_sexpr_is_symbol(val_expr)) {
                     {
                         __auto_type val_name = parser_sexpr_get_symbol_name(val_expr);
@@ -421,7 +421,7 @@ type_extract_TstTypeEntry* tester_extract_enum_type_entry(slop_arena* arena, slo
                         idx = (idx + 1);
                     }
                 }
-            } else if (!_mv_1633.has_value) {
+            } else if (!_mv_1634.has_value) {
             }
             i = (i + 1);
         }
@@ -430,35 +430,35 @@ type_extract_TstTypeEntry* tester_extract_enum_type_entry(slop_arena* arena, slo
 }
 
 slop_string tester_sexpr_to_string_simple(slop_arena* arena, types_SExpr* expr) {
-    __auto_type _mv_1634 = (*expr);
-    switch (_mv_1634.tag) {
+    __auto_type _mv_1635 = (*expr);
+    switch (_mv_1635.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1634.data.sym;
+            __auto_type sym = _mv_1635.data.sym;
             return sym.name;
         }
         case types_SExpr_num:
         {
-            __auto_type num = _mv_1634.data.num;
+            __auto_type num = _mv_1635.data.num;
             return num.raw;
         }
         case types_SExpr_str:
         {
-            __auto_type str = _mv_1634.data.str;
+            __auto_type str = _mv_1635.data.str;
             return str.value;
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_1634.data.lst;
+            __auto_type l = _mv_1635.data.lst;
             {
                 __auto_type items = l.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type result = SLOP_STR("");
                 __auto_type i = 0;
                 while (i < len) {
-                    __auto_type _mv_1635 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1635.has_value) {
-                        __auto_type child = _mv_1635.value;
+                    __auto_type _mv_1636 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1636.has_value) {
+                        __auto_type child = _mv_1636.value;
                         {
                             __auto_type child_str = tester_sexpr_to_string_simple(arena, child);
                             if (i == 0) {
@@ -467,7 +467,7 @@ slop_string tester_sexpr_to_string_simple(slop_arena* arena, types_SExpr* expr) 
                                 result = string_concat(arena, result, string_concat(arena, SLOP_STR(" "), child_str));
                             }
                         }
-                    } else if (!_mv_1635.has_value) {
+                    } else if (!_mv_1636.has_value) {
                     }
                     i = (i + 1);
                 }

--- a/bootstrap/tester/slop_tester_main.c
+++ b/bootstrap/tester/slop_tester_main.c
@@ -101,11 +101,11 @@ slop_string tester_main_lines_to_string(slop_arena* arena, slop_list_string line
                 int64_t total = 0;
                 int64_t i = 0;
                 while (i < len) {
-                    __auto_type _mv_1636 = ({ __auto_type _lst = lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1636.has_value) {
-                        __auto_type line = _mv_1636.value;
+                    __auto_type _mv_1637 = ({ __auto_type _lst = lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1637.has_value) {
+                        __auto_type line = _mv_1637.value;
                         total = (total + (((int64_t)(line.len)) + 1));
-                    } else if (!_mv_1636.has_value) {
+                    } else if (!_mv_1637.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -114,9 +114,9 @@ slop_string tester_main_lines_to_string(slop_arena* arena, slop_list_string line
                     int64_t pos = 0;
                     int64_t j = 0;
                     while (j < len) {
-                        __auto_type _mv_1637 = ({ __auto_type _lst = lines; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1637.has_value) {
-                            __auto_type line = _mv_1637.value;
+                        __auto_type _mv_1638 = ({ __auto_type _lst = lines; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1638.has_value) {
+                            __auto_type line = _mv_1638.value;
                             {
                                 __auto_type line_len = ((int64_t)(line.len));
                                 __auto_type line_data = line.data;
@@ -129,7 +129,7 @@ slop_string tester_main_lines_to_string(slop_arena* arena, slop_list_string line
                                 buf[pos] = 10;
                                 pos = (pos + 1);
                             }
-                        } else if (!_mv_1637.has_value) {
+                        } else if (!_mv_1638.has_value) {
                         }
                         j = (j + 1);
                     }
@@ -162,11 +162,11 @@ slop_list_string tester_main_read_import_files(slop_arena* arena, int64_t argc, 
         while (i < argc) {
             {
                 __auto_type path_ptr = ((char*)(argv[i]));
-                __auto_type _mv_1638 = tester_main_read_file(arena, path_ptr);
-                if (_mv_1638.has_value) {
-                    __auto_type source = _mv_1638.value;
+                __auto_type _mv_1639 = tester_main_read_file(arena, path_ptr);
+                if (_mv_1639.has_value) {
+                    __auto_type source = _mv_1639.value;
                     ({ __auto_type _lst_p = &(sources); __auto_type _item = (source); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                } else if (!_mv_1638.has_value) {
+                } else if (!_mv_1639.has_value) {
                 }
             }
             i = (i + 1);
@@ -196,9 +196,9 @@ int main(int argc, char** _c_argv) {
             SLOP_PRE(_arena.base != NULL, "arena allocation failed");
             #endif
             slop_arena* arena = &_arena;
-            __auto_type _mv_1639 = tester_main_read_file(arena, ((char*)(argv[1])));
-            if (_mv_1639.has_value) {
-                __auto_type source = _mv_1639.value;
+            __auto_type _mv_1640 = tester_main_read_file(arena, ((char*)(argv[1])));
+            if (_mv_1640.has_value) {
+                __auto_type source = _mv_1640.value;
                 {
                     __auto_type import_sources = tester_main_read_import_files(arena, argc, argv);
                     __auto_type result = tester_generate_tests_with_imports(arena, source, import_sources, strlib_cstring_to_string(argv[1]));
@@ -225,7 +225,7 @@ int main(int argc, char** _c_argv) {
                         return 1;
                     }
                 }
-            } else if (!_mv_1639.has_value) {
+            } else if (!_mv_1640.has_value) {
                 tester_main_print_str(((char*)(SLOP_STR("{\"error\":\"Could not read file\"}\n").data)));
                 return 1;
             }

--- a/bootstrap/tester/slop_transpiler.c
+++ b/bootstrap/tester/slop_transpiler.c
@@ -101,6 +101,7 @@ void transpiler_emit_primitive_option_types_header(context_TranspileContext* ctx
 uint8_t transpiler_is_primitive_or_runtime_type(slop_string type_name);
 void transpiler_emit_imported_list_types_header(context_TranspileContext* ctx);
 void transpiler_emit_imported_option_types_header(context_TranspileContext* ctx);
+void transpiler_emit_late_registered_list_types_header(context_TranspileContext* ctx);
 void transpiler_emit_late_registered_option_types_header(context_TranspileContext* ctx);
 void transpiler_emit_value_list_types_header(context_TranspileContext* ctx);
 void transpiler_emit_complex_value_list_types_header(context_TranspileContext* ctx);
@@ -2474,6 +2475,7 @@ void transpiler_transpile_module(context_TranspileContext* ctx, types_SExpr* mod
                             transpiler_emit_fn_forward_decls(ctx, items, body_start);
                             transpiler_emit_module_functions(ctx, items, body_start);
                             transpiler_emit_late_registered_option_types_header(ctx);
+                            transpiler_emit_late_registered_list_types_header(ctx);
                             transpiler_emit_header_guard_close(ctx);
                         }
                     }
@@ -4169,6 +4171,24 @@ void transpiler_emit_imported_option_types_header(context_TranspileContext* ctx)
     }
 }
 
+void transpiler_emit_late_registered_list_types_header(context_TranspileContext* ctx) {
+    SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
+    {
+        __auto_type list_types = context_ctx_get_list_types(ctx);
+        __auto_type len = ((int64_t)((list_types).len));
+        int64_t i = 0;
+        while (i < len) {
+            __auto_type _mv_1360 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1360.has_value) {
+                __auto_type lt = _mv_1360.value;
+                transpiler_emit_single_list_type_header(ctx, lt);
+            } else if (!_mv_1360.has_value) {
+            }
+            i = (i + 1);
+        }
+    }
+}
+
 void transpiler_emit_late_registered_option_types_header(context_TranspileContext* ctx) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
@@ -4176,11 +4196,11 @@ void transpiler_emit_late_registered_option_types_header(context_TranspileContex
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1360 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1360.has_value) {
-                __auto_type ot = _mv_1360.value;
+            __auto_type _mv_1361 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1361.has_value) {
+                __auto_type ot = _mv_1361.value;
                 transpiler_emit_single_option_type_header(ctx, ot);
-            } else if (!_mv_1360.has_value) {
+            } else if (!_mv_1361.has_value) {
             }
             i = (i + 1);
         }
@@ -4194,13 +4214,13 @@ void transpiler_emit_value_list_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1361 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1361.has_value) {
-                __auto_type lt = _mv_1361.value;
+            __auto_type _mv_1362 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1362.has_value) {
+                __auto_type lt = _mv_1362.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_is_type_emitted_or_primitive(ctx, lt.elem_type)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1361.has_value) {
+            } else if (!_mv_1362.has_value) {
             }
             i = (i + 1);
         }
@@ -4214,13 +4234,13 @@ void transpiler_emit_complex_value_list_types_header(context_TranspileContext* c
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1362 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1362.has_value) {
-                __auto_type lt = _mv_1362.value;
+            __auto_type _mv_1363 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1363.has_value) {
+                __auto_type lt = _mv_1363.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && !(context_ctx_is_type_emitted(ctx, lt.c_name))) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1362.has_value) {
+            } else if (!_mv_1363.has_value) {
             }
             i = (i + 1);
         }
@@ -4256,9 +4276,9 @@ void transpiler_emit_union_payload_hash_eq(context_TranspileContext* ctx, slop_l
         __auto_type len = ((int64_t)((variants).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1363 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1363.has_value) {
-                __auto_type variant = _mv_1363.value;
+            __auto_type _mv_1364 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1364.has_value) {
+                __auto_type variant = _mv_1364.value;
                 {
                     __auto_type slop_type = variant.slop_type;
                     __auto_type c_payload_type = variant.c_type;
@@ -4278,7 +4298,7 @@ void transpiler_emit_union_payload_hash_eq(context_TranspileContext* ctx, slop_l
                         }
                     }
                 }
-            } else if (!_mv_1363.has_value) {
+            } else if (!_mv_1364.has_value) {
             }
             i = (i + 1);
         }
@@ -4291,9 +4311,9 @@ void transpiler_emit_record_field_dependencies(context_TranspileContext* ctx, sl
         __auto_type len = ((int64_t)((fields).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1364 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1364.has_value) {
-                __auto_type field = _mv_1364.value;
+            __auto_type _mv_1365 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1365.has_value) {
+                __auto_type field = _mv_1365.value;
                 {
                     __auto_type slop_type = field.slop_type;
                     __auto_type c_type = field.c_type;
@@ -4329,7 +4349,7 @@ void transpiler_emit_record_field_dependencies(context_TranspileContext* ctx, sl
                         }
                     }
                 }
-            } else if (!_mv_1364.has_value) {
+            } else if (!_mv_1365.has_value) {
             }
             i = (i + 1);
         }
@@ -4386,9 +4406,9 @@ uint8_t transpiler_is_primitive_slop_type(slop_string slop_type) {
 
 uint8_t transpiler_is_range_type_alias(context_TranspileContext* ctx, slop_string slop_type) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
-    __auto_type _mv_1365 = context_ctx_lookup_type_alias(ctx, slop_type);
-    if (_mv_1365.has_value) {
-        __auto_type underlying = _mv_1365.value;
+    __auto_type _mv_1366 = context_ctx_lookup_type_alias(ctx, slop_type);
+    if (_mv_1366.has_value) {
+        __auto_type underlying = _mv_1366.value;
         if (strlib_starts_with(underlying, SLOP_STR("(Int"))) {
             return 1;
         } else if (strlib_starts_with(underlying, SLOP_STR("(I64"))) {
@@ -4410,7 +4430,7 @@ uint8_t transpiler_is_range_type_alias(context_TranspileContext* ctx, slop_strin
         } else {
             return 0;
         }
-    } else if (!_mv_1365.has_value) {
+    } else if (!_mv_1366.has_value) {
         return 0;
     }
 }
@@ -4424,11 +4444,11 @@ void transpiler_emit_union_hash_fn(context_TranspileContext* ctx, slop_string c_
         __auto_type len = ((int64_t)((variants).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1366 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1366.has_value) {
-                __auto_type variant = _mv_1366.value;
+            __auto_type _mv_1367 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1367.has_value) {
+                __auto_type variant = _mv_1367.value;
                 transpiler_emit_union_variant_hash(ctx, c_type, variant);
-            } else if (!_mv_1366.has_value) {
+            } else if (!_mv_1367.has_value) {
             }
             i = (i + 1);
         }
@@ -4485,11 +4505,11 @@ void transpiler_emit_union_eq_fn(context_TranspileContext* ctx, slop_string c_ty
         __auto_type len = ((int64_t)((variants).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1367 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1367.has_value) {
-                __auto_type variant = _mv_1367.value;
+            __auto_type _mv_1368 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1368.has_value) {
+                __auto_type variant = _mv_1368.value;
                 transpiler_emit_union_variant_eq(ctx, c_type, variant);
-            } else if (!_mv_1367.has_value) {
+            } else if (!_mv_1368.has_value) {
             }
             i = (i + 1);
         }
@@ -4536,11 +4556,11 @@ void transpiler_emit_struct_hash_fn(context_TranspileContext* ctx, slop_string c
         __auto_type len = ((int64_t)((fields).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1368 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1368.has_value) {
-                __auto_type field = _mv_1368.value;
+            __auto_type _mv_1369 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1369.has_value) {
+                __auto_type field = _mv_1369.value;
                 transpiler_emit_field_hash(ctx, field);
-            } else if (!_mv_1368.has_value) {
+            } else if (!_mv_1369.has_value) {
             }
             i = (i + 1);
         }
@@ -4607,11 +4627,11 @@ void transpiler_emit_struct_eq_fn(context_TranspileContext* ctx, slop_string c_t
             {
                 int64_t i = 0;
                 while (i < len) {
-                    __auto_type _mv_1369 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1369.has_value) {
-                        __auto_type field = _mv_1369.value;
+                    __auto_type _mv_1370 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1370.has_value) {
+                        __auto_type field = _mv_1370.value;
                         transpiler_emit_field_eq(ctx, field);
-                    } else if (!_mv_1369.has_value) {
+                    } else if (!_mv_1370.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -4672,12 +4692,12 @@ void transpiler_emit_struct_key_types_header(context_TranspileContext* ctx) {
             context_ctx_emit_header(ctx, SLOP_STR("/* Hash/eq functions and list types for struct map/set keys */"));
         }
         while (i < ((int64_t)((struct_key_types).len))) {
-            __auto_type _mv_1370 = ({ __auto_type _lst = struct_key_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1370.has_value) {
-                __auto_type c_type = _mv_1370.value;
+            __auto_type _mv_1371 = ({ __auto_type _lst = struct_key_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1371.has_value) {
+                __auto_type c_type = _mv_1371.value;
                 {
                     __auto_type guard_name = context_ctx_str3(ctx, transpiler_uppercase_name(ctx, c_type), SLOP_STR("_HASH_EQ_DEFINED"), SLOP_STR(""));
-                    __auto_type list_c_name = context_ctx_str(ctx, SLOP_STR("slop_list_"), c_type);
+                    __auto_type list_c_name = context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier((*ctx).arena, c_type));
                     context_ctx_emit_header(ctx, context_ctx_str(ctx, SLOP_STR("#ifndef "), guard_name));
                     context_ctx_emit_header(ctx, context_ctx_str(ctx, SLOP_STR("#define "), guard_name));
                     transpiler_emit_struct_hash_eq(ctx, c_type);
@@ -4688,7 +4708,7 @@ void transpiler_emit_struct_key_types_header(context_TranspileContext* ctx) {
                     context_ctx_emit_header(ctx, SLOP_STR("#endif"));
                     context_ctx_emit_header(ctx, SLOP_STR(""));
                 }
-            } else if (!_mv_1370.has_value) {
+            } else if (!_mv_1371.has_value) {
             }
             i = (i + 1);
         }
@@ -4784,9 +4804,9 @@ void transpiler_emit_chan_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((chan_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1371 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1371.has_value) {
-                __auto_type ct = _mv_1371.value;
+            __auto_type _mv_1372 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1372.has_value) {
+                __auto_type ct = _mv_1372.value;
                 {
                     __auto_type elem_type = ct.elem_type;
                     __auto_type c_name = ct.c_name;
@@ -4811,7 +4831,7 @@ void transpiler_emit_chan_types_header(context_TranspileContext* ctx) {
                         }
                     }
                 }
-            } else if (!_mv_1371.has_value) {
+            } else if (!_mv_1372.has_value) {
             }
             i = (i + 1);
         }
@@ -4825,9 +4845,9 @@ void transpiler_emit_chan_funcs_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((chan_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1372 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1372.has_value) {
-                __auto_type ct = _mv_1372.value;
+            __auto_type _mv_1373 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1373.has_value) {
+                __auto_type ct = _mv_1373.value;
                 {
                     __auto_type elem_type = ct.elem_type;
                     __auto_type c_name = ct.c_name;
@@ -4835,7 +4855,7 @@ void transpiler_emit_chan_funcs_header(context_TranspileContext* ctx) {
                         transpiler_emit_chan_send_recv_funcs(ctx, c_name, elem_type);
                     }
                 }
-            } else if (!_mv_1372.has_value) {
+            } else if (!_mv_1373.has_value) {
             }
             i = (i + 1);
         }
@@ -4971,9 +4991,9 @@ void transpiler_emit_thread_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((thread_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1373 = ({ __auto_type _lst = thread_types; size_t _idx = (size_t)i; slop_option_context_ThreadType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1373.has_value) {
-                __auto_type tt = _mv_1373.value;
+            __auto_type _mv_1374 = ({ __auto_type _lst = thread_types; size_t _idx = (size_t)i; slop_option_context_ThreadType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1374.has_value) {
+                __auto_type tt = _mv_1374.value;
                 {
                     __auto_type result_type = tt.result_type;
                     __auto_type c_name = tt.c_name;
@@ -5005,7 +5025,7 @@ void transpiler_emit_thread_types_header(context_TranspileContext* ctx) {
                         }
                     }
                 }
-            } else if (!_mv_1373.has_value) {
+            } else if (!_mv_1374.has_value) {
             }
             i = (i + 1);
         }
@@ -5050,44 +5070,44 @@ slop_string transpiler_uppercase_name(context_TranspileContext* ctx, slop_string
 
 uint8_t transpiler_is_simple_enum_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1374 = (*item);
-    switch (_mv_1374.tag) {
+    __auto_type _mv_1375 = (*item);
+    switch (_mv_1375.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1374.data.lst;
+            __auto_type lst = _mv_1375.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 3) {
                     return 0;
                 } else {
-                    __auto_type _mv_1375 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1375.has_value) {
-                        __auto_type def_expr = _mv_1375.value;
-                        __auto_type _mv_1376 = (*def_expr);
-                        switch (_mv_1376.tag) {
+                    __auto_type _mv_1376 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1376.has_value) {
+                        __auto_type def_expr = _mv_1376.value;
+                        __auto_type _mv_1377 = (*def_expr);
+                        switch (_mv_1377.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type def_lst = _mv_1376.data.lst;
+                                __auto_type def_lst = _mv_1377.data.lst;
                                 {
                                     __auto_type def_items = def_lst.items;
                                     if (((int64_t)((def_items).len)) < 1) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1377 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1377.has_value) {
-                                            __auto_type head = _mv_1377.value;
-                                            __auto_type _mv_1378 = (*head);
-                                            switch (_mv_1378.tag) {
+                                        __auto_type _mv_1378 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1378.has_value) {
+                                            __auto_type head = _mv_1378.value;
+                                            __auto_type _mv_1379 = (*head);
+                                            switch (_mv_1379.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_1378.data.sym;
+                                                    __auto_type sym = _mv_1379.data.sym;
                                                     return (string_eq(sym.name, SLOP_STR("enum")) && !(transpiler_has_enum_payload_variants(def_items)));
                                                 }
                                                 default: {
                                                     return 0;
                                                 }
                                             }
-                                        } else if (!_mv_1377.has_value) {
+                                        } else if (!_mv_1378.has_value) {
                                             return 0;
                                         }
                                     }
@@ -5097,7 +5117,7 @@ uint8_t transpiler_is_simple_enum_def(types_SExpr* item) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1375.has_value) {
+                    } else if (!_mv_1376.has_value) {
                         return 0;
                     }
                 }
@@ -5116,23 +5136,11 @@ void transpiler_emit_module_types_header(context_TranspileContext* ctx, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1379 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1379.has_value) {
-                __auto_type item = _mv_1379.value;
-                if (transpiler_is_type_def(item) && transpiler_is_type_alias_def(item)) {
-                    transpiler_emit_type_alias_to_header(ctx, item);
-                }
-            } else if (!_mv_1379.has_value) {
-            }
-            i = (i + 1);
-        }
-        i = start;
-        while (i < len) {
             __auto_type _mv_1380 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_1380.has_value) {
                 __auto_type item = _mv_1380.value;
-                if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
-                    transpiler_emit_type_to_header(ctx, item);
+                if (transpiler_is_type_def(item) && transpiler_is_type_alias_def(item)) {
+                    transpiler_emit_type_alias_to_header(ctx, item);
                 }
             } else if (!_mv_1380.has_value) {
             }
@@ -5143,10 +5151,22 @@ void transpiler_emit_module_types_header(context_TranspileContext* ctx, slop_lis
             __auto_type _mv_1381 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_1381.has_value) {
                 __auto_type item = _mv_1381.value;
-                if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
+                if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
                     transpiler_emit_type_to_header(ctx, item);
                 }
             } else if (!_mv_1381.has_value) {
+            }
+            i = (i + 1);
+        }
+        i = start;
+        while (i < len) {
+            __auto_type _mv_1382 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1382.has_value) {
+                __auto_type item = _mv_1382.value;
+                if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
+                    transpiler_emit_type_to_header(ctx, item);
+                }
+            } else if (!_mv_1382.has_value) {
             }
             i = (i + 1);
         }
@@ -5159,13 +5179,13 @@ void transpiler_emit_simple_type_aliases_header(context_TranspileContext* ctx, s
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1382 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1382.has_value) {
-                __auto_type item = _mv_1382.value;
+            __auto_type _mv_1383 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1383.has_value) {
+                __auto_type item = _mv_1383.value;
                 if ((transpiler_is_type_def(item)) && (transpiler_is_type_alias_def(item)) && (!(transpiler_is_result_type_alias_def(item)))) {
                     transpiler_emit_type_alias_to_header(ctx, item);
                 }
-            } else if (!_mv_1382.has_value) {
+            } else if (!_mv_1383.has_value) {
             }
             i = (i + 1);
         }
@@ -5178,13 +5198,13 @@ void transpiler_emit_type_aliases_header(context_TranspileContext* ctx, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1383 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1383.has_value) {
-                __auto_type item = _mv_1383.value;
+            __auto_type _mv_1384 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1384.has_value) {
+                __auto_type item = _mv_1384.value;
                 if ((transpiler_is_type_def(item)) && (transpiler_is_type_alias_def(item)) && (transpiler_is_result_type_alias_def(item))) {
                     transpiler_emit_type_alias_to_header(ctx, item);
                 }
-            } else if (!_mv_1383.has_value) {
+            } else if (!_mv_1384.has_value) {
             }
             i = (i + 1);
         }
@@ -5197,13 +5217,13 @@ void transpiler_emit_simple_enums_header(context_TranspileContext* ctx, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1384 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1384.has_value) {
-                __auto_type item = _mv_1384.value;
+            __auto_type _mv_1385 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1385.has_value) {
+                __auto_type item = _mv_1385.value;
                 if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
                     transpiler_emit_type_to_header(ctx, item);
                 }
-            } else if (!_mv_1384.has_value) {
+            } else if (!_mv_1385.has_value) {
             }
             i = (i + 1);
         }
@@ -5218,9 +5238,9 @@ void transpiler_emit_pending_container_deps(context_TranspileContext* ctx, types
         __auto_type len = ((int64_t)((field_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1385 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1385.has_value) {
-                __auto_type field_type = _mv_1385.value;
+            __auto_type _mv_1386 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1386.has_value) {
+                __auto_type field_type = _mv_1386.value;
                 if (!(context_ctx_is_type_emitted(ctx, field_type)) && transpiler_is_emittable_container_type(ctx, field_type)) {
                     if (strlib_starts_with(field_type, SLOP_STR("slop_option_"))) {
                         transpiler_emit_option_by_c_name(ctx, field_type);
@@ -5229,7 +5249,7 @@ void transpiler_emit_pending_container_deps(context_TranspileContext* ctx, types
                         transpiler_emit_list_by_c_name(ctx, field_type);
                     }
                 }
-            } else if (!_mv_1385.has_value) {
+            } else if (!_mv_1386.has_value) {
             }
             i = (i + 1);
         }
@@ -5243,13 +5263,13 @@ void transpiler_emit_option_by_c_name(context_TranspileContext* ctx, slop_string
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1386 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1386.has_value) {
-                __auto_type ot = _mv_1386.value;
+            __auto_type _mv_1387 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1387.has_value) {
+                __auto_type ot = _mv_1387.value;
                 if (string_eq(ot.c_name, c_name)) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1386.has_value) {
+            } else if (!_mv_1387.has_value) {
             }
             i = (i + 1);
         }
@@ -5263,13 +5283,13 @@ void transpiler_emit_list_by_c_name(context_TranspileContext* ctx, slop_string c
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1387 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1387.has_value) {
-                __auto_type lt = _mv_1387.value;
+            __auto_type _mv_1388 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1388.has_value) {
+                __auto_type lt = _mv_1388.value;
                 if (string_eq(lt.c_name, c_name)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1387.has_value) {
+            } else if (!_mv_1388.has_value) {
             }
             i = (i + 1);
         }
@@ -5290,9 +5310,9 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                 int64_t i = start;
                 while (i < len) {
                     if (!(transpiler_index_in_list(emitted, i))) {
-                        __auto_type _mv_1388 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1388.has_value) {
-                            __auto_type item = _mv_1388.value;
+                        __auto_type _mv_1389 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1389.has_value) {
+                            __auto_type item = _mv_1389.value;
                             if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                                 if (transpiler_type_deps_satisfied(ctx, item)) {
                                     transpiler_emit_pending_container_deps(ctx, item);
@@ -5302,7 +5322,7 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                                     transpiler_emit_option_list_for_type(ctx, item);
                                 }
                             }
-                        } else if (!_mv_1388.has_value) {
+                        } else if (!_mv_1389.has_value) {
                         }
                     }
                     i = (i + 1);
@@ -5319,9 +5339,9 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                     int64_t i = start;
                     while (i < len) {
                         if (!(transpiler_index_in_list(emitted, i))) {
-                            __auto_type _mv_1389 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1389.has_value) {
-                                __auto_type item = _mv_1389.value;
+                            __auto_type _mv_1390 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1390.has_value) {
+                                __auto_type item = _mv_1390.value;
                                 if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                                     if (transpiler_type_deps_satisfied(ctx, item)) {
                                         transpiler_emit_pending_container_deps(ctx, item);
@@ -5331,7 +5351,7 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                                         transpiler_emit_option_list_for_type(ctx, item);
                                     }
                                 }
-                            } else if (!_mv_1389.has_value) {
+                            } else if (!_mv_1390.has_value) {
                             }
                         }
                         i = (i + 1);
@@ -5348,13 +5368,13 @@ uint8_t transpiler_has_unemitted_struct_types(slop_list_types_SExpr_ptr items, i
         uint8_t found = 0;
         while ((i < len) && !(found)) {
             if (!(transpiler_index_in_list(emitted, i))) {
-                __auto_type _mv_1390 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1390.has_value) {
-                    __auto_type item = _mv_1390.value;
+                __auto_type _mv_1391 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1391.has_value) {
+                    __auto_type item = _mv_1391.value;
                     if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                         found = 1;
                     }
-                } else if (!_mv_1390.has_value) {
+                } else if (!_mv_1391.has_value) {
                 }
             }
             i = (i + 1);
@@ -5369,26 +5389,26 @@ void transpiler_break_list_cycles(context_TranspileContext* ctx, slop_list_types
         int64_t i = start;
         while (i < len) {
             if (!(transpiler_index_in_list(emitted, i))) {
-                __auto_type _mv_1391 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1391.has_value) {
-                    __auto_type item = _mv_1391.value;
+                __auto_type _mv_1392 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1392.has_value) {
+                    __auto_type item = _mv_1392.value;
                     if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                         {
                             __auto_type blocking_deps = transpiler_find_blocking_list_deps(ctx, item);
                             __auto_type dep_len = ((int64_t)((blocking_deps).len));
                             __auto_type j = 0;
                             while (j < dep_len) {
-                                __auto_type _mv_1392 = ({ __auto_type _lst = blocking_deps; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1392.has_value) {
-                                    __auto_type dep_name = _mv_1392.value;
+                                __auto_type _mv_1393 = ({ __auto_type _lst = blocking_deps; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1393.has_value) {
+                                    __auto_type dep_name = _mv_1393.value;
                                     transpiler_emit_list_declare_by_c_name(ctx, dep_name);
-                                } else if (!_mv_1392.has_value) {
+                                } else if (!_mv_1393.has_value) {
                                 }
                                 j = (j + 1);
                             }
                         }
                     }
-                } else if (!_mv_1391.has_value) {
+                } else if (!_mv_1392.has_value) {
                 }
             }
             i = (i + 1);
@@ -5406,13 +5426,13 @@ slop_list_string transpiler_find_blocking_list_deps(context_TranspileContext* ct
         __auto_type result = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1393 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1393.has_value) {
-                __auto_type field_type = _mv_1393.value;
+            __auto_type _mv_1394 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1394.has_value) {
+                __auto_type field_type = _mv_1394.value;
                 if ((strlib_starts_with(field_type, SLOP_STR("slop_list_"))) && (!(context_ctx_is_type_emitted(ctx, field_type))) && (!(transpiler_is_runtime_list_type(field_type)))) {
                     ({ __auto_type _lst_p = &(result); __auto_type _item = (field_type); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                 }
-            } else if (!_mv_1393.has_value) {
+            } else if (!_mv_1394.has_value) {
             }
             i = (i + 1);
         }
@@ -5427,13 +5447,13 @@ void transpiler_emit_list_declare_by_c_name(context_TranspileContext* ctx, slop_
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1394 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1394.has_value) {
-                __auto_type lt = _mv_1394.value;
+            __auto_type _mv_1395 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1395.has_value) {
+                __auto_type lt = _mv_1395.value;
                 if (string_eq(lt.c_name, c_name)) {
                     transpiler_emit_list_type_declare_only(ctx, lt);
                 }
-            } else if (!_mv_1394.has_value) {
+            } else if (!_mv_1395.has_value) {
             }
             i = (i + 1);
         }
@@ -5446,13 +5466,13 @@ uint8_t transpiler_index_in_list(slop_list_int lst, int64_t idx) {
         int64_t i = 0;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1395 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_int _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1395.has_value) {
-                __auto_type v = _mv_1395.value;
+            __auto_type _mv_1396 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_int _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1396.has_value) {
+                __auto_type v = _mv_1396.value;
                 if (v == idx) {
                     found = 1;
                 }
-            } else if (!_mv_1395.has_value) {
+            } else if (!_mv_1396.has_value) {
             }
             i = (i + 1);
         }
@@ -5469,13 +5489,13 @@ uint8_t transpiler_type_deps_satisfied(context_TranspileContext* ctx, types_SExp
         int64_t i = 0;
         uint8_t all_satisfied = 1;
         while ((i < len) && all_satisfied) {
-            __auto_type _mv_1396 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1396.has_value) {
-                __auto_type field_type = _mv_1396.value;
+            __auto_type _mv_1397 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1397.has_value) {
+                __auto_type field_type = _mv_1397.value;
                 if (!(transpiler_type_is_available(ctx, field_type))) {
                     all_satisfied = 0;
                 }
-            } else if (!_mv_1396.has_value) {
+            } else if (!_mv_1397.has_value) {
             }
             i = (i + 1);
         }
@@ -5522,34 +5542,34 @@ slop_list_string transpiler_get_type_field_types(context_TranspileContext* ctx, 
     {
         __auto_type arena = (*ctx).arena;
         __auto_type result = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
-        __auto_type _mv_1397 = (*type_def);
-        switch (_mv_1397.tag) {
+        __auto_type _mv_1398 = (*type_def);
+        switch (_mv_1398.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1397.data.lst;
+                __auto_type lst = _mv_1398.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_1398 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1398.has_value) {
-                            __auto_type def_expr = _mv_1398.value;
-                            __auto_type _mv_1399 = (*def_expr);
-                            switch (_mv_1399.tag) {
+                        __auto_type _mv_1399 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1399.has_value) {
+                            __auto_type def_expr = _mv_1399.value;
+                            __auto_type _mv_1400 = (*def_expr);
+                            switch (_mv_1400.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type def_lst = _mv_1399.data.lst;
+                                    __auto_type def_lst = _mv_1400.data.lst;
                                     {
                                         __auto_type def_items = def_lst.items;
                                         __auto_type def_len = ((int64_t)((def_items).len));
                                         if (def_len > 0) {
-                                            __auto_type _mv_1400 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1400.has_value) {
-                                                __auto_type head = _mv_1400.value;
-                                                __auto_type _mv_1401 = (*head);
-                                                switch (_mv_1401.tag) {
+                                            __auto_type _mv_1401 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1401.has_value) {
+                                                __auto_type head = _mv_1401.value;
+                                                __auto_type _mv_1402 = (*head);
+                                                switch (_mv_1402.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type sym = _mv_1401.data.sym;
+                                                        __auto_type sym = _mv_1402.data.sym;
                                                         {
                                                             __auto_type kind = sym.name;
                                                             if (string_eq(kind, SLOP_STR("record"))) {
@@ -5565,7 +5585,7 @@ slop_list_string transpiler_get_type_field_types(context_TranspileContext* ctx, 
                                                         break;
                                                     }
                                                 }
-                                            } else if (!_mv_1400.has_value) {
+                                            } else if (!_mv_1401.has_value) {
                                             }
                                         }
                                     }
@@ -5575,7 +5595,7 @@ slop_list_string transpiler_get_type_field_types(context_TranspileContext* ctx, 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1398.has_value) {
+                        } else if (!_mv_1399.has_value) {
                         }
                     }
                 }
@@ -5597,25 +5617,25 @@ slop_list_string transpiler_extract_record_field_types(context_TranspileContext*
         __auto_type len = ((int64_t)((def_items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1402 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1402.has_value) {
-                __auto_type field_expr = _mv_1402.value;
-                __auto_type _mv_1403 = (*field_expr);
-                switch (_mv_1403.tag) {
+            __auto_type _mv_1403 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1403.has_value) {
+                __auto_type field_expr = _mv_1403.value;
+                __auto_type _mv_1404 = (*field_expr);
+                switch (_mv_1404.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type field_lst = _mv_1403.data.lst;
+                        __auto_type field_lst = _mv_1404.data.lst;
                         if (((int64_t)((field_lst.items).len)) >= 2) {
-                            __auto_type _mv_1404 = ({ __auto_type _lst = field_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1404.has_value) {
-                                __auto_type type_expr = _mv_1404.value;
+                            __auto_type _mv_1405 = ({ __auto_type _lst = field_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1405.has_value) {
+                                __auto_type type_expr = _mv_1405.value;
                                 {
                                     __auto_type type_str = transpiler_get_field_type_string(ctx, type_expr);
                                     if (!(string_eq(type_str, SLOP_STR("")))) {
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (type_str); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
                                 }
-                            } else if (!_mv_1404.has_value) {
+                            } else if (!_mv_1405.has_value) {
                             }
                         }
                         break;
@@ -5624,7 +5644,7 @@ slop_list_string transpiler_extract_record_field_types(context_TranspileContext*
                         break;
                     }
                 }
-            } else if (!_mv_1402.has_value) {
+            } else if (!_mv_1403.has_value) {
             }
             i = (i + 1);
         }
@@ -5640,25 +5660,25 @@ slop_list_string transpiler_extract_union_variant_types(context_TranspileContext
         __auto_type len = ((int64_t)((def_items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1405 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1405.has_value) {
-                __auto_type variant_expr = _mv_1405.value;
-                __auto_type _mv_1406 = (*variant_expr);
-                switch (_mv_1406.tag) {
+            __auto_type _mv_1406 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1406.has_value) {
+                __auto_type variant_expr = _mv_1406.value;
+                __auto_type _mv_1407 = (*variant_expr);
+                switch (_mv_1407.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type variant_lst = _mv_1406.data.lst;
+                        __auto_type variant_lst = _mv_1407.data.lst;
                         if (((int64_t)((variant_lst.items).len)) >= 2) {
-                            __auto_type _mv_1407 = ({ __auto_type _lst = variant_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1407.has_value) {
-                                __auto_type type_expr = _mv_1407.value;
+                            __auto_type _mv_1408 = ({ __auto_type _lst = variant_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1408.has_value) {
+                                __auto_type type_expr = _mv_1408.value;
                                 {
                                     __auto_type type_str = transpiler_get_field_type_string(ctx, type_expr);
                                     if (!(string_eq(type_str, SLOP_STR("")))) {
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (type_str); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
                                 }
-                            } else if (!_mv_1407.has_value) {
+                            } else if (!_mv_1408.has_value) {
                             }
                         }
                         break;
@@ -5667,7 +5687,7 @@ slop_list_string transpiler_extract_union_variant_types(context_TranspileContext
                         break;
                     }
                 }
-            } else if (!_mv_1405.has_value) {
+            } else if (!_mv_1406.has_value) {
             }
             i = (i + 1);
         }
@@ -5680,62 +5700,43 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1408 = (*type_expr);
-        switch (_mv_1408.tag) {
+        __auto_type _mv_1409 = (*type_expr);
+        switch (_mv_1409.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1408.data.sym;
+                __auto_type sym = _mv_1409.data.sym;
                 {
                     __auto_type name = sym.name;
-                    __auto_type _mv_1409 = context_ctx_lookup_type(ctx, name);
-                    if (_mv_1409.has_value) {
-                        __auto_type entry = _mv_1409.value;
+                    __auto_type _mv_1410 = context_ctx_lookup_type(ctx, name);
+                    if (_mv_1410.has_value) {
+                        __auto_type entry = _mv_1410.value;
                         return entry.c_name;
-                    } else if (!_mv_1409.has_value) {
+                    } else if (!_mv_1410.has_value) {
                         return ctype_to_c_type(arena, type_expr);
                     }
                 }
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1408.data.lst;
+                __auto_type lst = _mv_1409.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 1) {
                         return SLOP_STR("");
                     } else {
-                        __auto_type _mv_1410 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1410.has_value) {
-                            __auto_type head = _mv_1410.value;
-                            __auto_type _mv_1411 = (*head);
-                            switch (_mv_1411.tag) {
+                        __auto_type _mv_1411 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1411.has_value) {
+                            __auto_type head = _mv_1411.value;
+                            __auto_type _mv_1412 = (*head);
+                            switch (_mv_1412.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1411.data.sym;
+                                    __auto_type sym = _mv_1412.data.sym;
                                     {
                                         __auto_type kind = sym.name;
                                         if (string_eq(kind, SLOP_STR("Ptr"))) {
                                             return SLOP_STR("");
                                         } else if (string_eq(kind, SLOP_STR("Option"))) {
-                                            if (((int64_t)((items).len)) >= 2) {
-                                                __auto_type _mv_1412 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1412.has_value) {
-                                                    __auto_type inner = _mv_1412.value;
-                                                    {
-                                                        __auto_type inner_str = transpiler_get_field_type_string(ctx, inner);
-                                                        if (string_eq(inner_str, SLOP_STR(""))) {
-                                                            return SLOP_STR("");
-                                                        } else {
-                                                            return context_ctx_str(ctx, SLOP_STR("slop_option_"), ctype_type_to_identifier(arena, inner_str));
-                                                        }
-                                                    }
-                                                } else if (!_mv_1412.has_value) {
-                                                    return SLOP_STR("");
-                                                }
-                                            } else {
-                                                return SLOP_STR("");
-                                            }
-                                        } else if (string_eq(kind, SLOP_STR("List"))) {
                                             if (((int64_t)((items).len)) >= 2) {
                                                 __auto_type _mv_1413 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                                 if (_mv_1413.has_value) {
@@ -5745,10 +5746,29 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                                                         if (string_eq(inner_str, SLOP_STR(""))) {
                                                             return SLOP_STR("");
                                                         } else {
-                                                            return context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, inner_str));
+                                                            return context_ctx_str(ctx, SLOP_STR("slop_option_"), ctype_type_to_identifier(arena, inner_str));
                                                         }
                                                     }
                                                 } else if (!_mv_1413.has_value) {
+                                                    return SLOP_STR("");
+                                                }
+                                            } else {
+                                                return SLOP_STR("");
+                                            }
+                                        } else if (string_eq(kind, SLOP_STR("List"))) {
+                                            if (((int64_t)((items).len)) >= 2) {
+                                                __auto_type _mv_1414 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1414.has_value) {
+                                                    __auto_type inner = _mv_1414.value;
+                                                    {
+                                                        __auto_type inner_str = transpiler_get_field_type_string(ctx, inner);
+                                                        if (string_eq(inner_str, SLOP_STR(""))) {
+                                                            return SLOP_STR("");
+                                                        } else {
+                                                            return context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, inner_str));
+                                                        }
+                                                    }
+                                                } else if (!_mv_1414.has_value) {
                                                     return SLOP_STR("");
                                                 }
                                             } else {
@@ -5763,7 +5783,7 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                                     return SLOP_STR("");
                                 }
                             }
-                        } else if (!_mv_1410.has_value) {
+                        } else if (!_mv_1411.has_value) {
                             return SLOP_STR("");
                         }
                     }
@@ -5791,31 +5811,31 @@ void transpiler_emit_option_list_for_type(context_TranspileContext* ctx, types_S
 slop_string transpiler_get_type_c_name(context_TranspileContext* ctx, types_SExpr* type_def) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
-    __auto_type _mv_1414 = (*type_def);
-    switch (_mv_1414.tag) {
+    __auto_type _mv_1415 = (*type_def);
+    switch (_mv_1415.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1414.data.lst;
+            __auto_type lst = _mv_1415.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return SLOP_STR("");
                 } else {
-                    __auto_type _mv_1415 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1415.has_value) {
-                        __auto_type name_expr = _mv_1415.value;
-                        __auto_type _mv_1416 = (*name_expr);
-                        switch (_mv_1416.tag) {
+                    __auto_type _mv_1416 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1416.has_value) {
+                        __auto_type name_expr = _mv_1416.value;
+                        __auto_type _mv_1417 = (*name_expr);
+                        switch (_mv_1417.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1416.data.sym;
+                                __auto_type sym = _mv_1417.data.sym;
                                 {
                                     __auto_type name = sym.name;
-                                    __auto_type _mv_1417 = context_ctx_lookup_type(ctx, name);
-                                    if (_mv_1417.has_value) {
-                                        __auto_type entry = _mv_1417.value;
+                                    __auto_type _mv_1418 = context_ctx_lookup_type(ctx, name);
+                                    if (_mv_1418.has_value) {
+                                        __auto_type entry = _mv_1418.value;
                                         return entry.c_name;
-                                    } else if (!_mv_1417.has_value) {
+                                    } else if (!_mv_1418.has_value) {
                                         return SLOP_STR("");
                                     }
                                 }
@@ -5824,7 +5844,7 @@ slop_string transpiler_get_type_c_name(context_TranspileContext* ctx, types_SExp
                                 return SLOP_STR("");
                             }
                         }
-                    } else if (!_mv_1415.has_value) {
+                    } else if (!_mv_1416.has_value) {
                         return SLOP_STR("");
                     }
                 }
@@ -5843,13 +5863,13 @@ void transpiler_emit_option_for_inner_type(context_TranspileContext* ctx, slop_s
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1418 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1418.has_value) {
-                __auto_type ot = _mv_1418.value;
+            __auto_type _mv_1419 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1419.has_value) {
+                __auto_type ot = _mv_1419.value;
                 if (string_eq(ot.inner_type, inner_c_name) && !(transpiler_is_pointer_elem_type(ot.inner_type))) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1418.has_value) {
+            } else if (!_mv_1419.has_value) {
             }
             i = (i + 1);
         }
@@ -5863,14 +5883,14 @@ void transpiler_emit_list_for_elem_type(context_TranspileContext* ctx, slop_stri
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1419 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1419.has_value) {
-                __auto_type lt = _mv_1419.value;
+            __auto_type _mv_1420 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1420.has_value) {
+                __auto_type lt = _mv_1420.value;
                 if (string_eq(lt.elem_type, elem_c_name) && !(transpiler_is_pointer_elem_type(lt.elem_type))) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                     transpiler_emit_option_for_inner_type(ctx, lt.c_name);
                 }
-            } else if (!_mv_1419.has_value) {
+            } else if (!_mv_1420.has_value) {
             }
             i = (i + 1);
         }
@@ -5888,13 +5908,13 @@ uint8_t transpiler_struct_uses_value_list_or_option(context_TranspileContext* ct
             __auto_type len = ((int64_t)((list_types).len));
             int64_t i = 0;
             while ((i < len) && !(found)) {
-                __auto_type _mv_1420 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1420.has_value) {
-                    __auto_type lt = _mv_1420.value;
+                __auto_type _mv_1421 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1421.has_value) {
+                    __auto_type lt = _mv_1421.value;
                     if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_struct_uses_list_type(ctx, type_def, lt.c_name)) {
                         found = 1;
                     }
-                } else if (!_mv_1420.has_value) {
+                } else if (!_mv_1421.has_value) {
                 }
                 i = (i + 1);
             }
@@ -5904,13 +5924,13 @@ uint8_t transpiler_struct_uses_value_list_or_option(context_TranspileContext* ct
                 __auto_type len2 = ((int64_t)((option_types).len));
                 int64_t j = 0;
                 while ((j < len2) && !(found)) {
-                    __auto_type _mv_1421 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)j; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1421.has_value) {
-                        __auto_type ot = _mv_1421.value;
+                    __auto_type _mv_1422 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)j; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1422.has_value) {
+                        __auto_type ot = _mv_1422.value;
                         if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_struct_uses_option_type(ctx, type_def, ot.c_name)) {
                             found = 1;
                         }
-                    } else if (!_mv_1421.has_value) {
+                    } else if (!_mv_1422.has_value) {
                     }
                     j = (j + 1);
                 }
@@ -5928,13 +5948,13 @@ void transpiler_emit_struct_dependent_list_types(context_TranspileContext* ctx, 
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1422 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1422.has_value) {
-                __auto_type lt = _mv_1422.value;
+            __auto_type _mv_1423 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1423.has_value) {
+                __auto_type lt = _mv_1423.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_struct_uses_list_type(ctx, type_def, lt.c_name)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1422.has_value) {
+            } else if (!_mv_1423.has_value) {
             }
             i = (i + 1);
         }
@@ -5949,14 +5969,14 @@ void transpiler_emit_struct_dependent_option_types(context_TranspileContext* ctx
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1423 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1423.has_value) {
-                __auto_type ot = _mv_1423.value;
+            __auto_type _mv_1424 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1424.has_value) {
+                __auto_type ot = _mv_1424.value;
                 if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_struct_uses_option_type(ctx, type_def, ot.c_name)) {
                     transpiler_emit_list_type_if_needed(ctx, ot.inner_type);
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1423.has_value) {
+            } else if (!_mv_1424.has_value) {
             }
             i = (i + 1);
         }
@@ -5971,15 +5991,15 @@ void transpiler_emit_struct_dependent_list_types_safe(context_TranspileContext* 
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1424 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1424.has_value) {
-                __auto_type lt = _mv_1424.value;
+            __auto_type _mv_1425 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1425.has_value) {
+                __auto_type lt = _mv_1425.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_struct_uses_list_type(ctx, type_def, lt.c_name)) {
                     if (transpiler_is_type_emitted_or_primitive(ctx, lt.elem_type)) {
                         transpiler_emit_single_list_type_header(ctx, lt);
                     }
                 }
-            } else if (!_mv_1424.has_value) {
+            } else if (!_mv_1425.has_value) {
             }
             i = (i + 1);
         }
@@ -5994,16 +6014,16 @@ void transpiler_emit_struct_dependent_option_types_safe(context_TranspileContext
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1425 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1425.has_value) {
-                __auto_type ot = _mv_1425.value;
+            __auto_type _mv_1426 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1426.has_value) {
+                __auto_type ot = _mv_1426.value;
                 if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_struct_uses_option_type(ctx, type_def, ot.c_name)) {
                     if (transpiler_is_type_emitted_or_primitive(ctx, ot.inner_type)) {
                         transpiler_emit_list_type_if_needed_safe(ctx, ot.inner_type);
                         transpiler_emit_single_option_type_header(ctx, ot);
                     }
                 }
-            } else if (!_mv_1425.has_value) {
+            } else if (!_mv_1426.has_value) {
             }
             i = (i + 1);
         }
@@ -6028,9 +6048,9 @@ uint8_t transpiler_is_imported_type(context_TranspileContext* ctx, slop_string t
     if (strlib_starts_with(type_name, SLOP_STR("slop_list_")) || strlib_starts_with(type_name, SLOP_STR("slop_option_"))) {
         return 0;
     } else {
-        __auto_type _mv_1426 = context_ctx_get_module(ctx);
-        if (_mv_1426.has_value) {
-            __auto_type current_mod = _mv_1426.value;
+        __auto_type _mv_1427 = context_ctx_get_module(ctx);
+        if (_mv_1427.has_value) {
+            __auto_type current_mod = _mv_1427.value;
             {
                 __auto_type arena = (*ctx).arena;
                 __auto_type c_mod = ctype_to_c_name(arena, current_mod);
@@ -6044,7 +6064,7 @@ uint8_t transpiler_is_imported_type(context_TranspileContext* ctx, slop_string t
                     }
                 }
             }
-        } else if (!_mv_1426.has_value) {
+        } else if (!_mv_1427.has_value) {
             return 0;
         }
     }
@@ -6075,13 +6095,13 @@ void transpiler_emit_list_type_if_needed_safe(context_TranspileContext* ctx, slo
             __auto_type len = ((int64_t)((list_types).len));
             int64_t i = 0;
             while (i < len) {
-                __auto_type _mv_1427 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1427.has_value) {
-                    __auto_type lt = _mv_1427.value;
+                __auto_type _mv_1428 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1428.has_value) {
+                    __auto_type lt = _mv_1428.value;
                     if (string_eq(lt.c_name, inner_type) && transpiler_is_type_emitted_or_primitive(ctx, lt.elem_type)) {
                         transpiler_emit_single_list_type_header(ctx, lt);
                     }
-                } else if (!_mv_1427.has_value) {
+                } else if (!_mv_1428.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6097,13 +6117,13 @@ void transpiler_emit_list_type_if_needed(context_TranspileContext* ctx, slop_str
             __auto_type len = ((int64_t)((list_types).len));
             int64_t i = 0;
             while (i < len) {
-                __auto_type _mv_1428 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1428.has_value) {
-                    __auto_type lt = _mv_1428.value;
+                __auto_type _mv_1429 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1429.has_value) {
+                    __auto_type lt = _mv_1429.value;
                     if (string_eq(lt.c_name, inner_type)) {
                         transpiler_emit_single_list_type_header(ctx, lt);
                     }
-                } else if (!_mv_1428.has_value) {
+                } else if (!_mv_1429.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6116,21 +6136,21 @@ uint8_t transpiler_struct_uses_list_type(context_TranspileContext* ctx, types_SE
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1429 = (*type_def);
-        switch (_mv_1429.tag) {
+        __auto_type _mv_1430 = (*type_def);
+        switch (_mv_1430.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1429.data.lst;
+                __auto_type lst = _mv_1430.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 3) {
                         return 0;
                     } else {
-                        __auto_type _mv_1430 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1430.has_value) {
-                            __auto_type body_expr = _mv_1430.value;
+                        __auto_type _mv_1431 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1431.has_value) {
+                            __auto_type body_expr = _mv_1431.value;
                             return transpiler_type_body_uses_typename(ctx, body_expr, list_type_name);
-                        } else if (!_mv_1430.has_value) {
+                        } else if (!_mv_1431.has_value) {
                             return 0;
                         }
                     }
@@ -6154,24 +6174,24 @@ uint8_t transpiler_type_body_uses_typename(context_TranspileContext* ctx, types_
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1431 = (*body_expr);
-        switch (_mv_1431.tag) {
+        __auto_type _mv_1432 = (*body_expr);
+        switch (_mv_1432.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1431.data.lst;
+                __auto_type lst = _mv_1432.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type found = 0;
                     __auto_type i = 1;
                     while ((i < len) && !(found)) {
-                        __auto_type _mv_1432 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1432.has_value) {
-                            __auto_type field_expr = _mv_1432.value;
+                        __auto_type _mv_1433 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1433.has_value) {
+                            __auto_type field_expr = _mv_1433.value;
                             if (transpiler_field_uses_typename(ctx, field_expr, typename)) {
                                 found = 1;
                             }
-                        } else if (!_mv_1432.has_value) {
+                        } else if (!_mv_1433.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -6188,24 +6208,24 @@ uint8_t transpiler_type_body_uses_typename(context_TranspileContext* ctx, types_
 uint8_t transpiler_field_uses_typename(context_TranspileContext* ctx, types_SExpr* field_expr, slop_string typename) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((field_expr != NULL)), "(!= field-expr nil)");
-    __auto_type _mv_1433 = (*field_expr);
-    switch (_mv_1433.tag) {
+    __auto_type _mv_1434 = (*field_expr);
+    switch (_mv_1434.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1433.data.lst;
+            __auto_type lst = _mv_1434.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return 0;
                 } else {
-                    __auto_type _mv_1434 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1434.has_value) {
-                        __auto_type type_expr = _mv_1434.value;
+                    __auto_type _mv_1435 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1435.has_value) {
+                        __auto_type type_expr = _mv_1435.value;
                         {
                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                             return string_eq(c_type, typename);
                         }
-                    } else if (!_mv_1434.has_value) {
+                    } else if (!_mv_1435.has_value) {
                         return 0;
                     }
                 }
@@ -6222,33 +6242,33 @@ void transpiler_emit_type_to_header(context_TranspileContext* ctx, types_SExpr* 
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1435 = (*type_def);
-        switch (_mv_1435.tag) {
+        __auto_type _mv_1436 = (*type_def);
+        switch (_mv_1436.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1435.data.lst;
+                __auto_type lst = _mv_1436.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 3) {
-                        __auto_type _mv_1436 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1436.has_value) {
-                            __auto_type name_expr = _mv_1436.value;
-                            __auto_type _mv_1437 = (*name_expr);
-                            switch (_mv_1437.tag) {
+                        __auto_type _mv_1437 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1437.has_value) {
+                            __auto_type name_expr = _mv_1437.value;
+                            __auto_type _mv_1438 = (*name_expr);
+                            switch (_mv_1438.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1437.data.sym;
+                                    __auto_type name_sym = _mv_1438.data.sym;
                                     {
                                         __auto_type type_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, type_name);
                                         __auto_type c_name = ((context_ctx_prefixing_enabled(ctx)) ? ({ __auto_type _mv = context_ctx_get_module(ctx); _mv.has_value ? ({ __auto_type mod_name = _mv.value; context_ctx_str(ctx, ctype_to_c_name(arena, mod_name), context_ctx_str(ctx, SLOP_STR("_"), base_name)); }) : (base_name); }) : base_name);
-                                        __auto_type _mv_1438 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1438.has_value) {
-                                            __auto_type body_expr = _mv_1438.value;
+                                        __auto_type _mv_1439 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1439.has_value) {
+                                            __auto_type body_expr = _mv_1439.value;
                                             transpiler_emit_type_body_to_header(ctx, type_name, c_name, body_expr);
                                             context_ctx_mark_type_emitted(ctx, c_name);
-                                        } else if (!_mv_1438.has_value) {
+                                        } else if (!_mv_1439.has_value) {
                                         }
                                     }
                                     break;
@@ -6257,7 +6277,7 @@ void transpiler_emit_type_to_header(context_TranspileContext* ctx, types_SExpr* 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1436.has_value) {
+                        } else if (!_mv_1437.has_value) {
                         }
                     }
                 }
@@ -6275,23 +6295,23 @@ void transpiler_emit_type_body_to_header(context_TranspileContext* ctx, slop_str
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1439 = (*body_expr);
-        switch (_mv_1439.tag) {
+        __auto_type _mv_1440 = (*body_expr);
+        switch (_mv_1440.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1439.data.lst;
+                __auto_type lst = _mv_1440.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 1) {
                     } else {
-                        __auto_type _mv_1440 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1440.has_value) {
-                            __auto_type kind_expr = _mv_1440.value;
-                            __auto_type _mv_1441 = (*kind_expr);
-                            switch (_mv_1441.tag) {
+                        __auto_type _mv_1441 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1441.has_value) {
+                            __auto_type kind_expr = _mv_1441.value;
+                            __auto_type _mv_1442 = (*kind_expr);
+                            switch (_mv_1442.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type kind_sym = _mv_1441.data.sym;
+                                    __auto_type kind_sym = _mv_1442.data.sym;
                                     {
                                         __auto_type kind = kind_sym.name;
                                         if (string_eq(kind, SLOP_STR("enum"))) {
@@ -6309,7 +6329,7 @@ void transpiler_emit_type_body_to_header(context_TranspileContext* ctx, slop_str
                                     break;
                                 }
                             }
-                        } else if (!_mv_1440.has_value) {
+                        } else if (!_mv_1441.has_value) {
                         }
                     }
                 }
@@ -6330,14 +6350,14 @@ void transpiler_emit_enum_to_header(context_TranspileContext* ctx, slop_string c
         int64_t i = 1;
         context_ctx_emit_header(ctx, SLOP_STR("typedef enum {"));
         while (i < len) {
-            __auto_type _mv_1442 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1442.has_value) {
-                __auto_type variant_expr = _mv_1442.value;
-                __auto_type _mv_1443 = (*variant_expr);
-                switch (_mv_1443.tag) {
+            __auto_type _mv_1443 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1443.has_value) {
+                __auto_type variant_expr = _mv_1443.value;
+                __auto_type _mv_1444 = (*variant_expr);
+                switch (_mv_1444.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type variant_sym = _mv_1443.data.sym;
+                        __auto_type variant_sym = _mv_1444.data.sym;
                         {
                             __auto_type variant_name = variant_sym.name;
                             __auto_type c_variant = context_ctx_str3(ctx, c_name, SLOP_STR("_"), ctype_to_c_name(arena, variant_name));
@@ -6354,7 +6374,7 @@ void transpiler_emit_enum_to_header(context_TranspileContext* ctx, slop_string c
                         break;
                     }
                 }
-            } else if (!_mv_1442.has_value) {
+            } else if (!_mv_1443.has_value) {
             }
             i = (i + 1);
         }
@@ -6372,11 +6392,11 @@ void transpiler_emit_struct_to_header(context_TranspileContext* ctx, slop_string
         int64_t i = 1;
         context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("struct "), c_name, SLOP_STR(" {")));
         while (i < len) {
-            __auto_type _mv_1444 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1444.has_value) {
-                __auto_type field_expr = _mv_1444.value;
+            __auto_type _mv_1445 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1445.has_value) {
+                __auto_type field_expr = _mv_1445.value;
                 transpiler_emit_field_to_header(ctx, raw_type_name, c_name, field_expr);
-            } else if (!_mv_1444.has_value) {
+            } else if (!_mv_1445.has_value) {
             }
             i = (i + 1);
         }
@@ -6391,28 +6411,28 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
     SLOP_PRE(((field_expr != NULL)), "(!= field-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1445 = (*field_expr);
-        switch (_mv_1445.tag) {
+        __auto_type _mv_1446 = (*field_expr);
+        switch (_mv_1446.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1445.data.lst;
+                __auto_type lst = _mv_1446.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_1446 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1446.has_value) {
-                            __auto_type name_expr = _mv_1446.value;
-                            __auto_type _mv_1447 = (*name_expr);
-                            switch (_mv_1447.tag) {
+                        __auto_type _mv_1447 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1447.has_value) {
+                            __auto_type name_expr = _mv_1447.value;
+                            __auto_type _mv_1448 = (*name_expr);
+                            switch (_mv_1448.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1447.data.sym;
+                                    __auto_type name_sym = _mv_1448.data.sym;
                                     {
                                         __auto_type field_name = name_sym.name;
                                         __auto_type c_field_name = ctype_to_c_name(arena, field_name);
-                                        __auto_type _mv_1448 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1448.has_value) {
-                                            __auto_type type_expr = _mv_1448.value;
+                                        __auto_type _mv_1449 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1449.has_value) {
+                                            __auto_type type_expr = _mv_1449.value;
                                             {
                                                 __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                 __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
@@ -6421,7 +6441,7 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
                                                 context_ctx_register_field_type(ctx, raw_type_name, field_name, c_type, slop_type_str, is_ptr);
                                                 context_ctx_register_field_type(ctx, c_type_name, field_name, c_type, slop_type_str, is_ptr);
                                             }
-                                        } else if (!_mv_1448.has_value) {
+                                        } else if (!_mv_1449.has_value) {
                                         }
                                     }
                                     break;
@@ -6430,7 +6450,7 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1446.has_value) {
+                        } else if (!_mv_1447.has_value) {
                         }
                     }
                 }
@@ -6445,31 +6465,31 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
 
 uint8_t transpiler_is_pointer_type_expr_header(types_SExpr* type_expr) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_1449 = (*type_expr);
-    switch (_mv_1449.tag) {
+    __auto_type _mv_1450 = (*type_expr);
+    switch (_mv_1450.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1449.data.lst;
+            __auto_type lst = _mv_1450.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1450 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1450.has_value) {
-                        __auto_type head = _mv_1450.value;
-                        __auto_type _mv_1451 = (*head);
-                        switch (_mv_1451.tag) {
+                    __auto_type _mv_1451 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1451.has_value) {
+                        __auto_type head = _mv_1451.value;
+                        __auto_type _mv_1452 = (*head);
+                        switch (_mv_1452.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1451.data.sym;
+                                __auto_type sym = _mv_1452.data.sym;
                                 return string_eq(sym.name, SLOP_STR("Ptr"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1450.has_value) {
+                    } else if (!_mv_1451.has_value) {
                         return 0;
                     }
                 }
@@ -6491,9 +6511,9 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
         {
             int64_t i = 1;
             while (i < len) {
-                __auto_type _mv_1452 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1452.has_value) {
-                    __auto_type variant_expr = _mv_1452.value;
+                __auto_type _mv_1453 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1453.has_value) {
+                    __auto_type variant_expr = _mv_1453.value;
                     {
                         __auto_type variant_name = transpiler_get_variant_name(variant_expr);
                         __auto_type c_variant = context_ctx_str3(ctx, c_name, SLOP_STR("_"), ctype_to_c_name(arena, variant_name));
@@ -6504,7 +6524,7 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
                             context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("    "), c_variant, SLOP_STR(",")));
                         }
                     }
-                } else if (!_mv_1452.has_value) {
+                } else if (!_mv_1453.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6517,11 +6537,11 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
         {
             int64_t i = 1;
             while (i < len) {
-                __auto_type _mv_1453 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1453.has_value) {
-                    __auto_type variant_expr = _mv_1453.value;
+                __auto_type _mv_1454 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1454.has_value) {
+                    __auto_type variant_expr = _mv_1454.value;
                     transpiler_emit_union_variant_to_header(ctx, variant_expr);
-                } else if (!_mv_1453.has_value) {
+                } else if (!_mv_1454.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6535,36 +6555,36 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
 
 slop_string transpiler_get_variant_name(types_SExpr* variant_expr) {
     SLOP_PRE(((variant_expr != NULL)), "(!= variant-expr nil)");
-    __auto_type _mv_1454 = (*variant_expr);
-    switch (_mv_1454.tag) {
+    __auto_type _mv_1455 = (*variant_expr);
+    switch (_mv_1455.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1454.data.sym;
+            __auto_type sym = _mv_1455.data.sym;
             return sym.name;
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1454.data.lst;
+            __auto_type lst = _mv_1455.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return SLOP_STR("unknown");
                 } else {
-                    __auto_type _mv_1455 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1455.has_value) {
-                        __auto_type name_expr = _mv_1455.value;
-                        __auto_type _mv_1456 = (*name_expr);
-                        switch (_mv_1456.tag) {
+                    __auto_type _mv_1456 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1456.has_value) {
+                        __auto_type name_expr = _mv_1456.value;
+                        __auto_type _mv_1457 = (*name_expr);
+                        switch (_mv_1457.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type name_sym = _mv_1456.data.sym;
+                                __auto_type name_sym = _mv_1457.data.sym;
                                 return name_sym.name;
                             }
                             default: {
                                 return SLOP_STR("unknown");
                             }
                         }
-                    } else if (!_mv_1455.has_value) {
+                    } else if (!_mv_1456.has_value) {
                         return SLOP_STR("unknown");
                     }
                 }
@@ -6581,35 +6601,35 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
     SLOP_PRE(((variant_expr != NULL)), "(!= variant-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1457 = (*variant_expr);
-        switch (_mv_1457.tag) {
+        __auto_type _mv_1458 = (*variant_expr);
+        switch (_mv_1458.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1457.data.sym;
+                __auto_type sym = _mv_1458.data.sym;
                 break;
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1457.data.lst;
+                __auto_type lst = _mv_1458.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type num_items = ((int64_t)((items).len));
                     if (num_items >= 2) {
-                        __auto_type _mv_1458 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1458.has_value) {
-                            __auto_type name_expr = _mv_1458.value;
-                            __auto_type _mv_1459 = (*name_expr);
-                            switch (_mv_1459.tag) {
+                        __auto_type _mv_1459 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1459.has_value) {
+                            __auto_type name_expr = _mv_1459.value;
+                            __auto_type _mv_1460 = (*name_expr);
+                            switch (_mv_1460.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1459.data.sym;
+                                    __auto_type name_sym = _mv_1460.data.sym;
                                     {
                                         __auto_type variant_name = name_sym.name;
                                         __auto_type c_field = ctype_to_c_name(arena, variant_name);
                                         if (num_items == 2) {
-                                            __auto_type _mv_1460 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1460.has_value) {
-                                                __auto_type type_expr = _mv_1460.value;
+                                            __auto_type _mv_1461 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1461.has_value) {
+                                                __auto_type type_expr = _mv_1461.value;
                                                 {
                                                     __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                     {
@@ -6617,14 +6637,14 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
                                                         context_ctx_emit_header(ctx, context_ctx_str4(ctx, SLOP_STR("        "), actual_type, SLOP_STR(" "), context_ctx_str(ctx, c_field, SLOP_STR(";"))));
                                                     }
                                                 }
-                                            } else if (!_mv_1460.has_value) {
+                                            } else if (!_mv_1461.has_value) {
                                             }
                                         } else if (num_items >= 3) {
                                             context_ctx_emit_header(ctx, SLOP_STR("        struct {"));
                                             for (int64_t fi = 1; fi < num_items; fi++) {
-                                                __auto_type _mv_1461 = ({ __auto_type _lst = items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1461.has_value) {
-                                                    __auto_type type_expr = _mv_1461.value;
+                                                __auto_type _mv_1462 = ({ __auto_type _lst = items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1462.has_value) {
+                                                    __auto_type type_expr = _mv_1462.value;
                                                     {
                                                         __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                         {
@@ -6633,7 +6653,7 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
                                                             context_ctx_emit_header(ctx, context_ctx_str5(ctx, SLOP_STR("            "), actual_type, SLOP_STR(" "), field_name, SLOP_STR(";")));
                                                         }
                                                     }
-                                                } else if (!_mv_1461.has_value) {
+                                                } else if (!_mv_1462.has_value) {
                                                 }
                                             }
                                             context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("        } "), c_field, SLOP_STR(";")));
@@ -6646,7 +6666,7 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
                                     break;
                                 }
                             }
-                        } else if (!_mv_1458.has_value) {
+                        } else if (!_mv_1459.has_value) {
                         }
                     }
                 }
@@ -6666,9 +6686,9 @@ void transpiler_emit_module_consts(context_TranspileContext* ctx, slop_list_type
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1462 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1462.has_value) {
-                __auto_type item = _mv_1462.value;
+            __auto_type _mv_1463 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1463.has_value) {
+                __auto_type item = _mv_1463.value;
                 if (transpiler_is_const_def(item)) {
                     {
                         __auto_type const_name = transpiler_get_const_name(item);
@@ -6677,7 +6697,7 @@ void transpiler_emit_module_consts(context_TranspileContext* ctx, slop_list_type
                     }
                     emitted_any = 1;
                 }
-            } else if (!_mv_1462.has_value) {
+            } else if (!_mv_1463.has_value) {
             }
             i = (i + 1);
         }
@@ -6689,31 +6709,31 @@ void transpiler_emit_module_consts(context_TranspileContext* ctx, slop_list_type
 
 slop_string transpiler_get_const_name(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1463 = (*item);
-    switch (_mv_1463.tag) {
+    __auto_type _mv_1464 = (*item);
+    switch (_mv_1464.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1463.data.lst;
+            __auto_type lst = _mv_1464.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return SLOP_STR("");
                 } else {
-                    __auto_type _mv_1464 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1464.has_value) {
-                        __auto_type name_expr = _mv_1464.value;
-                        __auto_type _mv_1465 = (*name_expr);
-                        switch (_mv_1465.tag) {
+                    __auto_type _mv_1465 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1465.has_value) {
+                        __auto_type name_expr = _mv_1465.value;
+                        __auto_type _mv_1466 = (*name_expr);
+                        switch (_mv_1466.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1465.data.sym;
+                                __auto_type sym = _mv_1466.data.sym;
                                 return sym.name;
                             }
                             default: {
                                 return SLOP_STR("");
                             }
                         }
-                    } else if (!_mv_1464.has_value) {
+                    } else if (!_mv_1465.has_value) {
                         return SLOP_STR("");
                     }
                 }
@@ -6732,15 +6752,15 @@ void transpiler_emit_module_consts_header(context_TranspileContext* ctx, slop_li
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1466 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1466.has_value) {
-                __auto_type item = _mv_1466.value;
+            __auto_type _mv_1467 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1467.has_value) {
+                __auto_type item = _mv_1467.value;
                 if (transpiler_is_const_def(item)) {
                     if (transpiler_emit_const_header_if_exported(ctx, item, exports)) {
                         emitted_any = 1;
                     }
                 }
-            } else if (!_mv_1466.has_value) {
+            } else if (!_mv_1467.has_value) {
             }
             i = (i + 1);
         }
@@ -6753,35 +6773,35 @@ void transpiler_emit_module_consts_header(context_TranspileContext* ctx, slop_li
 uint8_t transpiler_emit_const_header_if_exported(context_TranspileContext* ctx, types_SExpr* item, slop_list_string exports) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1467 = (*item);
-    switch (_mv_1467.tag) {
+    __auto_type _mv_1468 = (*item);
+    switch (_mv_1468.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1467.data.lst;
+            __auto_type lst = _mv_1468.data.lst;
             {
                 __auto_type const_items = lst.items;
                 if (((int64_t)((const_items).len)) < 4) {
                     return 0;
                 } else {
-                    __auto_type _mv_1468 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1468.has_value) {
-                        __auto_type name_expr = _mv_1468.value;
-                        __auto_type _mv_1469 = (*name_expr);
-                        switch (_mv_1469.tag) {
+                    __auto_type _mv_1469 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1469.has_value) {
+                        __auto_type name_expr = _mv_1469.value;
+                        __auto_type _mv_1470 = (*name_expr);
+                        switch (_mv_1470.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type name_sym = _mv_1469.data.sym;
+                                __auto_type name_sym = _mv_1470.data.sym;
                                 {
                                     __auto_type raw_name = name_sym.name;
                                     if (!(transpiler_list_contains_str(exports, raw_name))) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1470 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1470.has_value) {
-                                            __auto_type type_expr = _mv_1470.value;
+                                        __auto_type _mv_1471 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1471.has_value) {
+                                            __auto_type type_expr = _mv_1471.value;
                                             transpiler_emit_const_header_decl(ctx, raw_name, type_expr, ({ __auto_type _mv = ({ __auto_type _lst = const_items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type v = _mv.value; v; }) : (NULL); }));
                                             return 1;
-                                        } else if (!_mv_1470.has_value) {
+                                        } else if (!_mv_1471.has_value) {
                                             return 0;
                                         }
                                     }
@@ -6791,7 +6811,7 @@ uint8_t transpiler_emit_const_header_if_exported(context_TranspileContext* ctx, 
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1468.has_value) {
+                    } else if (!_mv_1469.has_value) {
                         return 0;
                     }
                 }
@@ -6841,13 +6861,13 @@ void transpiler_emit_module_functions(context_TranspileContext* ctx, slop_list_t
         int64_t i = start;
         context_ctx_start_function_buffer(ctx);
         while (i < len) {
-            __auto_type _mv_1471 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1471.has_value) {
-                __auto_type item = _mv_1471.value;
+            __auto_type _mv_1472 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1472.has_value) {
+                __auto_type item = _mv_1472.value;
                 if (transpiler_is_fn_def(item)) {
                     defn_transpile_function(ctx, item);
                 }
-            } else if (!_mv_1471.has_value) {
+            } else if (!_mv_1472.has_value) {
             }
             i = (i + 1);
         }
@@ -6865,12 +6885,12 @@ void transpiler_emit_all_lambdas(context_TranspileContext* ctx) {
         int64_t i = 0;
         if (count > 0) {
             while (i < count) {
-                __auto_type _mv_1472 = ({ __auto_type _lst = lambdas; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1472.has_value) {
-                    __auto_type lambda_code = _mv_1472.value;
+                __auto_type _mv_1473 = ({ __auto_type _lst = lambdas; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1473.has_value) {
+                    __auto_type lambda_code = _mv_1473.value;
                     context_ctx_emit(ctx, lambda_code);
                     context_ctx_emit(ctx, SLOP_STR(""));
-                } else if (!_mv_1472.has_value) {
+                } else if (!_mv_1473.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6888,11 +6908,11 @@ slop_string transpiler_generate_c_output(context_TranspileContext* ctx) {
         __auto_type result = SLOP_STR("");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1473 = ({ __auto_type _lst = output_lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1473.has_value) {
-                __auto_type line = _mv_1473.value;
+            __auto_type _mv_1474 = ({ __auto_type _lst = output_lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1474.has_value) {
+                __auto_type line = _mv_1474.value;
                 result = context_ctx_str3(ctx, result, line, SLOP_STR("\n"));
-            } else if (!_mv_1473.has_value) {
+            } else if (!_mv_1474.has_value) {
             }
             i = (i + 1);
         }
@@ -6906,11 +6926,11 @@ void transpiler_transpile_file(context_TranspileContext* ctx, slop_list_types_SE
         __auto_type len = ((int64_t)((exprs).len));
         int64_t i = 0;
         if ((len > 0) && transpiler_is_module_expr(exprs)) {
-            __auto_type _mv_1474 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1474.has_value) {
-                __auto_type module_expr = _mv_1474.value;
+            __auto_type _mv_1475 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1475.has_value) {
+                __auto_type module_expr = _mv_1475.value;
                 transpiler_transpile_module(ctx, module_expr);
-            } else if (!_mv_1474.has_value) {
+            } else if (!_mv_1475.has_value) {
             }
         } else {
             emit_emit_standard_includes(ctx);
@@ -6926,34 +6946,34 @@ uint8_t transpiler_is_module_expr(slop_list_types_SExpr_ptr exprs) {
     if (((int64_t)((exprs).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_1475 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1475.has_value) {
-            __auto_type first = _mv_1475.value;
-            __auto_type _mv_1476 = (*first);
-            switch (_mv_1476.tag) {
+        __auto_type _mv_1476 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1476.has_value) {
+            __auto_type first = _mv_1476.value;
+            __auto_type _mv_1477 = (*first);
+            switch (_mv_1477.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type lst = _mv_1476.data.lst;
+                    __auto_type lst = _mv_1477.data.lst;
                     {
                         __auto_type items = lst.items;
                         if (((int64_t)((items).len)) < 1) {
                             return 0;
                         } else {
-                            __auto_type _mv_1477 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1477.has_value) {
-                                __auto_type head = _mv_1477.value;
-                                __auto_type _mv_1478 = (*head);
-                                switch (_mv_1478.tag) {
+                            __auto_type _mv_1478 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1478.has_value) {
+                                __auto_type head = _mv_1478.value;
+                                __auto_type _mv_1479 = (*head);
+                                switch (_mv_1479.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1478.data.sym;
+                                        __auto_type sym = _mv_1479.data.sym;
                                         return string_eq(sym.name, SLOP_STR("module"));
                                     }
                                     default: {
                                         return 0;
                                     }
                                 }
-                            } else if (!_mv_1477.has_value) {
+                            } else if (!_mv_1478.has_value) {
                                 return 0;
                             }
                         }
@@ -6963,7 +6983,7 @@ uint8_t transpiler_is_module_expr(slop_list_types_SExpr_ptr exprs) {
                     return 0;
                 }
             }
-        } else if (!_mv_1475.has_value) {
+        } else if (!_mv_1476.has_value) {
             return 0;
         }
     }

--- a/bootstrap/tester/slop_transpiler.h
+++ b/bootstrap/tester/slop_transpiler.h
@@ -182,6 +182,7 @@ void transpiler_emit_primitive_option_types_header(context_TranspileContext* ctx
 uint8_t transpiler_is_primitive_or_runtime_type(slop_string type_name);
 void transpiler_emit_imported_list_types_header(context_TranspileContext* ctx);
 void transpiler_emit_imported_option_types_header(context_TranspileContext* ctx);
+void transpiler_emit_late_registered_list_types_header(context_TranspileContext* ctx);
 void transpiler_emit_late_registered_option_types_header(context_TranspileContext* ctx);
 void transpiler_emit_value_list_types_header(context_TranspileContext* ctx);
 void transpiler_emit_complex_value_list_types_header(context_TranspileContext* ctx);

--- a/bootstrap/tester/slop_type_extract.c
+++ b/bootstrap/tester/slop_type_extract.c
@@ -71,16 +71,16 @@ type_extract_TypeRegistry* type_extract_extract_types_from_ast_with_imports(slop
             __auto_type len = ((int64_t)((ast).len));
             int64_t i = 0;
             while (i < len) {
-                __auto_type _mv_1479 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1479.has_value) {
-                    __auto_type expr = _mv_1479.value;
+                __auto_type _mv_1480 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1480.has_value) {
+                    __auto_type expr = _mv_1480.value;
                     if (parser_is_form(expr, SLOP_STR("module"))) {
                         type_extract_extract_types_from_module(arena, expr, reg_ptr, module_prefix);
                     }
                     if (parser_is_form(expr, SLOP_STR("type"))) {
                         type_extract_extract_type_def(arena, expr, reg_ptr, module_prefix);
                     }
-                } else if (!_mv_1479.has_value) {
+                } else if (!_mv_1480.has_value) {
                 }
                 i = (i + 1);
             }
@@ -94,13 +94,13 @@ void type_extract_extract_types_from_module(slop_arena* arena, types_SExpr* modu
         __auto_type len = parser_sexpr_list_len(module_form);
         int64_t i = 2;
         while (i < len) {
-            __auto_type _mv_1480 = parser_sexpr_list_get(module_form, i);
-            if (_mv_1480.has_value) {
-                __auto_type form = _mv_1480.value;
+            __auto_type _mv_1481 = parser_sexpr_list_get(module_form, i);
+            if (_mv_1481.has_value) {
+                __auto_type form = _mv_1481.value;
                 if (parser_is_form(form, SLOP_STR("type"))) {
                     type_extract_extract_type_def(arena, form, reg_ptr, prefix);
                 }
-            } else if (!_mv_1480.has_value) {
+            } else if (!_mv_1481.has_value) {
             }
             i = (i + 1);
         }
@@ -109,16 +109,16 @@ void type_extract_extract_types_from_module(slop_arena* arena, types_SExpr* modu
 
 void type_extract_extract_type_def(slop_arena* arena, types_SExpr* type_form, type_extract_TypeRegistry* reg_ptr, slop_string prefix) {
     if (parser_sexpr_list_len(type_form) >= 3) {
-        __auto_type _mv_1481 = parser_sexpr_list_get(type_form, 1);
-        if (_mv_1481.has_value) {
-            __auto_type name_expr = _mv_1481.value;
+        __auto_type _mv_1482 = parser_sexpr_list_get(type_form, 1);
+        if (_mv_1482.has_value) {
+            __auto_type name_expr = _mv_1482.value;
             if (parser_sexpr_is_symbol(name_expr)) {
                 {
                     __auto_type type_name = parser_sexpr_get_symbol_name(name_expr);
                     __auto_type c_name = type_extract_make_c_type_name(arena, prefix, type_name);
-                    __auto_type _mv_1482 = parser_sexpr_list_get(type_form, 2);
-                    if (_mv_1482.has_value) {
-                        __auto_type def_expr = _mv_1482.value;
+                    __auto_type _mv_1483 = parser_sexpr_list_get(type_form, 2);
+                    if (_mv_1483.has_value) {
+                        __auto_type def_expr = _mv_1483.value;
                         if (parser_is_form(def_expr, SLOP_STR("record"))) {
                             {
                                 __auto_type entry = type_extract_extract_record_type(arena, type_name, c_name, def_expr);
@@ -148,11 +148,11 @@ void type_extract_extract_type_def(slop_arena* arena, types_SExpr* type_form, ty
                                 ({ __auto_type _lst_p = &((*reg_ptr).types); __auto_type _item = (entry); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                             }
                         }
-                    } else if (!_mv_1482.has_value) {
+                    } else if (!_mv_1483.has_value) {
                     }
                 }
             }
-        } else if (!_mv_1481.has_value) {
+        } else if (!_mv_1482.has_value) {
         }
     }
 }
@@ -163,32 +163,32 @@ type_extract_TstTypeEntry* type_extract_extract_record_type(slop_arena* arena, s
         __auto_type len = parser_sexpr_list_len(def);
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1483 = parser_sexpr_list_get(def, i);
-            if (_mv_1483.has_value) {
-                __auto_type field_def = _mv_1483.value;
+            __auto_type _mv_1484 = parser_sexpr_list_get(def, i);
+            if (_mv_1484.has_value) {
+                __auto_type field_def = _mv_1484.value;
                 if (parser_sexpr_list_len(field_def) >= 2) {
-                    __auto_type _mv_1484 = parser_sexpr_list_get(field_def, 0);
-                    if (_mv_1484.has_value) {
-                        __auto_type field_name_expr = _mv_1484.value;
+                    __auto_type _mv_1485 = parser_sexpr_list_get(field_def, 0);
+                    if (_mv_1485.has_value) {
+                        __auto_type field_name_expr = _mv_1485.value;
                         if (parser_sexpr_is_symbol(field_name_expr)) {
                             {
                                 __auto_type field_name = parser_sexpr_get_symbol_name(field_name_expr);
-                                __auto_type _mv_1485 = parser_sexpr_list_get(field_def, 1);
-                                if (_mv_1485.has_value) {
-                                    __auto_type field_type_expr = _mv_1485.value;
+                                __auto_type _mv_1486 = parser_sexpr_list_get(field_def, 1);
+                                if (_mv_1486.has_value) {
+                                    __auto_type field_type_expr = _mv_1486.value;
                                     {
                                         __auto_type field_type = parser_pretty_print(arena, field_type_expr);
                                         __auto_type fe = type_extract_field_entry_new(field_name, field_type);
                                         ({ __auto_type _lst_p = &((*entry).fields); __auto_type _item = (fe); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
-                                } else if (!_mv_1485.has_value) {
+                                } else if (!_mv_1486.has_value) {
                                 }
                             }
                         }
-                    } else if (!_mv_1484.has_value) {
+                    } else if (!_mv_1485.has_value) {
                     }
                 }
-            } else if (!_mv_1483.has_value) {
+            } else if (!_mv_1484.has_value) {
             }
             i = (i + 1);
         }
@@ -203,15 +203,15 @@ type_extract_TstTypeEntry* type_extract_extract_union_type(slop_arena* arena, sl
         int64_t i = 1;
         int64_t idx = 0;
         while (i < len) {
-            __auto_type _mv_1486 = parser_sexpr_list_get(def, i);
-            if (_mv_1486.has_value) {
-                __auto_type variant_def = _mv_1486.value;
+            __auto_type _mv_1487 = parser_sexpr_list_get(def, i);
+            if (_mv_1487.has_value) {
+                __auto_type variant_def = _mv_1487.value;
                 {
                     __auto_type vlen = parser_sexpr_list_len(variant_def);
                     if (vlen >= 1) {
-                        __auto_type _mv_1487 = parser_sexpr_list_get(variant_def, 0);
-                        if (_mv_1487.has_value) {
-                            __auto_type variant_name_expr = _mv_1487.value;
+                        __auto_type _mv_1488 = parser_sexpr_list_get(variant_def, 0);
+                        if (_mv_1488.has_value) {
+                            __auto_type variant_name_expr = _mv_1488.value;
                             if (parser_sexpr_is_symbol(variant_name_expr)) {
                                 {
                                     __auto_type variant_name = parser_sexpr_get_symbol_name(variant_name_expr);
@@ -221,11 +221,11 @@ type_extract_TstTypeEntry* type_extract_extract_union_type(slop_arena* arena, sl
                                     idx = (idx + 1);
                                 }
                             }
-                        } else if (!_mv_1487.has_value) {
+                        } else if (!_mv_1488.has_value) {
                         }
                     }
                 }
-            } else if (!_mv_1486.has_value) {
+            } else if (!_mv_1487.has_value) {
             }
             i = (i + 1);
         }
@@ -240,9 +240,9 @@ type_extract_TstTypeEntry* type_extract_extract_enum_type(slop_arena* arena, slo
         int64_t i = 1;
         int64_t idx = 0;
         while (i < len) {
-            __auto_type _mv_1488 = parser_sexpr_list_get(def, i);
-            if (_mv_1488.has_value) {
-                __auto_type val_expr = _mv_1488.value;
+            __auto_type _mv_1489 = parser_sexpr_list_get(def, i);
+            if (_mv_1489.has_value) {
+                __auto_type val_expr = _mv_1489.value;
                 if (parser_sexpr_is_symbol(val_expr)) {
                     {
                         __auto_type val_name = parser_sexpr_get_symbol_name(val_expr);
@@ -251,7 +251,7 @@ type_extract_TstTypeEntry* type_extract_extract_enum_type(slop_arena* arena, slo
                         idx = (idx + 1);
                     }
                 }
-            } else if (!_mv_1488.has_value) {
+            } else if (!_mv_1489.has_value) {
             }
             i = (i + 1);
         }
@@ -266,13 +266,13 @@ slop_option_type_extract_TstTypeEntry_ptr type_extract_registry_lookup(type_extr
         int64_t i = 0;
         slop_option_type_extract_TstTypeEntry_ptr found = (slop_option_type_extract_TstTypeEntry_ptr){.has_value = false};
         while ((i < len) && ({ __auto_type _mv = found; _mv.has_value ? (0) : (1); })) {
-            __auto_type _mv_1489 = ({ __auto_type _lst = types; size_t _idx = (size_t)i; slop_option_type_extract_TstTypeEntry_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1489.has_value) {
-                __auto_type entry = _mv_1489.value;
+            __auto_type _mv_1490 = ({ __auto_type _lst = types; size_t _idx = (size_t)i; slop_option_type_extract_TstTypeEntry_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1490.has_value) {
+                __auto_type entry = _mv_1490.value;
                 if (string_eq((*entry).name, name)) {
                     found = (slop_option_type_extract_TstTypeEntry_ptr){.has_value = 1, .value = entry};
                 }
-            } else if (!_mv_1489.has_value) {
+            } else if (!_mv_1490.has_value) {
             }
             i = (i + 1);
         }
@@ -287,9 +287,9 @@ slop_option_type_extract_TstTypeEntry_ptr type_extract_registry_lookup_variant(t
         int64_t i = 0;
         slop_option_type_extract_TstTypeEntry_ptr found = (slop_option_type_extract_TstTypeEntry_ptr){.has_value = false};
         while ((i < len) && ({ __auto_type _mv = found; _mv.has_value ? (0) : (1); })) {
-            __auto_type _mv_1490 = ({ __auto_type _lst = types; size_t _idx = (size_t)i; slop_option_type_extract_TstTypeEntry_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1490.has_value) {
-                __auto_type entry = _mv_1490.value;
+            __auto_type _mv_1491 = ({ __auto_type _lst = types; size_t _idx = (size_t)i; slop_option_type_extract_TstTypeEntry_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1491.has_value) {
+                __auto_type entry = _mv_1491.value;
                 if ((*entry).kind == type_extract_TstTypeEntryKind_te_union) {
                     {
                         __auto_type variants = (*entry).variants;
@@ -297,20 +297,20 @@ slop_option_type_extract_TstTypeEntry_ptr type_extract_registry_lookup_variant(t
                         __auto_type j = 0;
                         __auto_type vfound = 0;
                         while ((j < vlen) && !(vfound)) {
-                            __auto_type _mv_1491 = ({ __auto_type _lst = variants; size_t _idx = (size_t)j; slop_option_type_extract_VariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1491.has_value) {
-                                __auto_type ve = _mv_1491.value;
+                            __auto_type _mv_1492 = ({ __auto_type _lst = variants; size_t _idx = (size_t)j; slop_option_type_extract_VariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1492.has_value) {
+                                __auto_type ve = _mv_1492.value;
                                 if (string_eq(ve.name, variant_name)) {
                                     vfound = 1;
                                     found = (slop_option_type_extract_TstTypeEntry_ptr){.has_value = 1, .value = entry};
                                 }
-                            } else if (!_mv_1491.has_value) {
+                            } else if (!_mv_1492.has_value) {
                             }
                             j = (j + 1);
                         }
                     }
                 }
-            } else if (!_mv_1490.has_value) {
+            } else if (!_mv_1491.has_value) {
             }
             i = (i + 1);
         }
@@ -325,9 +325,9 @@ slop_option_type_extract_TstTypeEntry_ptr type_extract_registry_lookup_enum_valu
         int64_t i = 0;
         slop_option_type_extract_TstTypeEntry_ptr found = (slop_option_type_extract_TstTypeEntry_ptr){.has_value = false};
         while ((i < len) && ({ __auto_type _mv = found; _mv.has_value ? (0) : (1); })) {
-            __auto_type _mv_1492 = ({ __auto_type _lst = types; size_t _idx = (size_t)i; slop_option_type_extract_TstTypeEntry_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1492.has_value) {
-                __auto_type entry = _mv_1492.value;
+            __auto_type _mv_1493 = ({ __auto_type _lst = types; size_t _idx = (size_t)i; slop_option_type_extract_TstTypeEntry_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1493.has_value) {
+                __auto_type entry = _mv_1493.value;
                 if ((*entry).kind == type_extract_TstTypeEntryKind_te_enum) {
                     {
                         __auto_type values = (*entry).enum_values;
@@ -335,20 +335,20 @@ slop_option_type_extract_TstTypeEntry_ptr type_extract_registry_lookup_enum_valu
                         __auto_type j = 0;
                         __auto_type vfound = 0;
                         while ((j < vlen) && !(vfound)) {
-                            __auto_type _mv_1493 = ({ __auto_type _lst = values; size_t _idx = (size_t)j; slop_option_type_extract_EnumValueEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1493.has_value) {
-                                __auto_type eve = _mv_1493.value;
+                            __auto_type _mv_1494 = ({ __auto_type _lst = values; size_t _idx = (size_t)j; slop_option_type_extract_EnumValueEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1494.has_value) {
+                                __auto_type eve = _mv_1494.value;
                                 if (string_eq(eve.name, value_name)) {
                                     vfound = 1;
                                     found = (slop_option_type_extract_TstTypeEntry_ptr){.has_value = 1, .value = entry};
                                 }
-                            } else if (!_mv_1493.has_value) {
+                            } else if (!_mv_1494.has_value) {
                             }
                             j = (j + 1);
                         }
                     }
                 }
-            } else if (!_mv_1492.has_value) {
+            } else if (!_mv_1493.has_value) {
             }
             i = (i + 1);
         }
@@ -363,26 +363,26 @@ slop_option_string type_extract_registry_lookup_import(type_extract_TypeRegistry
         int64_t i = 0;
         slop_option_string found = (slop_option_string){.has_value = false};
         while ((i < len) && ({ __auto_type _mv = found; _mv.has_value ? (0) : (1); })) {
-            __auto_type _mv_1494 = ({ __auto_type _lst = entries; size_t _idx = (size_t)i; slop_option_type_extract_ImportEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1494.has_value) {
-                __auto_type entry = _mv_1494.value;
+            __auto_type _mv_1495 = ({ __auto_type _lst = entries; size_t _idx = (size_t)i; slop_option_type_extract_ImportEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1495.has_value) {
+                __auto_type entry = _mv_1495.value;
                 {
                     __auto_type symbols = entry.symbols;
                     __auto_type slen = ((int64_t)((symbols).len));
                     __auto_type j = 0;
                     while ((j < slen) && ({ __auto_type _mv = found; _mv.has_value ? (0) : (1); })) {
-                        __auto_type _mv_1495 = ({ __auto_type _lst = symbols; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1495.has_value) {
-                            __auto_type sym = _mv_1495.value;
+                        __auto_type _mv_1496 = ({ __auto_type _lst = symbols; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1496.has_value) {
+                            __auto_type sym = _mv_1496.value;
                             if (string_eq(sym, symbol_name)) {
                                 found = (slop_option_string){.has_value = 1, .value = entry.module_name};
                             }
-                        } else if (!_mv_1495.has_value) {
+                        } else if (!_mv_1496.has_value) {
                         }
                         j = (j + 1);
                     }
                 }
-            } else if (!_mv_1494.has_value) {
+            } else if (!_mv_1495.has_value) {
             }
             i = (i + 1);
         }
@@ -391,72 +391,72 @@ slop_option_string type_extract_registry_lookup_import(type_extract_TypeRegistry
 }
 
 uint8_t type_extract_registry_is_union(type_extract_TypeRegistry reg, slop_string name) {
-    __auto_type _mv_1496 = type_extract_registry_lookup(reg, name);
-    if (_mv_1496.has_value) {
-        __auto_type entry = _mv_1496.value;
-        return ((*entry).kind == type_extract_TstTypeEntryKind_te_union);
-    } else if (!_mv_1496.has_value) {
-        return 0;
-    }
-}
-
-uint8_t type_extract_registry_is_record(type_extract_TypeRegistry reg, slop_string name) {
     __auto_type _mv_1497 = type_extract_registry_lookup(reg, name);
     if (_mv_1497.has_value) {
         __auto_type entry = _mv_1497.value;
-        return ((*entry).kind == type_extract_TstTypeEntryKind_te_record);
+        return ((*entry).kind == type_extract_TstTypeEntryKind_te_union);
     } else if (!_mv_1497.has_value) {
         return 0;
     }
 }
 
-uint8_t type_extract_registry_is_enum(type_extract_TypeRegistry reg, slop_string name) {
+uint8_t type_extract_registry_is_record(type_extract_TypeRegistry reg, slop_string name) {
     __auto_type _mv_1498 = type_extract_registry_lookup(reg, name);
     if (_mv_1498.has_value) {
         __auto_type entry = _mv_1498.value;
-        return ((*entry).kind == type_extract_TstTypeEntryKind_te_enum);
+        return ((*entry).kind == type_extract_TstTypeEntryKind_te_record);
     } else if (!_mv_1498.has_value) {
         return 0;
     }
 }
 
-slop_option_type_extract_VariantEntry type_extract_registry_get_variant_info(type_extract_TypeRegistry reg, slop_string variant_name) {
-    __auto_type _mv_1499 = type_extract_registry_lookup_variant(reg, variant_name);
+uint8_t type_extract_registry_is_enum(type_extract_TypeRegistry reg, slop_string name) {
+    __auto_type _mv_1499 = type_extract_registry_lookup(reg, name);
     if (_mv_1499.has_value) {
         __auto_type entry = _mv_1499.value;
+        return ((*entry).kind == type_extract_TstTypeEntryKind_te_enum);
+    } else if (!_mv_1499.has_value) {
+        return 0;
+    }
+}
+
+slop_option_type_extract_VariantEntry type_extract_registry_get_variant_info(type_extract_TypeRegistry reg, slop_string variant_name) {
+    __auto_type _mv_1500 = type_extract_registry_lookup_variant(reg, variant_name);
+    if (_mv_1500.has_value) {
+        __auto_type entry = _mv_1500.value;
         {
             __auto_type variants = (*entry).variants;
             __auto_type vlen = ((int64_t)((variants).len));
             __auto_type i = 0;
             slop_option_type_extract_VariantEntry found = (slop_option_type_extract_VariantEntry){.has_value = false};
             while ((i < vlen) && ({ __auto_type _mv = found; _mv.has_value ? (0) : (1); })) {
-                __auto_type _mv_1500 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_type_extract_VariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1500.has_value) {
-                    __auto_type ve = _mv_1500.value;
+                __auto_type _mv_1501 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_type_extract_VariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1501.has_value) {
+                    __auto_type ve = _mv_1501.value;
                     if (string_eq(ve.name, variant_name)) {
                         found = (slop_option_type_extract_VariantEntry){.has_value = 1, .value = ve};
                     }
-                } else if (!_mv_1500.has_value) {
+                } else if (!_mv_1501.has_value) {
                 }
                 i = (i + 1);
             }
             return found;
         }
-    } else if (!_mv_1499.has_value) {
+    } else if (!_mv_1500.has_value) {
         return (slop_option_type_extract_VariantEntry){.has_value = false};
     }
 }
 
 slop_option_list_type_extract_TstFieldEntry type_extract_registry_get_record_fields(type_extract_TypeRegistry reg, slop_string name) {
-    __auto_type _mv_1501 = type_extract_registry_lookup(reg, name);
-    if (_mv_1501.has_value) {
-        __auto_type entry = _mv_1501.value;
+    __auto_type _mv_1502 = type_extract_registry_lookup(reg, name);
+    if (_mv_1502.has_value) {
+        __auto_type entry = _mv_1502.value;
         if ((*entry).kind == type_extract_TstTypeEntryKind_te_record) {
             return (slop_option_list_type_extract_TstFieldEntry){.has_value = 1, .value = (*entry).fields};
         } else {
             return (slop_option_list_type_extract_TstFieldEntry){.has_value = false};
         }
-    } else if (!_mv_1501.has_value) {
+    } else if (!_mv_1502.has_value) {
         return (slop_option_list_type_extract_TstFieldEntry){.has_value = false};
     }
 }

--- a/bootstrap/transpiler/slop_ctype.c
+++ b/bootstrap/transpiler/slop_ctype.c
@@ -11,6 +11,7 @@ uint8_t ctype_is_numeric_type(slop_string name);
 slop_option_string ctype_builtin_type_c(slop_arena* arena, slop_string name);
 slop_string ctype_to_c_name(slop_arena* arena, slop_string name);
 slop_string ctype_type_to_identifier(slop_arena* arena, slop_string c_type);
+slop_string ctype_unwrap_ptr_container_type(slop_arena* arena, slop_string slop_type);
 uint8_t ctype_is_type_variable(slop_string name);
 slop_string ctype_to_c_type(slop_arena* arena, types_SExpr* expr);
 slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_ptr items);
@@ -148,6 +149,20 @@ slop_string ctype_type_to_identifier(slop_arena* arena, slop_string c_type) {
         }
         return result;
     }
+}
+
+slop_string ctype_unwrap_ptr_container_type(slop_arena* arena, slop_string slop_type) {
+    slop_string _retval = {0};
+    if (strlib_starts_with(slop_type, SLOP_STR("(Ptr (Map ")) || strlib_starts_with(slop_type, SLOP_STR("(Ptr (Set "))) {
+        {
+            __auto_type inner_len = ((int64_t)((string_len(slop_type) - 6)));
+            _retval = strlib_substring(arena, slop_type, 5, inner_len);
+        }
+    } else {
+        _retval = slop_type;
+    }
+    SLOP_POST(((string_len(_retval) <= string_len(slop_type))), "(<= (string-len $result) (string-len slop-type))");
+    return _retval;
 }
 
 uint8_t ctype_is_type_variable(slop_string name) {

--- a/bootstrap/transpiler/slop_ctype.h
+++ b/bootstrap/transpiler/slop_ctype.h
@@ -32,6 +32,7 @@ uint8_t ctype_is_numeric_type(slop_string name);
 slop_option_string ctype_builtin_type_c(slop_arena* arena, slop_string name);
 slop_string ctype_to_c_name(slop_arena* arena, slop_string name);
 slop_string ctype_type_to_identifier(slop_arena* arena, slop_string c_type);
+slop_string ctype_unwrap_ptr_container_type(slop_arena* arena, slop_string slop_type);
 uint8_t ctype_is_type_variable(slop_string name);
 slop_string ctype_to_c_type(slop_arena* arena, types_SExpr* expr);
 slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_ptr items);

--- a/bootstrap/transpiler/slop_expr.c
+++ b/bootstrap/transpiler/slop_expr.c
@@ -47,10 +47,10 @@ slop_string expr_infer_field_access_list_type(context_TranspileContext* ctx, typ
 slop_string expr_list_type_to_option_type(context_TranspileContext* ctx, slop_string c_type);
 slop_string expr_prefix_list_element_type(context_TranspileContext* ctx, slop_string elem_type);
 slop_string expr_substring_after_prefix(slop_arena* arena, slop_string s, slop_string prefix);
-slop_string expr_extract_map_value_from_slop_type(slop_arena* arena, slop_string slop_type);
+slop_string expr_extract_map_value_from_slop_type(slop_arena* arena, slop_string raw_slop_type);
 slop_string expr_slop_value_type_to_c_type(context_TranspileContext* ctx, slop_string slop_type);
 slop_string expr_get_var_name_from_expr(types_SExpr* expr);
-slop_string expr_extract_map_key_from_slop_type(slop_arena* arena, slop_string slop_type);
+slop_string expr_extract_map_key_from_slop_type(slop_arena* arena, slop_string raw_slop_type);
 slop_string expr_resolve_type_alias(context_TranspileContext* ctx, slop_string slop_type);
 slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr* expr);
 slop_string expr_infer_map_key_c_type_from_slop_type(context_TranspileContext* ctx, slop_string slop_type);
@@ -60,7 +60,7 @@ slop_string expr_extract_list_elem_from_inferred(context_TranspileContext* ctx, 
 slop_string expr_infer_map_key_c_type(context_TranspileContext* ctx, types_SExpr* map_expr);
 uint8_t expr_is_set_type(slop_string slop_type);
 uint8_t expr_is_map_type(slop_string slop_type);
-slop_string expr_extract_set_elem_from_slop_type(slop_arena* arena, slop_string slop_type);
+slop_string expr_extract_set_elem_from_slop_type(slop_arena* arena, slop_string raw_slop_type);
 slop_string expr_infer_set_elem_c_type(context_TranspileContext* ctx, types_SExpr* set_expr);
 slop_string expr_compound_slop_type_to_id(slop_arena* arena, slop_string slop_type);
 slop_string expr_slop_value_type_to_option_id(slop_arena* arena, slop_string slop_type);
@@ -129,6 +129,8 @@ slop_string expr_get_arena_from_field_access(context_TranspileContext* ctx, type
 slop_string expr_get_arena_from_base(context_TranspileContext* ctx, types_SExpr* base_expr);
 slop_string expr_get_arena_for_list_push(context_TranspileContext* ctx, slop_string list_c);
 uint8_t expr_is_ptr_to_ptr_map(context_TranspileContext* ctx, types_SExpr* expr);
+slop_string expr_deref_container_c(context_TranspileContext* ctx, slop_string container_c, slop_string slop_type);
+slop_string expr_resolve_container_c(context_TranspileContext* ctx, types_SExpr* container_expr);
 slop_string expr_transpile_record_new(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items);
 slop_string expr_transpile_record_fields(context_TranspileContext* ctx, slop_string type_name, slop_list_types_SExpr_ptr items, int64_t start_idx);
 slop_string expr_build_inline_struct_type(context_TranspileContext* ctx, slop_list_types_SExpr_ptr type_items);
@@ -1756,46 +1758,49 @@ slop_string expr_substring_after_prefix(slop_arena* arena, slop_string s, slop_s
     }
 }
 
-slop_string expr_extract_map_value_from_slop_type(slop_arena* arena, slop_string slop_type) {
+slop_string expr_extract_map_value_from_slop_type(slop_arena* arena, slop_string raw_slop_type) {
     {
-        __auto_type len = string_len(slop_type);
-        if (len < 10) {
-            return SLOP_STR("");
-        } else {
-            if (!(strlib_starts_with(slop_type, SLOP_STR("(Map ")))) {
+        __auto_type slop_type = ctype_unwrap_ptr_container_type(arena, raw_slop_type);
+        {
+            __auto_type len = string_len(slop_type);
+            if (len < 10) {
                 return SLOP_STR("");
             } else {
-                {
-                    int64_t i = 5;
-                    int64_t nesting = 1;
-                    int64_t key_space = 0;
-                    uint8_t found_key = 0;
-                    __auto_type end_idx = (len - 1);
-                    while ((i < end_idx) && !(found_key)) {
-                        {
-                            __auto_type c = strlib_char_at(slop_type, ((int64_t)(i)));
-                            if (c == 40) {
-                                nesting = (nesting + 1);
-                            } else if (c == 41) {
-                                nesting = (nesting - 1);
-                            } else if ((c == 32) && (nesting == 1)) {
-                                key_space = i;
-                                found_key = 1;
-                            } else {
+                if (!(strlib_starts_with(slop_type, SLOP_STR("(Map ")))) {
+                    return SLOP_STR("");
+                } else {
+                    {
+                        int64_t i = 5;
+                        int64_t nesting = 1;
+                        int64_t key_space = 0;
+                        uint8_t found_key = 0;
+                        __auto_type end_idx = (len - 1);
+                        while ((i < end_idx) && !(found_key)) {
+                            {
+                                __auto_type c = strlib_char_at(slop_type, ((int64_t)(i)));
+                                if (c == 40) {
+                                    nesting = (nesting + 1);
+                                } else if (c == 41) {
+                                    nesting = (nesting - 1);
+                                } else if ((c == 32) && (nesting == 1)) {
+                                    key_space = i;
+                                    found_key = 1;
+                                } else {
+                                }
                             }
+                            i = (i + 1);
                         }
-                        i = (i + 1);
-                    }
-                    if (!(found_key)) {
-                        return SLOP_STR("");
-                    } else {
-                        {
-                            __auto_type value_start = (key_space + 1);
-                            __auto_type value_len = (end_idx - value_start);
-                            if (value_len > 0) {
-                                return strlib_substring(arena, slop_type, ((int64_t)(value_start)), ((int64_t)(value_len)));
-                            } else {
-                                return SLOP_STR("");
+                        if (!(found_key)) {
+                            return SLOP_STR("");
+                        } else {
+                            {
+                                __auto_type value_start = (key_space + 1);
+                                __auto_type value_len = (end_idx - value_start);
+                                if (value_len > 0) {
+                                    return strlib_substring(arena, slop_type, ((int64_t)(value_start)), ((int64_t)(value_len)));
+                                } else {
+                                    return SLOP_STR("");
+                                }
                             }
                         }
                     }
@@ -1851,46 +1856,49 @@ slop_string expr_get_var_name_from_expr(types_SExpr* expr) {
     }
 }
 
-slop_string expr_extract_map_key_from_slop_type(slop_arena* arena, slop_string slop_type) {
+slop_string expr_extract_map_key_from_slop_type(slop_arena* arena, slop_string raw_slop_type) {
     {
-        __auto_type len = string_len(slop_type);
-        if (len < 10) {
-            return SLOP_STR("");
-        } else {
-            if (!(strlib_starts_with(slop_type, SLOP_STR("(Map ")))) {
+        __auto_type slop_type = ctype_unwrap_ptr_container_type(arena, raw_slop_type);
+        {
+            __auto_type len = string_len(slop_type);
+            if (len < 10) {
                 return SLOP_STR("");
             } else {
-                {
-                    int64_t i = 5;
-                    int64_t nesting = 1;
-                    int64_t key_space = 0;
-                    uint8_t found_key = 0;
-                    __auto_type end_idx = (len - 1);
-                    while ((i < end_idx) && !(found_key)) {
-                        {
-                            __auto_type c = strlib_char_at(slop_type, ((int64_t)(i)));
-                            if (c == 40) {
-                                nesting = (nesting + 1);
-                            } else if (c == 41) {
-                                nesting = (nesting - 1);
-                            } else if ((c == 32) && (nesting == 1)) {
-                                key_space = i;
-                                found_key = 1;
-                            } else {
+                if (!(strlib_starts_with(slop_type, SLOP_STR("(Map ")))) {
+                    return SLOP_STR("");
+                } else {
+                    {
+                        int64_t i = 5;
+                        int64_t nesting = 1;
+                        int64_t key_space = 0;
+                        uint8_t found_key = 0;
+                        __auto_type end_idx = (len - 1);
+                        while ((i < end_idx) && !(found_key)) {
+                            {
+                                __auto_type c = strlib_char_at(slop_type, ((int64_t)(i)));
+                                if (c == 40) {
+                                    nesting = (nesting + 1);
+                                } else if (c == 41) {
+                                    nesting = (nesting - 1);
+                                } else if ((c == 32) && (nesting == 1)) {
+                                    key_space = i;
+                                    found_key = 1;
+                                } else {
+                                }
                             }
+                            i = (i + 1);
                         }
-                        i = (i + 1);
-                    }
-                    if (!(found_key)) {
-                        return SLOP_STR("");
-                    } else {
-                        {
-                            __auto_type key_start = 5;
-                            __auto_type key_len = (key_space - key_start);
-                            if (key_len > 0) {
-                                return strlib_substring(arena, slop_type, ((int64_t)(key_start)), ((int64_t)(key_len)));
-                            } else {
-                                return SLOP_STR("");
+                        if (!(found_key)) {
+                            return SLOP_STR("");
+                        } else {
+                            {
+                                __auto_type key_start = 5;
+                                __auto_type key_len = (key_space - key_start);
+                                if (key_len > 0) {
+                                    return strlib_substring(arena, slop_type, ((int64_t)(key_start)), ((int64_t)(key_len)));
+                                } else {
+                                    return SLOP_STR("");
+                                }
                             }
                         }
                     }
@@ -2293,22 +2301,25 @@ uint8_t expr_is_map_type(slop_string slop_type) {
     return (strlib_starts_with(slop_type, SLOP_STR("(Map ")) || strlib_starts_with(slop_type, SLOP_STR("(Ptr (Map ")));
 }
 
-slop_string expr_extract_set_elem_from_slop_type(slop_arena* arena, slop_string slop_type) {
+slop_string expr_extract_set_elem_from_slop_type(slop_arena* arena, slop_string raw_slop_type) {
     {
-        __auto_type len = string_len(slop_type);
-        if (len < 7) {
-            return SLOP_STR("");
-        } else {
-            if (!(strlib_starts_with(slop_type, SLOP_STR("(Set ")))) {
+        __auto_type slop_type = ctype_unwrap_ptr_container_type(arena, raw_slop_type);
+        {
+            __auto_type len = string_len(slop_type);
+            if (len < 7) {
                 return SLOP_STR("");
             } else {
-                {
-                    __auto_type elem_start = 5;
-                    __auto_type elem_len = ((len - 1) - elem_start);
-                    if (elem_len > 0) {
-                        return strlib_substring(arena, slop_type, ((int64_t)(elem_start)), ((int64_t)(elem_len)));
-                    } else {
-                        return SLOP_STR("");
+                if (!(strlib_starts_with(slop_type, SLOP_STR("(Set ")))) {
+                    return SLOP_STR("");
+                } else {
+                    {
+                        __auto_type elem_start = 5;
+                        __auto_type elem_len = ((len - 1) - elem_start);
+                        if (elem_len > 0) {
+                            return strlib_substring(arena, slop_type, ((int64_t)(elem_start)), ((int64_t)(elem_len)));
+                        } else {
+                            return SLOP_STR("");
+                        }
                     }
                 }
             }
@@ -5171,12 +5182,12 @@ slop_string expr_slop_type_to_c_type(context_TranspileContext* ctx, slop_string 
             } else if (strlib_starts_with(slop_type, SLOP_STR("(List "))) {
                 {
                     __auto_type inner = strlib_substring(arena, slop_type, 6, ((0) > ((((int64_t)(string_len(slop_type))) - 7)) ? (0) : ((((int64_t)(string_len(slop_type))) - 7))));
-                    return context_ctx_str(ctx, SLOP_STR("slop_list_"), expr_slop_type_to_c_type(ctx, inner));
+                    return context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, expr_slop_type_to_c_type(ctx, inner)));
                 }
             } else if (strlib_starts_with(slop_type, SLOP_STR("(Option "))) {
                 {
                     __auto_type inner = strlib_substring(arena, slop_type, 8, ((0) > ((((int64_t)(string_len(slop_type))) - 9)) ? (0) : ((((int64_t)(string_len(slop_type))) - 9))));
-                    return context_ctx_str(ctx, SLOP_STR("slop_option_"), expr_slop_type_to_c_type(ctx, inner));
+                    return context_ctx_str(ctx, SLOP_STR("slop_option_"), ctype_type_to_identifier(arena, expr_slop_type_to_c_type(ctx, inner)));
                 }
             } else if (strlib_starts_with(slop_type, SLOP_STR("(Chan "))) {
                 {
@@ -6853,7 +6864,32 @@ uint8_t expr_is_ptr_to_ptr_map(context_TranspileContext* ctx, types_SExpr* expr)
             }
         }
         default: {
-            return 0;
+            {
+                __auto_type slop_type = expr_resolve_type_alias(ctx, expr_infer_expr_slop_type(ctx, expr));
+                return (strlib_starts_with(slop_type, SLOP_STR("(Ptr (Map ")) || strlib_starts_with(slop_type, SLOP_STR("(Ptr (Set ")));
+            }
+        }
+    }
+}
+
+slop_string expr_deref_container_c(context_TranspileContext* ctx, slop_string container_c, slop_string slop_type) {
+    SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
+    if (strlib_starts_with(slop_type, SLOP_STR("(Ptr (Map ")) || strlib_starts_with(slop_type, SLOP_STR("(Ptr (Set "))) {
+        return context_ctx_str3(ctx, SLOP_STR("(*"), container_c, SLOP_STR(")"));
+    } else {
+        return container_c;
+    }
+}
+
+slop_string expr_resolve_container_c(context_TranspileContext* ctx, types_SExpr* container_expr) {
+    SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
+    SLOP_PRE(((container_expr != NULL)), "(!= container-expr nil)");
+    {
+        __auto_type c = expr_transpile_expr(ctx, container_expr);
+        if (expr_is_ptr_to_ptr_map(ctx, container_expr)) {
+            return context_ctx_str3(ctx, SLOP_STR("(*"), c, SLOP_STR(")"));
+        } else {
+            return c;
         }
     }
 }
@@ -7471,33 +7507,20 @@ slop_string expr_transpile_map_put(context_TranspileContext* ctx, slop_list_type
                     if (_mv_489.has_value) {
                         __auto_type val_expr = _mv_489.value;
                         {
-                            __auto_type map_c = expr_transpile_expr(ctx, map_expr);
+                            __auto_type map_c = expr_resolve_container_c(ctx, map_expr);
                             __auto_type key_c = expr_transpile_expr(ctx, key_expr);
                             __auto_type val_c = expr_transpile_expr(ctx, val_expr);
                             __auto_type key_ptr = expr_wrap_map_key_as_ptr(ctx, key_c, key_expr, map_expr);
-                            __auto_type needs_deref = expr_is_ptr_to_ptr_map(ctx, map_expr);
                             __auto_type val_decl_type = expr_map_put_value_decl_type(ctx, map_expr);
                             __auto_type arena_c = expr_resolve_arena_c_name(ctx, SLOP_STR("map-put"), items);
-                            if (needs_deref) {
-                                {
-                                    __auto_type s1 = context_ctx_str4(ctx, SLOP_STR("({ "), val_decl_type, SLOP_STR(" _val = "), val_c);
-                                    __auto_type s2 = context_ctx_str(ctx, s1, context_ctx_str5(ctx, SLOP_STR("; void* _vptr = slop_arena_alloc("), arena_c, SLOP_STR(", sizeof(_val)); memcpy(_vptr, &_val, sizeof(_val)); slop_map_put("), arena_c, SLOP_STR(", (*")));
-                                    __auto_type s3 = context_ctx_str(ctx, s2, map_c);
-                                    __auto_type s4 = context_ctx_str(ctx, s3, SLOP_STR("), "));
-                                    __auto_type s5 = context_ctx_str(ctx, s4, key_ptr);
-                                    __auto_type s6 = context_ctx_str(ctx, s5, SLOP_STR(", _vptr); })"));
-                                    return s6;
-                                }
-                            } else {
-                                {
-                                    __auto_type s1 = context_ctx_str4(ctx, SLOP_STR("({ "), val_decl_type, SLOP_STR(" _val = "), val_c);
-                                    __auto_type s2 = context_ctx_str(ctx, s1, context_ctx_str5(ctx, SLOP_STR("; void* _vptr = slop_arena_alloc("), arena_c, SLOP_STR(", sizeof(_val)); memcpy(_vptr, &_val, sizeof(_val)); slop_map_put("), arena_c, SLOP_STR(", ")));
-                                    __auto_type s3 = context_ctx_str(ctx, s2, map_c);
-                                    __auto_type s4 = context_ctx_str(ctx, s3, SLOP_STR(", "));
-                                    __auto_type s5 = context_ctx_str(ctx, s4, key_ptr);
-                                    __auto_type s6 = context_ctx_str(ctx, s5, SLOP_STR(", _vptr); })"));
-                                    return s6;
-                                }
+                            {
+                                __auto_type s1 = context_ctx_str4(ctx, SLOP_STR("({ "), val_decl_type, SLOP_STR(" _val = "), val_c);
+                                __auto_type s2 = context_ctx_str(ctx, s1, context_ctx_str5(ctx, SLOP_STR("; void* _vptr = slop_arena_alloc("), arena_c, SLOP_STR(", sizeof(_val)); memcpy(_vptr, &_val, sizeof(_val)); slop_map_put("), arena_c, SLOP_STR(", ")));
+                                __auto_type s3 = context_ctx_str(ctx, s2, map_c);
+                                __auto_type s4 = context_ctx_str(ctx, s3, SLOP_STR(", "));
+                                __auto_type s5 = context_ctx_str(ctx, s4, key_ptr);
+                                __auto_type s6 = context_ctx_str(ctx, s5, SLOP_STR(", _vptr); })"));
+                                return s6;
                             }
                         }
                     } else if (!_mv_489.has_value) {
@@ -7532,7 +7555,7 @@ slop_string expr_transpile_map_get(context_TranspileContext* ctx, slop_list_type
                 if (_mv_491.has_value) {
                     __auto_type key_expr = _mv_491.value;
                     {
-                        __auto_type map_c = expr_transpile_expr(ctx, map_expr);
+                        __auto_type map_c = expr_resolve_container_c(ctx, map_expr);
                         __auto_type key_c = expr_transpile_expr(ctx, key_expr);
                         __auto_type key_ptr = expr_wrap_map_key_as_ptr(ctx, key_c, key_expr, map_expr);
                         __auto_type option_type = expr_infer_map_value_option_type(ctx, map_expr);
@@ -7574,7 +7597,7 @@ slop_string expr_transpile_map_has(context_TranspileContext* ctx, slop_list_type
                 if (_mv_493.has_value) {
                     __auto_type key_expr = _mv_493.value;
                     {
-                        __auto_type map_c = expr_transpile_expr(ctx, map_expr);
+                        __auto_type map_c = expr_resolve_container_c(ctx, map_expr);
                         __auto_type key_c = expr_transpile_expr(ctx, key_expr);
                         __auto_type key_ptr = expr_wrap_map_key_as_ptr(ctx, key_c, key_expr, map_expr);
                         return context_ctx_str(ctx, SLOP_STR("(slop_map_get("), context_ctx_str(ctx, map_c, context_ctx_str(ctx, SLOP_STR(", "), context_ctx_str(ctx, key_ptr, SLOP_STR(") != NULL)")))));
@@ -7606,15 +7629,10 @@ slop_string expr_transpile_map_remove(context_TranspileContext* ctx, slop_list_t
                 if (_mv_495.has_value) {
                     __auto_type key_expr = _mv_495.value;
                     {
-                        __auto_type map_c = expr_transpile_expr(ctx, map_expr);
+                        __auto_type map_c = expr_resolve_container_c(ctx, map_expr);
                         __auto_type key_c = expr_transpile_expr(ctx, key_expr);
                         __auto_type key_ptr = expr_wrap_map_key_as_ptr(ctx, key_c, key_expr, map_expr);
-                        __auto_type needs_deref = expr_is_ptr_to_ptr_map(ctx, map_expr);
-                        if (needs_deref) {
-                            return context_ctx_str(ctx, SLOP_STR("slop_map_remove((*"), context_ctx_str(ctx, map_c, context_ctx_str(ctx, SLOP_STR("), "), context_ctx_str(ctx, key_ptr, SLOP_STR(")")))));
-                        } else {
-                            return context_ctx_str(ctx, SLOP_STR("slop_map_remove("), context_ctx_str(ctx, map_c, context_ctx_str(ctx, SLOP_STR(", "), context_ctx_str(ctx, key_ptr, SLOP_STR(")")))));
-                        }
+                        return context_ctx_str(ctx, SLOP_STR("slop_map_remove("), context_ctx_str(ctx, map_c, context_ctx_str(ctx, SLOP_STR(", "), context_ctx_str(ctx, key_ptr, SLOP_STR(")")))));
                     }
                 } else if (!_mv_495.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("map-remove: missing key"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
@@ -7641,16 +7659,20 @@ slop_string expr_transpile_map_keys(context_TranspileContext* ctx, slop_list_typ
             if (_mv_496.has_value) {
                 __auto_type map_expr = _mv_496.value;
                 {
-                    __auto_type map_c = expr_transpile_expr(ctx, map_expr);
+                    __auto_type map_c = expr_resolve_container_c(ctx, map_expr);
                     __auto_type key_c_type = expr_infer_map_key_c_type(ctx, map_expr);
-                    __auto_type debug_var_name = expr_get_var_name_from_expr(map_expr);
-                    __auto_type debug_slop_type = ({ __auto_type _mv = context_ctx_lookup_var(ctx, debug_var_name); _mv.has_value ? ({ __auto_type entry = _mv.value; entry.slop_type; }) : (SLOP_STR("VAR_NOT_FOUND")); });
                     __auto_type arena_c = expr_resolve_arena_c_name(ctx, SLOP_STR("map-keys"), items);
-                    if (string_eq(key_c_type, SLOP_STR("slop_string")) || (string_len(key_c_type) == 0)) {
-                        return context_ctx_str(ctx, SLOP_STR("/* DEBUG: var="), context_ctx_str(ctx, debug_var_name, context_ctx_str(ctx, SLOP_STR(" slop="), context_ctx_str(ctx, debug_slop_type, context_ctx_str(ctx, SLOP_STR(" key="), context_ctx_str(ctx, key_c_type, context_ctx_str(ctx, context_ctx_str3(ctx, SLOP_STR(" */ slop_map_keys("), arena_c, SLOP_STR(", ")), context_ctx_str(ctx, map_c, SLOP_STR(")")))))))));
+                    if (string_eq(key_c_type, SLOP_STR("slop_string"))) {
+                        return context_ctx_str(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map_keys("), arena_c, SLOP_STR(", ")), context_ctx_str(ctx, map_c, SLOP_STR(")")));
+                    } else if (string_len(key_c_type) == 0) {
+                        context_ctx_add_error_at(ctx, SLOP_STR("map-keys: cannot infer key type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
+                        return SLOP_STR("NULL");
                     } else {
                         {
-                            __auto_type list_type = context_ctx_str(ctx, SLOP_STR("slop_list_"), key_c_type);
+                            __auto_type key_id = ctype_type_to_identifier(arena, key_c_type);
+                            __auto_type list_type = context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, key_c_type));
+                            context_ctx_register_list_type(ctx, key_c_type, list_type);
+                            context_ctx_register_option_type(ctx, key_c_type, context_ctx_str(ctx, SLOP_STR("slop_option_"), key_id));
                             return context_ctx_str(ctx, context_ctx_str3(ctx, SLOP_STR("({ slop_set_elements_result _r = slop_set_elements_raw("), arena_c, SLOP_STR(", ")), context_ctx_str(ctx, map_c, context_ctx_str(ctx, SLOP_STR("); ("), context_ctx_str(ctx, list_type, context_ctx_str(ctx, SLOP_STR("){.data = ("), context_ctx_str(ctx, key_c_type, context_ctx_str(ctx, SLOP_STR("*)_r.data, .len = _r.len, .cap = _r.cap}; })"), SLOP_STR(""))))))));
                         }
                     }
@@ -7709,7 +7731,7 @@ slop_string expr_transpile_set_put(context_TranspileContext* ctx, slop_list_type
                 if (_mv_500.has_value) {
                     __auto_type elem_expr = _mv_500.value;
                     {
-                        __auto_type set_c = expr_transpile_expr(ctx, set_expr);
+                        __auto_type set_c = expr_resolve_container_c(ctx, set_expr);
                         __auto_type elem_c = expr_transpile_expr(ctx, elem_expr);
                         __auto_type elem_ptr = expr_wrap_map_key_as_ptr(ctx, elem_c, elem_expr, set_expr);
                         __auto_type arena_c = expr_resolve_arena_c_name(ctx, SLOP_STR("set-put"), items);
@@ -7742,7 +7764,7 @@ slop_string expr_transpile_set_has(context_TranspileContext* ctx, slop_list_type
                 if (_mv_502.has_value) {
                     __auto_type elem_expr = _mv_502.value;
                     {
-                        __auto_type set_c = expr_transpile_expr(ctx, set_expr);
+                        __auto_type set_c = expr_resolve_container_c(ctx, set_expr);
                         __auto_type elem_c = expr_transpile_expr(ctx, elem_expr);
                         __auto_type elem_ptr = expr_wrap_map_key_as_ptr(ctx, elem_c, elem_expr, set_expr);
                         return context_ctx_str(ctx, SLOP_STR("(slop_map_get("), context_ctx_str(ctx, set_c, context_ctx_str(ctx, SLOP_STR(", "), context_ctx_str(ctx, elem_ptr, SLOP_STR(") != NULL)")))));
@@ -7774,7 +7796,7 @@ slop_string expr_transpile_set_remove(context_TranspileContext* ctx, slop_list_t
                 if (_mv_504.has_value) {
                     __auto_type elem_expr = _mv_504.value;
                     {
-                        __auto_type set_c = expr_transpile_expr(ctx, set_expr);
+                        __auto_type set_c = expr_resolve_container_c(ctx, set_expr);
                         __auto_type elem_c = expr_transpile_expr(ctx, elem_expr);
                         __auto_type elem_ptr = expr_wrap_map_key_as_ptr(ctx, elem_c, elem_expr, set_expr);
                         return context_ctx_str(ctx, SLOP_STR("slop_map_remove("), context_ctx_str(ctx, set_c, context_ctx_str(ctx, SLOP_STR(", "), context_ctx_str(ctx, elem_ptr, SLOP_STR(")")))));
@@ -7795,6 +7817,7 @@ slop_string expr_transpile_set_elements(context_TranspileContext* ctx, slop_list
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type len = ((int64_t)((items).len));
+        __auto_type arena = (*ctx).arena;
         if (len < 2) {
             context_ctx_add_error_at(ctx, SLOP_STR("set-elements: needs set"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             return SLOP_STR("NULL");
@@ -7803,14 +7826,20 @@ slop_string expr_transpile_set_elements(context_TranspileContext* ctx, slop_list
             if (_mv_505.has_value) {
                 __auto_type set_expr = _mv_505.value;
                 {
-                    __auto_type set_c = expr_transpile_expr(ctx, set_expr);
+                    __auto_type set_c = expr_resolve_container_c(ctx, set_expr);
                     __auto_type elem_c_type = expr_infer_set_elem_c_type(ctx, set_expr);
                     __auto_type arena_c = expr_resolve_arena_c_name(ctx, SLOP_STR("set-elements"), items);
-                    if (string_eq(elem_c_type, SLOP_STR("slop_string")) || (string_len(elem_c_type) == 0)) {
+                    if (string_eq(elem_c_type, SLOP_STR("slop_string"))) {
                         return context_ctx_str(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map_keys("), arena_c, SLOP_STR(", ")), context_ctx_str(ctx, set_c, SLOP_STR(")")));
+                    } else if (string_len(elem_c_type) == 0) {
+                        context_ctx_add_error_at(ctx, SLOP_STR("set-elements: cannot infer element type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
+                        return SLOP_STR("NULL");
                     } else {
                         {
-                            __auto_type list_type = context_ctx_str(ctx, SLOP_STR("slop_list_"), elem_c_type);
+                            __auto_type elem_id = ctype_type_to_identifier(arena, elem_c_type);
+                            __auto_type list_type = context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, elem_c_type));
+                            context_ctx_register_list_type(ctx, elem_c_type, list_type);
+                            context_ctx_register_option_type(ctx, elem_c_type, context_ctx_str(ctx, SLOP_STR("slop_option_"), elem_id));
                             return context_ctx_str(ctx, context_ctx_str3(ctx, SLOP_STR("({ slop_set_elements_result _r = slop_set_elements_raw("), arena_c, SLOP_STR(", ")), context_ctx_str(ctx, set_c, context_ctx_str(ctx, SLOP_STR("); ("), context_ctx_str(ctx, list_type, context_ctx_str(ctx, SLOP_STR("){.data = ("), context_ctx_str(ctx, elem_c_type, context_ctx_str(ctx, SLOP_STR("*)_r.data, .len = _r.len, .cap = _r.cap}; })"), SLOP_STR(""))))))));
                         }
                     }
@@ -8077,7 +8106,7 @@ slop_string expr_transpile_for_each_set_as_expr(context_TranspileContext* ctx, s
         __auto_type elem_slop_type = expr_extract_set_elem_from_slop_type(arena, resolved_type);
         __auto_type elem_c_type = expr_slop_value_type_to_c_type(ctx, elem_slop_type);
         {
-            __auto_type result = context_ctx_str3(ctx, SLOP_STR("({ slop_map* _coll = (slop_map*)"), coll_c, SLOP_STR("; for (size_t _i = 0; _i < _coll->cap; _i++) { "));
+            __auto_type result = context_ctx_str3(ctx, SLOP_STR("({ slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, coll_c, resolved_type), SLOP_STR("; for (size_t _i = 0; _i < _coll->cap; _i++) { "));
             __auto_type if_part = SLOP_STR("if (_coll->entries[_i].occupied) { ");
             __auto_type cast_part = context_ctx_str(ctx, elem_c_type, SLOP_STR("*)_coll->entries[_i].key"));
             __auto_type assign_prefix = context_ctx_str4(ctx, elem_c_type, SLOP_STR(" "), var_name, SLOP_STR(" = *("));
@@ -8115,7 +8144,7 @@ slop_string expr_transpile_for_each_map_keys_as_expr(context_TranspileContext* c
         __auto_type key_slop_type = expr_extract_map_key_from_slop_type(arena, resolved_type);
         __auto_type key_c_type = expr_slop_value_type_to_c_type(ctx, key_slop_type);
         {
-            __auto_type result = context_ctx_str3(ctx, SLOP_STR("({ slop_map* _coll = (slop_map*)"), coll_c, SLOP_STR("; for (size_t _i = 0; _i < _coll->cap; _i++) { "));
+            __auto_type result = context_ctx_str3(ctx, SLOP_STR("({ slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, coll_c, resolved_type), SLOP_STR("; for (size_t _i = 0; _i < _coll->cap; _i++) { "));
             __auto_type if_part = SLOP_STR("if (_coll->entries[_i].occupied) { ");
             __auto_type cast_part = context_ctx_str(ctx, key_c_type, SLOP_STR("*)_coll->entries[_i].key"));
             __auto_type assign_prefix = context_ctx_str4(ctx, key_c_type, SLOP_STR(" "), var_name, SLOP_STR(" = *("));
@@ -8191,7 +8220,7 @@ slop_string expr_transpile_for_each_map_kv_as_expr(context_TranspileContext* ctx
                                                             __auto_type key_c_type = expr_slop_value_type_to_c_type(ctx, key_slop_type);
                                                             __auto_type val_c_type = expr_slop_value_type_to_c_type(ctx, val_slop_type);
                                                             {
-                                                                __auto_type result = context_ctx_str3(ctx, SLOP_STR("({ slop_map* _coll = (slop_map*)"), map_c, SLOP_STR("; for (size_t _i = 0; _i < _coll->cap; _i++) { "));
+                                                                __auto_type result = context_ctx_str3(ctx, SLOP_STR("({ slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, map_c, resolved_type), SLOP_STR("; for (size_t _i = 0; _i < _coll->cap; _i++) { "));
                                                                 __auto_type if_part = SLOP_STR("if (_coll->entries[_i].occupied) { ");
                                                                 __auto_type k_cast = context_ctx_str(ctx, key_c_type, SLOP_STR("*)_coll->entries[_i].key"));
                                                                 __auto_type k_prefix = context_ctx_str4(ctx, key_c_type, SLOP_STR(" "), k_name, SLOP_STR(" = *("));
@@ -9926,9 +9955,9 @@ slop_string expr_infer_elem_from_type(context_TranspileContext* ctx, types_SExpr
                             return SLOP_STR("");
                         }
                     }
-                } else if (strlib_starts_with(resolved_type, SLOP_STR("(Set "))) {
+                } else if (expr_is_set_type(resolved_type)) {
                     return expr_extract_set_elem_from_slop_type(arena, resolved_type);
-                } else if (strlib_starts_with(resolved_type, SLOP_STR("(Map "))) {
+                } else if (expr_is_map_type(resolved_type)) {
                     return expr_extract_map_key_from_slop_type(arena, resolved_type);
                 } else {
                     return SLOP_STR("");

--- a/bootstrap/transpiler/slop_expr.h
+++ b/bootstrap/transpiler/slop_expr.h
@@ -65,10 +65,10 @@ slop_string expr_infer_field_access_list_type(context_TranspileContext* ctx, typ
 slop_string expr_list_type_to_option_type(context_TranspileContext* ctx, slop_string c_type);
 slop_string expr_prefix_list_element_type(context_TranspileContext* ctx, slop_string elem_type);
 slop_string expr_substring_after_prefix(slop_arena* arena, slop_string s, slop_string prefix);
-slop_string expr_extract_map_value_from_slop_type(slop_arena* arena, slop_string slop_type);
+slop_string expr_extract_map_value_from_slop_type(slop_arena* arena, slop_string raw_slop_type);
 slop_string expr_slop_value_type_to_c_type(context_TranspileContext* ctx, slop_string slop_type);
 slop_string expr_get_var_name_from_expr(types_SExpr* expr);
-slop_string expr_extract_map_key_from_slop_type(slop_arena* arena, slop_string slop_type);
+slop_string expr_extract_map_key_from_slop_type(slop_arena* arena, slop_string raw_slop_type);
 slop_string expr_resolve_type_alias(context_TranspileContext* ctx, slop_string slop_type);
 slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr* expr);
 slop_string expr_infer_map_key_c_type_from_slop_type(context_TranspileContext* ctx, slop_string slop_type);
@@ -78,7 +78,7 @@ slop_string expr_extract_list_elem_from_inferred(context_TranspileContext* ctx, 
 slop_string expr_infer_map_key_c_type(context_TranspileContext* ctx, types_SExpr* map_expr);
 uint8_t expr_is_set_type(slop_string slop_type);
 uint8_t expr_is_map_type(slop_string slop_type);
-slop_string expr_extract_set_elem_from_slop_type(slop_arena* arena, slop_string slop_type);
+slop_string expr_extract_set_elem_from_slop_type(slop_arena* arena, slop_string raw_slop_type);
 slop_string expr_infer_set_elem_c_type(context_TranspileContext* ctx, types_SExpr* set_expr);
 slop_string expr_compound_slop_type_to_id(slop_arena* arena, slop_string slop_type);
 slop_string expr_slop_value_type_to_option_id(slop_arena* arena, slop_string slop_type);
@@ -147,6 +147,8 @@ slop_string expr_get_arena_from_field_access(context_TranspileContext* ctx, type
 slop_string expr_get_arena_from_base(context_TranspileContext* ctx, types_SExpr* base_expr);
 slop_string expr_get_arena_for_list_push(context_TranspileContext* ctx, slop_string list_c);
 uint8_t expr_is_ptr_to_ptr_map(context_TranspileContext* ctx, types_SExpr* expr);
+slop_string expr_deref_container_c(context_TranspileContext* ctx, slop_string container_c, slop_string slop_type);
+slop_string expr_resolve_container_c(context_TranspileContext* ctx, types_SExpr* container_expr);
 slop_string expr_transpile_record_new(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items);
 slop_string expr_transpile_record_fields(context_TranspileContext* ctx, slop_string type_name, slop_list_types_SExpr_ptr items, int64_t start_idx);
 slop_string expr_build_inline_struct_type(context_TranspileContext* ctx, slop_list_types_SExpr_ptr type_items);

--- a/bootstrap/transpiler/slop_match.c
+++ b/bootstrap/transpiler/slop_match.c
@@ -2233,7 +2233,7 @@ void match_emit_inline_for_each_set(context_TranspileContext* ctx, slop_string v
         __auto_type elem_c_type = expr_slop_value_type_to_c_type(ctx, elem_slop_type);
         context_ctx_emit(ctx, SLOP_STR("{"));
         context_ctx_indent(ctx);
-        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), coll_c, SLOP_STR(";")));
+        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, coll_c, resolved_type), SLOP_STR(";")));
         context_ctx_emit(ctx, SLOP_STR("for (size_t _i = 0; _i < _coll->cap; _i++) {"));
         context_ctx_indent(ctx);
         context_ctx_emit(ctx, SLOP_STR("if (_coll->entries[_i].occupied) {"));
@@ -2265,7 +2265,7 @@ void match_emit_inline_for_each_map_keys(context_TranspileContext* ctx, slop_str
         __auto_type key_c_type = expr_slop_value_type_to_c_type(ctx, key_slop_type);
         context_ctx_emit(ctx, SLOP_STR("{"));
         context_ctx_indent(ctx);
-        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), coll_c, SLOP_STR(";")));
+        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, coll_c, resolved_type), SLOP_STR(";")));
         context_ctx_emit(ctx, SLOP_STR("for (size_t _i = 0; _i < _coll->cap; _i++) {"));
         context_ctx_indent(ctx);
         context_ctx_emit(ctx, SLOP_STR("if (_coll->entries[_i].occupied) {"));
@@ -2337,7 +2337,7 @@ void match_emit_inline_for_each_map_kv(context_TranspileContext* ctx, slop_list_
                                                             __auto_type val_c_type = expr_slop_value_type_to_c_type(ctx, val_slop_type);
                                                             context_ctx_emit(ctx, SLOP_STR("{"));
                                                             context_ctx_indent(ctx);
-                                                            context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), map_c, SLOP_STR(";")));
+                                                            context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, map_c, resolved_type), SLOP_STR(";")));
                                                             context_ctx_emit(ctx, SLOP_STR("for (size_t _i = 0; _i < _coll->cap; _i++) {"));
                                                             context_ctx_indent(ctx);
                                                             context_ctx_emit(ctx, SLOP_STR("if (_coll->entries[_i].occupied) {"));

--- a/bootstrap/transpiler/slop_stmt.c
+++ b/bootstrap/transpiler/slop_stmt.c
@@ -28,8 +28,6 @@ void stmt_transpile_with_arena(context_TranspileContext* ctx, types_SExpr* expr,
 void stmt_transpile_cond(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return);
 void stmt_transpile_cond_body(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items, int64_t start, uint8_t is_return);
 void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr);
-uint8_t stmt_is_set_type(slop_string slop_type);
-uint8_t stmt_is_map_type(slop_string slop_type);
 void stmt_transpile_for_each_set(context_TranspileContext* ctx, slop_string var_name, types_SExprSymbol var_sym, slop_string coll_c, slop_string resolved_type, slop_list_types_SExpr_ptr items, int64_t len);
 void stmt_transpile_for_each_map_keys(context_TranspileContext* ctx, slop_string var_name, types_SExprSymbol var_sym, slop_string coll_c, slop_string resolved_type, slop_list_types_SExpr_ptr items, int64_t len);
 void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_types_SExpr_ptr binding_items, slop_list_types_SExpr_ptr items, int64_t len);
@@ -1449,14 +1447,6 @@ void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr) {
     }
 }
 
-uint8_t stmt_is_set_type(slop_string slop_type) {
-    return (strlib_starts_with(slop_type, SLOP_STR("(Set ")) || strlib_starts_with(slop_type, SLOP_STR("(Ptr (Set ")));
-}
-
-uint8_t stmt_is_map_type(slop_string slop_type) {
-    return (strlib_starts_with(slop_type, SLOP_STR("(Map ")) || strlib_starts_with(slop_type, SLOP_STR("(Ptr (Map ")));
-}
-
 void stmt_transpile_for_each_set(context_TranspileContext* ctx, slop_string var_name, types_SExprSymbol var_sym, slop_string coll_c, slop_string resolved_type, slop_list_types_SExpr_ptr items, int64_t len) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
@@ -1465,7 +1455,7 @@ void stmt_transpile_for_each_set(context_TranspileContext* ctx, slop_string var_
         __auto_type elem_c_type = expr_slop_value_type_to_c_type(ctx, elem_slop_type);
         context_ctx_emit(ctx, SLOP_STR("{"));
         context_ctx_indent(ctx);
-        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), coll_c, SLOP_STR(";")));
+        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, coll_c, resolved_type), SLOP_STR(";")));
         context_ctx_emit(ctx, SLOP_STR("for (size_t _i = 0; _i < _coll->cap; _i++) {"));
         context_ctx_indent(ctx);
         context_ctx_emit(ctx, SLOP_STR("if (_coll->entries[_i].occupied) {"));
@@ -1508,7 +1498,7 @@ void stmt_transpile_for_each_map_keys(context_TranspileContext* ctx, slop_string
         __auto_type key_c_type = expr_slop_value_type_to_c_type(ctx, key_slop_type);
         context_ctx_emit(ctx, SLOP_STR("{"));
         context_ctx_indent(ctx);
-        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), coll_c, SLOP_STR(";")));
+        context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, coll_c, resolved_type), SLOP_STR(";")));
         context_ctx_emit(ctx, SLOP_STR("for (size_t _i = 0; _i < _coll->cap; _i++) {"));
         context_ctx_indent(ctx);
         context_ctx_emit(ctx, SLOP_STR("if (_coll->entries[_i].occupied) {"));
@@ -1591,7 +1581,7 @@ void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_typ
                                                             __auto_type val_c_type = expr_slop_value_type_to_c_type(ctx, val_slop_type);
                                                             context_ctx_emit(ctx, SLOP_STR("{"));
                                                             context_ctx_indent(ctx);
-                                                            context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), map_c, SLOP_STR(";")));
+                                                            context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_map* _coll = (slop_map*)"), expr_deref_container_c(ctx, map_c, resolved_type), SLOP_STR(";")));
                                                             context_ctx_emit(ctx, SLOP_STR("for (size_t _i = 0; _i < _coll->cap; _i++) {"));
                                                             context_ctx_indent(ctx);
                                                             context_ctx_emit(ctx, SLOP_STR("if (_coll->entries[_i].occupied) {"));
@@ -1721,12 +1711,12 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
                                                                 {
                                                                     __auto_type coll_slop_type = expr_infer_expr_slop_type(ctx, coll_expr);
                                                                     __auto_type resolved_type = expr_resolve_type_alias(ctx, coll_slop_type);
-                                                                    if (stmt_is_set_type(resolved_type)) {
+                                                                    if (expr_is_set_type(resolved_type)) {
                                                                         {
                                                                             __auto_type coll_c = expr_transpile_expr(ctx, coll_expr);
                                                                             stmt_transpile_for_each_set(ctx, var_name, var_sym, coll_c, resolved_type, items, len);
                                                                         }
-                                                                    } else if (stmt_is_map_type(resolved_type)) {
+                                                                    } else if (expr_is_map_type(resolved_type)) {
                                                                         {
                                                                             __auto_type coll_c = expr_transpile_expr(ctx, coll_expr);
                                                                             stmt_transpile_for_each_map_keys(ctx, var_name, var_sym, coll_c, resolved_type, items, len);

--- a/bootstrap/transpiler/slop_stmt.h
+++ b/bootstrap/transpiler/slop_stmt.h
@@ -49,8 +49,6 @@ void stmt_transpile_with_arena(context_TranspileContext* ctx, types_SExpr* expr,
 void stmt_transpile_cond(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return);
 void stmt_transpile_cond_body(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items, int64_t start, uint8_t is_return);
 void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr);
-uint8_t stmt_is_set_type(slop_string slop_type);
-uint8_t stmt_is_map_type(slop_string slop_type);
 void stmt_transpile_for_each_set(context_TranspileContext* ctx, slop_string var_name, types_SExprSymbol var_sym, slop_string coll_c, slop_string resolved_type, slop_list_types_SExpr_ptr items, int64_t len);
 void stmt_transpile_for_each_map_keys(context_TranspileContext* ctx, slop_string var_name, types_SExprSymbol var_sym, slop_string coll_c, slop_string resolved_type, slop_list_types_SExpr_ptr items, int64_t len);
 void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_types_SExpr_ptr binding_items, slop_list_types_SExpr_ptr items, int64_t len);

--- a/bootstrap/transpiler/slop_transpiler.c
+++ b/bootstrap/transpiler/slop_transpiler.c
@@ -101,6 +101,7 @@ void transpiler_emit_primitive_option_types_header(context_TranspileContext* ctx
 uint8_t transpiler_is_primitive_or_runtime_type(slop_string type_name);
 void transpiler_emit_imported_list_types_header(context_TranspileContext* ctx);
 void transpiler_emit_imported_option_types_header(context_TranspileContext* ctx);
+void transpiler_emit_late_registered_list_types_header(context_TranspileContext* ctx);
 void transpiler_emit_late_registered_option_types_header(context_TranspileContext* ctx);
 void transpiler_emit_value_list_types_header(context_TranspileContext* ctx);
 void transpiler_emit_complex_value_list_types_header(context_TranspileContext* ctx);
@@ -2474,6 +2475,7 @@ void transpiler_transpile_module(context_TranspileContext* ctx, types_SExpr* mod
                             transpiler_emit_fn_forward_decls(ctx, items, body_start);
                             transpiler_emit_module_functions(ctx, items, body_start);
                             transpiler_emit_late_registered_option_types_header(ctx);
+                            transpiler_emit_late_registered_list_types_header(ctx);
                             transpiler_emit_header_guard_close(ctx);
                         }
                     }
@@ -4169,6 +4171,24 @@ void transpiler_emit_imported_option_types_header(context_TranspileContext* ctx)
     }
 }
 
+void transpiler_emit_late_registered_list_types_header(context_TranspileContext* ctx) {
+    SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
+    {
+        __auto_type list_types = context_ctx_get_list_types(ctx);
+        __auto_type len = ((int64_t)((list_types).len));
+        int64_t i = 0;
+        while (i < len) {
+            __auto_type _mv_1360 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1360.has_value) {
+                __auto_type lt = _mv_1360.value;
+                transpiler_emit_single_list_type_header(ctx, lt);
+            } else if (!_mv_1360.has_value) {
+            }
+            i = (i + 1);
+        }
+    }
+}
+
 void transpiler_emit_late_registered_option_types_header(context_TranspileContext* ctx) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
@@ -4176,11 +4196,11 @@ void transpiler_emit_late_registered_option_types_header(context_TranspileContex
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1360 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1360.has_value) {
-                __auto_type ot = _mv_1360.value;
+            __auto_type _mv_1361 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1361.has_value) {
+                __auto_type ot = _mv_1361.value;
                 transpiler_emit_single_option_type_header(ctx, ot);
-            } else if (!_mv_1360.has_value) {
+            } else if (!_mv_1361.has_value) {
             }
             i = (i + 1);
         }
@@ -4194,13 +4214,13 @@ void transpiler_emit_value_list_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1361 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1361.has_value) {
-                __auto_type lt = _mv_1361.value;
+            __auto_type _mv_1362 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1362.has_value) {
+                __auto_type lt = _mv_1362.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_is_type_emitted_or_primitive(ctx, lt.elem_type)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1361.has_value) {
+            } else if (!_mv_1362.has_value) {
             }
             i = (i + 1);
         }
@@ -4214,13 +4234,13 @@ void transpiler_emit_complex_value_list_types_header(context_TranspileContext* c
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1362 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1362.has_value) {
-                __auto_type lt = _mv_1362.value;
+            __auto_type _mv_1363 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1363.has_value) {
+                __auto_type lt = _mv_1363.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && !(context_ctx_is_type_emitted(ctx, lt.c_name))) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1362.has_value) {
+            } else if (!_mv_1363.has_value) {
             }
             i = (i + 1);
         }
@@ -4256,9 +4276,9 @@ void transpiler_emit_union_payload_hash_eq(context_TranspileContext* ctx, slop_l
         __auto_type len = ((int64_t)((variants).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1363 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1363.has_value) {
-                __auto_type variant = _mv_1363.value;
+            __auto_type _mv_1364 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1364.has_value) {
+                __auto_type variant = _mv_1364.value;
                 {
                     __auto_type slop_type = variant.slop_type;
                     __auto_type c_payload_type = variant.c_type;
@@ -4278,7 +4298,7 @@ void transpiler_emit_union_payload_hash_eq(context_TranspileContext* ctx, slop_l
                         }
                     }
                 }
-            } else if (!_mv_1363.has_value) {
+            } else if (!_mv_1364.has_value) {
             }
             i = (i + 1);
         }
@@ -4291,9 +4311,9 @@ void transpiler_emit_record_field_dependencies(context_TranspileContext* ctx, sl
         __auto_type len = ((int64_t)((fields).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1364 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1364.has_value) {
-                __auto_type field = _mv_1364.value;
+            __auto_type _mv_1365 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1365.has_value) {
+                __auto_type field = _mv_1365.value;
                 {
                     __auto_type slop_type = field.slop_type;
                     __auto_type c_type = field.c_type;
@@ -4329,7 +4349,7 @@ void transpiler_emit_record_field_dependencies(context_TranspileContext* ctx, sl
                         }
                     }
                 }
-            } else if (!_mv_1364.has_value) {
+            } else if (!_mv_1365.has_value) {
             }
             i = (i + 1);
         }
@@ -4386,9 +4406,9 @@ uint8_t transpiler_is_primitive_slop_type(slop_string slop_type) {
 
 uint8_t transpiler_is_range_type_alias(context_TranspileContext* ctx, slop_string slop_type) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
-    __auto_type _mv_1365 = context_ctx_lookup_type_alias(ctx, slop_type);
-    if (_mv_1365.has_value) {
-        __auto_type underlying = _mv_1365.value;
+    __auto_type _mv_1366 = context_ctx_lookup_type_alias(ctx, slop_type);
+    if (_mv_1366.has_value) {
+        __auto_type underlying = _mv_1366.value;
         if (strlib_starts_with(underlying, SLOP_STR("(Int"))) {
             return 1;
         } else if (strlib_starts_with(underlying, SLOP_STR("(I64"))) {
@@ -4410,7 +4430,7 @@ uint8_t transpiler_is_range_type_alias(context_TranspileContext* ctx, slop_strin
         } else {
             return 0;
         }
-    } else if (!_mv_1365.has_value) {
+    } else if (!_mv_1366.has_value) {
         return 0;
     }
 }
@@ -4424,11 +4444,11 @@ void transpiler_emit_union_hash_fn(context_TranspileContext* ctx, slop_string c_
         __auto_type len = ((int64_t)((variants).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1366 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1366.has_value) {
-                __auto_type variant = _mv_1366.value;
+            __auto_type _mv_1367 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1367.has_value) {
+                __auto_type variant = _mv_1367.value;
                 transpiler_emit_union_variant_hash(ctx, c_type, variant);
-            } else if (!_mv_1366.has_value) {
+            } else if (!_mv_1367.has_value) {
             }
             i = (i + 1);
         }
@@ -4485,11 +4505,11 @@ void transpiler_emit_union_eq_fn(context_TranspileContext* ctx, slop_string c_ty
         __auto_type len = ((int64_t)((variants).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1367 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1367.has_value) {
-                __auto_type variant = _mv_1367.value;
+            __auto_type _mv_1368 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1368.has_value) {
+                __auto_type variant = _mv_1368.value;
                 transpiler_emit_union_variant_eq(ctx, c_type, variant);
-            } else if (!_mv_1367.has_value) {
+            } else if (!_mv_1368.has_value) {
             }
             i = (i + 1);
         }
@@ -4536,11 +4556,11 @@ void transpiler_emit_struct_hash_fn(context_TranspileContext* ctx, slop_string c
         __auto_type len = ((int64_t)((fields).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1368 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1368.has_value) {
-                __auto_type field = _mv_1368.value;
+            __auto_type _mv_1369 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1369.has_value) {
+                __auto_type field = _mv_1369.value;
                 transpiler_emit_field_hash(ctx, field);
-            } else if (!_mv_1368.has_value) {
+            } else if (!_mv_1369.has_value) {
             }
             i = (i + 1);
         }
@@ -4607,11 +4627,11 @@ void transpiler_emit_struct_eq_fn(context_TranspileContext* ctx, slop_string c_t
             {
                 int64_t i = 0;
                 while (i < len) {
-                    __auto_type _mv_1369 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1369.has_value) {
-                        __auto_type field = _mv_1369.value;
+                    __auto_type _mv_1370 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1370.has_value) {
+                        __auto_type field = _mv_1370.value;
                         transpiler_emit_field_eq(ctx, field);
-                    } else if (!_mv_1369.has_value) {
+                    } else if (!_mv_1370.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -4672,12 +4692,12 @@ void transpiler_emit_struct_key_types_header(context_TranspileContext* ctx) {
             context_ctx_emit_header(ctx, SLOP_STR("/* Hash/eq functions and list types for struct map/set keys */"));
         }
         while (i < ((int64_t)((struct_key_types).len))) {
-            __auto_type _mv_1370 = ({ __auto_type _lst = struct_key_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1370.has_value) {
-                __auto_type c_type = _mv_1370.value;
+            __auto_type _mv_1371 = ({ __auto_type _lst = struct_key_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1371.has_value) {
+                __auto_type c_type = _mv_1371.value;
                 {
                     __auto_type guard_name = context_ctx_str3(ctx, transpiler_uppercase_name(ctx, c_type), SLOP_STR("_HASH_EQ_DEFINED"), SLOP_STR(""));
-                    __auto_type list_c_name = context_ctx_str(ctx, SLOP_STR("slop_list_"), c_type);
+                    __auto_type list_c_name = context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier((*ctx).arena, c_type));
                     context_ctx_emit_header(ctx, context_ctx_str(ctx, SLOP_STR("#ifndef "), guard_name));
                     context_ctx_emit_header(ctx, context_ctx_str(ctx, SLOP_STR("#define "), guard_name));
                     transpiler_emit_struct_hash_eq(ctx, c_type);
@@ -4688,7 +4708,7 @@ void transpiler_emit_struct_key_types_header(context_TranspileContext* ctx) {
                     context_ctx_emit_header(ctx, SLOP_STR("#endif"));
                     context_ctx_emit_header(ctx, SLOP_STR(""));
                 }
-            } else if (!_mv_1370.has_value) {
+            } else if (!_mv_1371.has_value) {
             }
             i = (i + 1);
         }
@@ -4784,9 +4804,9 @@ void transpiler_emit_chan_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((chan_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1371 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1371.has_value) {
-                __auto_type ct = _mv_1371.value;
+            __auto_type _mv_1372 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1372.has_value) {
+                __auto_type ct = _mv_1372.value;
                 {
                     __auto_type elem_type = ct.elem_type;
                     __auto_type c_name = ct.c_name;
@@ -4811,7 +4831,7 @@ void transpiler_emit_chan_types_header(context_TranspileContext* ctx) {
                         }
                     }
                 }
-            } else if (!_mv_1371.has_value) {
+            } else if (!_mv_1372.has_value) {
             }
             i = (i + 1);
         }
@@ -4825,9 +4845,9 @@ void transpiler_emit_chan_funcs_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((chan_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1372 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1372.has_value) {
-                __auto_type ct = _mv_1372.value;
+            __auto_type _mv_1373 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1373.has_value) {
+                __auto_type ct = _mv_1373.value;
                 {
                     __auto_type elem_type = ct.elem_type;
                     __auto_type c_name = ct.c_name;
@@ -4835,7 +4855,7 @@ void transpiler_emit_chan_funcs_header(context_TranspileContext* ctx) {
                         transpiler_emit_chan_send_recv_funcs(ctx, c_name, elem_type);
                     }
                 }
-            } else if (!_mv_1372.has_value) {
+            } else if (!_mv_1373.has_value) {
             }
             i = (i + 1);
         }
@@ -4971,9 +4991,9 @@ void transpiler_emit_thread_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((thread_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1373 = ({ __auto_type _lst = thread_types; size_t _idx = (size_t)i; slop_option_context_ThreadType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1373.has_value) {
-                __auto_type tt = _mv_1373.value;
+            __auto_type _mv_1374 = ({ __auto_type _lst = thread_types; size_t _idx = (size_t)i; slop_option_context_ThreadType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1374.has_value) {
+                __auto_type tt = _mv_1374.value;
                 {
                     __auto_type result_type = tt.result_type;
                     __auto_type c_name = tt.c_name;
@@ -5005,7 +5025,7 @@ void transpiler_emit_thread_types_header(context_TranspileContext* ctx) {
                         }
                     }
                 }
-            } else if (!_mv_1373.has_value) {
+            } else if (!_mv_1374.has_value) {
             }
             i = (i + 1);
         }
@@ -5050,44 +5070,44 @@ slop_string transpiler_uppercase_name(context_TranspileContext* ctx, slop_string
 
 uint8_t transpiler_is_simple_enum_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1374 = (*item);
-    switch (_mv_1374.tag) {
+    __auto_type _mv_1375 = (*item);
+    switch (_mv_1375.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1374.data.lst;
+            __auto_type lst = _mv_1375.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 3) {
                     return 0;
                 } else {
-                    __auto_type _mv_1375 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1375.has_value) {
-                        __auto_type def_expr = _mv_1375.value;
-                        __auto_type _mv_1376 = (*def_expr);
-                        switch (_mv_1376.tag) {
+                    __auto_type _mv_1376 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1376.has_value) {
+                        __auto_type def_expr = _mv_1376.value;
+                        __auto_type _mv_1377 = (*def_expr);
+                        switch (_mv_1377.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type def_lst = _mv_1376.data.lst;
+                                __auto_type def_lst = _mv_1377.data.lst;
                                 {
                                     __auto_type def_items = def_lst.items;
                                     if (((int64_t)((def_items).len)) < 1) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1377 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1377.has_value) {
-                                            __auto_type head = _mv_1377.value;
-                                            __auto_type _mv_1378 = (*head);
-                                            switch (_mv_1378.tag) {
+                                        __auto_type _mv_1378 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1378.has_value) {
+                                            __auto_type head = _mv_1378.value;
+                                            __auto_type _mv_1379 = (*head);
+                                            switch (_mv_1379.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_1378.data.sym;
+                                                    __auto_type sym = _mv_1379.data.sym;
                                                     return (string_eq(sym.name, SLOP_STR("enum")) && !(transpiler_has_enum_payload_variants(def_items)));
                                                 }
                                                 default: {
                                                     return 0;
                                                 }
                                             }
-                                        } else if (!_mv_1377.has_value) {
+                                        } else if (!_mv_1378.has_value) {
                                             return 0;
                                         }
                                     }
@@ -5097,7 +5117,7 @@ uint8_t transpiler_is_simple_enum_def(types_SExpr* item) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1375.has_value) {
+                    } else if (!_mv_1376.has_value) {
                         return 0;
                     }
                 }
@@ -5116,23 +5136,11 @@ void transpiler_emit_module_types_header(context_TranspileContext* ctx, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1379 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1379.has_value) {
-                __auto_type item = _mv_1379.value;
-                if (transpiler_is_type_def(item) && transpiler_is_type_alias_def(item)) {
-                    transpiler_emit_type_alias_to_header(ctx, item);
-                }
-            } else if (!_mv_1379.has_value) {
-            }
-            i = (i + 1);
-        }
-        i = start;
-        while (i < len) {
             __auto_type _mv_1380 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_1380.has_value) {
                 __auto_type item = _mv_1380.value;
-                if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
-                    transpiler_emit_type_to_header(ctx, item);
+                if (transpiler_is_type_def(item) && transpiler_is_type_alias_def(item)) {
+                    transpiler_emit_type_alias_to_header(ctx, item);
                 }
             } else if (!_mv_1380.has_value) {
             }
@@ -5143,10 +5151,22 @@ void transpiler_emit_module_types_header(context_TranspileContext* ctx, slop_lis
             __auto_type _mv_1381 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_1381.has_value) {
                 __auto_type item = _mv_1381.value;
-                if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
+                if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
                     transpiler_emit_type_to_header(ctx, item);
                 }
             } else if (!_mv_1381.has_value) {
+            }
+            i = (i + 1);
+        }
+        i = start;
+        while (i < len) {
+            __auto_type _mv_1382 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1382.has_value) {
+                __auto_type item = _mv_1382.value;
+                if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
+                    transpiler_emit_type_to_header(ctx, item);
+                }
+            } else if (!_mv_1382.has_value) {
             }
             i = (i + 1);
         }
@@ -5159,13 +5179,13 @@ void transpiler_emit_simple_type_aliases_header(context_TranspileContext* ctx, s
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1382 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1382.has_value) {
-                __auto_type item = _mv_1382.value;
+            __auto_type _mv_1383 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1383.has_value) {
+                __auto_type item = _mv_1383.value;
                 if ((transpiler_is_type_def(item)) && (transpiler_is_type_alias_def(item)) && (!(transpiler_is_result_type_alias_def(item)))) {
                     transpiler_emit_type_alias_to_header(ctx, item);
                 }
-            } else if (!_mv_1382.has_value) {
+            } else if (!_mv_1383.has_value) {
             }
             i = (i + 1);
         }
@@ -5178,13 +5198,13 @@ void transpiler_emit_type_aliases_header(context_TranspileContext* ctx, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1383 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1383.has_value) {
-                __auto_type item = _mv_1383.value;
+            __auto_type _mv_1384 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1384.has_value) {
+                __auto_type item = _mv_1384.value;
                 if ((transpiler_is_type_def(item)) && (transpiler_is_type_alias_def(item)) && (transpiler_is_result_type_alias_def(item))) {
                     transpiler_emit_type_alias_to_header(ctx, item);
                 }
-            } else if (!_mv_1383.has_value) {
+            } else if (!_mv_1384.has_value) {
             }
             i = (i + 1);
         }
@@ -5197,13 +5217,13 @@ void transpiler_emit_simple_enums_header(context_TranspileContext* ctx, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1384 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1384.has_value) {
-                __auto_type item = _mv_1384.value;
+            __auto_type _mv_1385 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1385.has_value) {
+                __auto_type item = _mv_1385.value;
                 if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
                     transpiler_emit_type_to_header(ctx, item);
                 }
-            } else if (!_mv_1384.has_value) {
+            } else if (!_mv_1385.has_value) {
             }
             i = (i + 1);
         }
@@ -5218,9 +5238,9 @@ void transpiler_emit_pending_container_deps(context_TranspileContext* ctx, types
         __auto_type len = ((int64_t)((field_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1385 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1385.has_value) {
-                __auto_type field_type = _mv_1385.value;
+            __auto_type _mv_1386 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1386.has_value) {
+                __auto_type field_type = _mv_1386.value;
                 if (!(context_ctx_is_type_emitted(ctx, field_type)) && transpiler_is_emittable_container_type(ctx, field_type)) {
                     if (strlib_starts_with(field_type, SLOP_STR("slop_option_"))) {
                         transpiler_emit_option_by_c_name(ctx, field_type);
@@ -5229,7 +5249,7 @@ void transpiler_emit_pending_container_deps(context_TranspileContext* ctx, types
                         transpiler_emit_list_by_c_name(ctx, field_type);
                     }
                 }
-            } else if (!_mv_1385.has_value) {
+            } else if (!_mv_1386.has_value) {
             }
             i = (i + 1);
         }
@@ -5243,13 +5263,13 @@ void transpiler_emit_option_by_c_name(context_TranspileContext* ctx, slop_string
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1386 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1386.has_value) {
-                __auto_type ot = _mv_1386.value;
+            __auto_type _mv_1387 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1387.has_value) {
+                __auto_type ot = _mv_1387.value;
                 if (string_eq(ot.c_name, c_name)) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1386.has_value) {
+            } else if (!_mv_1387.has_value) {
             }
             i = (i + 1);
         }
@@ -5263,13 +5283,13 @@ void transpiler_emit_list_by_c_name(context_TranspileContext* ctx, slop_string c
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1387 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1387.has_value) {
-                __auto_type lt = _mv_1387.value;
+            __auto_type _mv_1388 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1388.has_value) {
+                __auto_type lt = _mv_1388.value;
                 if (string_eq(lt.c_name, c_name)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1387.has_value) {
+            } else if (!_mv_1388.has_value) {
             }
             i = (i + 1);
         }
@@ -5290,9 +5310,9 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                 int64_t i = start;
                 while (i < len) {
                     if (!(transpiler_index_in_list(emitted, i))) {
-                        __auto_type _mv_1388 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1388.has_value) {
-                            __auto_type item = _mv_1388.value;
+                        __auto_type _mv_1389 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1389.has_value) {
+                            __auto_type item = _mv_1389.value;
                             if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                                 if (transpiler_type_deps_satisfied(ctx, item)) {
                                     transpiler_emit_pending_container_deps(ctx, item);
@@ -5302,7 +5322,7 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                                     transpiler_emit_option_list_for_type(ctx, item);
                                 }
                             }
-                        } else if (!_mv_1388.has_value) {
+                        } else if (!_mv_1389.has_value) {
                         }
                     }
                     i = (i + 1);
@@ -5319,9 +5339,9 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                     int64_t i = start;
                     while (i < len) {
                         if (!(transpiler_index_in_list(emitted, i))) {
-                            __auto_type _mv_1389 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1389.has_value) {
-                                __auto_type item = _mv_1389.value;
+                            __auto_type _mv_1390 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1390.has_value) {
+                                __auto_type item = _mv_1390.value;
                                 if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                                     if (transpiler_type_deps_satisfied(ctx, item)) {
                                         transpiler_emit_pending_container_deps(ctx, item);
@@ -5331,7 +5351,7 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                                         transpiler_emit_option_list_for_type(ctx, item);
                                     }
                                 }
-                            } else if (!_mv_1389.has_value) {
+                            } else if (!_mv_1390.has_value) {
                             }
                         }
                         i = (i + 1);
@@ -5348,13 +5368,13 @@ uint8_t transpiler_has_unemitted_struct_types(slop_list_types_SExpr_ptr items, i
         uint8_t found = 0;
         while ((i < len) && !(found)) {
             if (!(transpiler_index_in_list(emitted, i))) {
-                __auto_type _mv_1390 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1390.has_value) {
-                    __auto_type item = _mv_1390.value;
+                __auto_type _mv_1391 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1391.has_value) {
+                    __auto_type item = _mv_1391.value;
                     if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                         found = 1;
                     }
-                } else if (!_mv_1390.has_value) {
+                } else if (!_mv_1391.has_value) {
                 }
             }
             i = (i + 1);
@@ -5369,26 +5389,26 @@ void transpiler_break_list_cycles(context_TranspileContext* ctx, slop_list_types
         int64_t i = start;
         while (i < len) {
             if (!(transpiler_index_in_list(emitted, i))) {
-                __auto_type _mv_1391 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1391.has_value) {
-                    __auto_type item = _mv_1391.value;
+                __auto_type _mv_1392 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1392.has_value) {
+                    __auto_type item = _mv_1392.value;
                     if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                         {
                             __auto_type blocking_deps = transpiler_find_blocking_list_deps(ctx, item);
                             __auto_type dep_len = ((int64_t)((blocking_deps).len));
                             __auto_type j = 0;
                             while (j < dep_len) {
-                                __auto_type _mv_1392 = ({ __auto_type _lst = blocking_deps; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1392.has_value) {
-                                    __auto_type dep_name = _mv_1392.value;
+                                __auto_type _mv_1393 = ({ __auto_type _lst = blocking_deps; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1393.has_value) {
+                                    __auto_type dep_name = _mv_1393.value;
                                     transpiler_emit_list_declare_by_c_name(ctx, dep_name);
-                                } else if (!_mv_1392.has_value) {
+                                } else if (!_mv_1393.has_value) {
                                 }
                                 j = (j + 1);
                             }
                         }
                     }
-                } else if (!_mv_1391.has_value) {
+                } else if (!_mv_1392.has_value) {
                 }
             }
             i = (i + 1);
@@ -5406,13 +5426,13 @@ slop_list_string transpiler_find_blocking_list_deps(context_TranspileContext* ct
         __auto_type result = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1393 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1393.has_value) {
-                __auto_type field_type = _mv_1393.value;
+            __auto_type _mv_1394 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1394.has_value) {
+                __auto_type field_type = _mv_1394.value;
                 if ((strlib_starts_with(field_type, SLOP_STR("slop_list_"))) && (!(context_ctx_is_type_emitted(ctx, field_type))) && (!(transpiler_is_runtime_list_type(field_type)))) {
                     ({ __auto_type _lst_p = &(result); __auto_type _item = (field_type); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                 }
-            } else if (!_mv_1393.has_value) {
+            } else if (!_mv_1394.has_value) {
             }
             i = (i + 1);
         }
@@ -5427,13 +5447,13 @@ void transpiler_emit_list_declare_by_c_name(context_TranspileContext* ctx, slop_
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1394 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1394.has_value) {
-                __auto_type lt = _mv_1394.value;
+            __auto_type _mv_1395 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1395.has_value) {
+                __auto_type lt = _mv_1395.value;
                 if (string_eq(lt.c_name, c_name)) {
                     transpiler_emit_list_type_declare_only(ctx, lt);
                 }
-            } else if (!_mv_1394.has_value) {
+            } else if (!_mv_1395.has_value) {
             }
             i = (i + 1);
         }
@@ -5446,13 +5466,13 @@ uint8_t transpiler_index_in_list(slop_list_int lst, int64_t idx) {
         int64_t i = 0;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1395 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_int _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1395.has_value) {
-                __auto_type v = _mv_1395.value;
+            __auto_type _mv_1396 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_int _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1396.has_value) {
+                __auto_type v = _mv_1396.value;
                 if (v == idx) {
                     found = 1;
                 }
-            } else if (!_mv_1395.has_value) {
+            } else if (!_mv_1396.has_value) {
             }
             i = (i + 1);
         }
@@ -5469,13 +5489,13 @@ uint8_t transpiler_type_deps_satisfied(context_TranspileContext* ctx, types_SExp
         int64_t i = 0;
         uint8_t all_satisfied = 1;
         while ((i < len) && all_satisfied) {
-            __auto_type _mv_1396 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1396.has_value) {
-                __auto_type field_type = _mv_1396.value;
+            __auto_type _mv_1397 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1397.has_value) {
+                __auto_type field_type = _mv_1397.value;
                 if (!(transpiler_type_is_available(ctx, field_type))) {
                     all_satisfied = 0;
                 }
-            } else if (!_mv_1396.has_value) {
+            } else if (!_mv_1397.has_value) {
             }
             i = (i + 1);
         }
@@ -5522,34 +5542,34 @@ slop_list_string transpiler_get_type_field_types(context_TranspileContext* ctx, 
     {
         __auto_type arena = (*ctx).arena;
         __auto_type result = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
-        __auto_type _mv_1397 = (*type_def);
-        switch (_mv_1397.tag) {
+        __auto_type _mv_1398 = (*type_def);
+        switch (_mv_1398.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1397.data.lst;
+                __auto_type lst = _mv_1398.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_1398 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1398.has_value) {
-                            __auto_type def_expr = _mv_1398.value;
-                            __auto_type _mv_1399 = (*def_expr);
-                            switch (_mv_1399.tag) {
+                        __auto_type _mv_1399 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1399.has_value) {
+                            __auto_type def_expr = _mv_1399.value;
+                            __auto_type _mv_1400 = (*def_expr);
+                            switch (_mv_1400.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type def_lst = _mv_1399.data.lst;
+                                    __auto_type def_lst = _mv_1400.data.lst;
                                     {
                                         __auto_type def_items = def_lst.items;
                                         __auto_type def_len = ((int64_t)((def_items).len));
                                         if (def_len > 0) {
-                                            __auto_type _mv_1400 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1400.has_value) {
-                                                __auto_type head = _mv_1400.value;
-                                                __auto_type _mv_1401 = (*head);
-                                                switch (_mv_1401.tag) {
+                                            __auto_type _mv_1401 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1401.has_value) {
+                                                __auto_type head = _mv_1401.value;
+                                                __auto_type _mv_1402 = (*head);
+                                                switch (_mv_1402.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type sym = _mv_1401.data.sym;
+                                                        __auto_type sym = _mv_1402.data.sym;
                                                         {
                                                             __auto_type kind = sym.name;
                                                             if (string_eq(kind, SLOP_STR("record"))) {
@@ -5565,7 +5585,7 @@ slop_list_string transpiler_get_type_field_types(context_TranspileContext* ctx, 
                                                         break;
                                                     }
                                                 }
-                                            } else if (!_mv_1400.has_value) {
+                                            } else if (!_mv_1401.has_value) {
                                             }
                                         }
                                     }
@@ -5575,7 +5595,7 @@ slop_list_string transpiler_get_type_field_types(context_TranspileContext* ctx, 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1398.has_value) {
+                        } else if (!_mv_1399.has_value) {
                         }
                     }
                 }
@@ -5597,25 +5617,25 @@ slop_list_string transpiler_extract_record_field_types(context_TranspileContext*
         __auto_type len = ((int64_t)((def_items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1402 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1402.has_value) {
-                __auto_type field_expr = _mv_1402.value;
-                __auto_type _mv_1403 = (*field_expr);
-                switch (_mv_1403.tag) {
+            __auto_type _mv_1403 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1403.has_value) {
+                __auto_type field_expr = _mv_1403.value;
+                __auto_type _mv_1404 = (*field_expr);
+                switch (_mv_1404.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type field_lst = _mv_1403.data.lst;
+                        __auto_type field_lst = _mv_1404.data.lst;
                         if (((int64_t)((field_lst.items).len)) >= 2) {
-                            __auto_type _mv_1404 = ({ __auto_type _lst = field_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1404.has_value) {
-                                __auto_type type_expr = _mv_1404.value;
+                            __auto_type _mv_1405 = ({ __auto_type _lst = field_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1405.has_value) {
+                                __auto_type type_expr = _mv_1405.value;
                                 {
                                     __auto_type type_str = transpiler_get_field_type_string(ctx, type_expr);
                                     if (!(string_eq(type_str, SLOP_STR("")))) {
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (type_str); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
                                 }
-                            } else if (!_mv_1404.has_value) {
+                            } else if (!_mv_1405.has_value) {
                             }
                         }
                         break;
@@ -5624,7 +5644,7 @@ slop_list_string transpiler_extract_record_field_types(context_TranspileContext*
                         break;
                     }
                 }
-            } else if (!_mv_1402.has_value) {
+            } else if (!_mv_1403.has_value) {
             }
             i = (i + 1);
         }
@@ -5640,25 +5660,25 @@ slop_list_string transpiler_extract_union_variant_types(context_TranspileContext
         __auto_type len = ((int64_t)((def_items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1405 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1405.has_value) {
-                __auto_type variant_expr = _mv_1405.value;
-                __auto_type _mv_1406 = (*variant_expr);
-                switch (_mv_1406.tag) {
+            __auto_type _mv_1406 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1406.has_value) {
+                __auto_type variant_expr = _mv_1406.value;
+                __auto_type _mv_1407 = (*variant_expr);
+                switch (_mv_1407.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type variant_lst = _mv_1406.data.lst;
+                        __auto_type variant_lst = _mv_1407.data.lst;
                         if (((int64_t)((variant_lst.items).len)) >= 2) {
-                            __auto_type _mv_1407 = ({ __auto_type _lst = variant_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1407.has_value) {
-                                __auto_type type_expr = _mv_1407.value;
+                            __auto_type _mv_1408 = ({ __auto_type _lst = variant_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1408.has_value) {
+                                __auto_type type_expr = _mv_1408.value;
                                 {
                                     __auto_type type_str = transpiler_get_field_type_string(ctx, type_expr);
                                     if (!(string_eq(type_str, SLOP_STR("")))) {
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (type_str); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
                                 }
-                            } else if (!_mv_1407.has_value) {
+                            } else if (!_mv_1408.has_value) {
                             }
                         }
                         break;
@@ -5667,7 +5687,7 @@ slop_list_string transpiler_extract_union_variant_types(context_TranspileContext
                         break;
                     }
                 }
-            } else if (!_mv_1405.has_value) {
+            } else if (!_mv_1406.has_value) {
             }
             i = (i + 1);
         }
@@ -5680,62 +5700,43 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1408 = (*type_expr);
-        switch (_mv_1408.tag) {
+        __auto_type _mv_1409 = (*type_expr);
+        switch (_mv_1409.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1408.data.sym;
+                __auto_type sym = _mv_1409.data.sym;
                 {
                     __auto_type name = sym.name;
-                    __auto_type _mv_1409 = context_ctx_lookup_type(ctx, name);
-                    if (_mv_1409.has_value) {
-                        __auto_type entry = _mv_1409.value;
+                    __auto_type _mv_1410 = context_ctx_lookup_type(ctx, name);
+                    if (_mv_1410.has_value) {
+                        __auto_type entry = _mv_1410.value;
                         return entry.c_name;
-                    } else if (!_mv_1409.has_value) {
+                    } else if (!_mv_1410.has_value) {
                         return ctype_to_c_type(arena, type_expr);
                     }
                 }
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1408.data.lst;
+                __auto_type lst = _mv_1409.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 1) {
                         return SLOP_STR("");
                     } else {
-                        __auto_type _mv_1410 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1410.has_value) {
-                            __auto_type head = _mv_1410.value;
-                            __auto_type _mv_1411 = (*head);
-                            switch (_mv_1411.tag) {
+                        __auto_type _mv_1411 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1411.has_value) {
+                            __auto_type head = _mv_1411.value;
+                            __auto_type _mv_1412 = (*head);
+                            switch (_mv_1412.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1411.data.sym;
+                                    __auto_type sym = _mv_1412.data.sym;
                                     {
                                         __auto_type kind = sym.name;
                                         if (string_eq(kind, SLOP_STR("Ptr"))) {
                                             return SLOP_STR("");
                                         } else if (string_eq(kind, SLOP_STR("Option"))) {
-                                            if (((int64_t)((items).len)) >= 2) {
-                                                __auto_type _mv_1412 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1412.has_value) {
-                                                    __auto_type inner = _mv_1412.value;
-                                                    {
-                                                        __auto_type inner_str = transpiler_get_field_type_string(ctx, inner);
-                                                        if (string_eq(inner_str, SLOP_STR(""))) {
-                                                            return SLOP_STR("");
-                                                        } else {
-                                                            return context_ctx_str(ctx, SLOP_STR("slop_option_"), ctype_type_to_identifier(arena, inner_str));
-                                                        }
-                                                    }
-                                                } else if (!_mv_1412.has_value) {
-                                                    return SLOP_STR("");
-                                                }
-                                            } else {
-                                                return SLOP_STR("");
-                                            }
-                                        } else if (string_eq(kind, SLOP_STR("List"))) {
                                             if (((int64_t)((items).len)) >= 2) {
                                                 __auto_type _mv_1413 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                                 if (_mv_1413.has_value) {
@@ -5745,10 +5746,29 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                                                         if (string_eq(inner_str, SLOP_STR(""))) {
                                                             return SLOP_STR("");
                                                         } else {
-                                                            return context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, inner_str));
+                                                            return context_ctx_str(ctx, SLOP_STR("slop_option_"), ctype_type_to_identifier(arena, inner_str));
                                                         }
                                                     }
                                                 } else if (!_mv_1413.has_value) {
+                                                    return SLOP_STR("");
+                                                }
+                                            } else {
+                                                return SLOP_STR("");
+                                            }
+                                        } else if (string_eq(kind, SLOP_STR("List"))) {
+                                            if (((int64_t)((items).len)) >= 2) {
+                                                __auto_type _mv_1414 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1414.has_value) {
+                                                    __auto_type inner = _mv_1414.value;
+                                                    {
+                                                        __auto_type inner_str = transpiler_get_field_type_string(ctx, inner);
+                                                        if (string_eq(inner_str, SLOP_STR(""))) {
+                                                            return SLOP_STR("");
+                                                        } else {
+                                                            return context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, inner_str));
+                                                        }
+                                                    }
+                                                } else if (!_mv_1414.has_value) {
                                                     return SLOP_STR("");
                                                 }
                                             } else {
@@ -5763,7 +5783,7 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                                     return SLOP_STR("");
                                 }
                             }
-                        } else if (!_mv_1410.has_value) {
+                        } else if (!_mv_1411.has_value) {
                             return SLOP_STR("");
                         }
                     }
@@ -5791,31 +5811,31 @@ void transpiler_emit_option_list_for_type(context_TranspileContext* ctx, types_S
 slop_string transpiler_get_type_c_name(context_TranspileContext* ctx, types_SExpr* type_def) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
-    __auto_type _mv_1414 = (*type_def);
-    switch (_mv_1414.tag) {
+    __auto_type _mv_1415 = (*type_def);
+    switch (_mv_1415.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1414.data.lst;
+            __auto_type lst = _mv_1415.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return SLOP_STR("");
                 } else {
-                    __auto_type _mv_1415 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1415.has_value) {
-                        __auto_type name_expr = _mv_1415.value;
-                        __auto_type _mv_1416 = (*name_expr);
-                        switch (_mv_1416.tag) {
+                    __auto_type _mv_1416 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1416.has_value) {
+                        __auto_type name_expr = _mv_1416.value;
+                        __auto_type _mv_1417 = (*name_expr);
+                        switch (_mv_1417.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1416.data.sym;
+                                __auto_type sym = _mv_1417.data.sym;
                                 {
                                     __auto_type name = sym.name;
-                                    __auto_type _mv_1417 = context_ctx_lookup_type(ctx, name);
-                                    if (_mv_1417.has_value) {
-                                        __auto_type entry = _mv_1417.value;
+                                    __auto_type _mv_1418 = context_ctx_lookup_type(ctx, name);
+                                    if (_mv_1418.has_value) {
+                                        __auto_type entry = _mv_1418.value;
                                         return entry.c_name;
-                                    } else if (!_mv_1417.has_value) {
+                                    } else if (!_mv_1418.has_value) {
                                         return SLOP_STR("");
                                     }
                                 }
@@ -5824,7 +5844,7 @@ slop_string transpiler_get_type_c_name(context_TranspileContext* ctx, types_SExp
                                 return SLOP_STR("");
                             }
                         }
-                    } else if (!_mv_1415.has_value) {
+                    } else if (!_mv_1416.has_value) {
                         return SLOP_STR("");
                     }
                 }
@@ -5843,13 +5863,13 @@ void transpiler_emit_option_for_inner_type(context_TranspileContext* ctx, slop_s
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1418 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1418.has_value) {
-                __auto_type ot = _mv_1418.value;
+            __auto_type _mv_1419 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1419.has_value) {
+                __auto_type ot = _mv_1419.value;
                 if (string_eq(ot.inner_type, inner_c_name) && !(transpiler_is_pointer_elem_type(ot.inner_type))) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1418.has_value) {
+            } else if (!_mv_1419.has_value) {
             }
             i = (i + 1);
         }
@@ -5863,14 +5883,14 @@ void transpiler_emit_list_for_elem_type(context_TranspileContext* ctx, slop_stri
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1419 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1419.has_value) {
-                __auto_type lt = _mv_1419.value;
+            __auto_type _mv_1420 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1420.has_value) {
+                __auto_type lt = _mv_1420.value;
                 if (string_eq(lt.elem_type, elem_c_name) && !(transpiler_is_pointer_elem_type(lt.elem_type))) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                     transpiler_emit_option_for_inner_type(ctx, lt.c_name);
                 }
-            } else if (!_mv_1419.has_value) {
+            } else if (!_mv_1420.has_value) {
             }
             i = (i + 1);
         }
@@ -5888,13 +5908,13 @@ uint8_t transpiler_struct_uses_value_list_or_option(context_TranspileContext* ct
             __auto_type len = ((int64_t)((list_types).len));
             int64_t i = 0;
             while ((i < len) && !(found)) {
-                __auto_type _mv_1420 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1420.has_value) {
-                    __auto_type lt = _mv_1420.value;
+                __auto_type _mv_1421 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1421.has_value) {
+                    __auto_type lt = _mv_1421.value;
                     if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_struct_uses_list_type(ctx, type_def, lt.c_name)) {
                         found = 1;
                     }
-                } else if (!_mv_1420.has_value) {
+                } else if (!_mv_1421.has_value) {
                 }
                 i = (i + 1);
             }
@@ -5904,13 +5924,13 @@ uint8_t transpiler_struct_uses_value_list_or_option(context_TranspileContext* ct
                 __auto_type len2 = ((int64_t)((option_types).len));
                 int64_t j = 0;
                 while ((j < len2) && !(found)) {
-                    __auto_type _mv_1421 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)j; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1421.has_value) {
-                        __auto_type ot = _mv_1421.value;
+                    __auto_type _mv_1422 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)j; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1422.has_value) {
+                        __auto_type ot = _mv_1422.value;
                         if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_struct_uses_option_type(ctx, type_def, ot.c_name)) {
                             found = 1;
                         }
-                    } else if (!_mv_1421.has_value) {
+                    } else if (!_mv_1422.has_value) {
                     }
                     j = (j + 1);
                 }
@@ -5928,13 +5948,13 @@ void transpiler_emit_struct_dependent_list_types(context_TranspileContext* ctx, 
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1422 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1422.has_value) {
-                __auto_type lt = _mv_1422.value;
+            __auto_type _mv_1423 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1423.has_value) {
+                __auto_type lt = _mv_1423.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_struct_uses_list_type(ctx, type_def, lt.c_name)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1422.has_value) {
+            } else if (!_mv_1423.has_value) {
             }
             i = (i + 1);
         }
@@ -5949,14 +5969,14 @@ void transpiler_emit_struct_dependent_option_types(context_TranspileContext* ctx
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1423 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1423.has_value) {
-                __auto_type ot = _mv_1423.value;
+            __auto_type _mv_1424 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1424.has_value) {
+                __auto_type ot = _mv_1424.value;
                 if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_struct_uses_option_type(ctx, type_def, ot.c_name)) {
                     transpiler_emit_list_type_if_needed(ctx, ot.inner_type);
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1423.has_value) {
+            } else if (!_mv_1424.has_value) {
             }
             i = (i + 1);
         }
@@ -5971,15 +5991,15 @@ void transpiler_emit_struct_dependent_list_types_safe(context_TranspileContext* 
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1424 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1424.has_value) {
-                __auto_type lt = _mv_1424.value;
+            __auto_type _mv_1425 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1425.has_value) {
+                __auto_type lt = _mv_1425.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_struct_uses_list_type(ctx, type_def, lt.c_name)) {
                     if (transpiler_is_type_emitted_or_primitive(ctx, lt.elem_type)) {
                         transpiler_emit_single_list_type_header(ctx, lt);
                     }
                 }
-            } else if (!_mv_1424.has_value) {
+            } else if (!_mv_1425.has_value) {
             }
             i = (i + 1);
         }
@@ -5994,16 +6014,16 @@ void transpiler_emit_struct_dependent_option_types_safe(context_TranspileContext
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1425 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1425.has_value) {
-                __auto_type ot = _mv_1425.value;
+            __auto_type _mv_1426 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1426.has_value) {
+                __auto_type ot = _mv_1426.value;
                 if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_struct_uses_option_type(ctx, type_def, ot.c_name)) {
                     if (transpiler_is_type_emitted_or_primitive(ctx, ot.inner_type)) {
                         transpiler_emit_list_type_if_needed_safe(ctx, ot.inner_type);
                         transpiler_emit_single_option_type_header(ctx, ot);
                     }
                 }
-            } else if (!_mv_1425.has_value) {
+            } else if (!_mv_1426.has_value) {
             }
             i = (i + 1);
         }
@@ -6028,9 +6048,9 @@ uint8_t transpiler_is_imported_type(context_TranspileContext* ctx, slop_string t
     if (strlib_starts_with(type_name, SLOP_STR("slop_list_")) || strlib_starts_with(type_name, SLOP_STR("slop_option_"))) {
         return 0;
     } else {
-        __auto_type _mv_1426 = context_ctx_get_module(ctx);
-        if (_mv_1426.has_value) {
-            __auto_type current_mod = _mv_1426.value;
+        __auto_type _mv_1427 = context_ctx_get_module(ctx);
+        if (_mv_1427.has_value) {
+            __auto_type current_mod = _mv_1427.value;
             {
                 __auto_type arena = (*ctx).arena;
                 __auto_type c_mod = ctype_to_c_name(arena, current_mod);
@@ -6044,7 +6064,7 @@ uint8_t transpiler_is_imported_type(context_TranspileContext* ctx, slop_string t
                     }
                 }
             }
-        } else if (!_mv_1426.has_value) {
+        } else if (!_mv_1427.has_value) {
             return 0;
         }
     }
@@ -6075,13 +6095,13 @@ void transpiler_emit_list_type_if_needed_safe(context_TranspileContext* ctx, slo
             __auto_type len = ((int64_t)((list_types).len));
             int64_t i = 0;
             while (i < len) {
-                __auto_type _mv_1427 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1427.has_value) {
-                    __auto_type lt = _mv_1427.value;
+                __auto_type _mv_1428 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1428.has_value) {
+                    __auto_type lt = _mv_1428.value;
                     if (string_eq(lt.c_name, inner_type) && transpiler_is_type_emitted_or_primitive(ctx, lt.elem_type)) {
                         transpiler_emit_single_list_type_header(ctx, lt);
                     }
-                } else if (!_mv_1427.has_value) {
+                } else if (!_mv_1428.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6097,13 +6117,13 @@ void transpiler_emit_list_type_if_needed(context_TranspileContext* ctx, slop_str
             __auto_type len = ((int64_t)((list_types).len));
             int64_t i = 0;
             while (i < len) {
-                __auto_type _mv_1428 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1428.has_value) {
-                    __auto_type lt = _mv_1428.value;
+                __auto_type _mv_1429 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1429.has_value) {
+                    __auto_type lt = _mv_1429.value;
                     if (string_eq(lt.c_name, inner_type)) {
                         transpiler_emit_single_list_type_header(ctx, lt);
                     }
-                } else if (!_mv_1428.has_value) {
+                } else if (!_mv_1429.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6116,21 +6136,21 @@ uint8_t transpiler_struct_uses_list_type(context_TranspileContext* ctx, types_SE
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1429 = (*type_def);
-        switch (_mv_1429.tag) {
+        __auto_type _mv_1430 = (*type_def);
+        switch (_mv_1430.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1429.data.lst;
+                __auto_type lst = _mv_1430.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 3) {
                         return 0;
                     } else {
-                        __auto_type _mv_1430 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1430.has_value) {
-                            __auto_type body_expr = _mv_1430.value;
+                        __auto_type _mv_1431 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1431.has_value) {
+                            __auto_type body_expr = _mv_1431.value;
                             return transpiler_type_body_uses_typename(ctx, body_expr, list_type_name);
-                        } else if (!_mv_1430.has_value) {
+                        } else if (!_mv_1431.has_value) {
                             return 0;
                         }
                     }
@@ -6154,24 +6174,24 @@ uint8_t transpiler_type_body_uses_typename(context_TranspileContext* ctx, types_
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1431 = (*body_expr);
-        switch (_mv_1431.tag) {
+        __auto_type _mv_1432 = (*body_expr);
+        switch (_mv_1432.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1431.data.lst;
+                __auto_type lst = _mv_1432.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type found = 0;
                     __auto_type i = 1;
                     while ((i < len) && !(found)) {
-                        __auto_type _mv_1432 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1432.has_value) {
-                            __auto_type field_expr = _mv_1432.value;
+                        __auto_type _mv_1433 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1433.has_value) {
+                            __auto_type field_expr = _mv_1433.value;
                             if (transpiler_field_uses_typename(ctx, field_expr, typename)) {
                                 found = 1;
                             }
-                        } else if (!_mv_1432.has_value) {
+                        } else if (!_mv_1433.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -6188,24 +6208,24 @@ uint8_t transpiler_type_body_uses_typename(context_TranspileContext* ctx, types_
 uint8_t transpiler_field_uses_typename(context_TranspileContext* ctx, types_SExpr* field_expr, slop_string typename) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((field_expr != NULL)), "(!= field-expr nil)");
-    __auto_type _mv_1433 = (*field_expr);
-    switch (_mv_1433.tag) {
+    __auto_type _mv_1434 = (*field_expr);
+    switch (_mv_1434.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1433.data.lst;
+            __auto_type lst = _mv_1434.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return 0;
                 } else {
-                    __auto_type _mv_1434 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1434.has_value) {
-                        __auto_type type_expr = _mv_1434.value;
+                    __auto_type _mv_1435 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1435.has_value) {
+                        __auto_type type_expr = _mv_1435.value;
                         {
                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                             return string_eq(c_type, typename);
                         }
-                    } else if (!_mv_1434.has_value) {
+                    } else if (!_mv_1435.has_value) {
                         return 0;
                     }
                 }
@@ -6222,33 +6242,33 @@ void transpiler_emit_type_to_header(context_TranspileContext* ctx, types_SExpr* 
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1435 = (*type_def);
-        switch (_mv_1435.tag) {
+        __auto_type _mv_1436 = (*type_def);
+        switch (_mv_1436.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1435.data.lst;
+                __auto_type lst = _mv_1436.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 3) {
-                        __auto_type _mv_1436 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1436.has_value) {
-                            __auto_type name_expr = _mv_1436.value;
-                            __auto_type _mv_1437 = (*name_expr);
-                            switch (_mv_1437.tag) {
+                        __auto_type _mv_1437 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1437.has_value) {
+                            __auto_type name_expr = _mv_1437.value;
+                            __auto_type _mv_1438 = (*name_expr);
+                            switch (_mv_1438.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1437.data.sym;
+                                    __auto_type name_sym = _mv_1438.data.sym;
                                     {
                                         __auto_type type_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, type_name);
                                         __auto_type c_name = ((context_ctx_prefixing_enabled(ctx)) ? ({ __auto_type _mv = context_ctx_get_module(ctx); _mv.has_value ? ({ __auto_type mod_name = _mv.value; context_ctx_str(ctx, ctype_to_c_name(arena, mod_name), context_ctx_str(ctx, SLOP_STR("_"), base_name)); }) : (base_name); }) : base_name);
-                                        __auto_type _mv_1438 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1438.has_value) {
-                                            __auto_type body_expr = _mv_1438.value;
+                                        __auto_type _mv_1439 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1439.has_value) {
+                                            __auto_type body_expr = _mv_1439.value;
                                             transpiler_emit_type_body_to_header(ctx, type_name, c_name, body_expr);
                                             context_ctx_mark_type_emitted(ctx, c_name);
-                                        } else if (!_mv_1438.has_value) {
+                                        } else if (!_mv_1439.has_value) {
                                         }
                                     }
                                     break;
@@ -6257,7 +6277,7 @@ void transpiler_emit_type_to_header(context_TranspileContext* ctx, types_SExpr* 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1436.has_value) {
+                        } else if (!_mv_1437.has_value) {
                         }
                     }
                 }
@@ -6275,23 +6295,23 @@ void transpiler_emit_type_body_to_header(context_TranspileContext* ctx, slop_str
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1439 = (*body_expr);
-        switch (_mv_1439.tag) {
+        __auto_type _mv_1440 = (*body_expr);
+        switch (_mv_1440.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1439.data.lst;
+                __auto_type lst = _mv_1440.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 1) {
                     } else {
-                        __auto_type _mv_1440 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1440.has_value) {
-                            __auto_type kind_expr = _mv_1440.value;
-                            __auto_type _mv_1441 = (*kind_expr);
-                            switch (_mv_1441.tag) {
+                        __auto_type _mv_1441 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1441.has_value) {
+                            __auto_type kind_expr = _mv_1441.value;
+                            __auto_type _mv_1442 = (*kind_expr);
+                            switch (_mv_1442.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type kind_sym = _mv_1441.data.sym;
+                                    __auto_type kind_sym = _mv_1442.data.sym;
                                     {
                                         __auto_type kind = kind_sym.name;
                                         if (string_eq(kind, SLOP_STR("enum"))) {
@@ -6309,7 +6329,7 @@ void transpiler_emit_type_body_to_header(context_TranspileContext* ctx, slop_str
                                     break;
                                 }
                             }
-                        } else if (!_mv_1440.has_value) {
+                        } else if (!_mv_1441.has_value) {
                         }
                     }
                 }
@@ -6330,14 +6350,14 @@ void transpiler_emit_enum_to_header(context_TranspileContext* ctx, slop_string c
         int64_t i = 1;
         context_ctx_emit_header(ctx, SLOP_STR("typedef enum {"));
         while (i < len) {
-            __auto_type _mv_1442 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1442.has_value) {
-                __auto_type variant_expr = _mv_1442.value;
-                __auto_type _mv_1443 = (*variant_expr);
-                switch (_mv_1443.tag) {
+            __auto_type _mv_1443 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1443.has_value) {
+                __auto_type variant_expr = _mv_1443.value;
+                __auto_type _mv_1444 = (*variant_expr);
+                switch (_mv_1444.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type variant_sym = _mv_1443.data.sym;
+                        __auto_type variant_sym = _mv_1444.data.sym;
                         {
                             __auto_type variant_name = variant_sym.name;
                             __auto_type c_variant = context_ctx_str3(ctx, c_name, SLOP_STR("_"), ctype_to_c_name(arena, variant_name));
@@ -6354,7 +6374,7 @@ void transpiler_emit_enum_to_header(context_TranspileContext* ctx, slop_string c
                         break;
                     }
                 }
-            } else if (!_mv_1442.has_value) {
+            } else if (!_mv_1443.has_value) {
             }
             i = (i + 1);
         }
@@ -6372,11 +6392,11 @@ void transpiler_emit_struct_to_header(context_TranspileContext* ctx, slop_string
         int64_t i = 1;
         context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("struct "), c_name, SLOP_STR(" {")));
         while (i < len) {
-            __auto_type _mv_1444 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1444.has_value) {
-                __auto_type field_expr = _mv_1444.value;
+            __auto_type _mv_1445 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1445.has_value) {
+                __auto_type field_expr = _mv_1445.value;
                 transpiler_emit_field_to_header(ctx, raw_type_name, c_name, field_expr);
-            } else if (!_mv_1444.has_value) {
+            } else if (!_mv_1445.has_value) {
             }
             i = (i + 1);
         }
@@ -6391,28 +6411,28 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
     SLOP_PRE(((field_expr != NULL)), "(!= field-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1445 = (*field_expr);
-        switch (_mv_1445.tag) {
+        __auto_type _mv_1446 = (*field_expr);
+        switch (_mv_1446.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1445.data.lst;
+                __auto_type lst = _mv_1446.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_1446 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1446.has_value) {
-                            __auto_type name_expr = _mv_1446.value;
-                            __auto_type _mv_1447 = (*name_expr);
-                            switch (_mv_1447.tag) {
+                        __auto_type _mv_1447 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1447.has_value) {
+                            __auto_type name_expr = _mv_1447.value;
+                            __auto_type _mv_1448 = (*name_expr);
+                            switch (_mv_1448.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1447.data.sym;
+                                    __auto_type name_sym = _mv_1448.data.sym;
                                     {
                                         __auto_type field_name = name_sym.name;
                                         __auto_type c_field_name = ctype_to_c_name(arena, field_name);
-                                        __auto_type _mv_1448 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1448.has_value) {
-                                            __auto_type type_expr = _mv_1448.value;
+                                        __auto_type _mv_1449 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1449.has_value) {
+                                            __auto_type type_expr = _mv_1449.value;
                                             {
                                                 __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                 __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
@@ -6421,7 +6441,7 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
                                                 context_ctx_register_field_type(ctx, raw_type_name, field_name, c_type, slop_type_str, is_ptr);
                                                 context_ctx_register_field_type(ctx, c_type_name, field_name, c_type, slop_type_str, is_ptr);
                                             }
-                                        } else if (!_mv_1448.has_value) {
+                                        } else if (!_mv_1449.has_value) {
                                         }
                                     }
                                     break;
@@ -6430,7 +6450,7 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1446.has_value) {
+                        } else if (!_mv_1447.has_value) {
                         }
                     }
                 }
@@ -6445,31 +6465,31 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
 
 uint8_t transpiler_is_pointer_type_expr_header(types_SExpr* type_expr) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_1449 = (*type_expr);
-    switch (_mv_1449.tag) {
+    __auto_type _mv_1450 = (*type_expr);
+    switch (_mv_1450.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1449.data.lst;
+            __auto_type lst = _mv_1450.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1450 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1450.has_value) {
-                        __auto_type head = _mv_1450.value;
-                        __auto_type _mv_1451 = (*head);
-                        switch (_mv_1451.tag) {
+                    __auto_type _mv_1451 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1451.has_value) {
+                        __auto_type head = _mv_1451.value;
+                        __auto_type _mv_1452 = (*head);
+                        switch (_mv_1452.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1451.data.sym;
+                                __auto_type sym = _mv_1452.data.sym;
                                 return string_eq(sym.name, SLOP_STR("Ptr"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1450.has_value) {
+                    } else if (!_mv_1451.has_value) {
                         return 0;
                     }
                 }
@@ -6491,9 +6511,9 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
         {
             int64_t i = 1;
             while (i < len) {
-                __auto_type _mv_1452 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1452.has_value) {
-                    __auto_type variant_expr = _mv_1452.value;
+                __auto_type _mv_1453 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1453.has_value) {
+                    __auto_type variant_expr = _mv_1453.value;
                     {
                         __auto_type variant_name = transpiler_get_variant_name(variant_expr);
                         __auto_type c_variant = context_ctx_str3(ctx, c_name, SLOP_STR("_"), ctype_to_c_name(arena, variant_name));
@@ -6504,7 +6524,7 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
                             context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("    "), c_variant, SLOP_STR(",")));
                         }
                     }
-                } else if (!_mv_1452.has_value) {
+                } else if (!_mv_1453.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6517,11 +6537,11 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
         {
             int64_t i = 1;
             while (i < len) {
-                __auto_type _mv_1453 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1453.has_value) {
-                    __auto_type variant_expr = _mv_1453.value;
+                __auto_type _mv_1454 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1454.has_value) {
+                    __auto_type variant_expr = _mv_1454.value;
                     transpiler_emit_union_variant_to_header(ctx, variant_expr);
-                } else if (!_mv_1453.has_value) {
+                } else if (!_mv_1454.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6535,36 +6555,36 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
 
 slop_string transpiler_get_variant_name(types_SExpr* variant_expr) {
     SLOP_PRE(((variant_expr != NULL)), "(!= variant-expr nil)");
-    __auto_type _mv_1454 = (*variant_expr);
-    switch (_mv_1454.tag) {
+    __auto_type _mv_1455 = (*variant_expr);
+    switch (_mv_1455.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1454.data.sym;
+            __auto_type sym = _mv_1455.data.sym;
             return sym.name;
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1454.data.lst;
+            __auto_type lst = _mv_1455.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return SLOP_STR("unknown");
                 } else {
-                    __auto_type _mv_1455 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1455.has_value) {
-                        __auto_type name_expr = _mv_1455.value;
-                        __auto_type _mv_1456 = (*name_expr);
-                        switch (_mv_1456.tag) {
+                    __auto_type _mv_1456 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1456.has_value) {
+                        __auto_type name_expr = _mv_1456.value;
+                        __auto_type _mv_1457 = (*name_expr);
+                        switch (_mv_1457.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type name_sym = _mv_1456.data.sym;
+                                __auto_type name_sym = _mv_1457.data.sym;
                                 return name_sym.name;
                             }
                             default: {
                                 return SLOP_STR("unknown");
                             }
                         }
-                    } else if (!_mv_1455.has_value) {
+                    } else if (!_mv_1456.has_value) {
                         return SLOP_STR("unknown");
                     }
                 }
@@ -6581,35 +6601,35 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
     SLOP_PRE(((variant_expr != NULL)), "(!= variant-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1457 = (*variant_expr);
-        switch (_mv_1457.tag) {
+        __auto_type _mv_1458 = (*variant_expr);
+        switch (_mv_1458.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1457.data.sym;
+                __auto_type sym = _mv_1458.data.sym;
                 break;
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1457.data.lst;
+                __auto_type lst = _mv_1458.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type num_items = ((int64_t)((items).len));
                     if (num_items >= 2) {
-                        __auto_type _mv_1458 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1458.has_value) {
-                            __auto_type name_expr = _mv_1458.value;
-                            __auto_type _mv_1459 = (*name_expr);
-                            switch (_mv_1459.tag) {
+                        __auto_type _mv_1459 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1459.has_value) {
+                            __auto_type name_expr = _mv_1459.value;
+                            __auto_type _mv_1460 = (*name_expr);
+                            switch (_mv_1460.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1459.data.sym;
+                                    __auto_type name_sym = _mv_1460.data.sym;
                                     {
                                         __auto_type variant_name = name_sym.name;
                                         __auto_type c_field = ctype_to_c_name(arena, variant_name);
                                         if (num_items == 2) {
-                                            __auto_type _mv_1460 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1460.has_value) {
-                                                __auto_type type_expr = _mv_1460.value;
+                                            __auto_type _mv_1461 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1461.has_value) {
+                                                __auto_type type_expr = _mv_1461.value;
                                                 {
                                                     __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                     {
@@ -6617,14 +6637,14 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
                                                         context_ctx_emit_header(ctx, context_ctx_str4(ctx, SLOP_STR("        "), actual_type, SLOP_STR(" "), context_ctx_str(ctx, c_field, SLOP_STR(";"))));
                                                     }
                                                 }
-                                            } else if (!_mv_1460.has_value) {
+                                            } else if (!_mv_1461.has_value) {
                                             }
                                         } else if (num_items >= 3) {
                                             context_ctx_emit_header(ctx, SLOP_STR("        struct {"));
                                             for (int64_t fi = 1; fi < num_items; fi++) {
-                                                __auto_type _mv_1461 = ({ __auto_type _lst = items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1461.has_value) {
-                                                    __auto_type type_expr = _mv_1461.value;
+                                                __auto_type _mv_1462 = ({ __auto_type _lst = items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1462.has_value) {
+                                                    __auto_type type_expr = _mv_1462.value;
                                                     {
                                                         __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                         {
@@ -6633,7 +6653,7 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
                                                             context_ctx_emit_header(ctx, context_ctx_str5(ctx, SLOP_STR("            "), actual_type, SLOP_STR(" "), field_name, SLOP_STR(";")));
                                                         }
                                                     }
-                                                } else if (!_mv_1461.has_value) {
+                                                } else if (!_mv_1462.has_value) {
                                                 }
                                             }
                                             context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("        } "), c_field, SLOP_STR(";")));
@@ -6646,7 +6666,7 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
                                     break;
                                 }
                             }
-                        } else if (!_mv_1458.has_value) {
+                        } else if (!_mv_1459.has_value) {
                         }
                     }
                 }
@@ -6666,9 +6686,9 @@ void transpiler_emit_module_consts(context_TranspileContext* ctx, slop_list_type
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1462 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1462.has_value) {
-                __auto_type item = _mv_1462.value;
+            __auto_type _mv_1463 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1463.has_value) {
+                __auto_type item = _mv_1463.value;
                 if (transpiler_is_const_def(item)) {
                     {
                         __auto_type const_name = transpiler_get_const_name(item);
@@ -6677,7 +6697,7 @@ void transpiler_emit_module_consts(context_TranspileContext* ctx, slop_list_type
                     }
                     emitted_any = 1;
                 }
-            } else if (!_mv_1462.has_value) {
+            } else if (!_mv_1463.has_value) {
             }
             i = (i + 1);
         }
@@ -6689,31 +6709,31 @@ void transpiler_emit_module_consts(context_TranspileContext* ctx, slop_list_type
 
 slop_string transpiler_get_const_name(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1463 = (*item);
-    switch (_mv_1463.tag) {
+    __auto_type _mv_1464 = (*item);
+    switch (_mv_1464.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1463.data.lst;
+            __auto_type lst = _mv_1464.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return SLOP_STR("");
                 } else {
-                    __auto_type _mv_1464 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1464.has_value) {
-                        __auto_type name_expr = _mv_1464.value;
-                        __auto_type _mv_1465 = (*name_expr);
-                        switch (_mv_1465.tag) {
+                    __auto_type _mv_1465 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1465.has_value) {
+                        __auto_type name_expr = _mv_1465.value;
+                        __auto_type _mv_1466 = (*name_expr);
+                        switch (_mv_1466.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1465.data.sym;
+                                __auto_type sym = _mv_1466.data.sym;
                                 return sym.name;
                             }
                             default: {
                                 return SLOP_STR("");
                             }
                         }
-                    } else if (!_mv_1464.has_value) {
+                    } else if (!_mv_1465.has_value) {
                         return SLOP_STR("");
                     }
                 }
@@ -6732,15 +6752,15 @@ void transpiler_emit_module_consts_header(context_TranspileContext* ctx, slop_li
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1466 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1466.has_value) {
-                __auto_type item = _mv_1466.value;
+            __auto_type _mv_1467 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1467.has_value) {
+                __auto_type item = _mv_1467.value;
                 if (transpiler_is_const_def(item)) {
                     if (transpiler_emit_const_header_if_exported(ctx, item, exports)) {
                         emitted_any = 1;
                     }
                 }
-            } else if (!_mv_1466.has_value) {
+            } else if (!_mv_1467.has_value) {
             }
             i = (i + 1);
         }
@@ -6753,35 +6773,35 @@ void transpiler_emit_module_consts_header(context_TranspileContext* ctx, slop_li
 uint8_t transpiler_emit_const_header_if_exported(context_TranspileContext* ctx, types_SExpr* item, slop_list_string exports) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1467 = (*item);
-    switch (_mv_1467.tag) {
+    __auto_type _mv_1468 = (*item);
+    switch (_mv_1468.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1467.data.lst;
+            __auto_type lst = _mv_1468.data.lst;
             {
                 __auto_type const_items = lst.items;
                 if (((int64_t)((const_items).len)) < 4) {
                     return 0;
                 } else {
-                    __auto_type _mv_1468 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1468.has_value) {
-                        __auto_type name_expr = _mv_1468.value;
-                        __auto_type _mv_1469 = (*name_expr);
-                        switch (_mv_1469.tag) {
+                    __auto_type _mv_1469 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1469.has_value) {
+                        __auto_type name_expr = _mv_1469.value;
+                        __auto_type _mv_1470 = (*name_expr);
+                        switch (_mv_1470.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type name_sym = _mv_1469.data.sym;
+                                __auto_type name_sym = _mv_1470.data.sym;
                                 {
                                     __auto_type raw_name = name_sym.name;
                                     if (!(transpiler_list_contains_str(exports, raw_name))) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1470 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1470.has_value) {
-                                            __auto_type type_expr = _mv_1470.value;
+                                        __auto_type _mv_1471 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1471.has_value) {
+                                            __auto_type type_expr = _mv_1471.value;
                                             transpiler_emit_const_header_decl(ctx, raw_name, type_expr, ({ __auto_type _mv = ({ __auto_type _lst = const_items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type v = _mv.value; v; }) : (NULL); }));
                                             return 1;
-                                        } else if (!_mv_1470.has_value) {
+                                        } else if (!_mv_1471.has_value) {
                                             return 0;
                                         }
                                     }
@@ -6791,7 +6811,7 @@ uint8_t transpiler_emit_const_header_if_exported(context_TranspileContext* ctx, 
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1468.has_value) {
+                    } else if (!_mv_1469.has_value) {
                         return 0;
                     }
                 }
@@ -6841,13 +6861,13 @@ void transpiler_emit_module_functions(context_TranspileContext* ctx, slop_list_t
         int64_t i = start;
         context_ctx_start_function_buffer(ctx);
         while (i < len) {
-            __auto_type _mv_1471 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1471.has_value) {
-                __auto_type item = _mv_1471.value;
+            __auto_type _mv_1472 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1472.has_value) {
+                __auto_type item = _mv_1472.value;
                 if (transpiler_is_fn_def(item)) {
                     defn_transpile_function(ctx, item);
                 }
-            } else if (!_mv_1471.has_value) {
+            } else if (!_mv_1472.has_value) {
             }
             i = (i + 1);
         }
@@ -6865,12 +6885,12 @@ void transpiler_emit_all_lambdas(context_TranspileContext* ctx) {
         int64_t i = 0;
         if (count > 0) {
             while (i < count) {
-                __auto_type _mv_1472 = ({ __auto_type _lst = lambdas; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1472.has_value) {
-                    __auto_type lambda_code = _mv_1472.value;
+                __auto_type _mv_1473 = ({ __auto_type _lst = lambdas; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1473.has_value) {
+                    __auto_type lambda_code = _mv_1473.value;
                     context_ctx_emit(ctx, lambda_code);
                     context_ctx_emit(ctx, SLOP_STR(""));
-                } else if (!_mv_1472.has_value) {
+                } else if (!_mv_1473.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6888,11 +6908,11 @@ slop_string transpiler_generate_c_output(context_TranspileContext* ctx) {
         __auto_type result = SLOP_STR("");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1473 = ({ __auto_type _lst = output_lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1473.has_value) {
-                __auto_type line = _mv_1473.value;
+            __auto_type _mv_1474 = ({ __auto_type _lst = output_lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1474.has_value) {
+                __auto_type line = _mv_1474.value;
                 result = context_ctx_str3(ctx, result, line, SLOP_STR("\n"));
-            } else if (!_mv_1473.has_value) {
+            } else if (!_mv_1474.has_value) {
             }
             i = (i + 1);
         }
@@ -6906,11 +6926,11 @@ void transpiler_transpile_file(context_TranspileContext* ctx, slop_list_types_SE
         __auto_type len = ((int64_t)((exprs).len));
         int64_t i = 0;
         if ((len > 0) && transpiler_is_module_expr(exprs)) {
-            __auto_type _mv_1474 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1474.has_value) {
-                __auto_type module_expr = _mv_1474.value;
+            __auto_type _mv_1475 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1475.has_value) {
+                __auto_type module_expr = _mv_1475.value;
                 transpiler_transpile_module(ctx, module_expr);
-            } else if (!_mv_1474.has_value) {
+            } else if (!_mv_1475.has_value) {
             }
         } else {
             emit_emit_standard_includes(ctx);
@@ -6926,34 +6946,34 @@ uint8_t transpiler_is_module_expr(slop_list_types_SExpr_ptr exprs) {
     if (((int64_t)((exprs).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_1475 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1475.has_value) {
-            __auto_type first = _mv_1475.value;
-            __auto_type _mv_1476 = (*first);
-            switch (_mv_1476.tag) {
+        __auto_type _mv_1476 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1476.has_value) {
+            __auto_type first = _mv_1476.value;
+            __auto_type _mv_1477 = (*first);
+            switch (_mv_1477.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type lst = _mv_1476.data.lst;
+                    __auto_type lst = _mv_1477.data.lst;
                     {
                         __auto_type items = lst.items;
                         if (((int64_t)((items).len)) < 1) {
                             return 0;
                         } else {
-                            __auto_type _mv_1477 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1477.has_value) {
-                                __auto_type head = _mv_1477.value;
-                                __auto_type _mv_1478 = (*head);
-                                switch (_mv_1478.tag) {
+                            __auto_type _mv_1478 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1478.has_value) {
+                                __auto_type head = _mv_1478.value;
+                                __auto_type _mv_1479 = (*head);
+                                switch (_mv_1479.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1478.data.sym;
+                                        __auto_type sym = _mv_1479.data.sym;
                                         return string_eq(sym.name, SLOP_STR("module"));
                                     }
                                     default: {
                                         return 0;
                                     }
                                 }
-                            } else if (!_mv_1477.has_value) {
+                            } else if (!_mv_1478.has_value) {
                                 return 0;
                             }
                         }
@@ -6963,7 +6983,7 @@ uint8_t transpiler_is_module_expr(slop_list_types_SExpr_ptr exprs) {
                     return 0;
                 }
             }
-        } else if (!_mv_1475.has_value) {
+        } else if (!_mv_1476.has_value) {
             return 0;
         }
     }

--- a/bootstrap/transpiler/slop_transpiler.h
+++ b/bootstrap/transpiler/slop_transpiler.h
@@ -182,6 +182,7 @@ void transpiler_emit_primitive_option_types_header(context_TranspileContext* ctx
 uint8_t transpiler_is_primitive_or_runtime_type(slop_string type_name);
 void transpiler_emit_imported_list_types_header(context_TranspileContext* ctx);
 void transpiler_emit_imported_option_types_header(context_TranspileContext* ctx);
+void transpiler_emit_late_registered_list_types_header(context_TranspileContext* ctx);
 void transpiler_emit_late_registered_option_types_header(context_TranspileContext* ctx);
 void transpiler_emit_value_list_types_header(context_TranspileContext* ctx);
 void transpiler_emit_complex_value_list_types_header(context_TranspileContext* ctx);

--- a/bootstrap/transpiler/slop_transpiler_main.c
+++ b/bootstrap/transpiler/slop_transpiler_main.c
@@ -103,11 +103,11 @@ slop_string transpiler_main_lines_to_string(slop_arena* arena, slop_list_string 
                 int64_t total = 0;
                 int64_t i = 0;
                 while (i < len) {
-                    __auto_type _mv_1479 = ({ __auto_type _lst = lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1479.has_value) {
-                        __auto_type line = _mv_1479.value;
+                    __auto_type _mv_1480 = ({ __auto_type _lst = lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1480.has_value) {
+                        __auto_type line = _mv_1480.value;
                         total = (total + (((int64_t)(line.len)) + 1));
-                    } else if (!_mv_1479.has_value) {
+                    } else if (!_mv_1480.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -116,9 +116,9 @@ slop_string transpiler_main_lines_to_string(slop_arena* arena, slop_list_string 
                     int64_t pos = 0;
                     int64_t j = 0;
                     while (j < len) {
-                        __auto_type _mv_1480 = ({ __auto_type _lst = lines; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1480.has_value) {
-                            __auto_type line = _mv_1480.value;
+                        __auto_type _mv_1481 = ({ __auto_type _lst = lines; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1481.has_value) {
+                            __auto_type line = _mv_1481.value;
                             {
                                 __auto_type line_len = ((int64_t)(line.len));
                                 __auto_type line_data = line.data;
@@ -131,7 +131,7 @@ slop_string transpiler_main_lines_to_string(slop_arena* arena, slop_list_string 
                                 buf[pos] = 10;
                                 pos = (pos + 1);
                             }
-                        } else if (!_mv_1480.has_value) {
+                        } else if (!_mv_1481.has_value) {
                         }
                         j = (j + 1);
                     }
@@ -147,43 +147,43 @@ slop_string transpiler_main_extract_module_name(slop_list_types_SExpr_ptr exprs)
     if (((int64_t)((exprs).len)) < 1) {
         return SLOP_STR("unknown");
     } else {
-        __auto_type _mv_1481 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1481.has_value) {
-            __auto_type first_expr = _mv_1481.value;
-            __auto_type _mv_1482 = (*first_expr);
-            switch (_mv_1482.tag) {
+        __auto_type _mv_1482 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1482.has_value) {
+            __auto_type first_expr = _mv_1482.value;
+            __auto_type _mv_1483 = (*first_expr);
+            switch (_mv_1483.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type lst = _mv_1482.data.lst;
+                    __auto_type lst = _mv_1483.data.lst;
                     {
                         __auto_type items = lst.items;
                         if (((int64_t)((items).len)) < 2) {
                             return SLOP_STR("unknown");
                         } else {
-                            __auto_type _mv_1483 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1483.has_value) {
-                                __auto_type head = _mv_1483.value;
-                                __auto_type _mv_1484 = (*head);
-                                switch (_mv_1484.tag) {
+                            __auto_type _mv_1484 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1484.has_value) {
+                                __auto_type head = _mv_1484.value;
+                                __auto_type _mv_1485 = (*head);
+                                switch (_mv_1485.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1484.data.sym;
+                                        __auto_type sym = _mv_1485.data.sym;
                                         if (string_eq(sym.name, SLOP_STR("module"))) {
-                                            __auto_type _mv_1485 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1485.has_value) {
-                                                __auto_type name_expr = _mv_1485.value;
-                                                __auto_type _mv_1486 = (*name_expr);
-                                                switch (_mv_1486.tag) {
+                                            __auto_type _mv_1486 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1486.has_value) {
+                                                __auto_type name_expr = _mv_1486.value;
+                                                __auto_type _mv_1487 = (*name_expr);
+                                                switch (_mv_1487.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type name_sym = _mv_1486.data.sym;
+                                                        __auto_type name_sym = _mv_1487.data.sym;
                                                         return name_sym.name;
                                                     }
                                                     default: {
                                                         return SLOP_STR("unknown");
                                                     }
                                                 }
-                                            } else if (!_mv_1485.has_value) {
+                                            } else if (!_mv_1486.has_value) {
                                                 return SLOP_STR("unknown");
                                             }
                                         } else {
@@ -194,7 +194,7 @@ slop_string transpiler_main_extract_module_name(slop_list_types_SExpr_ptr exprs)
                                         return SLOP_STR("unknown");
                                     }
                                 }
-                            } else if (!_mv_1483.has_value) {
+                            } else if (!_mv_1484.has_value) {
                                 return SLOP_STR("unknown");
                             }
                         }
@@ -204,7 +204,7 @@ slop_string transpiler_main_extract_module_name(slop_list_types_SExpr_ptr exprs)
                     return SLOP_STR("unknown");
                 }
             }
-        } else if (!_mv_1481.has_value) {
+        } else if (!_mv_1482.has_value) {
             return SLOP_STR("unknown");
         }
     }
@@ -238,14 +238,14 @@ int main(int argc, char** _c_argv) {
                             __auto_type filename_ptr = ((uint8_t*)(filename));
                             __auto_type filename_str = (slop_string){.len = strlen(filename_ptr), .data = filename_ptr};
                             context_ctx_set_file(ctx, filename_str);
-                            __auto_type _mv_1487 = transpiler_main_read_file(arena, filename);
-                            if (_mv_1487.has_value) {
-                                __auto_type source = _mv_1487.value;
+                            __auto_type _mv_1488 = transpiler_main_read_file(arena, filename);
+                            if (_mv_1488.has_value) {
+                                __auto_type source = _mv_1488.value;
                                 {
                                     __auto_type result = transpiler_main_transpile_single_file_with_ctx(ctx, source, first);
                                     first = 0;
                                 }
-                            } else if (!_mv_1487.has_value) {
+                            } else if (!_mv_1488.has_value) {
                                 transpiler_main_print_str(((char*)(SLOP_STR("Error: Could not read file\n").data)));
                             }
                         }
@@ -266,9 +266,9 @@ int64_t transpiler_main_transpile_single_file_with_ctx(context_TranspileContext*
     {
         __auto_type arena = (*ctx).arena;
         __auto_type parse_result = parser_parse(arena, source);
-        __auto_type _mv_1488 = parse_result;
-        if (_mv_1488.is_ok) {
-            __auto_type exprs = _mv_1488.data.ok;
+        __auto_type _mv_1489 = parse_result;
+        if (_mv_1489.is_ok) {
+            __auto_type exprs = _mv_1489.data.ok;
             {
                 __auto_type mod_name = transpiler_main_extract_module_name(exprs);
                 context_ctx_reset_for_new_module(ctx, mod_name);
@@ -283,8 +283,8 @@ int64_t transpiler_main_transpile_single_file_with_ctx(context_TranspileContext*
                 transpiler_main_output_module_json(arena, ctx, mod_name, first);
                 return 0;
             }
-        } else if (!_mv_1488.is_ok) {
-            __auto_type err = _mv_1488.data.err;
+        } else if (!_mv_1489.is_ok) {
+            __auto_type err = _mv_1489.data.err;
             transpiler_main_print_str(((char*)(SLOP_STR("Parse error at line ").data)));
             transpiler_main_print_string(int_to_string(arena, err.line));
             transpiler_main_print_str(((char*)(SLOP_STR(", col ").data)));
@@ -300,9 +300,9 @@ int64_t transpiler_main_transpile_single_file_with_ctx(context_TranspileContext*
 int64_t transpiler_main_transpile_single_file(slop_arena* arena, slop_string source, uint8_t first) {
     {
         __auto_type parse_result = parser_parse(arena, source);
-        __auto_type _mv_1489 = parse_result;
-        if (_mv_1489.is_ok) {
-            __auto_type exprs = _mv_1489.data.ok;
+        __auto_type _mv_1490 = parse_result;
+        if (_mv_1490.is_ok) {
+            __auto_type exprs = _mv_1490.data.ok;
             {
                 __auto_type mod_name = transpiler_main_extract_module_name(exprs);
                 __auto_type ctx = context_context_new(arena);
@@ -319,8 +319,8 @@ int64_t transpiler_main_transpile_single_file(slop_arena* arena, slop_string sou
                 transpiler_main_output_module_json(arena, ctx, mod_name, first);
                 return 0;
             }
-        } else if (!_mv_1489.is_ok) {
-            __auto_type err = _mv_1489.data.err;
+        } else if (!_mv_1490.is_ok) {
+            __auto_type err = _mv_1490.data.err;
             transpiler_main_print_str(((char*)(SLOP_STR("Parse error at line ").data)));
             transpiler_main_print_string(int_to_string(arena, err.line));
             transpiler_main_print_str(((char*)(SLOP_STR(", col ").data)));

--- a/lib/compiler/common/ctype.slop
+++ b/lib/compiler/common/ctype.slop
@@ -9,6 +9,8 @@
   (export
     ;; Type conversion
     to-c-type to-c-name type-to-identifier sexpr-to-type-string
+    ;; Pointer-to-container unwrapping
+    unwrap-ptr-container-type
     ;; Builtin type lookup
     builtin-type-c is-builtin-type is-builtin-c-type
     ;; Type category predicates
@@ -252,6 +254,37 @@
       (when (string-eq result "double")
         (set! result "float"))
       result))
+
+  ;; ============================================================
+  ;; Pointer-to-container Unwrapping
+  ;; ============================================================
+
+  (fn unwrap-ptr-container-type ((arena Arena) (slop-type String))
+    (@intent "Strip one (Ptr ...) layer from a Map or Set SLOP type, leaving every other type untouched")
+    (@spec ((Arena String) -> String))
+    (@alloc arena)
+    (@post (<= (string-len $result) (string-len slop-type)))
+    (@example (arena "(Ptr (Map String Int))") -> "(Map String Int)")
+    (@example (arena "(Ptr (Set Int))") -> "(Set Int)")
+    (@example (arena "(Ptr (Map Term (Set Term)))") -> "(Map Term (Set Term))")
+    (@example (arena "(Map String Int)") -> "(Map String Int)")
+    (@example (arena "(Set Int)") -> "(Set Int)")
+    (@example (arena "(Ptr Node)") -> "(Ptr Node)")
+    (@example (arena "Int") -> "Int")
+    (@example (arena "") -> "")
+    ;; A (Ptr (Map K V)) / (Ptr (Set T)) is slop_map** and names exactly the same key
+    ;; and element types as the container it points at. The extractors that read those
+    ;; types match a literal "(Map " / "(Set " prefix, so without this they answer ""
+    ;; for the pointer form and every inference downstream silently degrades.
+    ;; Only Map and Set are unwrapped: for any other (Ptr T) the pointer is part of the
+    ;; value's own type, not an indirection to a container.
+    (if (or (starts-with slop-type "(Ptr (Map ")
+            (starts-with slop-type "(Ptr (Set "))
+      ;; Drop the leading "(Ptr " (5 chars) and its matching trailing ")" (1 char).
+      ;; Both guards above are 10 chars, so the length can never go negative.
+      (let ((inner-len (cast (Int 0 ..) (- (string-len slop-type) 6))))
+        (substring arena slop-type 5 inner-len))
+      slop-type))
 
   ;; ============================================================
   ;; Type Variable Detection

--- a/lib/compiler/transpiler/expr.slop
+++ b/lib/compiler/transpiler/expr.slop
@@ -24,6 +24,8 @@
     slop-value-type-to-c-type
     ;; Set/Map type detection
     is-set-type is-map-type
+    ;; Pointer-to-container operand handling
+    resolve-container-c deref-container-c
     ;; Pointer detection
     is-pointer-expr
     ;; set! helpers
@@ -35,6 +37,7 @@
                    ctx-str ctx-str3 ctx-str4 ctx-str5 VarEntry FuncEntry FuncParamType TypeEntry
                    to-c-type-prefixed ctx-push-scope ctx-pop-scope ctx-bind-var
                    ctx-lookup-field-type-by-index ctx-lookup-field-type ctx-lookup-field-slop-type ctx-register-option-type
+                   ctx-register-list-type
                    ctx-register-struct-key-type ctx-has-struct-key-type ctx-lookup-type-alias ctx-register-chan-type
                    ctx-add-error ctx-add-error-at ctx-strict-unknown-symbols
                    ctx-sexpr-line ctx-sexpr-col ctx-list-first-line ctx-list-first-col
@@ -43,7 +46,7 @@
                    ctx-add-warning ctx-warn-fallback ctx-has-trampoline ctx-add-trampoline ctx-skip-trampoline-generation
                    ctx-register-generic-instantiation ctx-has-generic-instantiation mangle-generic-fn-name
                    ends-with-star))
-  (import ctype (to-c-type to-c-name type-to-identifier sexpr-to-type-string
+  (import ctype (to-c-type to-c-name type-to-identifier unwrap-ptr-container-type sexpr-to-type-string
                  get-node-resolved-type resolved-type-to-c))
   (import strlib (replace starts-with ends-with substring char-at count-occurrences index-of contains))
 
@@ -1253,42 +1256,46 @@
   ;; Map Type Helpers (for map-get Option type inference)
   ;; ============================================================
 
-  (fn extract-map-value-from-slop-type ((arena Arena) (slop-type String))
+  (fn extract-map-value-from-slop-type ((arena Arena) (raw-slop-type String))
     (@intent "Extract value type from '(Map K V)' SLOP type string")
     (@spec ((Arena String) -> String))
     ;; Handle cases like "(Map String Int)" -> "Int" or "(Map Term (Set Term))" -> "(Set Term)"
     ;; Returns "" if cannot parse
-    (let ((len (string-len slop-type)))
-      (if (< len 10)
-        ""
-        ;; Check for "(Map " prefix (5 chars)
-        (if (not (starts-with slop-type "(Map "))
+    ;; A (Ptr (Map K V)) / (Ptr (Set T)) names the same value type as the
+    ;; container it points at, but the offsets below assume a bare prefix, so
+    ;; unwrap first rather than answering "" for every pointer-to-container.
+    (let ((slop-type (unwrap-ptr-container-type arena raw-slop-type)))
+      (let ((len (string-len slop-type)))
+        (if (< len 10)
           ""
-          ;; Find the space between K and V at nesting level 1
-          ;; This handles compound value types like (Set Term)
-          (let ((mut i 5)
-                (mut nesting 1)
-                (mut key-space 0)
-                (mut found-key false)
-                (end-idx (- len 1)))
-            ;; Skip past key type to find space at level 1
-            (while (and (< i end-idx) (not found-key))
-              (let ((c (char-at slop-type (cast (Int 0 ..) i))))
-                (cond
-                  ((== c 40) (set! nesting (+ nesting 1)))
-                  ((== c 41) (set! nesting (- nesting 1)))
-                  ((and (== c 32) (== nesting 1))
-                    (set! key-space i)
-                    (set! found-key true))
-                  (else (do))))
-              (set! i (+ i 1)))
-            (if (not found-key)
-              ""
-              (let ((value-start (+ key-space 1))
-                    (value-len (- end-idx value-start)))
-                (if (> value-len 0)
-                  (substring arena slop-type (cast (Int 0 ..) value-start) (cast (Int 0 ..) value-len))
-                  ""))))))))
+          ;; Check for "(Map " prefix (5 chars)
+          (if (not (starts-with slop-type "(Map "))
+            ""
+            ;; Find the space between K and V at nesting level 1
+            ;; This handles compound value types like (Set Term)
+            (let ((mut i 5)
+                  (mut nesting 1)
+                  (mut key-space 0)
+                  (mut found-key false)
+                  (end-idx (- len 1)))
+              ;; Skip past key type to find space at level 1
+              (while (and (< i end-idx) (not found-key))
+                (let ((c (char-at slop-type (cast (Int 0 ..) i))))
+                  (cond
+                    ((== c 40) (set! nesting (+ nesting 1)))
+                    ((== c 41) (set! nesting (- nesting 1)))
+                    ((and (== c 32) (== nesting 1))
+                      (set! key-space i)
+                      (set! found-key true))
+                    (else (do))))
+                (set! i (+ i 1)))
+              (if (not found-key)
+                ""
+                (let ((value-start (+ key-space 1))
+                      (value-len (- end-idx value-start)))
+                  (if (> value-len 0)
+                    (substring arena slop-type (cast (Int 0 ..) value-start) (cast (Int 0 ..) value-len))
+                    "")))))))))
 
   (fn slop-value-type-to-c-type ((ctx (Ptr TranspileContext)) (slop-type String))
     (@intent "Convert SLOP value type name to C type with proper module prefix")
@@ -1320,42 +1327,46 @@
       ((sym sym) (. sym name))
       (_ "")))
 
-  (fn extract-map-key-from-slop-type ((arena Arena) (slop-type String))
+  (fn extract-map-key-from-slop-type ((arena Arena) (raw-slop-type String))
     (@intent "Extract key type from '(Map K V)' SLOP type string")
     (@spec ((Arena String) -> String))
     ;; Handle cases like "(Map String Int)" -> "String"
     ;; Returns "" if cannot parse
-    (let ((len (string-len slop-type)))
-      (if (< len 10)
-        ""
-        ;; Check for "(Map " prefix (5 chars)
-        (if (not (starts-with slop-type "(Map "))
+    ;; A (Ptr (Map K V)) / (Ptr (Set T)) names the same key type as the
+    ;; container it points at, but the offsets below assume a bare prefix, so
+    ;; unwrap first rather than answering "" for every pointer-to-container.
+    (let ((slop-type (unwrap-ptr-container-type arena raw-slop-type)))
+      (let ((len (string-len slop-type)))
+        (if (< len 10)
           ""
-          ;; Find the space between K and V at nesting level 1
-          (let ((mut i 5)
-                (mut nesting 1)
-                (mut key-space 0)
-                (mut found-key false)
-                (end-idx (- len 1)))
-            ;; Skip past key type to find space at level 1
-            (while (and (< i end-idx) (not found-key))
-              (let ((c (char-at slop-type (cast (Int 0 ..) i))))
-                (cond
-                  ((== c 40) (set! nesting (+ nesting 1)))
-                  ((== c 41) (set! nesting (- nesting 1)))
-                  ((and (== c 32) (== nesting 1))
-                    (set! key-space i)
-                    (set! found-key true))
-                  (else (do))))
-              (set! i (+ i 1)))
-            (if (not found-key)
-              ""
-              ;; Key starts at position 5 and ends at key-space
-              (let ((key-start 5)
-                    (key-len (- key-space key-start)))
-                (if (> key-len 0)
-                  (substring arena slop-type (cast (Int 0 ..) key-start) (cast (Int 0 ..) key-len))
-                  ""))))))))
+          ;; Check for "(Map " prefix (5 chars)
+          (if (not (starts-with slop-type "(Map "))
+            ""
+            ;; Find the space between K and V at nesting level 1
+            (let ((mut i 5)
+                  (mut nesting 1)
+                  (mut key-space 0)
+                  (mut found-key false)
+                  (end-idx (- len 1)))
+              ;; Skip past key type to find space at level 1
+              (while (and (< i end-idx) (not found-key))
+                (let ((c (char-at slop-type (cast (Int 0 ..) i))))
+                  (cond
+                    ((== c 40) (set! nesting (+ nesting 1)))
+                    ((== c 41) (set! nesting (- nesting 1)))
+                    ((and (== c 32) (== nesting 1))
+                      (set! key-space i)
+                      (set! found-key true))
+                    (else (do))))
+                (set! i (+ i 1)))
+              (if (not found-key)
+                ""
+                ;; Key starts at position 5 and ends at key-space
+                (let ((key-start 5)
+                      (key-len (- key-space key-start)))
+                  (if (> key-len 0)
+                    (substring arena slop-type (cast (Int 0 ..) key-start) (cast (Int 0 ..) key-len))
+                    "")))))))))
 
   (fn resolve-type-alias ((ctx (Ptr TranspileContext)) (slop-type String))
     (@intent "Resolve a type alias to its underlying type")
@@ -1611,23 +1622,27 @@
     (or (starts-with slop-type "(Map ")
         (starts-with slop-type "(Ptr (Map ")))
 
-  (fn extract-set-elem-from-slop-type ((arena Arena) (slop-type String))
+  (fn extract-set-elem-from-slop-type ((arena Arena) (raw-slop-type String))
     (@intent "Extract element type from '(Set T)' SLOP type string")
     (@spec ((Arena String) -> String))
     ;; Handle cases like "(Set Int)" -> "Int" or "(Set Term)" -> "Term"
     ;; Returns "" if cannot parse
-    (let ((len (string-len slop-type)))
-      (if (< len 7)
-        ""
-        ;; Check for "(Set " prefix (5 chars)
-        (if (not (starts-with slop-type "(Set "))
+    ;; A (Ptr (Map K V)) / (Ptr (Set T)) names the same element type as the
+    ;; container it points at, but the offsets below assume a bare prefix, so
+    ;; unwrap first rather than answering "" for every pointer-to-container.
+    (let ((slop-type (unwrap-ptr-container-type arena raw-slop-type)))
+      (let ((len (string-len slop-type)))
+        (if (< len 7)
           ""
-          ;; Element type starts at position 5 and goes to the closing paren
-          (let ((elem-start 5)
-                (elem-len (- (- len 1) elem-start)))  ;; len - 1 to skip closing paren
-            (if (> elem-len 0)
-              (substring arena slop-type (cast (Int 0 ..) elem-start) (cast (Int 0 ..) elem-len))
-              ""))))))
+          ;; Check for "(Set " prefix (5 chars)
+          (if (not (starts-with slop-type "(Set "))
+            ""
+            ;; Element type starts at position 5 and goes to the closing paren
+            (let ((elem-start 5)
+                  (elem-len (- (- len 1) elem-start)))  ;; len - 1 to skip closing paren
+              (if (> elem-len 0)
+                (substring arena slop-type (cast (Int 0 ..) elem-start) (cast (Int 0 ..) elem-len))
+                "")))))))
 
   (fn infer-set-elem-c-type ((ctx (Ptr TranspileContext)) (set-expr (Ptr SExpr)))
     (@intent "Infer the C type of a set's element type from variable lookup")
@@ -3827,11 +3842,11 @@
             ;; List types -> need to generate list type name
             ((starts-with slop-type "(List ")
               (let ((inner (substring arena slop-type 6 (max 0 (- (cast Int (string-len slop-type)) 7)))))
-                (ctx-str ctx "slop_list_" (slop-type-to-c-type ctx inner))))
+                (ctx-str ctx "slop_list_" (type-to-identifier arena (slop-type-to-c-type ctx inner)))))
             ;; Option types
             ((starts-with slop-type "(Option ")
               (let ((inner (substring arena slop-type 8 (max 0 (- (cast Int (string-len slop-type)) 9)))))
-                (ctx-str ctx "slop_option_" (slop-type-to-c-type ctx inner))))
+                (ctx-str ctx "slop_option_" (type-to-identifier arena (slop-type-to-c-type ctx inner)))))
             ;; Chan types -> slop_chan_<inner>
             ((starts-with slop-type "(Chan ")
               (let ((inner (substring arena slop-type 6 (max 0 (- (cast Int (string-len slop-type)) 7)))))
@@ -5035,12 +5050,12 @@
   ;; ============================================================
 
   (fn is-ptr-to-ptr-map ((ctx (Ptr TranspileContext)) (expr (Ptr SExpr)))
-    (@intent "Check if expression is a pointer-to-pointer map (Ptr (Map ...)) -> slop_map**")
+    (@intent "Check if expression is a pointer to a Map or Set ((Ptr (Map ...)) / (Ptr (Set ...)) -> slop_map**)")
     (@spec (((Ptr TranspileContext) (Ptr SExpr)) -> Bool))
     (@pre {ctx != nil})
     (@pre {expr != nil})
-    ;; Check if expr is a symbol with type ending in **
     (match (deref expr)
+      ;; A plain variable: the var table already carries the C type.
       ((sym sym)
         (let ((name (. sym name)))
           (match (ctx-lookup-var ctx name)
@@ -5048,7 +5063,44 @@
               (let ((c-type (. entry c-type)))
                 (ends-with c-type "**")))
             ((none) false))))
-      (else false)))
+      ;; Field access, deref, a call returning a map... none of which the var table
+      ;; can answer, so fall back to the inferred SLOP type.
+      ;; This is strictly about expressions whose OWN type is (Ptr (Map/Set ...)).
+      ;; A plain (Map K V) field reached through a (Ptr Record) -- (. store items) --
+      ;; is already slop_map* and must not be dereferenced; only a field declared
+      ;; (Ptr (Map K V)) is slop_map**. tests/test_ptr_map_ops.slop pins both shapes
+      ;; so neither can be fixed by breaking the other.
+      (else
+        (let ((slop-type (resolve-type-alias ctx (infer-expr-slop-type ctx expr))))
+          (or (starts-with slop-type "(Ptr (Map ")
+              (starts-with slop-type "(Ptr (Set "))))))
+
+  (fn deref-container-c ((ctx (Ptr TranspileContext)) (container-c String) (slop-type String))
+    (@intent "Dereference an already-transpiled map/set operand when its SLOP type is a pointer to a container")
+    (@spec (((Ptr TranspileContext) String String) -> String))
+    (@pre {ctx != nil})
+    ;; Every runtime entry point -- slop_map_get, slop_map_put, slop_map_remove,
+    ;; slop_map_keys, slop_set_elements_raw -- takes a slop_map*, but (Ptr (Map K V))
+    ;; and (Ptr (Set T)) are slop_map**. Handing over the double pointer is merely a C
+    ;; warning, and slop build discards cc output; at the for-each sites it is not even
+    ;; a warning, because those cast explicitly. Either way the read is garbage.
+    ;; For callers holding the SExpr rather than a type string, see resolve-container-c.
+    (if (or (starts-with slop-type "(Ptr (Map ")
+            (starts-with slop-type "(Ptr (Set "))
+      (ctx-str3 ctx "(*" container-c ")")
+      container-c))
+
+  (fn resolve-container-c ((ctx (Ptr TranspileContext)) (container-expr (Ptr SExpr)))
+    (@intent "Transpile a map/set container operand, dereferencing it when it is a (Ptr (Map ...)) / (Ptr (Set ...))")
+    (@spec (((Ptr TranspileContext) (Ptr SExpr)) -> String))
+    (@pre {ctx != nil})
+    (@pre {container-expr != nil})
+    ;; The SExpr-shaped counterpart of deref-container-c. Every builtin that takes a
+    ;; map or set operand routes its container through here.
+    (let ((c (transpile-expr ctx container-expr)))
+      (if (is-ptr-to-ptr-map ctx container-expr)
+        (ctx-str3 ctx "(*" c ")")
+        c)))
 
   ;; ============================================================
   ;; Record-new, List Literal, and Map Operations
@@ -5520,13 +5572,11 @@
               ((some key-expr)
                 (match (list-get items 3)
                   ((some val-expr)
-                    (let ((map-c (transpile-expr ctx map-expr))
+                    (let ((map-c (resolve-container-c ctx map-expr))
                           (key-c (transpile-expr ctx key-expr))
                           (val-c (transpile-expr ctx val-expr))
                           ;; Wrap key as pointer for generic map API
                           (key-ptr (wrap-map-key-as-ptr ctx key-c key-expr map-expr))
-                          ;; Check if map is a pointer-to-pointer (Ptr Map -> slop_map**)
-                          (needs-deref (is-ptr-to-ptr-map ctx map-expr))
                           ;; Declare _val with the map's declared value type when that is
                           ;; provably safe, so sizeof(_val) matches what map-get and map
                           ;; for-each dereference. Falls back to "__auto_type".
@@ -5534,24 +5584,16 @@
                           ;; slop_arena_alloc and slop_map_put both take the arena in
                           ;; scope, which is not always the identifier "arena".
                           (arena-c (resolve-arena-c-name ctx "map-put" items)))
-                      ;; slop_map_put expects arena, slop_map* and key as const void*
-                      ;; Allocate value on arena so it persists beyond the statement
-                      ;; If we have slop_map**, dereference once
-                      (if needs-deref
-                        (let ((s1 (ctx-str4 ctx "({ " val-decl-type " _val = " val-c))
-                              (s2 (ctx-str ctx s1 (ctx-str5 ctx "; void* _vptr = slop_arena_alloc(" arena-c ", sizeof(_val)); memcpy(_vptr, &_val, sizeof(_val)); slop_map_put(" arena-c ", (*")))
-                              (s3 (ctx-str ctx s2 map-c))
-                              (s4 (ctx-str ctx s3 "), "))
-                              (s5 (ctx-str ctx s4 key-ptr))
-                              (s6 (ctx-str ctx s5 ", _vptr); })")))
-                          s6)
-                        (let ((s1 (ctx-str4 ctx "({ " val-decl-type " _val = " val-c))
-                              (s2 (ctx-str ctx s1 (ctx-str5 ctx "; void* _vptr = slop_arena_alloc(" arena-c ", sizeof(_val)); memcpy(_vptr, &_val, sizeof(_val)); slop_map_put(" arena-c ", ")))
-                              (s3 (ctx-str ctx s2 map-c))
-                              (s4 (ctx-str ctx s3 ", "))
-                              (s5 (ctx-str ctx s4 key-ptr))
-                              (s6 (ctx-str ctx s5 ", _vptr); })")))
-                          s6))))
+                      ;; slop_map_put expects arena, slop_map* and key as const void*.
+                      ;; Allocate value on arena so it persists beyond the statement.
+                      ;; map-c is already dereferenced when the map is a (Ptr (Map ...)).
+                      (let ((s1 (ctx-str4 ctx "({ " val-decl-type " _val = " val-c))
+                            (s2 (ctx-str ctx s1 (ctx-str5 ctx "; void* _vptr = slop_arena_alloc(" arena-c ", sizeof(_val)); memcpy(_vptr, &_val, sizeof(_val)); slop_map_put(" arena-c ", ")))
+                            (s3 (ctx-str ctx s2 map-c))
+                            (s4 (ctx-str ctx s3 ", "))
+                            (s5 (ctx-str ctx s4 key-ptr))
+                            (s6 (ctx-str ctx s5 ", _vptr); })")))
+                        s6)))
                   ((none)
                     (do
                       (ctx-add-error-at ctx "map-put: missing val" (ctx-list-first-line items) (ctx-list-first-col items))
@@ -5579,7 +5621,7 @@
           ((some map-expr)
             (match (list-get items 2)
               ((some key-expr)
-                (let ((map-c (transpile-expr ctx map-expr))
+                (let ((map-c (resolve-container-c ctx map-expr))
                       (key-c (transpile-expr ctx key-expr))
                       ;; Wrap key as pointer for generic map API
                       (key-ptr (wrap-map-key-as-ptr ctx key-c key-expr map-expr))
@@ -5631,7 +5673,7 @@
           ((some map-expr)
             (match (list-get items 2)
               ((some key-expr)
-                (let ((map-c (transpile-expr ctx map-expr))
+                (let ((map-c (resolve-container-c ctx map-expr))
                       (key-c (transpile-expr ctx key-expr))
                       ;; Wrap key as pointer for generic map API
                       (key-ptr (wrap-map-key-as-ptr ctx key-c key-expr map-expr)))
@@ -5659,17 +5701,14 @@
           ((some map-expr)
             (match (list-get items 2)
               ((some key-expr)
-                (let ((map-c (transpile-expr ctx map-expr))
+                (let ((map-c (resolve-container-c ctx map-expr))
                       (key-c (transpile-expr ctx key-expr))
                       ;; wrap-map-key-as-ptr tries the map key type first and only then
                       ;; the set element type, so passing the map expression is correct.
-                      (key-ptr (wrap-map-key-as-ptr ctx key-c key-expr map-expr))
-                      ;; (Ptr (Map K V)) is slop_map**; deref once, as map-put does.
-                      (needs-deref (is-ptr-to-ptr-map ctx map-expr)))
+                      (key-ptr (wrap-map-key-as-ptr ctx key-c key-expr map-expr)))
                   ;; slop_map_remove takes no arena, unlike map-put and map-keys.
-                  (if needs-deref
-                    (ctx-str ctx "slop_map_remove((*" (ctx-str ctx map-c (ctx-str ctx "), " (ctx-str ctx key-ptr ")"))))
-                    (ctx-str ctx "slop_map_remove(" (ctx-str ctx map-c (ctx-str ctx ", " (ctx-str ctx key-ptr ")")))))))
+                  ;; map-c is already dereferenced when the map is a (Ptr (Map ...)).
+                  (ctx-str ctx "slop_map_remove(" (ctx-str ctx map-c (ctx-str ctx ", " (ctx-str ctx key-ptr ")"))))))
               ((none)
                 (do
                   (ctx-add-error-at ctx "map-remove: missing key" (ctx-list-first-line items) (ctx-list-first-col items))
@@ -5691,31 +5730,46 @@
           "NULL")
         (match (list-get items 1)
           ((some map-expr)
-            (let ((map-c (transpile-expr ctx map-expr))
+            (let ((map-c (resolve-container-c ctx map-expr))
                   (key-c-type (infer-map-key-c-type ctx map-expr))
-                  ;; Debug: get variable name and slop-type
-                  (debug-var-name (get-var-name-from-expr map-expr))
-                  (debug-slop-type (match (ctx-lookup-var ctx debug-var-name)
-                                     ((some entry) (. entry slop-type))
-                                     ((none) "VAR_NOT_FOUND")))
                   ;; NB: the `arena` binding above is the compiler's own allocator.
                   ;; This is the arena in the *transpiled program's* scope.
                   (arena-c (resolve-arena-c-name ctx "map-keys" items)))
-              ;; Check if key type is string - use legacy slop_map_keys
-              (if (or (string-eq key-c-type "slop_string") (== (string-len key-c-type) 0))
-                ;; Generate: slop_map_keys(ARENA, MAP) with debug info
-                (ctx-str ctx "/* DEBUG: var=" (ctx-str ctx debug-var-name (ctx-str ctx " slop=" (ctx-str ctx debug-slop-type (ctx-str ctx " key=" (ctx-str ctx key-c-type (ctx-str ctx (ctx-str3 ctx " */ slop_map_keys(" arena-c ", ") (ctx-str ctx map-c ")"))))))))
+              (cond
+                ;; String keys: the runtime carries a dedicated slop_map_keys returning
+                ;; slop_list_string, so no typed list has to be generated at all.
+                ((string-eq key-c-type "slop_string")
+                  (ctx-str ctx (ctx-str3 ctx "slop_map_keys(" arena-c ", ") (ctx-str ctx map-c ")")))
+                ;; An uninferable key type used to fall through to the String path above,
+                ;; emitting a slop_string read for a map of some entirely other type.
+                ((== (string-len key-c-type) 0)
+                  (do
+                    (ctx-add-error-at ctx "map-keys: cannot infer key type" (ctx-list-first-line items) (ctx-list-first-col items))
+                    "NULL"))
                 ;; Generate typed list from raw elements:
                 ;; ({ slop_set_elements_result _r = slop_set_elements_raw(ARENA, MAP);
                 ;;    (slop_list_KeyType){.data = (KeyType*)_r.data, .len = _r.len, .cap = _r.cap}; })
-                (let ((list-type (ctx-str ctx "slop_list_" key-c-type)))
-                  (ctx-str ctx (ctx-str3 ctx "({ slop_set_elements_result _r = slop_set_elements_raw(" arena-c ", ")
-                    (ctx-str ctx map-c
-                      (ctx-str ctx "); ("
-                        (ctx-str ctx list-type
-                          (ctx-str ctx "){.data = ("
-                            (ctx-str ctx key-c-type
-                              (ctx-str ctx "*)_r.data, .len = _r.len, .cap = _r.cap}; })" "")))))))))))
+                (else
+                  ;; The typedef is named after the SLOP type (slop_list_int), not the C
+                  ;; type (slop_list_int64_t); type-to-identifier is what bridges the two.
+                  ;; Register it as well: the prescan only sees Map/Set inside type
+                  ;; annotations, so a map bound by an inferred let is never registered.
+                  (let ((key-id (type-to-identifier arena key-c-type))
+                        (list-type (ctx-str ctx "slop_list_" (type-to-identifier arena key-c-type))))
+                    (do
+                      (ctx-register-list-type ctx key-c-type list-type)
+                      ;; Pair the Option type with it, exactly as the prescan does for a
+                      ;; (Map K V) / (Set T) annotation: list-get over the returned list
+                      ;; needs slop_option_<id>, and only slop_option_{int,float,string,
+                      ;; ptr,bool} come from the runtime.
+                      (ctx-register-option-type ctx key-c-type (ctx-str ctx "slop_option_" key-id))
+                      (ctx-str ctx (ctx-str3 ctx "({ slop_set_elements_result _r = slop_set_elements_raw(" arena-c ", ")
+                        (ctx-str ctx map-c
+                          (ctx-str ctx "); ("
+                            (ctx-str ctx list-type
+                              (ctx-str ctx "){.data = ("
+                                (ctx-str ctx key-c-type
+                                  (ctx-str ctx "*)_r.data, .len = _r.len, .cap = _r.cap}; })" "")))))))))))))
           ((none)
             (do
               (ctx-add-error-at ctx "map-keys: missing map" (ctx-list-first-line items) (ctx-list-first-col items))
@@ -5767,7 +5821,7 @@
           ((some set-expr)
             (match (list-get items 2)
               ((some elem-expr)
-                (let ((set-c (transpile-expr ctx set-expr))
+                (let ((set-c (resolve-container-c ctx set-expr))
                       (elem-c (transpile-expr ctx elem-expr))
                       (elem-ptr (wrap-map-key-as-ptr ctx elem-c elem-expr set-expr))
                       (arena-c (resolve-arena-c-name ctx "set-put" items)))
@@ -5798,7 +5852,7 @@
           ((some set-expr)
             (match (list-get items 2)
               ((some elem-expr)
-                (let ((set-c (transpile-expr ctx set-expr))
+                (let ((set-c (resolve-container-c ctx set-expr))
                       (elem-c (transpile-expr ctx elem-expr))
                       (elem-ptr (wrap-map-key-as-ptr ctx elem-c elem-expr set-expr)))
                   (ctx-str ctx "(slop_map_get(" (ctx-str ctx set-c (ctx-str ctx ", " (ctx-str ctx elem-ptr ") != NULL)"))))))
@@ -5824,7 +5878,7 @@
           ((some set-expr)
             (match (list-get items 2)
               ((some elem-expr)
-                (let ((set-c (transpile-expr ctx set-expr))
+                (let ((set-c (resolve-container-c ctx set-expr))
                       (elem-c (transpile-expr ctx elem-expr))
                       (elem-ptr (wrap-map-key-as-ptr ctx elem-c elem-expr set-expr)))
                   (ctx-str ctx "slop_map_remove(" (ctx-str ctx set-c (ctx-str ctx ", " (ctx-str ctx elem-ptr ")"))))))
@@ -5841,31 +5895,52 @@
     (@intent "Transpile set-elements to properly typed list")
     (@spec (((Ptr TranspileContext) (List (Ptr SExpr))) -> String))
     (@pre {ctx != nil})
-    (let ((len (list-len items)))
+    (let ((len (list-len items))
+          (arena (. (deref ctx) arena)))
       (if (< len 2)
         (do
           (ctx-add-error-at ctx "set-elements: needs set" (ctx-list-first-line items) (ctx-list-first-col items))
           "NULL")
         (match (list-get items 1)
           ((some set-expr)
-            (let ((set-c (transpile-expr ctx set-expr))
+            (let ((set-c (resolve-container-c ctx set-expr))
                   (elem-c-type (infer-set-elem-c-type ctx set-expr))
                   (arena-c (resolve-arena-c-name ctx "set-elements" items)))
-              ;; Check if element type is string - use legacy slop_map_keys
-              (if (or (string-eq elem-c-type "slop_string") (== (string-len elem-c-type) 0))
-                ;; Generate: slop_map_keys(ARENA, SET)
-                (ctx-str ctx (ctx-str3 ctx "slop_map_keys(" arena-c ", ") (ctx-str ctx set-c ")"))
+              (cond
+                ;; String elements: the runtime carries slop_map_keys, which already
+                ;; returns slop_list_string, so no typed list has to be generated.
+                ((string-eq elem-c-type "slop_string")
+                  (ctx-str ctx (ctx-str3 ctx "slop_map_keys(" arena-c ", ") (ctx-str ctx set-c ")")))
+                ;; An uninferable element type used to fall through to the String path
+                ;; above, emitting a slop_string read for a set of some other type.
+                ((== (string-len elem-c-type) 0)
+                  (do
+                    (ctx-add-error-at ctx "set-elements: cannot infer element type" (ctx-list-first-line items) (ctx-list-first-col items))
+                    "NULL"))
                 ;; Generate typed list from raw elements:
                 ;; ({ slop_set_elements_result _r = slop_set_elements_raw(ARENA, SET);
                 ;;    (slop_list_ElemType){.data = (ElemType*)_r.data, .len = _r.len, .cap = _r.cap}; })
-                (let ((list-type (ctx-str ctx "slop_list_" elem-c-type)))
-                  (ctx-str ctx (ctx-str3 ctx "({ slop_set_elements_result _r = slop_set_elements_raw(" arena-c ", ")
-                    (ctx-str ctx set-c
-                      (ctx-str ctx "); ("
-                        (ctx-str ctx list-type
-                          (ctx-str ctx "){.data = ("
-                            (ctx-str ctx elem-c-type
-                              (ctx-str ctx "*)_r.data, .len = _r.len, .cap = _r.cap}; })" "")))))))))))
+                (else
+                  ;; The typedef is named after the SLOP type (slop_list_int), not the C
+                  ;; type (slop_list_int64_t); type-to-identifier is what bridges the two.
+                  ;; Register it as well: the prescan only sees Map/Set inside type
+                  ;; annotations, so a set bound by an inferred let is never registered.
+                  (let ((elem-id (type-to-identifier arena elem-c-type))
+                        (list-type (ctx-str ctx "slop_list_" (type-to-identifier arena elem-c-type))))
+                    (do
+                      (ctx-register-list-type ctx elem-c-type list-type)
+                      ;; Pair the Option type with it, exactly as the prescan does for a
+                      ;; (Map K V) / (Set T) annotation: list-get over the returned list
+                      ;; needs slop_option_<id>, and only slop_option_{int,float,string,
+                      ;; ptr,bool} come from the runtime.
+                      (ctx-register-option-type ctx elem-c-type (ctx-str ctx "slop_option_" elem-id))
+                      (ctx-str ctx (ctx-str3 ctx "({ slop_set_elements_result _r = slop_set_elements_raw(" arena-c ", ")
+                        (ctx-str ctx set-c
+                          (ctx-str ctx "); ("
+                            (ctx-str ctx list-type
+                              (ctx-str ctx "){.data = ("
+                                (ctx-str ctx elem-c-type
+                                  (ctx-str ctx "*)_r.data, .len = _r.len, .cap = _r.cap}; })" "")))))))))))))
           ((none)
             (do
               (ctx-add-error-at ctx "set-elements: missing set" (ctx-list-first-line items) (ctx-list-first-col items))
@@ -6079,7 +6154,7 @@
           (elem-slop-type (extract-set-elem-from-slop-type arena resolved-type))
           (elem-c-type (slop-value-type-to-c-type ctx elem-slop-type)))
       ;; Build: ({ slop_map* _coll = (slop_map*)coll; for (size_t _i = 0; _i < _coll->cap; _i++) { if (_coll->entries[_i].occupied) { ElementType var = *(ElementType*)_coll->entries[_i].key;
-      (let ((mut result (ctx-str3 ctx "({ slop_map* _coll = (slop_map*)" coll-c "; for (size_t _i = 0; _i < _coll->cap; _i++) { "))
+      (let ((mut result (ctx-str3 ctx "({ slop_map* _coll = (slop_map*)" (deref-container-c ctx coll-c resolved-type) "; for (size_t _i = 0; _i < _coll->cap; _i++) { "))
             (if-part "if (_coll->entries[_i].occupied) { ")
             (cast-part (ctx-str ctx elem-c-type "*)_coll->entries[_i].key"))
             (assign-prefix (ctx-str4 ctx elem-c-type " " var-name " = *("))
@@ -6121,7 +6196,7 @@
           (key-slop-type (extract-map-key-from-slop-type arena resolved-type))
           (key-c-type (slop-value-type-to-c-type ctx key-slop-type)))
       ;; Build: ({ slop_map* _coll = (slop_map*)coll; for (size_t _i = 0; _i < _coll->cap; _i++) { if (_coll->entries[_i].occupied) { KeyType var = *(KeyType*)_coll->entries[_i].key;
-      (let ((mut result (ctx-str3 ctx "({ slop_map* _coll = (slop_map*)" coll-c "; for (size_t _i = 0; _i < _coll->cap; _i++) { "))
+      (let ((mut result (ctx-str3 ctx "({ slop_map* _coll = (slop_map*)" (deref-container-c ctx coll-c resolved-type) "; for (size_t _i = 0; _i < _coll->cap; _i++) { "))
             (if-part "if (_coll->entries[_i].occupied) { ")
             (cast-part (ctx-str ctx key-c-type "*)_coll->entries[_i].key"))
             (assign-prefix (ctx-str4 ctx key-c-type " " var-name " = *("))
@@ -6184,7 +6259,7 @@
                                             (val-c-type (slop-value-type-to-c-type ctx val-slop-type)))
                                         ;; Build: ({ slop_map* _coll = (slop_map*)map; for (size_t _i = 0; _i < _coll->cap; _i++) { if (_coll->entries[_i].occupied) {
                                         ;;         KeyType k = *(KeyType*)_coll->entries[_i].key; ValueType v = *(ValueType*)_coll->entries[_i].value;
-                                        (let ((mut result (ctx-str3 ctx "({ slop_map* _coll = (slop_map*)" map-c "; for (size_t _i = 0; _i < _coll->cap; _i++) { "))
+                                        (let ((mut result (ctx-str3 ctx "({ slop_map* _coll = (slop_map*)" (deref-container-c ctx map-c resolved-type) "; for (size_t _i = 0; _i < _coll->cap; _i++) { "))
                                               (if-part "if (_coll->entries[_i].occupied) { ")
                                               (k-cast (ctx-str ctx key-c-type "*)_coll->entries[_i].key"))
                                               (k-prefix (ctx-str4 ctx key-c-type " " k-name " = *("))
@@ -7607,9 +7682,13 @@
                 (if (> elem-len 0)
                   (substring arena resolved-type 6 (cast (Int 0 ..) elem-len))
                   "")))
-            ((starts-with resolved-type "(Set ")
+            ;; is-set-type / is-map-type rather than a bare prefix test: iterating a
+            ;; (Ptr (Set T)) yields the same element type as iterating a (Set T).
+            ;; (compound-slop-type-to-id deliberately keeps the bare test -- there the
+            ;; two must NOT collide, since slop_map* and slop_map** are distinct types.)
+            ((is-set-type resolved-type)
               (extract-set-elem-from-slop-type arena resolved-type))
-            ((starts-with resolved-type "(Map ")
+            ((is-map-type resolved-type)
               ;; For maps, return the key type (used for iteration)
               (extract-map-key-from-slop-type arena resolved-type))
             (else ""))))))

--- a/lib/compiler/transpiler/match.slop
+++ b/lib/compiler/transpiler/match.slop
@@ -24,7 +24,7 @@
   (import strlib (starts-with ends-with char-at))
   (import ctype (to-c-name to-c-type sexpr-to-type-string))
   (import expr (transpile-expr infer-expr-c-type infer-expr-slop-type infer-option-inner-slop-type infer-result-ok-slop-type infer-result-err-slop-type c-type-to-option-type-name
-                resolve-type-alias infer-collection-element-slop-type is-set-type is-map-type
+                resolve-type-alias infer-collection-element-slop-type is-set-type is-map-type deref-container-c
                 extract-set-elem-from-slop-type extract-map-key-from-slop-type extract-map-value-from-slop-type
                 slop-value-type-to-c-type is-pointer-expr set-is-self-assign))
 
@@ -1608,7 +1608,7 @@
           (elem-c-type (slop-value-type-to-c-type ctx elem-slop-type)))
       (ctx-emit ctx "{")
       (ctx-indent ctx)
-      (ctx-emit ctx (ctx-str3 ctx "slop_map* _coll = (slop_map*)" coll-c ";"))
+      (ctx-emit ctx (ctx-str3 ctx "slop_map* _coll = (slop_map*)" (deref-container-c ctx coll-c resolved-type) ";"))
       (ctx-emit ctx "for (size_t _i = 0; _i < _coll->cap; _i++) {")
       (ctx-indent ctx)
       (ctx-emit ctx "if (_coll->entries[_i].occupied) {")
@@ -1647,7 +1647,7 @@
           (key-c-type (slop-value-type-to-c-type ctx key-slop-type)))
       (ctx-emit ctx "{")
       (ctx-indent ctx)
-      (ctx-emit ctx (ctx-str3 ctx "slop_map* _coll = (slop_map*)" coll-c ";"))
+      (ctx-emit ctx (ctx-str3 ctx "slop_map* _coll = (slop_map*)" (deref-container-c ctx coll-c resolved-type) ";"))
       (ctx-emit ctx "for (size_t _i = 0; _i < _coll->cap; _i++) {")
       (ctx-indent ctx)
       (ctx-emit ctx "if (_coll->entries[_i].occupied) {")
@@ -1707,7 +1707,7 @@
                                             (val-c-type (slop-value-type-to-c-type ctx val-slop-type)))
                                         (ctx-emit ctx "{")
                                         (ctx-indent ctx)
-                                        (ctx-emit ctx (ctx-str3 ctx "slop_map* _coll = (slop_map*)" map-c ";"))
+                                        (ctx-emit ctx (ctx-str3 ctx "slop_map* _coll = (slop_map*)" (deref-container-c ctx map-c resolved-type) ";"))
                                         (ctx-emit ctx "for (size_t _i = 0; _i < _coll->cap; _i++) {")
                                         (ctx-indent ctx)
                                         (ctx-emit ctx "if (_coll->entries[_i].occupied) {")

--- a/lib/compiler/transpiler/stmt.slop
+++ b/lib/compiler/transpiler/stmt.slop
@@ -29,7 +29,9 @@
               infer-collection-element-slop-type c-type-to-option-type-name
               resolve-type-alias extract-set-elem-from-slop-type
               extract-map-key-from-slop-type extract-map-value-from-slop-type
-              slop-value-type-to-c-type set-is-self-assign))
+              slop-value-type-to-c-type set-is-self-assign
+              ;; is-set-type / is-map-type used to be copied verbatim into this module
+              is-set-type is-map-type deref-container-c))
   (import strlib (starts-with ends-with))
   (import match (transpile-match))
 
@@ -1006,22 +1008,6 @@
         (else (ctx-add-error-at ctx "invalid for" (ctx-sexpr-line expr) (ctx-sexpr-col expr))))))
 
   ;; ============================================================
-  ;; Set/Map Type Detection Helpers
-  ;; ============================================================
-
-  (fn is-set-type ((slop-type String))
-    (@intent "Check if SLOP type is a Set type")
-    (@spec ((String) -> Bool))
-    (or (starts-with slop-type "(Set ")
-        (starts-with slop-type "(Ptr (Set ")))
-
-  (fn is-map-type ((slop-type String))
-    (@intent "Check if SLOP type is a Map type")
-    (@spec ((String) -> Bool))
-    (or (starts-with slop-type "(Map ")
-        (starts-with slop-type "(Ptr (Map ")))
-
-  ;; ============================================================
   ;; For-Each Loop: Set Iteration
   ;; ============================================================
 
@@ -1041,7 +1027,7 @@
       ;; Cache collection in block-scoped temp to avoid re-evaluation
       (ctx-emit ctx "{")
       (ctx-indent ctx)
-      (ctx-emit ctx (ctx-str3 ctx "slop_map* _coll = (slop_map*)" coll-c ";"))
+      (ctx-emit ctx (ctx-str3 ctx "slop_map* _coll = (slop_map*)" (deref-container-c ctx coll-c resolved-type) ";"))
       ;; for (size_t _i = 0; _i < _coll->cap; _i++) {
       (ctx-emit ctx "for (size_t _i = 0; _i < _coll->cap; _i++) {")
       (ctx-indent ctx)
@@ -1092,7 +1078,7 @@
       ;; Cache collection in block-scoped temp to avoid re-evaluation
       (ctx-emit ctx "{")
       (ctx-indent ctx)
-      (ctx-emit ctx (ctx-str3 ctx "slop_map* _coll = (slop_map*)" coll-c ";"))
+      (ctx-emit ctx (ctx-str3 ctx "slop_map* _coll = (slop_map*)" (deref-container-c ctx coll-c resolved-type) ";"))
       ;; for (size_t _i = 0; _i < _coll->cap; _i++) {
       (ctx-emit ctx "for (size_t _i = 0; _i < _coll->cap; _i++) {")
       (ctx-indent ctx)
@@ -1167,7 +1153,7 @@
                                         ;; Cache collection in block-scoped temp to avoid re-evaluation
                                         (ctx-emit ctx "{")
                                         (ctx-indent ctx)
-                                        (ctx-emit ctx (ctx-str3 ctx "slop_map* _coll = (slop_map*)" map-c ";"))
+                                        (ctx-emit ctx (ctx-str3 ctx "slop_map* _coll = (slop_map*)" (deref-container-c ctx map-c resolved-type) ";"))
                                         ;; Emit: for (size_t _i = 0; _i < _coll->cap; _i++) {
                                         (ctx-emit ctx "for (size_t _i = 0; _i < _coll->cap; _i++) {")
                                         (ctx-indent ctx)

--- a/lib/compiler/transpiler/transpiler.slop
+++ b/lib/compiler/transpiler/transpiler.slop
@@ -1566,6 +1566,8 @@
                 (emit-module-functions ctx items body-start)
                 ;; Emit any late-registered option types to header (discovered during function transpilation)
                 (emit-late-registered-option-types-header ctx)
+                ;; Same, for List types (set-elements / map-keys on an inferred local)
+                (emit-late-registered-list-types-header ctx)
                 ;; Now close the header guard
                 (emit-header-guard-close ctx)))))
         (else (ctx-emit ctx "/* invalid module */")))))
@@ -2782,6 +2784,27 @@
           ((none) (do)))
         (set! i (+ i 1)))))
 
+  (fn emit-late-registered-list-types-header ((ctx (Ptr TranspileContext)))
+    (@intent "Emit List types registered during function transpilation (e.g. by set-elements / map-keys)")
+    (@spec (((Ptr TranspileContext)) -> Unit))
+    (@pre {ctx != nil})
+    ;; The header is emitted before emit-module-functions runs, so a list type first
+    ;; discovered while transpiling a body -- a set built by an inferred let-binding
+    ;; never appears in a type annotation, so the prescan cannot see it -- would
+    ;; otherwise be referenced without ever being defined. Mirrors
+    ;; emit-late-registered-option-types-header. emit-single-list-type-header skips
+    ;; runtime-provided names and already-emitted ones, so re-walking the whole list
+    ;; is idempotent.
+    (let ((list-types (ctx-get-list-types ctx))
+          (len (list-len list-types))
+          (mut i 0))
+      (while (< i len)
+        (match (list-get list-types i)
+          ((some lt)
+            (emit-single-list-type-header ctx lt))
+          ((none) (do)))
+        (set! i (+ i 1)))))
+
   (fn emit-late-registered-option-types-header ((ctx (Ptr TranspileContext)))
     (@intent "Emit option types registered during function transpilation (e.g. set_* types)")
     (@spec (((Ptr TranspileContext)) -> Unit))
@@ -3296,7 +3319,7 @@
         (match (list-get struct-key-types i)
           ((some c-type)
             (let ((guard-name (ctx-str3 ctx (uppercase-name ctx c-type) "_HASH_EQ_DEFINED" ""))
-                  (list-c-name (ctx-str ctx "slop_list_" c-type)))
+                  (list-c-name (ctx-str ctx "slop_list_" (type-to-identifier (. (deref ctx) arena) c-type))))
               ;; #ifndef GUARD_DEFINED
               (ctx-emit-header ctx (ctx-str ctx "#ifndef " guard-name))
               ;; #define GUARD_DEFINED

--- a/scripts/run_native_tests.sh
+++ b/scripts/run_native_tests.sh
@@ -67,6 +67,10 @@ run_unit_tests "tests/example-harness" "example-harness"
 # alongside the negative fixture below, which independently proves the harness still
 # tells a pass from a skip from a failure.
 run_unit_tests "lib/compiler/tester" "tester"
+# Shared C-type/identifier helpers. These @example blocks predate this entry and were
+# never run by anything; the naming rules they pin (type-to-identifier, and the
+# Ptr-container unwrapping) are what issues #72 and #82 turned on.
+run_unit_tests "lib/compiler/common" "ctype"
 
 # A run whose @examples fail or cannot be compiled must exit non-zero and account
 # for each outcome separately. Before issue #71 was fixed an un-runnable @example

--- a/tests/test_ptr_map_ops.slop
+++ b/tests/test_ptr_map_ops.slop
@@ -1,0 +1,327 @@
+;; ============================================================
+;; Test: every container builtin through a (Ptr (Map ...)) / (Ptr (Set ...))
+;;
+;; Regression for issue #82. A (Ptr (Map K V)) / (Ptr (Set T)) is
+;; slop_map** in C, but every runtime entry point takes slop_map*.
+;; Only map-put derefed; the other eight builtins handed over the
+;; double pointer. Passing slop_map** where slop_map* is expected
+;; is merely a warning in C, and slop build discards cc output, so
+;; the build reported success and the program read a bad pointer.
+;;
+;; The for-each family was worse still: it emitted (slop_map*)coll,
+;; an EXPLICIT cast, which silences the warning entirely.
+;;
+;; Independently, the three extract-*-from-slop-type helpers matched
+;; a literal "(Map " / "(Set " prefix and so answered "" for the
+;; pointer form. That is why map-get fell back to an anonymous
+;; struct returning void*, and why for-each emitted bindings with no
+;; element type at all -- both hard C errors rather than warnings.
+;;
+;; Every helper below therefore has to be exercised through (addr x),
+;; and the assertions run against the plain binding. tests/multimod
+;; had two (Ptr (Map ...)) functions but is run by nothing, and
+;; (Ptr (Set T)) had no coverage anywhere in the repo.
+;; ============================================================
+
+(module test-ptr-map-ops
+
+  ;; ============================================================
+  ;; Helpers taking a pointer-to-container
+  ;; ============================================================
+
+  (fn p-map-put ((arena Arena) (m (Ptr (Map String Int))) (k String) (v Int))
+    (@intent "map-put through a Ptr Map")
+    (@spec ((Arena (Ptr (Map String Int)) String Int) -> Bool))
+    (@pre {m != nil})
+    (do (map-put m k v) true))
+
+  (fn p-map-get ((m (Ptr (Map String Int))) (k String))
+    (@intent "map-get through a Ptr Map; -1 when absent")
+    (@spec (((Ptr (Map String Int)) String) -> Int))
+    (@pre {m != nil})
+    (match (map-get m k)
+      ((some v) v)
+      ((none) -1)))
+
+  (fn p-map-has ((m (Ptr (Map String Int))) (k String))
+    (@intent "map-has through a Ptr Map")
+    (@spec (((Ptr (Map String Int)) String) -> Bool))
+    (@pre {m != nil})
+    (map-has m k))
+
+  (fn p-map-remove ((m (Ptr (Map String Int))) (k String))
+    (@intent "map-remove through a Ptr Map")
+    (@spec (((Ptr (Map String Int)) String) -> Bool))
+    (@pre {m != nil})
+    (do (map-remove m k) true))
+
+  (fn p-map-key-count ((arena Arena) (m (Ptr (Map String Int))))
+    (@intent "map-keys through a Ptr Map")
+    (@spec ((Arena (Ptr (Map String Int))) -> Int))
+    (@pre {m != nil})
+    (list-len (map-keys m)))
+
+  (fn p-map-value-sum ((m (Ptr (Map String Int))))
+    (@intent "for-each over a Ptr Map in statement position")
+    (@spec (((Ptr (Map String Int))) -> Int))
+    (@pre {m != nil})
+    (let ((mut total 0))
+      (for-each ((k v) m)
+        (set! total (+ total v)))
+      total))
+
+  (fn p-set-put ((arena Arena) (s (Ptr (Set Int))) (e Int))
+    (@intent "set-put through a Ptr Set")
+    (@spec ((Arena (Ptr (Set Int)) Int) -> Bool))
+    (@pre {s != nil})
+    (do (set-put s e) true))
+
+  (fn p-set-has ((s (Ptr (Set Int))) (e Int))
+    (@intent "set-has through a Ptr Set")
+    (@spec (((Ptr (Set Int)) Int) -> Bool))
+    (@pre {s != nil})
+    (set-has s e))
+
+  (fn p-set-remove ((s (Ptr (Set Int))) (e Int))
+    (@intent "set-remove through a Ptr Set")
+    (@spec (((Ptr (Set Int)) Int) -> Bool))
+    (@pre {s != nil})
+    (do (set-remove s e) true))
+
+  (fn p-set-elem-count ((arena Arena) (s (Ptr (Set Int))))
+    (@intent "set-elements through a Ptr Set")
+    (@spec ((Arena (Ptr (Set Int))) -> Int))
+    (@pre {s != nil})
+    (list-len (set-elements s)))
+
+  (fn p-set-sum ((s (Ptr (Set Int))))
+    (@intent "for-each over a Ptr Set in statement position")
+    (@spec (((Ptr (Set Int))) -> Int))
+    (@pre {s != nil})
+    (let ((mut total 0))
+      (for-each (e s)
+        (set! total (+ total e)))
+      total))
+
+  (fn p-map-sum-as-expr ((m (Ptr (Map String Int))))
+    (@intent "for-each over a Ptr Map in expression position")
+    (@spec (((Ptr (Map String Int))) -> Int))
+    (@pre {m != nil})
+    (let ((mut total 0))
+      ;; Binding the for-each inside a let routes it through the
+      ;; expression-position emitter, a separate copy of the same code.
+      (let ((result (do (for-each ((k v) m) (set! total (+ total v))) total)))
+        result)))
+
+  (fn p-set-sum-in-match ((m (Ptr (Map String Int))) (s (Ptr (Set Int))) (k String))
+    (@intent "for-each over a Ptr Set inside a match arm")
+    (@spec (((Ptr (Map String Int)) (Ptr (Set Int)) String) -> Int))
+    (@pre {m != nil})
+    (@pre {s != nil})
+    (let ((mut total 0))
+      ;; A for-each in a match branch goes through yet a third copy,
+      ;; the inline emitter in match.slop.
+      (match (map-get m k)
+        ((some base)
+          (do
+            (for-each (e s)
+              (set! total (+ total e)))
+            (+ total base)))
+        ((none) -1))))
+
+  ;; ============================================================
+  ;; Test 1: map builtins through a pointer
+  ;; ============================================================
+  (fn test-ptr-map-builtins ()
+    (@intent "map-put/get/has/remove/keys must all deref a Ptr Map")
+    (@spec (() -> Bool))
+    (with-arena 65536
+      (let ((m (map-new arena String Int))
+            (mut ok true))
+        (map-put m "a" 1)
+        (map-put m "b" 2)
+        ;; write through the pointer, read through the plain binding
+        (when (not (p-map-put arena (addr m) "c" 3)) (set! ok false))
+        (when (not (map-has m "c")) (set! ok false))
+        (match (map-get m "c")
+          ((some v) (when (not (== v 3)) (set! ok false)))
+          ((none) (set! ok false)))
+        ;; read through the pointer
+        (when (not (== (p-map-get (addr m) "b") 2)) (set! ok false))
+        (when (not (== (p-map-get (addr m) "zz") -1)) (set! ok false))
+        (when (not (p-map-has (addr m) "a")) (set! ok false))
+        (when (p-map-has (addr m) "zz") (set! ok false))
+        (when (not (== (p-map-key-count arena (addr m)) 3)) (set! ok false))
+        ;; remove through the pointer
+        (when (not (p-map-remove (addr m) "b")) (set! ok false))
+        (when (map-has m "b") (set! ok false))
+        (when (not (== (p-map-key-count arena (addr m)) 2)) (set! ok false))
+        ok)))
+
+  ;; ============================================================
+  ;; Test 2: set builtins through a pointer
+  ;; ============================================================
+  (fn test-ptr-set-builtins ()
+    (@intent "set-put/has/remove/elements must all deref a Ptr Set")
+    (@spec (() -> Bool))
+    (with-arena 65536
+      (let ((s (set-new arena Int))
+            (mut ok true))
+        (set-put s 10)
+        (set-put s 20)
+        (when (not (p-set-put arena (addr s) 30)) (set! ok false))
+        (when (not (set-has s 30)) (set! ok false))
+        (when (not (p-set-has (addr s) 10)) (set! ok false))
+        (when (p-set-has (addr s) 99) (set! ok false))
+        (when (not (== (p-set-elem-count arena (addr s)) 3)) (set! ok false))
+        (when (not (p-set-remove (addr s) 20)) (set! ok false))
+        (when (set-has s 20) (set! ok false))
+        (when (not (== (p-set-elem-count arena (addr s)) 2)) (set! ok false))
+        ok)))
+
+  ;; ============================================================
+  ;; Test 3: for-each in all three emitter positions
+  ;;
+  ;; The set/map-keys/map-kv for-each emitters are triplicated
+  ;; across stmt.slop, match.slop and expr.slop -- nine functions,
+  ;; nine identical casts. Statement position alone would leave six
+  ;; of them unexercised.
+  ;; ============================================================
+  (fn test-ptr-foreach-positions ()
+    (@intent "for-each over a Ptr container must deref in statement, expression and match positions")
+    (@spec (() -> Bool))
+    (with-arena 65536
+      (let ((m (map-new arena String Int))
+            (s (set-new arena Int))
+            (mut ok true))
+        (map-put m "a" 1)
+        (map-put m "b" 2)
+        (map-put m "c" 4)
+        (set-put s 100)
+        (set-put s 200)
+        ;; statement position
+        (when (not (== (p-map-value-sum (addr m)) 7)) (set! ok false))
+        (when (not (== (p-set-sum (addr s)) 300)) (set! ok false))
+        ;; expression position
+        (when (not (== (p-map-sum-as-expr (addr m)) 7)) (set! ok false))
+        ;; inside a match arm: 100 + 200 + m["b"]
+        (when (not (== (p-set-sum-in-match (addr m) (addr s) "b") 302)) (set! ok false))
+        (when (not (== (p-set-sum-in-match (addr m) (addr s) "zz") -1)) (set! ok false))
+        ok)))
+
+  ;; ============================================================
+  ;; Test 4: containers reached by field access rather than a bare symbol
+  ;;
+  ;; Two different shapes, and the distinction matters:
+  ;;
+  ;;   (. st items) where items is a (Map K V)       -> slop_map*,
+  ;;       already correct, and must NOT gain a deref.
+  ;;   (. st mref)  where mref  is a (Ptr (Map K V)) -> slop_map**,
+  ;;       and needs one.
+  ;;
+  ;; is-ptr-to-ptr-map only matched a bare symbol whose C type ended
+  ;; in **, so the second shape took the broken path. Both are here
+  ;; so a future change cannot fix one by breaking the other.
+  ;; ============================================================
+  (type Store (record (items (Map String Int))))
+  (type StoreRef (record (mref (Ptr (Map String Int))) (tag Int)))
+
+  (fn ref-count ((arena Arena) (sr (Ptr StoreRef)))
+    (@intent "map-keys on a map reached through a Ptr-Map field")
+    (@spec ((Arena (Ptr StoreRef)) -> Int))
+    (@pre {sr != nil})
+    (list-len (map-keys (. sr mref))))
+
+  (fn ref-lookup ((sr (Ptr StoreRef)) (k String))
+    (@intent "map-get on a map reached through a Ptr-Map field")
+    (@spec (((Ptr StoreRef) String) -> Int))
+    (@pre {sr != nil})
+    (match (map-get (. sr mref) k)
+      ((some v) v)
+      ((none) -1)))
+
+  (fn ref-sum ((sr (Ptr StoreRef)))
+    (@intent "for-each over a map reached through a Ptr-Map field")
+    (@spec (((Ptr StoreRef)) -> Int))
+    (@pre {sr != nil})
+    (let ((mut total 0))
+      (for-each ((k v) (. sr mref))
+        (set! total (+ total v)))
+      total))
+
+  (fn store-count ((arena Arena) (st (Ptr Store)))
+    (@intent "map-keys on a map reached through a field of a Ptr record")
+    (@spec ((Arena (Ptr Store)) -> Int))
+    (@pre {st != nil})
+    (list-len (map-keys (. st items))))
+
+  (fn store-lookup ((st (Ptr Store)) (k String))
+    (@intent "map-get on a map reached through a field of a Ptr record")
+    (@spec (((Ptr Store) String) -> Int))
+    (@pre {st != nil})
+    (match (map-get (. st items) k)
+      ((some v) v)
+      ((none) -1)))
+
+  (fn test-ptr-map-via-field ()
+    (@intent "Container builtins must work on a map reached by field access")
+    (@spec (() -> Bool))
+    (with-arena 65536
+      (let ((st (record-new Store (items (map-new arena String Int))))
+            (mut ok true))
+        (map-put (. st items) "x" 41)
+        (map-put (. st items) "y" 42)
+        (when (not (== (store-count arena (addr st)) 2)) (set! ok false))
+        (when (not (== (store-lookup (addr st) "y") 42)) (set! ok false))
+        (when (not (== (store-lookup (addr st) "nope") -1)) (set! ok false))
+        ok)))
+
+  (fn test-ptr-map-field-is-ptr ()
+    (@intent "A record field that is itself a (Ptr (Map ...)) must be dereferenced")
+    (@spec (() -> Bool))
+    (with-arena 65536
+      (let ((m (map-new arena String Int))
+            (mut ok true))
+        (map-put m "p" 5)
+        (map-put m "q" 7)
+        (let ((sr (record-new StoreRef (mref (addr m)) (tag 1))))
+          (when (not (== (ref-count arena (addr sr)) 2)) (set! ok false))
+          (when (not (== (ref-lookup (addr sr) "q") 7)) (set! ok false))
+          (when (not (== (ref-lookup (addr sr) "nope") -1)) (set! ok false))
+          (when (not (== (ref-sum (addr sr)) 12)) (set! ok false)))
+        ok)))
+
+  ;; ============================================================
+  ;; Main test runner
+  ;; ============================================================
+  (fn main ()
+    (@intent "Run all pointer-to-container regression tests")
+    (@spec (() -> Int))
+    (let ((mut failures 0))
+      (if (test-ptr-map-builtins)
+        (println "test-ptr-map-builtins: PASS")
+        (do (println "test-ptr-map-builtins: FAIL")
+            (set! failures (+ failures 1))))
+      (if (test-ptr-set-builtins)
+        (println "test-ptr-set-builtins: PASS")
+        (do (println "test-ptr-set-builtins: FAIL")
+            (set! failures (+ failures 1))))
+      (if (test-ptr-foreach-positions)
+        (println "test-ptr-foreach-positions: PASS")
+        (do (println "test-ptr-foreach-positions: FAIL")
+            (set! failures (+ failures 1))))
+      (if (test-ptr-map-via-field)
+        (println "test-ptr-map-via-field: PASS")
+        (do (println "test-ptr-map-via-field: FAIL")
+            (set! failures (+ failures 1))))
+      (if (test-ptr-map-field-is-ptr)
+        (println "test-ptr-map-field-is-ptr: PASS")
+        (do (println "test-ptr-map-field-is-ptr: FAIL")
+            (set! failures (+ failures 1))))
+      (println "")
+      (if (== failures 0)
+        (do (println "All tests passed!")
+            0)
+        (do (print failures)
+            (println " test(s) failed")
+            1)))))

--- a/tests/test_set_elements.slop
+++ b/tests/test_set_elements.slop
@@ -1,0 +1,255 @@
+;; ============================================================
+;; Test: set-elements / map-keys across element types
+;;
+;; Regression for issue #72. Both builtins named the generated C
+;; list type by concatenating the raw C type -- "slop_list_" +
+;; "int64_t" -- while the runtime's typedefs are named after the
+;; SLOP type (slop_list_int). Every other slop_list_ construction
+;; in the compiler routes through type-to-identifier, which maps
+;; int64_t -> int; these two were the only sites that did not, so
+;; they emitted an identifier that is never declared.
+;;
+;; In practice that meant set-elements only worked for (Set String),
+;; which short-circuits to slop_map_keys and never names a typed
+;; list at all. There were zero non-String call sites anywhere in
+;; the repo, so the typed branch was dead code.
+;;
+;; Element types are chosen to cover the three distinct outcomes:
+;;   Int / a record key -> a name the runtime already provides, or
+;;                         one the prescan registers
+;;   Bool               -> slop_list_u8, which the runtime does NOT
+;;                         predefine and no type annotation mentions,
+;;                         so it only exists if set-elements itself
+;;                         registers it and the late header pass
+;;                         emits SLOP_LIST_DEFINE(uint8_t, ...)
+;;   String             -> the legacy slop_map_keys path
+;;
+;; Iteration order of a hash table is unspecified, so every check
+;; below is over a sum or a count, never a position.
+;; ============================================================
+
+(module test-set-elements
+
+  (type Point (record (x Int) (y Int)))
+
+  ;; ============================================================
+  ;; A plain (List Int) consumer.
+  ;;
+  ;; This is what actually pins the naming rule. Registering the list
+  ;; type on demand is enough to make ANY name compile -- a wrong name
+  ;; just gets its own redundant SLOP_LIST_DEFINE -- so a test that only
+  ;; builds and counts cannot tell slop_list_int from slop_list_int64_t.
+  ;; Passing the result to a function declared to take (List Int), whose
+  ;; C type is slop_list_int, forces the two to be the same type.
+  ;; ============================================================
+  (fn sum-int-list ((xs (List Int)))
+    (@intent "Sum a (List Int), whatever produced it")
+    (@spec (((List Int)) -> Int))
+    (let ((n (list-len xs))
+          (mut i 0)
+          (mut total 0))
+      (while (< i n)
+        (do
+          (match (list-get xs i)
+            ((some v) (set! total (+ total v)))
+            ((none) (do)))
+          (set! i (+ i 1))))
+      total))
+
+  ;; ============================================================
+  ;; Test 1: (Set Int) -- was slop_list_int64_t, undeclared
+  ;; ============================================================
+  (fn test-set-elements-int ()
+    (@intent "set-elements on a (Set Int) must return every element")
+    (@spec (() -> Bool))
+    (with-arena 65536
+      (let ((s (set-new arena Int))
+            (mut i 0)
+            (mut n 0)
+            (mut sum 0))
+        (while (< i 10)
+          (do (set-put s (* i i)) (set! i (+ i 1))))
+        (let ((elems (set-elements s)))
+          (set! n (list-len elems))
+          (set! i 0)
+          (while (< i n)
+            (do
+              (match (list-get elems i)
+                ((some v) (set! sum (+ sum v)))
+                ((none) (do)))
+              (set! i (+ i 1)))))
+        ;; 0+1+4+9+16+25+36+49+64+81 = 285
+        ;; The third clause is the type-identity check: sum-int-list takes a
+        ;; (List Int), so this only compiles if set-elements produced exactly
+        ;; slop_list_int and not a parallel type of its own.
+        (and (== n 10)
+             (and (== sum 285)
+                  (== (sum-int-list (set-elements s)) 285))))))
+
+  ;; ============================================================
+  ;; Test 2: (Set Bool) -- needs an on-demand SLOP_LIST_DEFINE
+  ;;
+  ;; Bool is uint8_t, so the list type is slop_list_u8, which the
+  ;; runtime does not predefine. Nothing in this function carries a
+  ;; (Set Bool) type annotation, so the prescan never sees it --
+  ;; the typedef exists only if set-elements registers it itself.
+  ;; ============================================================
+  (fn test-set-elements-bool ()
+    (@intent "set-elements on a (Set Bool) must emit and use slop_list_u8")
+    (@spec (() -> Bool))
+    (with-arena 65536
+      (let ((s (set-new arena Bool))
+            (mut n 0)
+            (mut trues 0)
+            (mut i 0))
+        (set-put s true)
+        (set-put s false)
+        (set-put s true)
+        (let ((elems (set-elements s)))
+          (set! n (list-len elems))
+          (while (< i n)
+            (do
+              (match (list-get elems i)
+                ((some v) (when v (set! trues (+ trues 1))))
+                ((none) (do)))
+              (set! i (+ i 1)))))
+        ;; true was inserted twice, so the set holds exactly {true, false}
+        (and (== n 2) (== trues 1)))))
+
+  ;; ============================================================
+  ;; Test 3: (Set String) -- the legacy slop_map_keys path
+  ;; ============================================================
+  (fn test-set-elements-string ()
+    (@intent "set-elements on a (Set String) must keep working via slop_map_keys")
+    (@spec (() -> Bool))
+    (with-arena 65536
+      (let ((s (set-new arena String))
+            (mut n 0)
+            (mut chars 0)
+            (mut i 0))
+        (set-put s "alpha")
+        (set-put s "be")
+        (set-put s "gamma")
+        (let ((elems (set-elements s)))
+          (set! n (list-len elems))
+          (while (< i n)
+            (do
+              (match (list-get elems i)
+                ((some v) (set! chars (+ chars (string-len v))))
+                ((none) (do)))
+              (set! i (+ i 1)))))
+        ;; 5 + 2 + 5
+        (and (== n 3) (== chars 12)))))
+
+  ;; ============================================================
+  ;; Test 4: (Set Point) -- a record element type
+  ;; ============================================================
+  (fn test-set-elements-record ()
+    (@intent "set-elements on a set of records must return whole records")
+    (@spec (() -> Bool))
+    (with-arena 65536
+      (let ((s (set-new arena Point))
+            (mut n 0)
+            (mut total 0)
+            (mut i 0))
+        (set-put s (Point 1 2))
+        (set-put s (Point 10 20))
+        (let ((elems (set-elements s)))
+          (set! n (list-len elems))
+          (while (< i n)
+            (do
+              (match (list-get elems i)
+                ((some p) (set! total (+ total (+ (. p x) (. p y)))))
+                ((none) (do)))
+              (set! i (+ i 1)))))
+        ;; (1+2) + (10+20)
+        (and (== n 2) (== total 33)))))
+
+  ;; ============================================================
+  ;; Test 5: map-keys on an Int-keyed map -- the same typed path
+  ;; ============================================================
+  (fn test-map-keys-int ()
+    (@intent "map-keys on a (Map Int V) must return every key")
+    (@spec (() -> Bool))
+    (with-arena 65536
+      (let ((m (map-new arena Int String))
+            (mut n 0)
+            (mut sum 0)
+            (mut i 0))
+        (map-put m 3 "three")
+        (map-put m 5 "five")
+        (map-put m 11 "eleven")
+        (let ((ks (map-keys m)))
+          (set! n (list-len ks))
+          (while (< i n)
+            (do
+              (match (list-get ks i)
+                ((some k) (set! sum (+ sum k)))
+                ((none) (do)))
+              (set! i (+ i 1)))))
+        (and (== n 3)
+             (and (== sum 19)
+                  ;; same type-identity check on the map-keys path
+                  (== (sum-int-list (map-keys m)) 19))))))
+
+  ;; ============================================================
+  ;; Test 6: map-keys on a String-keyed map -- the legacy path
+  ;; ============================================================
+  (fn test-map-keys-string ()
+    (@intent "map-keys on a (Map String V) must keep working via slop_map_keys")
+    (@spec (() -> Bool))
+    (with-arena 65536
+      (let ((m (map-new arena String Int))
+            (mut n 0)
+            (mut chars 0)
+            (mut i 0))
+        (map-put m "aa" 1)
+        (map-put m "bbb" 2)
+        (let ((ks (map-keys m)))
+          (set! n (list-len ks))
+          (while (< i n)
+            (do
+              (match (list-get ks i)
+                ((some k) (set! chars (+ chars (string-len k))))
+                ((none) (do)))
+              (set! i (+ i 1)))))
+        (and (== n 2) (== chars 5)))))
+
+  ;; ============================================================
+  ;; Main test runner
+  ;; ============================================================
+  (fn main ()
+    (@intent "Run all set-elements / map-keys element-type tests")
+    (@spec (() -> Int))
+    (let ((mut failures 0))
+      (if (test-set-elements-int)
+        (println "test-set-elements-int: PASS")
+        (do (println "test-set-elements-int: FAIL")
+            (set! failures (+ failures 1))))
+      (if (test-set-elements-bool)
+        (println "test-set-elements-bool: PASS")
+        (do (println "test-set-elements-bool: FAIL")
+            (set! failures (+ failures 1))))
+      (if (test-set-elements-string)
+        (println "test-set-elements-string: PASS")
+        (do (println "test-set-elements-string: FAIL")
+            (set! failures (+ failures 1))))
+      (if (test-set-elements-record)
+        (println "test-set-elements-record: PASS")
+        (do (println "test-set-elements-record: FAIL")
+            (set! failures (+ failures 1))))
+      (if (test-map-keys-int)
+        (println "test-map-keys-int: PASS")
+        (do (println "test-map-keys-int: FAIL")
+            (set! failures (+ failures 1))))
+      (if (test-map-keys-string)
+        (println "test-map-keys-string: PASS")
+        (do (println "test-map-keys-string: FAIL")
+            (set! failures (+ failures 1))))
+      (println "")
+      (if (== failures 0)
+        (do (println "All tests passed!")
+            0)
+        (do (print failures)
+            (println " test(s) failed")
+            1)))))


### PR DESCRIPTION
Fixed together because they collide: unwrapping the Ptr in the type extractors makes (Ptr (Map Int V)) start inferring int64_t where it previously inferred "", and "" was what routed map-keys to the legacy String branch. Fixing #82 alone converts one failure into another.

#72 - set-elements and the typed map-keys path built the C typedef name by concatenating the raw C type, so (Set Int) named slop_list_int64_t. The runtime names its four list typedefs after the SLOP type, and every other slop_list_ construction in the compiler already routed through type-to-identifier; these two were the only sites that did not.

Correcting the name is not sufficient on its own. The runtime predefines only slop_list_{int,float,string,ptr}, so (Set Bool) needs an emitted SLOP_LIST_DEFINE(uint8_t, slop_list_u8). The registration machinery existed, but the prescan that drives it walks type annotations only, so a set bound by an inferred let is never seen -- and there was a late-emit pass for Option types with no List equivalent. Both sites now register at the point of use, and emit-late-registered-list-types-header runs beside the Option one. The paired Option type is registered too, since list-get over the result needs slop_option_u8, which is not predefined either.

Same defect class, also fixed: emit-struct-key-types-header (a registration site, so its name has to agree with the use site) and slop-type-to-c-type's (List T) and (Option T) branches, which sat directly above Chan/Thread branches that already did it correctly.

Behaviour change: an uninferable element type used to fall through to the String branch, silently emitting a slop_string read for a set of some other type. It is now a positioned transpiler error.

#82 - (Ptr (Map K V)) and (Ptr (Set T)) are slop_map**, but only map-put dereferenced. The other emitters passed the double pointer into a slop_map* parameter, which is merely a C warning -- and slop build discards cc output, so the build reported success and the program read a bad pointer. The for-each family was worse: it emitted an explicit (slop_map*) cast, which silences the warning entirely.

Independently, the three extract-*-from-slop-type helpers matched a literal "(Map " / "(Set " prefix and answered "" for the pointer form, which is why map-get fell back to an anonymous struct returning void* and for-each emitted bindings with no element type -- hard C errors.

Adds unwrap-ptr-container-type (in ctype.slop, with @example coverage) plus resolve-container-c / deref-container-c, then applies them to all nine container emitters and all nine (slop_map*) for-each casts; the for-each family is triplicated across stmt.slop, match.slop and expr.slop. map-put and map-remove fold onto the same helper, dropping their duplicated needs-deref branches. is-ptr-to-ptr-map gains an infer-expr-slop-type fallback so non-symbol expressions are covered. stmt.slop's byte-identical copies of is-set-type / is-map-type are deleted in favour of the exported originals.

A probe exercising every container builtin through a Ptr map and a Ptr set goes from 8 warnings and 5 errors to zero, hand-compiled with cc. map-put through a Ptr map also stops falling back to __auto_type, so the write-width hazard its own @intent documents is gone for that shape.

Tests
  tests/test_set_elements.slop  - Int, Bool, String and record element
    types, plus map-keys on Int- and String-keyed maps. Registering the
    list type on demand makes any name compile, so counting elements
    cannot tell slop_list_int from slop_list_int64_t; the assertions pass
    the result to a function taking (List Int) to force type identity.
  tests/test_ptr_map_ops.slop   - all nine builtins through (addr x),
    for-each in all three emitter positions, and both field-access
    shapes: a (Map K V) field must not gain a deref, a (Ptr (Map K V))
    field must. (Ptr (Set T)) had no coverage anywhere before this.

lib/compiler/common joins the run_unit_tests list, which also switches on 19 @example blocks in ctype.slop that nothing had ever run.

make test-native goes 37 -> 40. Closes #72, closes #82.