### PR TITLE
match exhaustiveness in the checker, unreachable trap in codegen (#86)

### DIFF
--- a/bootstrap/checker/slop_checker.c
+++ b/bootstrap/checker/slop_checker.c
@@ -51,9 +51,9 @@ void checker_check_all_functions(env_TypeEnv* env, slop_list_types_SExpr_ptr ast
     {
         __auto_type len = ((int64_t)((ast).len));
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_395 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_395.has_value) {
-                __auto_type expr = _mv_395.value;
+            __auto_type _mv_401 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_401.has_value) {
+                __auto_type expr = _mv_401.value;
                 if (parser_is_form(expr, SLOP_STR("fn"))) {
                     {
                         __auto_type _ = infer_infer_fn_body(env, expr);
@@ -62,7 +62,7 @@ void checker_check_all_functions(env_TypeEnv* env, slop_list_types_SExpr_ptr ast
                     checker_check_module_functions(env, expr);
                 } else {
                 }
-            } else if (!_mv_395.has_value) {
+            } else if (!_mv_401.has_value) {
             }
         }
     }
@@ -70,13 +70,14 @@ void checker_check_all_functions(env_TypeEnv* env, slop_list_types_SExpr_ptr ast
 
 uint8_t checker_is_annotation_form(types_SExpr* item) {
     if (parser_sexpr_is_list(item)) {
-        __auto_type _mv_396 = parser_sexpr_list_get(item, 0);
-        if (_mv_396.has_value) {
-            __auto_type head = _mv_396.value;
+        __auto_type _mv_402 = parser_sexpr_list_get(item, 0);
+        if (_mv_402.has_value) {
+            __auto_type head = _mv_402.value;
             return ((uint8_t)(({ __auto_type name = parser_sexpr_get_symbol_name(head); (((name.len > 0)) ? (name.data[0] == 64) : 0); })));
-        } else if (!_mv_396.has_value) {
+        } else if (!_mv_402.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     } else {
         return 0;
     }
@@ -106,13 +107,14 @@ uint8_t checker_is_valid_toplevel_form(types_SExpr* item) {
 
 slop_string checker_get_form_name(types_SExpr* item) {
     if (parser_sexpr_is_list(item)) {
-        __auto_type _mv_397 = parser_sexpr_list_get(item, 0);
-        if (_mv_397.has_value) {
-            __auto_type head = _mv_397.value;
+        __auto_type _mv_403 = parser_sexpr_list_get(item, 0);
+        if (_mv_403.has_value) {
+            __auto_type head = _mv_403.value;
             return parser_sexpr_get_symbol_name(head);
-        } else if (!_mv_397.has_value) {
+        } else if (!_mv_403.has_value) {
             return SLOP_STR("<empty>");
         }
+        SLOP_UNREACHABLE();
     } else {
         return SLOP_STR("<non-list>");
     }
@@ -122,23 +124,23 @@ void checker_check_module_functions(env_TypeEnv* env, types_SExpr* module_form) 
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((module_form != NULL)), "(!= module-form nil)");
     if (parser_sexpr_is_list(module_form)) {
-        __auto_type _mv_398 = parser_sexpr_list_get(module_form, 1);
-        if (_mv_398.has_value) {
-            __auto_type name_expr = _mv_398.value;
+        __auto_type _mv_404 = parser_sexpr_list_get(module_form, 1);
+        if (_mv_404.has_value) {
+            __auto_type name_expr = _mv_404.value;
             {
                 __auto_type mod_name = parser_sexpr_get_symbol_name(name_expr);
                 if (!(string_eq(mod_name, SLOP_STR("")))) {
                     env_env_set_module(env, (slop_option_string){.has_value = 1, .value = mod_name});
                 }
             }
-        } else if (!_mv_398.has_value) {
+        } else if (!_mv_404.has_value) {
         }
         {
             __auto_type len = parser_sexpr_list_len(module_form);
             for (int64_t i = 2; i < len; i++) {
-                __auto_type _mv_399 = parser_sexpr_list_get(module_form, i);
-                if (_mv_399.has_value) {
-                    __auto_type item = _mv_399.value;
+                __auto_type _mv_405 = parser_sexpr_list_get(module_form, i);
+                if (_mv_405.has_value) {
+                    __auto_type item = _mv_405.value;
                     if (parser_is_form(item, SLOP_STR("fn"))) {
                         {
                             __auto_type _ = infer_infer_fn_body(env, item);
@@ -151,7 +153,7 @@ void checker_check_module_functions(env_TypeEnv* env, types_SExpr* module_form) 
                             env_env_add_error(env, msg, parser_sexpr_line(item), parser_sexpr_col(item));
                         }
                     }
-                } else if (!_mv_399.has_value) {
+                } else if (!_mv_405.has_value) {
                 }
             }
         }
@@ -219,45 +221,46 @@ slop_string checker_extract_module_name(slop_list_types_SExpr_ptr exprs) {
     if (((int64_t)((exprs).len)) < 1) {
         return SLOP_STR("unknown");
     } else {
-        __auto_type _mv_400 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_400.has_value) {
-            __auto_type first_expr = _mv_400.value;
-            __auto_type _mv_401 = (*first_expr);
-            switch (_mv_401.tag) {
+        __auto_type _mv_406 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_406.has_value) {
+            __auto_type first_expr = _mv_406.value;
+            __auto_type _mv_407 = (*first_expr);
+            switch (_mv_407.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type lst = _mv_401.data.lst;
+                    __auto_type lst = _mv_407.data.lst;
                     {
                         __auto_type items = lst.items;
                         if (((int64_t)((items).len)) < 2) {
                             return SLOP_STR("unknown");
                         } else {
-                            __auto_type _mv_402 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_402.has_value) {
-                                __auto_type head = _mv_402.value;
-                                __auto_type _mv_403 = (*head);
-                                switch (_mv_403.tag) {
+                            __auto_type _mv_408 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_408.has_value) {
+                                __auto_type head = _mv_408.value;
+                                __auto_type _mv_409 = (*head);
+                                switch (_mv_409.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_403.data.sym;
+                                        __auto_type sym = _mv_409.data.sym;
                                         if (string_eq(sym.name, SLOP_STR("module"))) {
-                                            __auto_type _mv_404 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_404.has_value) {
-                                                __auto_type name_expr = _mv_404.value;
-                                                __auto_type _mv_405 = (*name_expr);
-                                                switch (_mv_405.tag) {
+                                            __auto_type _mv_410 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_410.has_value) {
+                                                __auto_type name_expr = _mv_410.value;
+                                                __auto_type _mv_411 = (*name_expr);
+                                                switch (_mv_411.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type name_sym = _mv_405.data.sym;
+                                                        __auto_type name_sym = _mv_411.data.sym;
                                                         return name_sym.name;
                                                     }
                                                     default: {
                                                         return SLOP_STR("unknown");
                                                     }
                                                 }
-                                            } else if (!_mv_404.has_value) {
+                                            } else if (!_mv_410.has_value) {
                                                 return SLOP_STR("unknown");
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else {
                                             return SLOP_STR("unknown");
                                         }
@@ -266,9 +269,10 @@ slop_string checker_extract_module_name(slop_list_types_SExpr_ptr exprs) {
                                         return SLOP_STR("unknown");
                                     }
                                 }
-                            } else if (!_mv_402.has_value) {
+                            } else if (!_mv_408.has_value) {
                                 return SLOP_STR("unknown");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -276,9 +280,10 @@ slop_string checker_extract_module_name(slop_list_types_SExpr_ptr exprs) {
                     return SLOP_STR("unknown");
                 }
             }
-        } else if (!_mv_400.has_value) {
+        } else if (!_mv_406.has_value) {
             return SLOP_STR("unknown");
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -289,10 +294,10 @@ void checker_print_diagnostic(slop_arena* arena, slop_string filename, types_Dia
     printf("%s", ":");
     printf("%lld", (long long)(diag.col));
     printf("%s", ": ");
-    __auto_type _mv_406 = diag.level;
-    if (_mv_406 == types_DiagnosticLevel_diag_warning) {
+    __auto_type _mv_412 = diag.level;
+    if (_mv_412 == types_DiagnosticLevel_diag_warning) {
         printf("%s", "warning: ");
-    } else if (_mv_406 == types_DiagnosticLevel_diag_error) {
+    } else if (_mv_412 == types_DiagnosticLevel_diag_error) {
         printf("%s", "error: ");
     }
     printf("%.*s\n", (int)(diag.message).len, (diag.message).data);
@@ -303,11 +308,11 @@ void checker_output_diagnostics_text(slop_arena* arena, slop_string filename, sl
         __auto_type len = ((int64_t)((diagnostics).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_407 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_407.has_value) {
-                __auto_type diag = _mv_407.value;
+            __auto_type _mv_413 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_413.has_value) {
+                __auto_type diag = _mv_413.value;
                 checker_print_diagnostic(arena, filename, diag);
-            } else if (!_mv_407.has_value) {
+            } else if (!_mv_413.has_value) {
             }
             i = (i + 1);
         }
@@ -323,11 +328,11 @@ void checker_output_diagnostics_json(slop_arena* arena, slop_list_types_Diagnost
             if (i > 0) {
                 putchar(44);
             }
-            __auto_type _mv_408 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_408.has_value) {
-                __auto_type diag = _mv_408.value;
+            __auto_type _mv_414 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_414.has_value) {
+                __auto_type diag = _mv_414.value;
                 checker_output_single_diagnostic_json(arena, diag);
-            } else if (!_mv_408.has_value) {
+            } else if (!_mv_414.has_value) {
             }
             i = (i + 1);
         }
@@ -338,10 +343,10 @@ void checker_output_diagnostics_json(slop_arena* arena, slop_list_types_Diagnost
 void checker_output_single_diagnostic_json(slop_arena* arena, types_Diagnostic diag) {
     putchar(123);
     checker_print_str(((uint8_t*)(SLOP_STR("\"level\":").data)));
-    __auto_type _mv_409 = diag.level;
-    if (_mv_409 == types_DiagnosticLevel_diag_warning) {
+    __auto_type _mv_415 = diag.level;
+    if (_mv_415 == types_DiagnosticLevel_diag_warning) {
         checker_print_str(((uint8_t*)(SLOP_STR("\"warning\"").data)));
-    } else if (_mv_409 == types_DiagnosticLevel_diag_error) {
+    } else if (_mv_415 == types_DiagnosticLevel_diag_error) {
         checker_print_str(((uint8_t*)(SLOP_STR("\"error\"").data)));
     }
     putchar(44);
@@ -373,27 +378,27 @@ int64_t checker_check_single_file(env_TypeEnv* env, slop_arena* arena, uint8_t* 
     SLOP_PRE(((filename != NULL)), "(!= filename nil)");
     {
         __auto_type filename_str = strlib_cstring_to_string(filename);
-        __auto_type _mv_410 = file_file_open(filename_str, file_FileMode_read);
-        if (!_mv_410.is_ok) {
-            __auto_type e = _mv_410.data.err;
+        __auto_type _mv_416 = file_file_open(filename_str, file_FileMode_read);
+        if (!_mv_416.is_ok) {
+            __auto_type e = _mv_416.data.err;
             printf("%s", "Error: Could not open file: ");
             printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
             return 1;
-        } else if (_mv_410.is_ok) {
-            __auto_type f = _mv_410.data.ok;
-            __auto_type _mv_411 = file_file_read_all(arena, (&f));
-            if (!_mv_411.is_ok) {
-                __auto_type e = _mv_411.data.err;
+        } else if (_mv_416.is_ok) {
+            __auto_type f = _mv_416.data.ok;
+            __auto_type _mv_417 = file_file_read_all(arena, (&f));
+            if (!_mv_417.is_ok) {
+                __auto_type e = _mv_417.data.err;
                 file_file_close((&f));
                 printf("%s", "Error: Could not read file: ");
                 printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
                 return 1;
-            } else if (_mv_411.is_ok) {
-                __auto_type source = _mv_411.data.ok;
+            } else if (_mv_417.is_ok) {
+                __auto_type source = _mv_417.data.ok;
                 file_file_close((&f));
-                __auto_type _mv_412 = parser_parse(arena, source);
-                if (_mv_412.is_ok) {
-                    __auto_type ast = _mv_412.data.ok;
+                __auto_type _mv_418 = parser_parse(arena, source);
+                if (_mv_418.is_ok) {
+                    __auto_type ast = _mv_418.data.ok;
                     {
                         __auto_type mod_name = checker_extract_module_name(ast);
                         env_env_clear_imports(env);
@@ -410,8 +415,8 @@ int64_t checker_check_single_file(env_TypeEnv* env, slop_arena* arena, uint8_t* 
                             return checker_count_errors(diagnostics);
                         }
                     }
-                } else if (!_mv_412.is_ok) {
-                    __auto_type parse_err = _mv_412.data.err;
+                } else if (!_mv_418.is_ok) {
+                    __auto_type parse_err = _mv_418.data.err;
                     printf("%.*s", (int)(filename_str).len, (filename_str).data);
                     printf("%s", ":");
                     printf("%lld", (long long)(parse_err.line));
@@ -421,8 +426,11 @@ int64_t checker_check_single_file(env_TypeEnv* env, slop_arena* arena, uint8_t* 
                     printf("%.*s\n", (int)(parse_err.message).len, (parse_err.message).data);
                     return 1;
                 }
+                SLOP_UNREACHABLE();
             }
+            SLOP_UNREACHABLE();
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -432,15 +440,15 @@ int64_t checker_count_errors(slop_list_types_Diagnostic diagnostics) {
         int64_t errors = 0;
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_413 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_413.has_value) {
-                __auto_type diag = _mv_413.value;
-                __auto_type _mv_414 = diag.level;
-                if (_mv_414 == types_DiagnosticLevel_diag_error) {
+            __auto_type _mv_419 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_419.has_value) {
+                __auto_type diag = _mv_419.value;
+                __auto_type _mv_420 = diag.level;
+                if (_mv_420 == types_DiagnosticLevel_diag_error) {
                     errors = (errors + 1);
-                } else if (_mv_414 == types_DiagnosticLevel_diag_warning) {
+                } else if (_mv_420 == types_DiagnosticLevel_diag_warning) {
                 }
-            } else if (!_mv_413.has_value) {
+            } else if (!_mv_419.has_value) {
             }
             i = (i + 1);
         }
@@ -457,15 +465,15 @@ slop_string checker_argv_to_string(uint8_t** argv, int64_t index) {
 
 types_ResolvedType* checker_resolve_type_string(env_TypeEnv* env, slop_arena* arena, slop_string type_str) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_415 = parser_parse(arena, type_str);
-    if (_mv_415.is_ok) {
-        __auto_type type_ast = _mv_415.data.ok;
+    __auto_type _mv_421 = parser_parse(arena, type_str);
+    if (_mv_421.is_ok) {
+        __auto_type type_ast = _mv_421.data.ok;
         if (((int64_t)((type_ast).len)) == 0) {
             return env_env_get_int_type(env);
         } else {
-            __auto_type _mv_416 = ({ __auto_type _lst = type_ast; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_416.has_value) {
-                __auto_type type_expr = _mv_416.value;
+            __auto_type _mv_422 = ({ __auto_type _lst = type_ast; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_422.has_value) {
+                __auto_type type_expr = _mv_422.value;
                 if (parser_sexpr_is_list(type_expr)) {
                     return infer_resolve_complex_type_expr(env, type_expr);
                 } else {
@@ -478,63 +486,65 @@ types_ResolvedType* checker_resolve_type_string(env_TypeEnv* env, slop_arena* ar
                         }
                     }
                 }
-            } else if (!_mv_416.has_value) {
+            } else if (!_mv_422.has_value) {
                 return env_env_get_int_type(env);
             }
+            SLOP_UNREACHABLE();
         }
-    } else if (!_mv_415.is_ok) {
-        __auto_type _ = _mv_415.data.err;
+    } else if (!_mv_421.is_ok) {
+        __auto_type _ = _mv_421.data.err;
         return env_env_get_int_type(env);
     }
+    SLOP_UNREACHABLE();
 }
 
 void checker_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_string params_str) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_417 = parser_parse(arena, params_str);
-    if (_mv_417.is_ok) {
-        __auto_type params_ast = _mv_417.data.ok;
+    __auto_type _mv_423 = parser_parse(arena, params_str);
+    if (_mv_423.is_ok) {
+        __auto_type params_ast = _mv_423.data.ok;
         if (((int64_t)((params_ast).len)) > 0) {
-            __auto_type _mv_418 = ({ __auto_type _lst = params_ast; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_418.has_value) {
-                __auto_type params_list = _mv_418.value;
-                __auto_type _mv_419 = (*params_list);
-                switch (_mv_419.tag) {
+            __auto_type _mv_424 = ({ __auto_type _lst = params_ast; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_424.has_value) {
+                __auto_type params_list = _mv_424.value;
+                __auto_type _mv_425 = (*params_list);
+                switch (_mv_425.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type lst = _mv_419.data.lst;
+                        __auto_type lst = _mv_425.data.lst;
                         {
                             __auto_type items = lst.items;
                             __auto_type len = ((int64_t)((items).len));
                             for (int64_t i = 0; i < len; i++) {
-                                __auto_type _mv_420 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_420.has_value) {
-                                    __auto_type param = _mv_420.value;
-                                    __auto_type _mv_421 = (*param);
-                                    switch (_mv_421.tag) {
+                                __auto_type _mv_426 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_426.has_value) {
+                                    __auto_type param = _mv_426.value;
+                                    __auto_type _mv_427 = (*param);
+                                    switch (_mv_427.tag) {
                                         case types_SExpr_lst:
                                         {
-                                            __auto_type param_lst = _mv_421.data.lst;
+                                            __auto_type param_lst = _mv_427.data.lst;
                                             {
                                                 __auto_type param_items = param_lst.items;
                                                 if (((int64_t)((param_items).len)) >= 2) {
-                                                    __auto_type _mv_422 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_422.has_value) {
-                                                        __auto_type name_expr = _mv_422.value;
-                                                        __auto_type _mv_423 = (*name_expr);
-                                                        switch (_mv_423.tag) {
+                                                    __auto_type _mv_428 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_428.has_value) {
+                                                        __auto_type name_expr = _mv_428.value;
+                                                        __auto_type _mv_429 = (*name_expr);
+                                                        switch (_mv_429.tag) {
                                                             case types_SExpr_sym:
                                                             {
-                                                                __auto_type name_sym = _mv_423.data.sym;
+                                                                __auto_type name_sym = _mv_429.data.sym;
                                                                 {
                                                                     __auto_type param_name = name_sym.name;
-                                                                    __auto_type _mv_424 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                    if (_mv_424.has_value) {
-                                                                        __auto_type type_expr = _mv_424.value;
-                                                                        __auto_type _mv_425 = (*type_expr);
-                                                                        switch (_mv_425.tag) {
+                                                                    __auto_type _mv_430 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                    if (_mv_430.has_value) {
+                                                                        __auto_type type_expr = _mv_430.value;
+                                                                        __auto_type _mv_431 = (*type_expr);
+                                                                        switch (_mv_431.tag) {
                                                                             case types_SExpr_sym:
                                                                             {
-                                                                                __auto_type type_sym = _mv_425.data.sym;
+                                                                                __auto_type type_sym = _mv_431.data.sym;
                                                                                 {
                                                                                     __auto_type param_type = checker_resolve_type_string(env, arena, type_sym.name);
                                                                                     env_env_bind_var(env, param_name, param_type);
@@ -543,7 +553,7 @@ void checker_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_str
                                                                             }
                                                                             case types_SExpr_lst:
                                                                             {
-                                                                                __auto_type _ = _mv_425.data.lst;
+                                                                                __auto_type _ = _mv_431.data.lst;
                                                                                 {
                                                                                     __auto_type param_type = infer_resolve_complex_type_expr(env, type_expr);
                                                                                     env_env_bind_var(env, param_name, param_type);
@@ -555,7 +565,7 @@ void checker_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_str
                                                                                 break;
                                                                             }
                                                                         }
-                                                                    } else if (!_mv_424.has_value) {
+                                                                    } else if (!_mv_430.has_value) {
                                                                     }
                                                                 }
                                                                 break;
@@ -564,7 +574,7 @@ void checker_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_str
                                                                 break;
                                                             }
                                                         }
-                                                    } else if (!_mv_422.has_value) {
+                                                    } else if (!_mv_428.has_value) {
                                                     }
                                                 }
                                             }
@@ -574,7 +584,7 @@ void checker_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_str
                                             break;
                                         }
                                     }
-                                } else if (!_mv_420.has_value) {
+                                } else if (!_mv_426.has_value) {
                                 }
                             }
                         }
@@ -584,11 +594,11 @@ void checker_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_str
                         break;
                     }
                 }
-            } else if (!_mv_418.has_value) {
+            } else if (!_mv_424.has_value) {
             }
         }
-    } else if (!_mv_417.is_ok) {
-        __auto_type _ = _mv_417.data.err;
+    } else if (!_mv_423.is_ok) {
+        __auto_type _ = _mv_423.data.err;
     }
 }
 
@@ -607,19 +617,21 @@ uint8_t checker_types_names_equal(types_ResolvedType* a, types_ResolvedType* b) 
         } else if (string_eq(a_name, SLOP_STR("Unknown")) || string_eq(b_name, SLOP_STR("Unknown"))) {
             return 1;
         } else if ((a_kind == types_ResolvedTypeKind_rk_option) && (b_kind == types_ResolvedTypeKind_rk_option)) {
-            __auto_type _mv_426 = (*a).inner_type;
-            if (_mv_426.has_value) {
-                __auto_type a_inner = _mv_426.value;
-                __auto_type _mv_427 = (*b).inner_type;
-                if (_mv_427.has_value) {
-                    __auto_type b_inner = _mv_427.value;
+            __auto_type _mv_432 = (*a).inner_type;
+            if (_mv_432.has_value) {
+                __auto_type a_inner = _mv_432.value;
+                __auto_type _mv_433 = (*b).inner_type;
+                if (_mv_433.has_value) {
+                    __auto_type b_inner = _mv_433.value;
                     return checker_types_names_equal(a_inner, b_inner);
-                } else if (!_mv_427.has_value) {
+                } else if (!_mv_433.has_value) {
                     return 1;
                 }
-            } else if (!_mv_426.has_value) {
+                SLOP_UNREACHABLE();
+            } else if (!_mv_432.has_value) {
                 return 1;
             }
+            SLOP_UNREACHABLE();
         } else if ((a_kind == types_ResolvedTypeKind_rk_result) && (b_kind == types_ResolvedTypeKind_rk_result)) {
             {
                 __auto_type ok_match = ({ __auto_type _mv = (*a).inner_type; _mv.has_value ? ({ __auto_type a_inner = _mv.value; ({ __auto_type _mv = (*b).inner_type; _mv.has_value ? ({ __auto_type b_inner = _mv.value; checker_types_names_equal(a_inner, b_inner); }) : (1); }); }) : (1); });
@@ -627,35 +639,39 @@ uint8_t checker_types_names_equal(types_ResolvedType* a, types_ResolvedType* b) 
                 return (ok_match && err_match);
             }
         } else if ((a_kind == types_ResolvedTypeKind_rk_ptr) && (b_kind == types_ResolvedTypeKind_rk_ptr)) {
-            __auto_type _mv_428 = (*a).inner_type;
-            if (_mv_428.has_value) {
-                __auto_type a_inner = _mv_428.value;
-                __auto_type _mv_429 = (*b).inner_type;
-                if (_mv_429.has_value) {
-                    __auto_type b_inner = _mv_429.value;
+            __auto_type _mv_434 = (*a).inner_type;
+            if (_mv_434.has_value) {
+                __auto_type a_inner = _mv_434.value;
+                __auto_type _mv_435 = (*b).inner_type;
+                if (_mv_435.has_value) {
+                    __auto_type b_inner = _mv_435.value;
                     return checker_types_names_equal(a_inner, b_inner);
-                } else if (!_mv_429.has_value) {
+                } else if (!_mv_435.has_value) {
                     return 1;
                 }
-            } else if (!_mv_428.has_value) {
+                SLOP_UNREACHABLE();
+            } else if (!_mv_434.has_value) {
                 return 1;
             }
+            SLOP_UNREACHABLE();
         } else if (a_kind == types_ResolvedTypeKind_rk_range) {
-            __auto_type _mv_430 = (*a).inner_type;
-            if (_mv_430.has_value) {
-                __auto_type base = _mv_430.value;
+            __auto_type _mv_436 = (*a).inner_type;
+            if (_mv_436.has_value) {
+                __auto_type base = _mv_436.value;
                 return checker_types_names_equal(base, b);
-            } else if (!_mv_430.has_value) {
+            } else if (!_mv_436.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         } else if (b_kind == types_ResolvedTypeKind_rk_range) {
-            __auto_type _mv_431 = (*b).inner_type;
-            if (_mv_431.has_value) {
-                __auto_type base = _mv_431.value;
+            __auto_type _mv_437 = (*b).inner_type;
+            if (_mv_437.has_value) {
+                __auto_type base = _mv_437.value;
                 return checker_types_names_equal(a, base);
-            } else if (!_mv_431.has_value) {
+            } else if (!_mv_437.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         } else if ((a_kind == types_ResolvedTypeKind_rk_primitive) && (b_kind == types_ResolvedTypeKind_rk_primitive)) {
             {
                 __auto_type a_match = ({ __auto_type _mv = (*a).inner_type; _mv.has_value ? ({ __auto_type a_base = _mv.value; checker_types_names_equal(a_base, b); }) : (0); });
@@ -663,21 +679,23 @@ uint8_t checker_types_names_equal(types_ResolvedType* a, types_ResolvedType* b) 
                 return (a_match || b_match);
             }
         } else if (a_kind == types_ResolvedTypeKind_rk_primitive) {
-            __auto_type _mv_432 = (*a).inner_type;
-            if (_mv_432.has_value) {
-                __auto_type a_base = _mv_432.value;
+            __auto_type _mv_438 = (*a).inner_type;
+            if (_mv_438.has_value) {
+                __auto_type a_base = _mv_438.value;
                 return checker_types_names_equal(a_base, b);
-            } else if (!_mv_432.has_value) {
+            } else if (!_mv_438.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         } else if (b_kind == types_ResolvedTypeKind_rk_primitive) {
-            __auto_type _mv_433 = (*b).inner_type;
-            if (_mv_433.has_value) {
-                __auto_type b_base = _mv_433.value;
+            __auto_type _mv_439 = (*b).inner_type;
+            if (_mv_439.has_value) {
+                __auto_type b_base = _mv_439.value;
                 return checker_types_names_equal(a, b_base);
-            } else if (!_mv_433.has_value) {
+            } else if (!_mv_439.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         } else {
             return 0;
         }
@@ -687,26 +705,26 @@ uint8_t checker_types_names_equal(types_ResolvedType* a, types_ResolvedType* b) 
 int64_t checker_check_expr_mode(slop_arena* arena, env_TypeEnv* env, slop_string expr_str, slop_string type_str, slop_string context_file, slop_string params_str) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     if (string_len(context_file) > 0) {
-        __auto_type _mv_434 = file_file_open(context_file, file_FileMode_read);
-        if (!_mv_434.is_ok) {
-            __auto_type _ = _mv_434.data.err;
-        } else if (_mv_434.is_ok) {
-            __auto_type f = _mv_434.data.ok;
-            __auto_type _mv_435 = file_file_read_all(arena, (&f));
-            if (!_mv_435.is_ok) {
-                __auto_type _ = _mv_435.data.err;
+        __auto_type _mv_440 = file_file_open(context_file, file_FileMode_read);
+        if (!_mv_440.is_ok) {
+            __auto_type _ = _mv_440.data.err;
+        } else if (_mv_440.is_ok) {
+            __auto_type f = _mv_440.data.ok;
+            __auto_type _mv_441 = file_file_read_all(arena, (&f));
+            if (!_mv_441.is_ok) {
+                __auto_type _ = _mv_441.data.err;
                 file_file_close((&f));
-            } else if (_mv_435.is_ok) {
-                __auto_type source = _mv_435.data.ok;
+            } else if (_mv_441.is_ok) {
+                __auto_type source = _mv_441.data.ok;
                 file_file_close((&f));
-                __auto_type _mv_436 = parser_parse(arena, source);
-                if (_mv_436.is_ok) {
-                    __auto_type context_ast = _mv_436.data.ok;
+                __auto_type _mv_442 = parser_parse(arena, source);
+                if (_mv_442.is_ok) {
+                    __auto_type context_ast = _mv_442.data.ok;
                     collect_collect_module(env, context_ast);
                     resolve_resolve_imports(env, context_ast);
                     env_env_clear_diagnostics(env);
-                } else if (!_mv_436.is_ok) {
-                    __auto_type _ = _mv_436.data.err;
+                } else if (!_mv_442.is_ok) {
+                    __auto_type _ = _mv_442.data.err;
                 }
             }
         }

--- a/bootstrap/checker/slop_collect.c
+++ b/bootstrap/checker/slop_collect.c
@@ -380,6 +380,7 @@ types_SExpr* collect_get_type_arg(types_SExpr* type_expr, int64_t idx) {
             } else if (!_mv_123.has_value) {
                 return type_expr;
             }
+            SLOP_UNREACHABLE();
         }
         default: {
             return type_expr;
@@ -413,6 +414,7 @@ types_ResolvedType* collect_get_field_type(env_TypeEnv* env, slop_arena* arena, 
                         return types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, type_name, ((slop_option_string){.has_value = false}), type_name);
                     }
                 }
+                SLOP_UNREACHABLE();
             }
         }
         case types_SExpr_lst:
@@ -489,6 +491,7 @@ types_ResolvedType* collect_get_field_type(env_TypeEnv* env, slop_arena* arena, 
                 } else if (!_mv_126.has_value) {
                     return env_env_get_unit_type(env);
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -544,6 +547,7 @@ types_ResolvedType* collect_get_field_type_generic(env_TypeEnv* env, slop_arena*
                             return types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, type_name, ((slop_option_string){.has_value = false}), type_name);
                         }
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -621,6 +625,7 @@ types_ResolvedType* collect_get_field_type_generic(env_TypeEnv* env, slop_arena*
                 } else if (!_mv_130.has_value) {
                     return env_env_get_unit_type(env);
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -711,6 +716,7 @@ types_ResolvedType* collect_extract_spec_return_type_generic(env_TypeEnv* env, t
                     } else if (!_mv_136.has_value) {
                         return env_env_get_unit_type(env);
                     }
+                    SLOP_UNREACHABLE();
                 }
             } else {
                 return env_env_get_unit_type(env);
@@ -718,6 +724,7 @@ types_ResolvedType* collect_extract_spec_return_type_generic(env_TypeEnv* env, t
         } else if (!_mv_135.has_value) {
             return env_env_get_unit_type(env);
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -850,6 +857,7 @@ slop_option_types_ResolvedType_ptr collect_lookup_payload_type(env_TypeEnv* env,
                 return (slop_option_types_ResolvedType_ptr){.has_value = false};
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -870,6 +878,7 @@ uint8_t collect_is_range_type_expr(types_SExpr* type_expr) {
             } else if (!_mv_145.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -891,6 +900,7 @@ types_ResolvedType* collect_get_range_base_type(env_TypeEnv* env, slop_arena* ar
                 } else if (!_mv_147.has_value) {
                     return env_env_get_int_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_int_type(env);
             }
@@ -898,6 +908,7 @@ types_ResolvedType* collect_get_range_base_type(env_TypeEnv* env, slop_arena* ar
     } else if (!_mv_146.has_value) {
         return env_env_get_int_type(env);
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string collect_get_type_name_from_expr(types_SExpr* expr) {
@@ -969,6 +980,7 @@ slop_option_types_ResolvedType_ptr collect_get_variant_payload_type(env_TypeEnv*
         } else if (!_mv_151.has_value) {
             return (slop_option_types_ResolvedType_ptr){.has_value = false};
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -984,6 +996,7 @@ slop_string collect_checker_get_variant_name(types_SExpr* variant_form) {
             } else if (!_mv_152.has_value) {
                 return SLOP_STR("");
             }
+            SLOP_UNREACHABLE();
         }
     } else {
         __auto_type _mv_153 = (*variant_form);
@@ -1033,6 +1046,7 @@ uint8_t collect_check_type_expr_recursive(types_SExpr* type_expr, slop_string un
                                     } else if (!_mv_157.has_value) {
                                         return 0;
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else {
                                     return 0;
                                 }
@@ -1044,6 +1058,7 @@ uint8_t collect_check_type_expr_recursive(types_SExpr* type_expr, slop_string un
                     } else if (!_mv_155.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1249,6 +1264,7 @@ types_ResolvedType* collect_get_const_type(env_TypeEnv* env, slop_arena* arena, 
                         return types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, type_name, ((slop_option_string){.has_value = false}), type_name);
                     }
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -1398,6 +1414,7 @@ uint8_t collect_ffi_has_variadic(types_SExpr* func_decl) {
             } else if (!_mv_175.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         } else {
             return 0;
         }
@@ -1462,6 +1479,7 @@ types_ResolvedType* collect_get_ffi_return_type(env_TypeEnv* env, slop_arena* ar
     } else if (!_mv_180.has_value) {
         return env_env_get_unit_type(env);
     }
+    SLOP_UNREACHABLE();
 }
 
 void collect_collect_single_function(env_TypeEnv* env, slop_arena* arena, types_SExpr* fn_form) {
@@ -1736,6 +1754,7 @@ types_ResolvedType* collect_checker_extract_spec_return_type(env_TypeEnv* env, t
                     } else if (!_mv_198.has_value) {
                         return env_env_get_unit_type(env);
                     }
+                    SLOP_UNREACHABLE();
                 }
             } else {
                 return env_env_get_unit_type(env);
@@ -1743,6 +1762,7 @@ types_ResolvedType* collect_checker_extract_spec_return_type(env_TypeEnv* env, t
         } else if (!_mv_197.has_value) {
             return env_env_get_unit_type(env);
         }
+        SLOP_UNREACHABLE();
     }
 }
 

--- a/bootstrap/checker/slop_env.c
+++ b/bootstrap/checker/slop_env.c
@@ -293,6 +293,7 @@ uint8_t env_env_constant_matches_module(env_ConstBinding binding, slop_string mo
     } else if (!_mv_23.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t env_env_constant_is_builtin(env_ConstBinding binding) {
@@ -303,6 +304,7 @@ uint8_t env_env_constant_is_builtin(env_ConstBinding binding) {
         __auto_type _ = _mv_24.value;
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t env_env_lookup_constant_in_module(env_TypeEnv* env, slop_string mod_name, slop_string const_name) {
@@ -481,6 +483,7 @@ slop_option_types_ResolvedType_ptr env_env_lookup_type(env_TypeEnv* env, slop_st
             } else if (!_mv_33.has_value) {
                 return (slop_option_types_ResolvedType_ptr){.has_value = false};
             }
+            SLOP_UNREACHABLE();
         }
     } else if (!_mv_32.has_value) {
         __auto_type _mv_34 = env_env_resolve_import(env, name);
@@ -490,7 +493,9 @@ slop_option_types_ResolvedType_ptr env_env_lookup_type(env_TypeEnv* env, slop_st
         } else if (!_mv_34.has_value) {
             return (slop_option_types_ResolvedType_ptr){.has_value = false};
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_option_types_ResolvedType_ptr env_env_lookup_type_qualified(env_TypeEnv* env, slop_string module_name, slop_string type_name) {
@@ -537,7 +542,9 @@ uint8_t env_env_is_type_visible(env_TypeEnv* env, types_ResolvedType* t) {
         } else if (!_mv_38.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t env_env_is_function_visible(env_TypeEnv* env, types_FnSignature* sig) {
@@ -555,7 +562,9 @@ uint8_t env_env_is_function_visible(env_TypeEnv* env, types_FnSignature* sig) {
         } else if (!_mv_40.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 void env_env_register_function(env_TypeEnv* env, types_FnSignature* sig) {
@@ -609,7 +618,9 @@ slop_option_types_FnSignature_ptr env_env_lookup_function(env_TypeEnv* env, slop
                 } else if (!_mv_44.has_value) {
                     return (slop_option_types_FnSignature_ptr){.has_value = false};
                 }
+                SLOP_UNREACHABLE();
             }
+            SLOP_UNREACHABLE();
         }
     } else if (!_mv_42.has_value) {
         __auto_type _mv_45 = env_env_resolve_import(env, name);
@@ -627,8 +638,11 @@ slop_option_types_FnSignature_ptr env_env_lookup_function(env_TypeEnv* env, slop
             } else if (!_mv_46.has_value) {
                 return (slop_option_types_FnSignature_ptr){.has_value = false};
             }
+            SLOP_UNREACHABLE();
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 void env_env_add_import(env_TypeEnv* env, slop_string local_name, slop_string qualified_name) {
@@ -679,6 +693,7 @@ uint8_t env_env_variant_matches_module(env_VariantMapping v, slop_string mod_nam
     } else if (!_mv_48.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t env_env_variant_is_builtin(env_VariantMapping v) {
@@ -689,6 +704,7 @@ uint8_t env_env_variant_is_builtin(env_VariantMapping v) {
         __auto_type _ = _mv_49.value;
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_option_string env_env_lookup_variant(env_TypeEnv* env, slop_string variant_name) {
@@ -815,6 +831,7 @@ uint8_t env_env_same_module_opt(slop_option_string a, slop_option_string b) {
             __auto_type _ = _mv_59.value;
             return 0;
         }
+        SLOP_UNREACHABLE();
     } else if (_mv_58.has_value) {
         __auto_type amod = _mv_58.value;
         __auto_type _mv_60 = b;
@@ -824,7 +841,9 @@ uint8_t env_env_same_module_opt(slop_option_string a, slop_option_string b) {
             __auto_type bmod = _mv_60.value;
             return string_eq(amod, bmod);
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 void env_env_set_module(env_TypeEnv* env, slop_option_string module_name) {

--- a/bootstrap/checker/slop_infer.c
+++ b/bootstrap/checker/slop_infer.c
@@ -36,6 +36,11 @@ types_ResolvedType* infer_infer_field_access(env_TypeEnv* env, types_SExpr* expr
 types_ResolvedType* infer_check_field_exists(env_TypeEnv* env, types_ResolvedType* obj_type, slop_string field_name, int64_t line, int64_t col);
 types_ResolvedType* infer_infer_cond_expr(env_TypeEnv* env, types_SExpr* expr, types_SExprList lst);
 void infer_bind_match_pattern(env_TypeEnv* env, types_ResolvedType* scrutinee_type, types_SExpr* pattern);
+slop_string infer_match_pattern_head(types_SExpr* pattern);
+uint8_t infer_is_wildcard_head(slop_string head);
+uint8_t infer_string_list_contains(slop_list_string names, slop_string name);
+slop_list_string infer_match_expected_variants(slop_arena* arena, types_ResolvedType* scrutinee_type);
+void infer_check_match_exhaustive(env_TypeEnv* env, types_ResolvedType* scrutinee_type, slop_list_string covered, uint8_t has_wildcard, int64_t line, int64_t col);
 types_ResolvedType* infer_infer_match_expr(env_TypeEnv* env, types_SExpr* expr, types_SExprList lst);
 void infer_check_return_type(env_TypeEnv* env, types_SExpr* fn_form, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col);
 void infer_check_spec_return_type(env_TypeEnv* env, types_SExpr* spec_form, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col);
@@ -378,6 +383,7 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
                 } else if (!_mv_219.has_value) {
                     return t;
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (kind == types_ResolvedTypeKind_rk_ptr) {
             __auto_type _mv_220 = (*t).inner_type;
@@ -394,6 +400,7 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
             } else if (!_mv_220.has_value) {
                 return t;
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_chan) {
             __auto_type _mv_221 = (*t).inner_type;
             if (_mv_221.has_value) {
@@ -407,6 +414,7 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
             } else if (!_mv_221.has_value) {
                 return t;
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_thread) {
             __auto_type _mv_222 = (*t).inner_type;
             if (_mv_222.has_value) {
@@ -420,6 +428,7 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
             } else if (!_mv_222.has_value) {
                 return t;
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_list) {
             __auto_type _mv_223 = (*t).inner_type;
             if (_mv_223.has_value) {
@@ -433,6 +442,7 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
             } else if (!_mv_223.has_value) {
                 return t;
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_option) {
             __auto_type _mv_224 = (*t).inner_type;
             if (_mv_224.has_value) {
@@ -448,6 +458,7 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
             } else if (!_mv_224.has_value) {
                 return t;
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_result) {
             {
                 __auto_type new_ok = ({ __auto_type _mv = (*t).inner_type; _mv.has_value ? ({ __auto_type ok = _mv.value; infer_substitute_type_vars(arena, ok, bind_names, bind_types); }) : (NULL); });
@@ -568,6 +579,7 @@ uint8_t infer_types_compatible_with_range(types_ResolvedType* a, types_ResolvedT
             } else if (!_mv_227.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         } else if (b_kind == types_ResolvedTypeKind_rk_range) {
             __auto_type _mv_228 = (*b).inner_type;
             if (_mv_228.has_value) {
@@ -576,6 +588,7 @@ uint8_t infer_types_compatible_with_range(types_ResolvedType* a, types_ResolvedT
             } else if (!_mv_228.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         } else {
             return 0;
         }
@@ -706,7 +719,9 @@ types_ResolvedType* infer_infer_expr_inner(env_TypeEnv* env, types_SExpr* expr) 
                                                         return env_env_get_int_type(env);
                                                     }
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     } else {
                                         __auto_type _mv_236 = env_env_lookup_type(env, name);
@@ -724,6 +739,7 @@ types_ResolvedType* infer_infer_expr_inner(env_TypeEnv* env, types_SExpr* expr) 
                                                 } else if (!_mv_238.has_value) {
                                                     return env_env_get_int_type(env);
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else if (!_mv_237.has_value) {
                                                 {
                                                     __auto_type arena = env_env_arena(env);
@@ -732,11 +748,16 @@ types_ResolvedType* infer_infer_expr_inner(env_TypeEnv* env, types_SExpr* expr) 
                                                     return env_env_get_int_type(env);
                                                 }
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
+                                SLOP_UNREACHABLE();
                             }
+                            SLOP_UNREACHABLE();
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -756,6 +777,7 @@ types_ResolvedType* infer_infer_expr_inner(env_TypeEnv* env, types_SExpr* expr) 
                 return infer_infer_list_expr(env, expr, lst);
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -788,6 +810,7 @@ types_ResolvedType* infer_infer_list_expr(env_TypeEnv* env, types_SExpr* expr, t
                     }
                 }
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -824,10 +847,12 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                         } else if (!_mv_243.has_value) {
                             return then_type;
                         }
+                        SLOP_UNREACHABLE();
                     }
                 } else if (!_mv_242.has_value) {
                     return env_env_get_unit_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_unit_type(env);
             }
@@ -845,6 +870,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                 } else if (!_mv_244.has_value) {
                     return env_env_get_unit_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_unit_type(env);
             }
@@ -955,11 +981,13 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                             } else if (!_mv_252.has_value) {
                                                 return env_env_get_unit_type(env);
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 } else if (!_mv_251.has_value) {
                                     return env_env_get_unit_type(env);
                                 }
+                                SLOP_UNREACHABLE();
                             } else {
                                 return env_env_get_unit_type(env);
                             }
@@ -970,6 +998,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                 } else if (!_mv_250.has_value) {
                     return env_env_get_unit_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_unit_type(env);
             }
@@ -1068,6 +1097,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             } else if (!_mv_260.has_value) {
                                 return env_env_get_unit_type(env);
                             }
+                            SLOP_UNREACHABLE();
                         } else {
                             return ptr_type;
                         }
@@ -1075,6 +1105,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                 } else if (!_mv_259.has_value) {
                     return env_env_get_unit_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_unit_type(env);
             }
@@ -1090,6 +1121,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                 } else if (!_mv_261.has_value) {
                     return env_env_get_unit_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_unit_type(env);
             }
@@ -1137,6 +1169,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                 } else if (!_mv_263.has_value) {
                                     return env_env_get_unknown_type(env);
                                 }
+                                SLOP_UNREACHABLE();
                             } else {
                                 return env_env_get_unknown_type(env);
                             }
@@ -1158,11 +1191,13 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                     return env_env_get_unknown_type(env);
                                 }
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 } else if (!_mv_262.has_value) {
                     return env_env_get_unknown_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_unknown_type(env);
             }
@@ -1186,14 +1221,17 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                 } else if (!_mv_267.has_value) {
                                     return env_env_get_unknown_type(env);
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (!_mv_266.has_value) {
                                 return env_env_get_unknown_type(env);
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 } else if (!_mv_265.has_value) {
                     return env_env_get_unknown_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_unknown_type(env);
             }
@@ -1211,6 +1249,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                 } else if (!_mv_268.has_value) {
                     return env_env_make_option_type(env, NULL);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_make_option_type(env, NULL);
             }
@@ -1250,11 +1289,13 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             } else if (!_mv_272.has_value) {
                                 return env_env_get_unit_type(env);
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 } else if (!_mv_271.has_value) {
                     return env_env_get_unit_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_unit_type(env);
             }
@@ -1285,11 +1326,13 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             } else if (!_mv_275.has_value) {
                                 return env_env_get_unit_type(env);
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 } else if (!_mv_274.has_value) {
                     return env_env_get_unit_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_unit_type(env);
             }
@@ -1379,17 +1422,20 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                                                 } else if (!_mv_283.has_value) {
                                                                     return env_env_get_int_type(env);
                                                                 }
+                                                                SLOP_UNREACHABLE();
                                                             }
                                                         }
                                                     } else if (!_mv_282.has_value) {
                                                         return env_env_get_int_type(env);
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 } else {
                                                     return env_env_get_int_type(env);
                                                 }
                                             } else if (!_mv_281.has_value) {
                                                 return env_env_get_int_type(env);
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else {
                                             return env_env_get_int_type(env);
                                         }
@@ -1405,11 +1451,13 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                             }
                                             return env_env_get_int_type(env);
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             } else if (!_mv_280.has_value) {
                                 return env_env_get_int_type(env);
                             }
+                            SLOP_UNREACHABLE();
                         }
                     } else if (string_eq(op, SLOP_STR("arena-new"))) {
                         infer_check_builtin_args(env, SLOP_STR("arena-new"), 1, (len - 1), line, col);
@@ -1513,6 +1561,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                         } else if (!_mv_289.has_value) {
                                             return env_env_get_int_type(env);
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else {
                                         return env_env_get_int_type(env);
                                     }
@@ -1520,6 +1569,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             } else if (!_mv_288.has_value) {
                                 return env_env_get_int_type(env);
                             }
+                            SLOP_UNREACHABLE();
                         } else {
                             return env_env_get_int_type(env);
                         }
@@ -1771,12 +1821,16 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                             return env_env_get_unknown_type(env);
                                         }
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
+                SLOP_UNREACHABLE();
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -1948,8 +2002,10 @@ types_ResolvedType* infer_infer_field_access(env_TypeEnv* env, types_SExpr* expr
                             }
                         }
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -1972,6 +2028,7 @@ types_ResolvedType* infer_check_field_exists(env_TypeEnv* env, types_ResolvedTyp
                     return env_env_get_unit_type(env);
                 }
             }
+            SLOP_UNREACHABLE();
         } else {
             if (string_eq(type_name, SLOP_STR("T"))) {
                 return env_env_get_generic_type(env);
@@ -1996,6 +2053,7 @@ types_ResolvedType* infer_check_field_exists(env_TypeEnv* env, types_ResolvedTyp
                             } else if (!_mv_313.has_value) {
                                 return env_env_get_unknown_type(env);
                             }
+                            SLOP_UNREACHABLE();
                         } else {
                             if (string_eq(type_name, SLOP_STR("Chan")) || string_eq(type_name, SLOP_STR("Thread"))) {
                                 return env_env_get_unknown_type(env);
@@ -2199,6 +2257,143 @@ void infer_bind_match_pattern(env_TypeEnv* env, types_ResolvedType* scrutinee_ty
     }
 }
 
+slop_string infer_match_pattern_head(types_SExpr* pattern) {
+    SLOP_PRE(((pattern != NULL)), "(!= pattern nil)");
+    if (parser_sexpr_is_list(pattern)) {
+        if (parser_sexpr_list_len(pattern) > 0) {
+            __auto_type _mv_326 = parser_sexpr_list_get(pattern, 0);
+            if (_mv_326.has_value) {
+                __auto_type head = _mv_326.value;
+                return parser_sexpr_get_symbol_name(head);
+            } else if (!_mv_326.has_value) {
+                return SLOP_STR("");
+            }
+            SLOP_UNREACHABLE();
+        } else {
+            return SLOP_STR("");
+        }
+    } else {
+        return parser_sexpr_get_symbol_name(pattern);
+    }
+}
+
+uint8_t infer_is_wildcard_head(slop_string head) {
+    return (string_eq(head, SLOP_STR("_")) || string_eq(head, SLOP_STR("else")));
+}
+
+uint8_t infer_string_list_contains(slop_list_string names, slop_string name) {
+    {
+        __auto_type n = ((int64_t)((names).len));
+        int64_t i = 0;
+        uint8_t found = 0;
+        while ((i < n) && !(found)) {
+            __auto_type _mv_327 = ({ __auto_type _lst = names; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_327.has_value) {
+                __auto_type existing = _mv_327.value;
+                if (string_eq(existing, name)) {
+                    found = 1;
+                }
+            } else if (!_mv_327.has_value) {
+            }
+            i = (i + 1);
+        }
+        return found;
+    }
+}
+
+slop_list_string infer_match_expected_variants(slop_arena* arena, types_ResolvedType* scrutinee_type) {
+    SLOP_PRE(((scrutinee_type != NULL)), "(!= scrutinee-type nil)");
+    {
+        __auto_type kind = (*scrutinee_type).kind;
+        __auto_type result = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
+        if ((kind == types_ResolvedTypeKind_rk_union) || (kind == types_ResolvedTypeKind_rk_enum)) {
+            {
+                __auto_type variants = (*scrutinee_type).variants;
+                __auto_type n = ((int64_t)((variants).len));
+                int64_t i = 0;
+                while (i < n) {
+                    __auto_type _mv_328 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_types_ResolvedVariant _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_328.has_value) {
+                        __auto_type v = _mv_328.value;
+                        ({ __auto_type _lst_p = &(result); __auto_type _item = (v.name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+                    } else if (!_mv_328.has_value) {
+                    }
+                    i = (i + 1);
+                }
+                return result;
+            }
+        } else if (kind == types_ResolvedTypeKind_rk_option) {
+            ({ __auto_type _lst_p = &(result); __auto_type _item = (SLOP_STR("some")); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+            ({ __auto_type _lst_p = &(result); __auto_type _item = (SLOP_STR("none")); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+            return result;
+        } else if (kind == types_ResolvedTypeKind_rk_result) {
+            ({ __auto_type _lst_p = &(result); __auto_type _item = (SLOP_STR("ok")); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+            ({ __auto_type _lst_p = &(result); __auto_type _item = (SLOP_STR("error")); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+            return result;
+        } else {
+            return result;
+        }
+    }
+}
+
+void infer_check_match_exhaustive(env_TypeEnv* env, types_ResolvedType* scrutinee_type, slop_list_string covered, uint8_t has_wildcard, int64_t line, int64_t col) {
+    SLOP_PRE(((env != NULL)), "(!= env nil)");
+    SLOP_PRE(((scrutinee_type != NULL)), "(!= scrutinee-type nil)");
+    if (!(has_wildcard)) {
+        {
+            __auto_type arena = env_env_arena(env);
+            __auto_type type_name = (*scrutinee_type).name;
+            __auto_type expected = infer_match_expected_variants(arena, scrutinee_type);
+            if ((((int64_t)((expected).len)) > 0) && !(string_eq(type_name, SLOP_STR("T")))) {
+                {
+                    __auto_type n = ((int64_t)((covered).len));
+                    int64_t i = 0;
+                    uint8_t all_known = 1;
+                    __auto_type missing = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
+                    while (i < n) {
+                        __auto_type _mv_329 = ({ __auto_type _lst = covered; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_329.has_value) {
+                            __auto_type head = _mv_329.value;
+                            if (!(infer_string_list_contains(expected, head))) {
+                                all_known = 0;
+                            }
+                        } else if (!_mv_329.has_value) {
+                        }
+                        i = (i + 1);
+                    }
+                    if (all_known) {
+                        {
+                            __auto_type e_len = ((int64_t)((expected).len));
+                            int64_t j = 0;
+                            while (j < e_len) {
+                                __auto_type _mv_330 = ({ __auto_type _lst = expected; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_330.has_value) {
+                                    __auto_type want = _mv_330.value;
+                                    if (!(infer_string_list_contains(covered, want))) {
+                                        ({ __auto_type _lst_p = &(missing); __auto_type _item = (want); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+                                    }
+                                } else if (!_mv_330.has_value) {
+                                }
+                                j = (j + 1);
+                            }
+                            if (((int64_t)((missing).len)) > 0) {
+                                {
+                                    __auto_type parts = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
+                                    ({ __auto_type _lst_p = &(parts); __auto_type _item = (SLOP_STR("non-exhaustive match on ")); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+                                    ({ __auto_type _lst_p = &(parts); __auto_type _item = (type_name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+                                    ({ __auto_type _lst_p = &(parts); __auto_type _item = (SLOP_STR(": missing ")); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+                                    ({ __auto_type _lst_p = &(parts); __auto_type _item = (strlib_join(arena, missing, SLOP_STR(", "))); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+                                    env_env_add_warning(env, strlib_string_build(arena, parts), line, col);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 types_ResolvedType* infer_infer_match_expr(env_TypeEnv* env, types_SExpr* expr, types_SExprList lst) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     {
@@ -2207,42 +2402,60 @@ types_ResolvedType* infer_infer_match_expr(env_TypeEnv* env, types_SExpr* expr, 
         __auto_type line = parser_sexpr_line(expr);
         __auto_type col = parser_sexpr_col(expr);
         uint8_t has_result = 0;
+        uint8_t has_wildcard = 0;
+        __auto_type match_arena = env_env_arena(env);
+        __auto_type covered = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(match_arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
         types_ResolvedType* result_type = env_env_get_unit_type(env);
         __auto_type scrutinee_type = (((len >= 2)) ? ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type scrutinee = _mv.value; infer_infer_expr(env, scrutinee); }) : (env_env_get_unit_type(env)); }) : env_env_get_unit_type(env));
         int64_t i = 2;
         while (i < len) {
-            __auto_type _mv_326 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_326.has_value) {
-                __auto_type clause = _mv_326.value;
-                __auto_type _mv_327 = (*clause);
-                switch (_mv_327.tag) {
+            __auto_type _mv_331 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_331.has_value) {
+                __auto_type clause = _mv_331.value;
+                __auto_type _mv_332 = (*clause);
+                switch (_mv_332.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type clause_lst = _mv_327.data.lst;
+                        __auto_type clause_lst = _mv_332.data.lst;
                         {
                             __auto_type clause_items = clause_lst.items;
                             __auto_type clause_len = ((int64_t)((clause_items).len));
+                            if (clause_len > 0) {
+                                __auto_type _mv_333 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_333.has_value) {
+                                    __auto_type pattern = _mv_333.value;
+                                    {
+                                        __auto_type head = infer_match_pattern_head(pattern);
+                                        if (infer_is_wildcard_head(head)) {
+                                            has_wildcard = 1;
+                                        } else {
+                                            ({ __auto_type _lst_p = &(covered); __auto_type _item = (head); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(match_arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+                                        }
+                                    }
+                                } else if (!_mv_333.has_value) {
+                                }
+                            }
                             if (clause_len > 1) {
                                 env_env_push_scope(env);
-                                __auto_type _mv_328 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_328.has_value) {
-                                    __auto_type pattern = _mv_328.value;
+                                __auto_type _mv_334 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_334.has_value) {
+                                    __auto_type pattern = _mv_334.value;
                                     infer_bind_match_pattern(env, scrutinee_type, pattern);
-                                } else if (!_mv_328.has_value) {
+                                } else if (!_mv_334.has_value) {
                                 }
                                 for (int64_t bi = 1; bi < (clause_len - 1); bi++) {
-                                    __auto_type _mv_329 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_329.has_value) {
-                                        __auto_type body_expr = _mv_329.value;
+                                    __auto_type _mv_335 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_335.has_value) {
+                                        __auto_type body_expr = _mv_335.value;
                                         {
                                             __auto_type _ = infer_infer_expr(env, body_expr);
                                         }
-                                    } else if (!_mv_329.has_value) {
+                                    } else if (!_mv_335.has_value) {
                                     }
                                 }
-                                __auto_type _mv_330 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)(clause_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_330.has_value) {
-                                    __auto_type body = _mv_330.value;
+                                __auto_type _mv_336 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)(clause_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_336.has_value) {
+                                    __auto_type body = _mv_336.value;
                                     {
                                         __auto_type body_type = infer_infer_expr(env, body);
                                         if (!(has_result)) {
@@ -2252,7 +2465,7 @@ types_ResolvedType* infer_infer_match_expr(env_TypeEnv* env, types_SExpr* expr, 
                                             result_type = infer_unify_branch_types(env, result_type, body_type, line, col);
                                         }
                                     }
-                                } else if (!_mv_330.has_value) {
+                                } else if (!_mv_336.has_value) {
                                 }
                                 env_env_pop_scope(env);
                             }
@@ -2263,10 +2476,11 @@ types_ResolvedType* infer_infer_match_expr(env_TypeEnv* env, types_SExpr* expr, 
                         break;
                     }
                 }
-            } else if (!_mv_326.has_value) {
+            } else if (!_mv_331.has_value) {
             }
             i = (i + 1);
         }
+        infer_check_match_exhaustive(env, scrutinee_type, covered, has_wildcard, line, col);
         return result_type;
     }
 }
@@ -2275,22 +2489,22 @@ void infer_check_return_type(env_TypeEnv* env, types_SExpr* fn_form, slop_string
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((fn_form != NULL)), "(!= fn-form nil)");
     SLOP_PRE(((inferred_type != NULL)), "(!= inferred-type nil)");
-    __auto_type _mv_331 = (*fn_form);
-    switch (_mv_331.tag) {
+    __auto_type _mv_337 = (*fn_form);
+    switch (_mv_337.tag) {
         case types_SExpr_lst:
         {
-            __auto_type fn_lst = _mv_331.data.lst;
+            __auto_type fn_lst = _mv_337.data.lst;
             {
                 __auto_type items = fn_lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 for (int64_t i = 3; i < len; i++) {
-                    __auto_type _mv_332 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_332.has_value) {
-                        __auto_type item = _mv_332.value;
+                    __auto_type _mv_338 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_338.has_value) {
+                        __auto_type item = _mv_338.value;
                         if (parser_is_form(item, SLOP_STR("@spec"))) {
                             infer_check_spec_return_type(env, item, fn_name, inferred_type, fn_line, fn_col);
                         }
-                    } else if (!_mv_332.has_value) {
+                    } else if (!_mv_338.has_value) {
                     }
                 }
             }
@@ -2305,18 +2519,18 @@ void infer_check_return_type(env_TypeEnv* env, types_SExpr* fn_form, slop_string
 void infer_check_spec_return_type(env_TypeEnv* env, types_SExpr* spec_form, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((spec_form != NULL)), "(!= spec-form nil)");
-    __auto_type _mv_333 = (*spec_form);
-    switch (_mv_333.tag) {
+    __auto_type _mv_339 = (*spec_form);
+    switch (_mv_339.tag) {
         case types_SExpr_lst:
         {
-            __auto_type spec_lst = _mv_333.data.lst;
+            __auto_type spec_lst = _mv_339.data.lst;
             {
                 __auto_type spec_items = spec_lst.items;
-                __auto_type _mv_334 = ({ __auto_type _lst = spec_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_334.has_value) {
-                    __auto_type spec_body = _mv_334.value;
+                __auto_type _mv_340 = ({ __auto_type _lst = spec_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_340.has_value) {
+                    __auto_type spec_body = _mv_340.value;
                     infer_check_spec_body_return(env, spec_body, fn_name, inferred_type, fn_line, fn_col);
-                } else if (!_mv_334.has_value) {
+                } else if (!_mv_340.has_value) {
                 }
             }
             break;
@@ -2330,19 +2544,19 @@ void infer_check_spec_return_type(env_TypeEnv* env, types_SExpr* spec_form, slop
 void infer_check_spec_body_return(env_TypeEnv* env, types_SExpr* spec_body, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((spec_body != NULL)), "(!= spec-body nil)");
-    __auto_type _mv_335 = (*spec_body);
-    switch (_mv_335.tag) {
+    __auto_type _mv_341 = (*spec_body);
+    switch (_mv_341.tag) {
         case types_SExpr_lst:
         {
-            __auto_type body_lst = _mv_335.data.lst;
+            __auto_type body_lst = _mv_341.data.lst;
             {
                 __auto_type body_items = body_lst.items;
                 __auto_type body_len = ((int64_t)((body_items).len));
-                __auto_type _mv_336 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_336.has_value) {
-                    __auto_type ret_expr = _mv_336.value;
+                __auto_type _mv_342 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_342.has_value) {
+                    __auto_type ret_expr = _mv_342.value;
                     infer_check_return_expr(env, ret_expr, fn_name, inferred_type, fn_line, fn_col);
-                } else if (!_mv_336.has_value) {
+                } else if (!_mv_342.has_value) {
                 }
             }
             break;
@@ -2364,11 +2578,11 @@ uint8_t infer_is_integer_type(slop_string name) {
 void infer_check_return_expr(env_TypeEnv* env, types_SExpr* ret_expr, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((ret_expr != NULL)), "(!= ret-expr nil)");
-    __auto_type _mv_337 = (*ret_expr);
-    switch (_mv_337.tag) {
+    __auto_type _mv_343 = (*ret_expr);
+    switch (_mv_343.tag) {
         case types_SExpr_sym:
         {
-            __auto_type ret_sym = _mv_337.data.sym;
+            __auto_type ret_sym = _mv_343.data.sym;
             {
                 __auto_type declared_name = ret_sym.name;
                 __auto_type inferred_name = (*inferred_type).name;
@@ -2392,16 +2606,16 @@ void infer_bind_param_from_form(env_TypeEnv* env, types_SExpr* param_form) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((param_form != NULL)), "(!= param-form nil)");
     if (parser_sexpr_is_list(param_form) && (parser_sexpr_list_len(param_form) >= 2)) {
-        __auto_type _mv_338 = parser_sexpr_list_get(param_form, 0);
-        if (_mv_338.has_value) {
-            __auto_type first_expr = _mv_338.value;
+        __auto_type _mv_344 = parser_sexpr_list_get(param_form, 0);
+        if (_mv_344.has_value) {
+            __auto_type first_expr = _mv_344.value;
             {
                 __auto_type first_name = parser_sexpr_get_symbol_name(first_expr);
                 if ((string_eq(first_name, SLOP_STR("in"))) || (string_eq(first_name, SLOP_STR("out"))) || (string_eq(first_name, SLOP_STR("mut")))) {
                     if (parser_sexpr_list_len(param_form) >= 3) {
-                        __auto_type _mv_339 = parser_sexpr_list_get(param_form, 1);
-                        if (_mv_339.has_value) {
-                            __auto_type name_expr = _mv_339.value;
+                        __auto_type _mv_345 = parser_sexpr_list_get(param_form, 1);
+                        if (_mv_345.has_value) {
+                            __auto_type name_expr = _mv_345.value;
                             {
                                 __auto_type param_name = parser_sexpr_get_symbol_name(name_expr);
                                 if (!(string_eq(param_name, SLOP_STR("")))) {
@@ -2411,7 +2625,7 @@ void infer_bind_param_from_form(env_TypeEnv* env, types_SExpr* param_form) {
                                     }
                                 }
                             }
-                        } else if (!_mv_339.has_value) {
+                        } else if (!_mv_345.has_value) {
                         }
                     }
                 } else {
@@ -2423,7 +2637,7 @@ void infer_bind_param_from_form(env_TypeEnv* env, types_SExpr* param_form) {
                     }
                 }
             }
-        } else if (!_mv_338.has_value) {
+        } else if (!_mv_344.has_value) {
         }
     }
 }
@@ -2433,9 +2647,9 @@ types_ResolvedType* infer_get_param_type_from_form(env_TypeEnv* env, types_SExpr
     SLOP_PRE(((param_form != NULL)), "(!= param-form nil)");
     {
         __auto_type type_pos = ({ __auto_type _mv = parser_sexpr_list_get(param_form, 0); _mv.has_value ? ({ __auto_type first_expr = _mv.value; ({ __auto_type first_name = parser_sexpr_get_symbol_name(first_expr); ((((string_eq(first_name, SLOP_STR("in"))) || (string_eq(first_name, SLOP_STR("out"))) || (string_eq(first_name, SLOP_STR("mut"))))) ? 2 : 1); }); }) : (1); });
-        __auto_type _mv_340 = parser_sexpr_list_get(param_form, type_pos);
-        if (_mv_340.has_value) {
-            __auto_type type_expr = _mv_340.value;
+        __auto_type _mv_346 = parser_sexpr_list_get(param_form, type_pos);
+        if (_mv_346.has_value) {
+            __auto_type type_expr = _mv_346.value;
             {
                 __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                 if (string_eq(type_name, SLOP_STR(""))) {
@@ -2448,18 +2662,19 @@ types_ResolvedType* infer_get_param_type_from_form(env_TypeEnv* env, types_SExpr
                     return infer_resolve_simple_type(env, type_name);
                 }
             }
-        } else if (!_mv_340.has_value) {
+        } else if (!_mv_346.has_value) {
             return env_env_get_unknown_type(env);
         }
+        SLOP_UNREACHABLE();
     }
 }
 
 types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExpr* type_expr) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_341 = parser_sexpr_list_get(type_expr, 0);
-    if (_mv_341.has_value) {
-        __auto_type head_expr = _mv_341.value;
+    __auto_type _mv_347 = parser_sexpr_list_get(type_expr, 0);
+    if (_mv_347.has_value) {
+        __auto_type head_expr = _mv_347.value;
         {
             __auto_type head_name = parser_sexpr_get_symbol_name(head_expr);
             if (string_eq(head_name, SLOP_STR("Option"))) {
@@ -2487,16 +2702,16 @@ types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExp
                     __auto_type map_type = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_map, SLOP_STR("Map"), ((slop_option_string){.has_value = false}), SLOP_STR("slop_map*"));
                     types_resolved_type_set_inner(map_type, key_type);
                     if (parser_sexpr_list_len(type_expr) >= 3) {
-                        __auto_type _mv_342 = parser_sexpr_list_get(type_expr, 2);
-                        if (_mv_342.has_value) {
-                            __auto_type val_expr = _mv_342.value;
+                        __auto_type _mv_348 = parser_sexpr_list_get(type_expr, 2);
+                        if (_mv_348.has_value) {
+                            __auto_type val_expr = _mv_348.value;
                             {
                                 __auto_type val_type = infer_resolve_simple_type(env, parser_sexpr_get_symbol_name(val_expr));
                                 if (val_type != NULL) {
                                     types_resolved_type_set_inner2(map_type, val_type);
                                 }
                             }
-                        } else if (!_mv_342.has_value) {
+                        } else if (!_mv_348.has_value) {
                         }
                     }
                     return map_type;
@@ -2530,9 +2745,9 @@ types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExp
                     __auto_type arena = env_env_arena(env);
                     __auto_type result_type = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_result, SLOP_STR("Result"), ((slop_option_string){.has_value = false}), SLOP_STR("Result"));
                     if (parser_sexpr_list_len(type_expr) >= 2) {
-                        __auto_type _mv_343 = parser_sexpr_list_get(type_expr, 1);
-                        if (_mv_343.has_value) {
-                            __auto_type ok_expr = _mv_343.value;
+                        __auto_type _mv_349 = parser_sexpr_list_get(type_expr, 1);
+                        if (_mv_349.has_value) {
+                            __auto_type ok_expr = _mv_349.value;
                             {
                                 __auto_type ok_name = parser_sexpr_get_symbol_name(ok_expr);
                                 {
@@ -2540,13 +2755,13 @@ types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExp
                                     types_resolved_type_set_inner(result_type, ok_type);
                                 }
                             }
-                        } else if (!_mv_343.has_value) {
+                        } else if (!_mv_349.has_value) {
                         }
                     }
                     if (parser_sexpr_list_len(type_expr) >= 3) {
-                        __auto_type _mv_344 = parser_sexpr_list_get(type_expr, 2);
-                        if (_mv_344.has_value) {
-                            __auto_type err_expr = _mv_344.value;
+                        __auto_type _mv_350 = parser_sexpr_list_get(type_expr, 2);
+                        if (_mv_350.has_value) {
+                            __auto_type err_expr = _mv_350.value;
                             {
                                 __auto_type err_name = parser_sexpr_get_symbol_name(err_expr);
                                 {
@@ -2554,24 +2769,26 @@ types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExp
                                     types_resolved_type_set_inner2(result_type, err_type);
                                 }
                             }
-                        } else if (!_mv_344.has_value) {
+                        } else if (!_mv_350.has_value) {
                         }
                     }
                     return result_type;
                 }
             } else {
-                __auto_type _mv_345 = env_env_lookup_type(env, head_name);
-                if (_mv_345.has_value) {
-                    __auto_type t = _mv_345.value;
+                __auto_type _mv_351 = env_env_lookup_type(env, head_name);
+                if (_mv_351.has_value) {
+                    __auto_type t = _mv_351.value;
                     return t;
-                } else if (!_mv_345.has_value) {
+                } else if (!_mv_351.has_value) {
                     return env_env_get_unknown_type(env);
                 }
+                SLOP_UNREACHABLE();
             }
         }
-    } else if (!_mv_341.has_value) {
+    } else if (!_mv_347.has_value) {
         return env_env_get_unknown_type(env);
     }
+    SLOP_UNREACHABLE();
 }
 
 types_ResolvedType* infer_resolve_option_inner_type(env_TypeEnv* env, types_SExpr* type_expr) {
@@ -2579,9 +2796,9 @@ types_ResolvedType* infer_resolve_option_inner_type(env_TypeEnv* env, types_SExp
     if (parser_sexpr_list_len(type_expr) < 2) {
         return env_env_get_unknown_type(env);
     } else {
-        __auto_type _mv_346 = parser_sexpr_list_get(type_expr, 1);
-        if (_mv_346.has_value) {
-            __auto_type inner_expr = _mv_346.value;
+        __auto_type _mv_352 = parser_sexpr_list_get(type_expr, 1);
+        if (_mv_352.has_value) {
+            __auto_type inner_expr = _mv_352.value;
             {
                 __auto_type inner_name = parser_sexpr_get_symbol_name(inner_expr);
                 if (string_eq(inner_name, SLOP_STR(""))) {
@@ -2590,9 +2807,10 @@ types_ResolvedType* infer_resolve_option_inner_type(env_TypeEnv* env, types_SExp
                     return infer_resolve_simple_type(env, inner_name);
                 }
             }
-        } else if (!_mv_346.has_value) {
+        } else if (!_mv_352.has_value) {
             return env_env_get_unknown_type(env);
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2601,9 +2819,9 @@ types_ResolvedType* infer_resolve_ptr_inner_type(env_TypeEnv* env, types_SExpr* 
     if (parser_sexpr_list_len(type_expr) < 2) {
         return env_env_get_unit_type(env);
     } else {
-        __auto_type _mv_347 = parser_sexpr_list_get(type_expr, 1);
-        if (_mv_347.has_value) {
-            __auto_type inner_expr = _mv_347.value;
+        __auto_type _mv_353 = parser_sexpr_list_get(type_expr, 1);
+        if (_mv_353.has_value) {
+            __auto_type inner_expr = _mv_353.value;
             {
                 __auto_type inner_name = parser_sexpr_get_symbol_name(inner_expr);
                 if (string_eq(inner_name, SLOP_STR(""))) {
@@ -2616,19 +2834,20 @@ types_ResolvedType* infer_resolve_ptr_inner_type(env_TypeEnv* env, types_SExpr* 
                     return infer_resolve_simple_type(env, inner_name);
                 }
             }
-        } else if (!_mv_347.has_value) {
+        } else if (!_mv_353.has_value) {
             return env_env_get_unit_type(env);
         }
+        SLOP_UNREACHABLE();
     }
 }
 
 types_ResolvedType* infer_resolve_type_lenient(env_TypeEnv* env, slop_string type_name) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_348 = env_env_lookup_type(env, type_name);
-    if (_mv_348.has_value) {
-        __auto_type t = _mv_348.value;
+    __auto_type _mv_354 = env_env_lookup_type(env, type_name);
+    if (_mv_354.has_value) {
+        __auto_type t = _mv_354.value;
         return t;
-    } else if (!_mv_348.has_value) {
+    } else if (!_mv_354.has_value) {
         {
             __auto_type arena = env_env_arena(env);
             if (string_eq(type_name, SLOP_STR("Int"))) {
@@ -2646,15 +2865,16 @@ types_ResolvedType* infer_resolve_type_lenient(env_TypeEnv* env, slop_string typ
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 types_ResolvedType* infer_resolve_simple_type(env_TypeEnv* env, slop_string type_name) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_349 = env_env_lookup_type(env, type_name);
-    if (_mv_349.has_value) {
-        __auto_type t = _mv_349.value;
+    __auto_type _mv_355 = env_env_lookup_type(env, type_name);
+    if (_mv_355.has_value) {
+        __auto_type t = _mv_355.value;
         return t;
-    } else if (!_mv_349.has_value) {
+    } else if (!_mv_355.has_value) {
         {
             __auto_type arena = env_env_arena(env);
             if (string_eq(type_name, SLOP_STR("Int"))) {
@@ -2705,30 +2925,31 @@ types_ResolvedType* infer_resolve_simple_type(env_TypeEnv* env, slop_string type
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 void infer_bind_let_binding(env_TypeEnv* env, types_SExpr* binding_form) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((binding_form != NULL)), "(!= binding-form nil)");
     if (parser_sexpr_is_list(binding_form) && (parser_sexpr_list_len(binding_form) >= 2)) {
-        __auto_type _mv_350 = parser_sexpr_list_get(binding_form, 0);
-        if (_mv_350.has_value) {
-            __auto_type first_expr = _mv_350.value;
+        __auto_type _mv_356 = parser_sexpr_list_get(binding_form, 0);
+        if (_mv_356.has_value) {
+            __auto_type first_expr = _mv_356.value;
             {
                 __auto_type first_name = parser_sexpr_get_symbol_name(first_expr);
                 if (string_eq(first_name, SLOP_STR("mut"))) {
                     if (parser_sexpr_list_len(binding_form) >= 3) {
-                        __auto_type _mv_351 = parser_sexpr_list_get(binding_form, 1);
-                        if (_mv_351.has_value) {
-                            __auto_type name_expr = _mv_351.value;
+                        __auto_type _mv_357 = parser_sexpr_list_get(binding_form, 1);
+                        if (_mv_357.has_value) {
+                            __auto_type name_expr = _mv_357.value;
                             {
                                 __auto_type var_name = parser_sexpr_get_symbol_name(name_expr);
                                 if (!(string_eq(var_name, SLOP_STR("")))) {
                                     {
                                         __auto_type binding_len = parser_sexpr_list_len(binding_form);
-                                        __auto_type _mv_352 = parser_sexpr_list_get(binding_form, (binding_len - 1));
-                                        if (_mv_352.has_value) {
-                                            __auto_type val_expr = _mv_352.value;
+                                        __auto_type _mv_358 = parser_sexpr_list_get(binding_form, (binding_len - 1));
+                                        if (_mv_358.has_value) {
+                                            __auto_type val_expr = _mv_358.value;
                                             {
                                                 __auto_type val_type = infer_infer_expr(env, val_expr);
                                                 __auto_type val_type_name = (*val_type).name;
@@ -2750,12 +2971,12 @@ void infer_bind_let_binding(env_TypeEnv* env, types_SExpr* binding_form) {
                                                     env_env_bind_var(env, var_name, val_type);
                                                 }
                                             }
-                                        } else if (!_mv_352.has_value) {
+                                        } else if (!_mv_358.has_value) {
                                         }
                                     }
                                 }
                             }
-                        } else if (!_mv_351.has_value) {
+                        } else if (!_mv_357.has_value) {
                         }
                     }
                 } else {
@@ -2763,31 +2984,31 @@ void infer_bind_let_binding(env_TypeEnv* env, types_SExpr* binding_form) {
                         {
                             __auto_type binding_len = parser_sexpr_list_len(binding_form);
                             if (binding_len == 3) {
-                                __auto_type _mv_353 = parser_sexpr_list_get(binding_form, 2);
-                                if (_mv_353.has_value) {
-                                    __auto_type val_expr = _mv_353.value;
+                                __auto_type _mv_359 = parser_sexpr_list_get(binding_form, 2);
+                                if (_mv_359.has_value) {
+                                    __auto_type val_expr = _mv_359.value;
                                     {
                                         __auto_type val_type = infer_infer_expr(env, val_expr);
                                         env_env_bind_var(env, first_name, val_type);
                                     }
-                                } else if (!_mv_353.has_value) {
+                                } else if (!_mv_359.has_value) {
                                 }
                             } else {
-                                __auto_type _mv_354 = parser_sexpr_list_get(binding_form, 1);
-                                if (_mv_354.has_value) {
-                                    __auto_type val_expr = _mv_354.value;
+                                __auto_type _mv_360 = parser_sexpr_list_get(binding_form, 1);
+                                if (_mv_360.has_value) {
+                                    __auto_type val_expr = _mv_360.value;
                                     {
                                         __auto_type val_type = infer_infer_expr(env, val_expr);
                                         env_env_bind_var(env, first_name, val_type);
                                     }
-                                } else if (!_mv_354.has_value) {
+                                } else if (!_mv_360.has_value) {
                                 }
                             }
                         }
                     }
                 }
             }
-        } else if (!_mv_350.has_value) {
+        } else if (!_mv_356.has_value) {
         }
     }
 }
@@ -2797,23 +3018,23 @@ types_ResolvedType* infer_infer_let_expr(env_TypeEnv* env, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     env_env_push_scope(env);
     if (parser_sexpr_is_list(expr)) {
-        __auto_type _mv_355 = parser_sexpr_list_get(expr, 1);
-        if (_mv_355.has_value) {
-            __auto_type bindings_expr = _mv_355.value;
+        __auto_type _mv_361 = parser_sexpr_list_get(expr, 1);
+        if (_mv_361.has_value) {
+            __auto_type bindings_expr = _mv_361.value;
             if (parser_sexpr_is_list(bindings_expr)) {
                 {
                     __auto_type num_bindings = parser_sexpr_list_len(bindings_expr);
                     for (int64_t i = 0; i < num_bindings; i++) {
-                        __auto_type _mv_356 = parser_sexpr_list_get(bindings_expr, i);
-                        if (_mv_356.has_value) {
-                            __auto_type binding = _mv_356.value;
+                        __auto_type _mv_362 = parser_sexpr_list_get(bindings_expr, i);
+                        if (_mv_362.has_value) {
+                            __auto_type binding = _mv_362.value;
                             infer_bind_let_binding(env, binding);
-                        } else if (!_mv_356.has_value) {
+                        } else if (!_mv_362.has_value) {
                         }
                     }
                 }
             }
-        } else if (!_mv_355.has_value) {
+        } else if (!_mv_361.has_value) {
         }
     }
     {
@@ -2841,14 +3062,14 @@ types_ResolvedType* infer_infer_with_arena_expr(env_TypeEnv* env, types_SExpr* e
                     env_env_add_error(env, SLOP_STR("with-arena :as requires name and size"), parser_sexpr_line(expr), parser_sexpr_col(expr));
                     return env_env_get_unit_type(env);
                 } else {
-                    __auto_type _mv_357 = parser_sexpr_list_get(expr, size_idx);
-                    if (_mv_357.has_value) {
-                        __auto_type size_expr = _mv_357.value;
-                        __auto_type _mv_358 = (*size_expr);
-                        switch (_mv_358.tag) {
+                    __auto_type _mv_363 = parser_sexpr_list_get(expr, size_idx);
+                    if (_mv_363.has_value) {
+                        __auto_type size_expr = _mv_363.value;
+                        __auto_type _mv_364 = (*size_expr);
+                        switch (_mv_364.tag) {
                             case types_SExpr_num:
                             {
-                                __auto_type num = _mv_358.data.num;
+                                __auto_type num = _mv_364.data.num;
                                 if (num.int_value <= 0) {
                                     env_env_add_error(env, SLOP_STR("with-arena size must be positive"), num.line, num.col);
                                 } else {
@@ -2859,18 +3080,18 @@ types_ResolvedType* infer_infer_with_arena_expr(env_TypeEnv* env, types_SExpr* e
                                 break;
                             }
                         }
-                    } else if (!_mv_357.has_value) {
+                    } else if (!_mv_363.has_value) {
                     }
                     env_env_push_scope(env);
                     env_env_bind_var(env, arena_name, env_env_get_arena_type(env));
                     {
                         types_ResolvedType* result_type = env_env_get_unit_type(env);
                         for (int64_t i = body_start; i < len; i++) {
-                            __auto_type _mv_359 = parser_sexpr_list_get(expr, i);
-                            if (_mv_359.has_value) {
-                                __auto_type body_expr = _mv_359.value;
+                            __auto_type _mv_365 = parser_sexpr_list_get(expr, i);
+                            if (_mv_365.has_value) {
+                                __auto_type body_expr = _mv_365.value;
                                 result_type = infer_infer_expr(env, body_expr);
-                            } else if (!_mv_359.has_value) {
+                            } else if (!_mv_365.has_value) {
                             }
                         }
                         env_env_pop_scope(env);
@@ -2890,9 +3111,9 @@ slop_string infer_get_fn_name(types_SExpr* fn_form) {
         if (parser_sexpr_list_len(fn_form) < 2) {
             return SLOP_STR("unknown");
         } else {
-            __auto_type _mv_360 = parser_sexpr_list_get(fn_form, 1);
-            if (_mv_360.has_value) {
-                __auto_type name_expr = _mv_360.value;
+            __auto_type _mv_366 = parser_sexpr_list_get(fn_form, 1);
+            if (_mv_366.has_value) {
+                __auto_type name_expr = _mv_366.value;
                 {
                     __auto_type name = parser_sexpr_get_symbol_name(name_expr);
                     if (string_eq(name, SLOP_STR(""))) {
@@ -2901,9 +3122,10 @@ slop_string infer_get_fn_name(types_SExpr* fn_form) {
                         return name;
                     }
                 }
-            } else if (!_mv_360.has_value) {
+            } else if (!_mv_366.has_value) {
                 return SLOP_STR("unknown");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -2913,19 +3135,19 @@ types_ResolvedType* infer_resolve_hole_type(env_TypeEnv* env, slop_list_types_SE
     if (len < 2) {
         return env_env_get_unit_type(env);
     } else {
-        __auto_type _mv_361 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_361.has_value) {
-            __auto_type type_expr = _mv_361.value;
+        __auto_type _mv_367 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_367.has_value) {
+            __auto_type type_expr = _mv_367.value;
             {
                 __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                 if (string_eq(type_name, SLOP_STR(""))) {
                     return env_env_get_unit_type(env);
                 } else {
-                    __auto_type _mv_362 = env_env_lookup_type(env, type_name);
-                    if (_mv_362.has_value) {
-                        __auto_type t = _mv_362.value;
+                    __auto_type _mv_368 = env_env_lookup_type(env, type_name);
+                    if (_mv_368.has_value) {
+                        __auto_type t = _mv_368.value;
                         return t;
-                    } else if (!_mv_362.has_value) {
+                    } else if (!_mv_368.has_value) {
                         if (string_eq(type_name, SLOP_STR("Int"))) {
                             return env_env_get_int_type(env);
                         } else if (string_eq(type_name, SLOP_STR("Bool"))) {
@@ -2938,11 +3160,13 @@ types_ResolvedType* infer_resolve_hole_type(env_TypeEnv* env, slop_list_types_SE
                             return env_env_get_unit_type(env);
                         }
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
-        } else if (!_mv_361.has_value) {
+        } else if (!_mv_367.has_value) {
             return env_env_get_unit_type(env);
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2950,23 +3174,24 @@ slop_string infer_get_hole_prompt(slop_list_types_SExpr_ptr items, int64_t len) 
     if (len < 3) {
         return SLOP_STR("(no description)");
     } else {
-        __auto_type _mv_363 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_363.has_value) {
-            __auto_type prompt_expr = _mv_363.value;
-            __auto_type _mv_364 = (*prompt_expr);
-            switch (_mv_364.tag) {
+        __auto_type _mv_369 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_369.has_value) {
+            __auto_type prompt_expr = _mv_369.value;
+            __auto_type _mv_370 = (*prompt_expr);
+            switch (_mv_370.tag) {
                 case types_SExpr_str:
                 {
-                    __auto_type str = _mv_364.data.str;
+                    __auto_type str = _mv_370.data.str;
                     return str.value;
                 }
                 default: {
                     return SLOP_STR("(no description)");
                 }
             }
-        } else if (!_mv_363.has_value) {
+        } else if (!_mv_369.has_value) {
             return SLOP_STR("(no description)");
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2982,37 +3207,38 @@ int64_t infer_find_last_body_idx(slop_list_types_SExpr_ptr items) {
 }
 
 uint8_t infer_is_c_name_related(slop_list_types_SExpr_ptr items, int64_t idx) {
-    __auto_type _mv_365 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-    if (_mv_365.has_value) {
-        __auto_type item = _mv_365.value;
-        __auto_type _mv_366 = (*item);
-        switch (_mv_366.tag) {
+    __auto_type _mv_371 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+    if (_mv_371.has_value) {
+        __auto_type item = _mv_371.value;
+        __auto_type _mv_372 = (*item);
+        switch (_mv_372.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_366.data.sym;
+                __auto_type sym = _mv_372.data.sym;
                 return string_eq(sym.name, SLOP_STR(":c-name"));
             }
             case types_SExpr_str:
             {
-                __auto_type _ = _mv_366.data.str;
+                __auto_type _ = _mv_372.data.str;
                 if (idx > 0) {
-                    __auto_type _mv_367 = ({ __auto_type _lst = items; size_t _idx = (size_t)(idx - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_367.has_value) {
-                        __auto_type prev = _mv_367.value;
-                        __auto_type _mv_368 = (*prev);
-                        switch (_mv_368.tag) {
+                    __auto_type _mv_373 = ({ __auto_type _lst = items; size_t _idx = (size_t)(idx - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_373.has_value) {
+                        __auto_type prev = _mv_373.value;
+                        __auto_type _mv_374 = (*prev);
+                        switch (_mv_374.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_368.data.sym;
+                                __auto_type sym = _mv_374.data.sym;
                                 return string_eq(sym.name, SLOP_STR(":c-name"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_367.has_value) {
+                    } else if (!_mv_373.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 } else {
                     return 0;
                 }
@@ -3021,31 +3247,33 @@ uint8_t infer_is_c_name_related(slop_list_types_SExpr_ptr items, int64_t idx) {
                 return 0;
             }
         }
-    } else if (!_mv_365.has_value) {
+    } else if (!_mv_371.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t infer_is_annotation_expr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     if (parser_sexpr_is_list(expr)) {
-        __auto_type _mv_369 = parser_sexpr_list_get(expr, 0);
-        if (_mv_369.has_value) {
-            __auto_type head = _mv_369.value;
-            __auto_type _mv_370 = (*head);
-            switch (_mv_370.tag) {
+        __auto_type _mv_375 = parser_sexpr_list_get(expr, 0);
+        if (_mv_375.has_value) {
+            __auto_type head = _mv_375.value;
+            __auto_type _mv_376 = (*head);
+            switch (_mv_376.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_370.data.sym;
+                    __auto_type sym = _mv_376.data.sym;
                     return strlib_starts_with(sym.name, SLOP_STR("@"));
                 }
                 default: {
                     return 0;
                 }
             }
-        } else if (!_mv_369.has_value) {
+        } else if (!_mv_375.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     } else {
         return 0;
     }
@@ -3053,14 +3281,14 @@ uint8_t infer_is_annotation_expr(types_SExpr* expr) {
 
 uint8_t infer_is_checkable_annotation(types_SExpr* expr) {
     if (parser_sexpr_is_list(expr)) {
-        __auto_type _mv_371 = parser_sexpr_list_get(expr, 0);
-        if (_mv_371.has_value) {
-            __auto_type head = _mv_371.value;
-            __auto_type _mv_372 = (*head);
-            switch (_mv_372.tag) {
+        __auto_type _mv_377 = parser_sexpr_list_get(expr, 0);
+        if (_mv_377.has_value) {
+            __auto_type head = _mv_377.value;
+            __auto_type _mv_378 = (*head);
+            switch (_mv_378.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_372.data.sym;
+                    __auto_type sym = _mv_378.data.sym;
                     {
                         __auto_type name = sym.name;
                         return ((string_eq(name, SLOP_STR("@pre"))) || (string_eq(name, SLOP_STR("@post"))) || (string_eq(name, SLOP_STR("@assume"))) || (string_eq(name, SLOP_STR("@assert"))));
@@ -3070,9 +3298,10 @@ uint8_t infer_is_checkable_annotation(types_SExpr* expr) {
                     return 0;
                 }
             }
-        } else if (!_mv_371.has_value) {
+        } else if (!_mv_377.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     } else {
         return 0;
     }
@@ -3093,23 +3322,23 @@ types_ResolvedType* infer_infer_fn_body(env_TypeEnv* env, types_SExpr* fn_form) 
             {
                 __auto_type params_len = parser_sexpr_list_len(fn_form);
                 if (params_len > 2) {
-                    __auto_type _mv_373 = parser_sexpr_list_get(fn_form, 2);
-                    if (_mv_373.has_value) {
-                        __auto_type params_expr = _mv_373.value;
+                    __auto_type _mv_379 = parser_sexpr_list_get(fn_form, 2);
+                    if (_mv_379.has_value) {
+                        __auto_type params_expr = _mv_379.value;
                         if (parser_sexpr_is_list(params_expr)) {
                             {
                                 __auto_type num_params = parser_sexpr_list_len(params_expr);
                                 for (int64_t k = 0; k < num_params; k++) {
-                                    __auto_type _mv_374 = parser_sexpr_list_get(params_expr, k);
-                                    if (_mv_374.has_value) {
-                                        __auto_type param_form = _mv_374.value;
+                                    __auto_type _mv_380 = parser_sexpr_list_get(params_expr, k);
+                                    if (_mv_380.has_value) {
+                                        __auto_type param_form = _mv_380.value;
                                         infer_bind_param_from_form(env, param_form);
-                                    } else if (!_mv_374.has_value) {
+                                    } else if (!_mv_380.has_value) {
                                     }
                                 }
                             }
                         }
-                    } else if (!_mv_373.has_value) {
+                    } else if (!_mv_379.has_value) {
                     }
                 }
             }
@@ -3131,34 +3360,34 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
         {
             __auto_type num_patterns = ((int64_t)((patterns).len));
             for (int64_t i = 0; i < num_patterns; i++) {
-                __auto_type _mv_375 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_375.has_value) {
-                    __auto_type pattern_case = _mv_375.value;
-                    __auto_type _mv_376 = (*pattern_case);
-                    switch (_mv_376.tag) {
+                __auto_type _mv_381 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_381.has_value) {
+                    __auto_type pattern_case = _mv_381.value;
+                    __auto_type _mv_382 = (*pattern_case);
+                    switch (_mv_382.tag) {
                         case types_SExpr_lst:
                         {
-                            __auto_type pattern_list = _mv_376.data.lst;
+                            __auto_type pattern_list = _mv_382.data.lst;
                             if (((int64_t)((pattern_list.items).len)) > 0) {
-                                __auto_type _mv_377 = ({ __auto_type _lst = pattern_list.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_377.has_value) {
-                                    __auto_type pattern_expr = _mv_377.value;
-                                    __auto_type _mv_378 = (*pattern_expr);
-                                    switch (_mv_378.tag) {
+                                __auto_type _mv_383 = ({ __auto_type _lst = pattern_list.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_383.has_value) {
+                                    __auto_type pattern_expr = _mv_383.value;
+                                    __auto_type _mv_384 = (*pattern_expr);
+                                    switch (_mv_384.tag) {
                                         case types_SExpr_lst:
                                         {
-                                            __auto_type variant_list = _mv_378.data.lst;
+                                            __auto_type variant_list = _mv_384.data.lst;
                                             {
                                                 __auto_type variant_items = variant_list.items;
                                                 if (((int64_t)((variant_items).len)) > 0) {
-                                                    __auto_type _mv_379 = ({ __auto_type _lst = variant_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_379.has_value) {
-                                                        __auto_type variant_name_expr = _mv_379.value;
-                                                        __auto_type _mv_380 = (*variant_name_expr);
-                                                        switch (_mv_380.tag) {
+                                                    __auto_type _mv_385 = ({ __auto_type _lst = variant_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_385.has_value) {
+                                                        __auto_type variant_name_expr = _mv_385.value;
+                                                        __auto_type _mv_386 = (*variant_name_expr);
+                                                        switch (_mv_386.tag) {
                                                             case types_SExpr_sym:
                                                             {
-                                                                __auto_type variant_sym = _mv_380.data.sym;
+                                                                __auto_type variant_sym = _mv_386.data.sym;
                                                                 {
                                                                     __auto_type variant_name = variant_sym.name;
                                                                     {
@@ -3168,24 +3397,24 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                                                                             {
                                                                                 __auto_type num_vt = ((int64_t)((variant_items).len));
                                                                                 for (int64_t vi = 1; vi < num_vt; vi++) {
-                                                                                    __auto_type _mv_381 = ({ __auto_type _lst = variant_items; size_t _idx = (size_t)vi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                                    if (_mv_381.has_value) {
-                                                                                        __auto_type binding_expr = _mv_381.value;
-                                                                                        __auto_type _mv_382 = (*binding_expr);
-                                                                                        switch (_mv_382.tag) {
+                                                                                    __auto_type _mv_387 = ({ __auto_type _lst = variant_items; size_t _idx = (size_t)vi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                                    if (_mv_387.has_value) {
+                                                                                        __auto_type binding_expr = _mv_387.value;
+                                                                                        __auto_type _mv_388 = (*binding_expr);
+                                                                                        switch (_mv_388.tag) {
                                                                                             case types_SExpr_sym:
                                                                                             {
-                                                                                                __auto_type binding_sym = _mv_382.data.sym;
+                                                                                                __auto_type binding_sym = _mv_388.data.sym;
                                                                                                 {
                                                                                                     __auto_type bname = binding_sym.name;
                                                                                                     __auto_type type_idx = (vi - 1);
                                                                                                     if (!(string_eq(bname, SLOP_STR("_"))) && !(string_eq(bname, SLOP_STR("")))) {
                                                                                                         if (type_idx < num_pt) {
-                                                                                                            __auto_type _mv_383 = ({ __auto_type _lst = payload_types; size_t _idx = (size_t)type_idx; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                                                            if (_mv_383.has_value) {
-                                                                                                                __auto_type pt = _mv_383.value;
+                                                                                                            __auto_type _mv_389 = ({ __auto_type _lst = payload_types; size_t _idx = (size_t)type_idx; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                                                            if (_mv_389.has_value) {
+                                                                                                                __auto_type pt = _mv_389.value;
                                                                                                                 env_env_bind_var(env, bname, pt);
-                                                                                                            } else if (!_mv_383.has_value) {
+                                                                                                            } else if (!_mv_389.has_value) {
                                                                                                                 env_env_bind_var(env, bname, env_env_get_generic_type(env));
                                                                                                             }
                                                                                                         } else {
@@ -3199,15 +3428,15 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                                                                                                 break;
                                                                                             }
                                                                                         }
-                                                                                    } else if (!_mv_381.has_value) {
+                                                                                    } else if (!_mv_387.has_value) {
                                                                                     }
                                                                                 }
                                                                             }
                                                                         } else {
-                                                                            __auto_type _mv_384 = types_resolved_type_get_variant_index(scrutinee_type, variant_name);
-                                                                            if (_mv_384.has_value) {
-                                                                                __auto_type _ = _mv_384.value;
-                                                                            } else if (!_mv_384.has_value) {
+                                                                            __auto_type _mv_390 = types_resolved_type_get_variant_index(scrutinee_type, variant_name);
+                                                                            if (_mv_390.has_value) {
+                                                                                __auto_type _ = _mv_390.value;
+                                                                            } else if (!_mv_390.has_value) {
                                                                             }
                                                                         }
                                                                     }
@@ -3218,7 +3447,7 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                                                                 break;
                                                             }
                                                         }
-                                                    } else if (!_mv_379.has_value) {
+                                                    } else if (!_mv_385.has_value) {
                                                     }
                                                 }
                                             }
@@ -3228,7 +3457,7 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                                             break;
                                         }
                                     }
-                                } else if (!_mv_377.has_value) {
+                                } else if (!_mv_383.has_value) {
                                 }
                             }
                             break;
@@ -3237,7 +3466,7 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                             break;
                         }
                     }
-                } else if (!_mv_375.has_value) {
+                } else if (!_mv_381.has_value) {
                 }
             }
         }

--- a/bootstrap/checker/slop_infer.h
+++ b/bootstrap/checker/slop_infer.h
@@ -65,6 +65,11 @@ types_ResolvedType* infer_infer_field_access(env_TypeEnv* env, types_SExpr* expr
 types_ResolvedType* infer_check_field_exists(env_TypeEnv* env, types_ResolvedType* obj_type, slop_string field_name, int64_t line, int64_t col);
 types_ResolvedType* infer_infer_cond_expr(env_TypeEnv* env, types_SExpr* expr, types_SExprList lst);
 void infer_bind_match_pattern(env_TypeEnv* env, types_ResolvedType* scrutinee_type, types_SExpr* pattern);
+slop_string infer_match_pattern_head(types_SExpr* pattern);
+uint8_t infer_is_wildcard_head(slop_string head);
+uint8_t infer_string_list_contains(slop_list_string names, slop_string name);
+slop_list_string infer_match_expected_variants(slop_arena* arena, types_ResolvedType* scrutinee_type);
+void infer_check_match_exhaustive(env_TypeEnv* env, types_ResolvedType* scrutinee_type, slop_list_string covered, uint8_t has_wildcard, int64_t line, int64_t col);
 types_ResolvedType* infer_infer_match_expr(env_TypeEnv* env, types_SExpr* expr, types_SExprList lst);
 void infer_check_return_type(env_TypeEnv* env, types_SExpr* fn_form, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col);
 void infer_check_spec_return_type(env_TypeEnv* env, types_SExpr* spec_form, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col);

--- a/bootstrap/checker/slop_parser.c
+++ b/bootstrap/checker/slop_parser.c
@@ -383,6 +383,7 @@ parser_Token parser_parser_peek(parser_ParserState* state) {
     } else if (!_mv_64.has_value) {
         return (parser_Token){parser_TokenType_tok_eof, SLOP_STR(""), 1, 1};
     }
+    SLOP_UNREACHABLE();
 }
 
 void parser_parser_advance(parser_ParserState* state) {
@@ -447,6 +448,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_expr(slop_arena* aren
                 __auto_type e = _mv_65.data.err;
                 return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
             }
+            SLOP_UNREACHABLE();
         } else if (tok.kind == parser_TokenType_tok_symbol) {
             parser_parser_advance(state);
             {
@@ -592,7 +594,9 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_paren_group(slo
             __auto_type _ = _mv_68.data.ok;
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = expr });
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_arena* arena, parser_ParserState* state) {
@@ -629,6 +633,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                         return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = node });
                     }
                 }
+                SLOP_UNREACHABLE();
             } else {
                 parser_parser_advance(state);
                 {
@@ -659,6 +664,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                     return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = node });
                 }
             }
+            SLOP_UNREACHABLE();
         } else if (tok.kind == parser_TokenType_tok_operator) {
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = (parser_ParseError){SLOP_STR("Unexpected operator in expression"), tok.line, tok.col} });
         } else if (tok.kind == parser_TokenType_tok_lparen) {
@@ -683,6 +689,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                         }
                     }
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (tok.kind == parser_TokenType_tok_quote) {
             parser_parser_advance(state);
@@ -703,6 +710,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                     return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = node });
                 }
             }
+            SLOP_UNREACHABLE();
         } else {
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = (parser_ParseError){SLOP_STR("Expected expression in infix"), tok.line, tok.col} });
         }
@@ -767,6 +775,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_prec(slop_arena
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix(slop_arena* arena, parser_ParserState* state) {
@@ -794,6 +803,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix(slop_arena* are
                     }
                 }
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -836,6 +846,7 @@ slop_result_list_types_SExpr_ptr_parser_ParseError parser_parse(slop_arena* aren
         __auto_type e = _mv_76.data.err;
         return ((slop_result_list_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
     }
+    SLOP_UNREACHABLE();
 }
 
 int64_t parser_sexpr_line(types_SExpr* expr) {
@@ -862,6 +873,7 @@ int64_t parser_sexpr_line(types_SExpr* expr) {
             return l.line;
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 int64_t parser_sexpr_col(types_SExpr* expr) {
@@ -888,6 +900,7 @@ int64_t parser_sexpr_col(types_SExpr* expr) {
             return l.col;
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t parser_sexpr_is_symbol_with_name(types_SExpr* expr, slop_string name) {
@@ -920,6 +933,7 @@ uint8_t parser_is_form(types_SExpr* expr, slop_string keyword) {
                 } else if (!_mv_82.has_value) {
                     return 0;
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -1197,6 +1211,7 @@ slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string parser_json_escape_string(slop_arena* arena, slop_string s) {
@@ -1324,5 +1339,6 @@ slop_string parser_json_print(slop_arena* arena, types_SExpr* expr) {
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 

--- a/bootstrap/checker/slop_path.c
+++ b/bootstrap/checker/slop_path.c
@@ -23,6 +23,7 @@ slop_string path_path_dirname(slop_arena* arena, slop_string path) {
             } else if (!_mv_199.has_value) {
                 return SLOP_STR(".");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -65,6 +66,7 @@ slop_string path_path_basename(slop_arena* arena, slop_string path) {
             } else if (!_mv_200.has_value) {
                 return path;
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -89,6 +91,7 @@ slop_string path_path_extension(slop_arena* arena, slop_string path) {
             } else if (!_mv_201.has_value) {
                 return SLOP_STR("");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }

--- a/bootstrap/checker/slop_resolve.c
+++ b/bootstrap/checker/slop_resolve.c
@@ -12,16 +12,16 @@ void resolve_resolve_imports(env_TypeEnv* env, slop_list_types_SExpr_ptr ast) {
     {
         __auto_type len = ((int64_t)((ast).len));
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_385 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_385.has_value) {
-                __auto_type expr = _mv_385.value;
+            __auto_type _mv_391 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_391.has_value) {
+                __auto_type expr = _mv_391.value;
                 if (parser_is_form(expr, SLOP_STR("import"))) {
                     resolve_resolve_import_stmt(env, expr);
                 } else if (parser_is_form(expr, SLOP_STR("module"))) {
                     resolve_resolve_module_imports(env, expr);
                 } else {
                 }
-            } else if (!_mv_385.has_value) {
+            } else if (!_mv_391.has_value) {
             }
         }
     }
@@ -34,13 +34,13 @@ void resolve_resolve_module_imports(env_TypeEnv* env, types_SExpr* module_form) 
         {
             __auto_type len = parser_sexpr_list_len(module_form);
             for (int64_t i = 2; i < len; i++) {
-                __auto_type _mv_386 = parser_sexpr_list_get(module_form, i);
-                if (_mv_386.has_value) {
-                    __auto_type item = _mv_386.value;
+                __auto_type _mv_392 = parser_sexpr_list_get(module_form, i);
+                if (_mv_392.has_value) {
+                    __auto_type item = _mv_392.value;
                     if (parser_is_form(item, SLOP_STR("import"))) {
                         resolve_resolve_import_stmt(env, item);
                     }
-                } else if (!_mv_386.has_value) {
+                } else if (!_mv_392.has_value) {
                 }
             }
         }
@@ -53,41 +53,41 @@ void resolve_resolve_import_stmt(env_TypeEnv* env, types_SExpr* import_form) {
     SLOP_PRE((parser_is_form(import_form, SLOP_STR("import"))), "(is-form import-form \"import\")");
     {
         __auto_type arena = env_env_arena(env);
-        __auto_type _mv_387 = (*import_form);
-        switch (_mv_387.tag) {
+        __auto_type _mv_393 = (*import_form);
+        switch (_mv_393.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_387.data.lst;
+                __auto_type lst = _mv_393.data.lst;
                 {
                     __auto_type items = lst.items;
-                    __auto_type _mv_388 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_388.has_value) {
-                        __auto_type mod_name_expr = _mv_388.value;
-                        __auto_type _mv_389 = (*mod_name_expr);
-                        switch (_mv_389.tag) {
+                    __auto_type _mv_394 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_394.has_value) {
+                        __auto_type mod_name_expr = _mv_394.value;
+                        __auto_type _mv_395 = (*mod_name_expr);
+                        switch (_mv_395.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type mod_sym = _mv_389.data.sym;
-                                __auto_type _mv_390 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_390.has_value) {
-                                    __auto_type names_expr = _mv_390.value;
-                                    __auto_type _mv_391 = (*names_expr);
-                                    switch (_mv_391.tag) {
+                                __auto_type mod_sym = _mv_395.data.sym;
+                                __auto_type _mv_396 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_396.has_value) {
+                                    __auto_type names_expr = _mv_396.value;
+                                    __auto_type _mv_397 = (*names_expr);
+                                    switch (_mv_397.tag) {
                                         case types_SExpr_lst:
                                         {
-                                            __auto_type names_lst = _mv_391.data.lst;
+                                            __auto_type names_lst = _mv_397.data.lst;
                                             {
                                                 __auto_type name_items = names_lst.items;
                                                 __auto_type name_len = ((int64_t)((name_items).len));
                                                 for (int64_t j = 0; j < name_len; j++) {
-                                                    __auto_type _mv_392 = ({ __auto_type _lst = name_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_392.has_value) {
-                                                        __auto_type name_expr = _mv_392.value;
-                                                        __auto_type _mv_393 = (*name_expr);
-                                                        switch (_mv_393.tag) {
+                                                    __auto_type _mv_398 = ({ __auto_type _lst = name_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_398.has_value) {
+                                                        __auto_type name_expr = _mv_398.value;
+                                                        __auto_type _mv_399 = (*name_expr);
+                                                        switch (_mv_399.tag) {
                                                             case types_SExpr_sym:
                                                             {
-                                                                __auto_type name_sym = _mv_393.data.sym;
+                                                                __auto_type name_sym = _mv_399.data.sym;
                                                                 {
                                                                     __auto_type local_name = name_sym.name;
                                                                     __auto_type actual_module = ({ __auto_type _mv = env_env_lookup_type_direct(env, local_name); _mv.has_value ? ({ __auto_type t = _mv.value; ({ __auto_type _mv = (*t).module_name; _mv.has_value ? ({ __auto_type mod = _mv.value; mod; }) : (mod_sym.name); }); }) : (mod_sym.name); });
@@ -103,7 +103,7 @@ void resolve_resolve_import_stmt(env_TypeEnv* env, types_SExpr* import_form) {
                                                                 break;
                                                             }
                                                         }
-                                                    } else if (!_mv_392.has_value) {
+                                                    } else if (!_mv_398.has_value) {
                                                     }
                                                 }
                                             }
@@ -113,7 +113,7 @@ void resolve_resolve_import_stmt(env_TypeEnv* env, types_SExpr* import_form) {
                                             break;
                                         }
                                     }
-                                } else if (!_mv_390.has_value) {
+                                } else if (!_mv_396.has_value) {
                                 }
                                 break;
                             }
@@ -121,7 +121,7 @@ void resolve_resolve_import_stmt(env_TypeEnv* env, types_SExpr* import_form) {
                                 break;
                             }
                         }
-                    } else if (!_mv_388.has_value) {
+                    } else if (!_mv_394.has_value) {
                     }
                 }
                 break;
@@ -150,9 +150,9 @@ slop_option_string resolve_resolve_module_file(slop_arena* arena, slop_string mo
     if (!(resolve_contains_slash(module_name))) {
         return (slop_option_string){.has_value = false};
     } else {
-        __auto_type _mv_394 = from_file;
-        if (_mv_394.has_value) {
-            __auto_type current_path = _mv_394.value;
+        __auto_type _mv_400 = from_file;
+        if (_mv_400.has_value) {
+            __auto_type current_path = _mv_400.value;
             {
                 __auto_type dir = path_path_dirname(arena, current_path);
                 __auto_type rel_path = string_concat(arena, module_name, SLOP_STR(".slop"));
@@ -163,9 +163,10 @@ slop_option_string resolve_resolve_module_file(slop_arena* arena, slop_string mo
                     return (slop_option_string){.has_value = false};
                 }
             }
-        } else if (!_mv_394.has_value) {
+        } else if (!_mv_400.has_value) {
             return (slop_option_string){.has_value = false};
         }
+        SLOP_UNREACHABLE();
     }
 }
 

--- a/bootstrap/checker/slop_strlib.c
+++ b/bootstrap/checker/slop_strlib.c
@@ -183,6 +183,7 @@ uint8_t strlib_contains(slop_string haystack, slop_string needle) {
     } else if (!_mv_14.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t strlib_starts_with(slop_string s, slop_string prefix) {
@@ -602,6 +603,7 @@ slop_string strlib_join(slop_arena* arena, slop_list_string strings, slop_string
                 } else if (!_mv_15.has_value) {
                     return (slop_string){.len = ((uint64_t)(0)), .data = ((uint8_t*)(({ __auto_type _alloc = (uint8_t*)slop_arena_alloc(arena, 1); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })))};
                 }
+                SLOP_UNREACHABLE();
             } else {
                 {
                     int64_t total_len = 0;
@@ -679,6 +681,7 @@ slop_string strlib_replace(slop_arena* arena, slop_string s, slop_string old, sl
             return (slop_string){.len = ((uint64_t)(result_len)), .data = ((uint8_t*)(buf))};
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string strlib_replace_all(slop_arena* arena, slop_string s, slop_string old, slop_string new) {

--- a/bootstrap/checker/slop_types.c
+++ b/bootstrap/checker/slop_types.c
@@ -347,6 +347,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_6.has_value) {
                     return SLOP_STR("Option");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_5 == types_ResolvedTypeKind_rk_ptr) {
                 __auto_type _mv_7 = (*t).inner_type;
                 if (_mv_7.has_value) {
@@ -355,6 +356,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_7.has_value) {
                     return SLOP_STR("Ptr");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_5 == types_ResolvedTypeKind_rk_list) {
                 __auto_type _mv_8 = (*t).inner_type;
                 if (_mv_8.has_value) {
@@ -363,6 +365,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_8.has_value) {
                     return SLOP_STR("List");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_5 == types_ResolvedTypeKind_rk_map) {
                 __auto_type _mv_9 = (*t).inner_type;
                 if (_mv_9.has_value) {
@@ -374,9 +377,11 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                     } else if (!_mv_10.has_value) {
                         return string_concat(arena, SLOP_STR("(Map "), string_concat(arena, types_resolved_type_to_slop_string(arena, key_type), SLOP_STR(")")));
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_9.has_value) {
                     return SLOP_STR("Map");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_5 == types_ResolvedTypeKind_rk_result) {
                 __auto_type _mv_11 = (*t).inner_type;
                 if (_mv_11.has_value) {
@@ -388,9 +393,11 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                     } else if (!_mv_12.has_value) {
                         return string_concat(arena, SLOP_STR("(Result "), string_concat(arena, types_resolved_type_to_slop_string(arena, ok_type), SLOP_STR(")")));
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_11.has_value) {
                     return SLOP_STR("Result");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_5 == types_ResolvedTypeKind_rk_array) {
                 __auto_type _mv_13 = (*t).inner_type;
                 if (_mv_13.has_value) {
@@ -399,6 +406,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_13.has_value) {
                     return SLOP_STR("Array");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_5 == types_ResolvedTypeKind_rk_typevar) {
                 return name;
             } else {

--- a/bootstrap/compiler/slop_collect.c
+++ b/bootstrap/compiler/slop_collect.c
@@ -380,6 +380,7 @@ types_SExpr* collect_get_type_arg(types_SExpr* type_expr, int64_t idx) {
             } else if (!_mv_1175.has_value) {
                 return type_expr;
             }
+            SLOP_UNREACHABLE();
         }
         default: {
             return type_expr;
@@ -413,6 +414,7 @@ types_ResolvedType* collect_get_field_type(env_TypeEnv* env, slop_arena* arena, 
                         return types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, type_name, ((slop_option_string){.has_value = false}), type_name);
                     }
                 }
+                SLOP_UNREACHABLE();
             }
         }
         case types_SExpr_lst:
@@ -489,6 +491,7 @@ types_ResolvedType* collect_get_field_type(env_TypeEnv* env, slop_arena* arena, 
                 } else if (!_mv_1178.has_value) {
                     return env_env_get_unit_type(env);
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -544,6 +547,7 @@ types_ResolvedType* collect_get_field_type_generic(env_TypeEnv* env, slop_arena*
                             return types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, type_name, ((slop_option_string){.has_value = false}), type_name);
                         }
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -621,6 +625,7 @@ types_ResolvedType* collect_get_field_type_generic(env_TypeEnv* env, slop_arena*
                 } else if (!_mv_1182.has_value) {
                     return env_env_get_unit_type(env);
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -711,6 +716,7 @@ types_ResolvedType* collect_extract_spec_return_type_generic(env_TypeEnv* env, t
                     } else if (!_mv_1188.has_value) {
                         return env_env_get_unit_type(env);
                     }
+                    SLOP_UNREACHABLE();
                 }
             } else {
                 return env_env_get_unit_type(env);
@@ -718,6 +724,7 @@ types_ResolvedType* collect_extract_spec_return_type_generic(env_TypeEnv* env, t
         } else if (!_mv_1187.has_value) {
             return env_env_get_unit_type(env);
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -850,6 +857,7 @@ slop_option_types_ResolvedType_ptr collect_lookup_payload_type(env_TypeEnv* env,
                 return (slop_option_types_ResolvedType_ptr){.has_value = false};
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -870,6 +878,7 @@ uint8_t collect_is_range_type_expr(types_SExpr* type_expr) {
             } else if (!_mv_1197.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -891,6 +900,7 @@ types_ResolvedType* collect_get_range_base_type(env_TypeEnv* env, slop_arena* ar
                 } else if (!_mv_1199.has_value) {
                     return env_env_get_int_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_int_type(env);
             }
@@ -898,6 +908,7 @@ types_ResolvedType* collect_get_range_base_type(env_TypeEnv* env, slop_arena* ar
     } else if (!_mv_1198.has_value) {
         return env_env_get_int_type(env);
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string collect_get_type_name_from_expr(types_SExpr* expr) {
@@ -969,6 +980,7 @@ slop_option_types_ResolvedType_ptr collect_get_variant_payload_type(env_TypeEnv*
         } else if (!_mv_1203.has_value) {
             return (slop_option_types_ResolvedType_ptr){.has_value = false};
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -984,6 +996,7 @@ slop_string collect_checker_get_variant_name(types_SExpr* variant_form) {
             } else if (!_mv_1204.has_value) {
                 return SLOP_STR("");
             }
+            SLOP_UNREACHABLE();
         }
     } else {
         __auto_type _mv_1205 = (*variant_form);
@@ -1033,6 +1046,7 @@ uint8_t collect_check_type_expr_recursive(types_SExpr* type_expr, slop_string un
                                     } else if (!_mv_1209.has_value) {
                                         return 0;
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else {
                                     return 0;
                                 }
@@ -1044,6 +1058,7 @@ uint8_t collect_check_type_expr_recursive(types_SExpr* type_expr, slop_string un
                     } else if (!_mv_1207.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1249,6 +1264,7 @@ types_ResolvedType* collect_get_const_type(env_TypeEnv* env, slop_arena* arena, 
                         return types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, type_name, ((slop_option_string){.has_value = false}), type_name);
                     }
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -1398,6 +1414,7 @@ uint8_t collect_ffi_has_variadic(types_SExpr* func_decl) {
             } else if (!_mv_1227.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         } else {
             return 0;
         }
@@ -1462,6 +1479,7 @@ types_ResolvedType* collect_get_ffi_return_type(env_TypeEnv* env, slop_arena* ar
     } else if (!_mv_1232.has_value) {
         return env_env_get_unit_type(env);
     }
+    SLOP_UNREACHABLE();
 }
 
 void collect_collect_single_function(env_TypeEnv* env, slop_arena* arena, types_SExpr* fn_form) {
@@ -1736,6 +1754,7 @@ types_ResolvedType* collect_checker_extract_spec_return_type(env_TypeEnv* env, t
                     } else if (!_mv_1250.has_value) {
                         return env_env_get_unit_type(env);
                     }
+                    SLOP_UNREACHABLE();
                 }
             } else {
                 return env_env_get_unit_type(env);
@@ -1743,6 +1762,7 @@ types_ResolvedType* collect_checker_extract_spec_return_type(env_TypeEnv* env, t
         } else if (!_mv_1249.has_value) {
             return env_env_get_unit_type(env);
         }
+        SLOP_UNREACHABLE();
     }
 }
 

--- a/bootstrap/compiler/slop_compiler.c
+++ b/bootstrap/compiler/slop_compiler.c
@@ -103,11 +103,11 @@ slop_string compiler_lines_to_string(slop_arena* arena, slop_list_string lines) 
                 int64_t total = 0;
                 int64_t i = 0;
                 while (i < len) {
-                    __auto_type _mv_1826 = ({ __auto_type _lst = lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1826.has_value) {
-                        __auto_type line = _mv_1826.value;
+                    __auto_type _mv_1832 = ({ __auto_type _lst = lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1832.has_value) {
+                        __auto_type line = _mv_1832.value;
                         total = (total + (((int64_t)(line.len)) + 1));
-                    } else if (!_mv_1826.has_value) {
+                    } else if (!_mv_1832.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -116,9 +116,9 @@ slop_string compiler_lines_to_string(slop_arena* arena, slop_list_string lines) 
                     int64_t pos = 0;
                     int64_t j = 0;
                     while (j < len) {
-                        __auto_type _mv_1827 = ({ __auto_type _lst = lines; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1827.has_value) {
-                            __auto_type line = _mv_1827.value;
+                        __auto_type _mv_1833 = ({ __auto_type _lst = lines; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1833.has_value) {
+                            __auto_type line = _mv_1833.value;
                             {
                                 __auto_type line_len = ((int64_t)(line.len));
                                 __auto_type line_data = line.data;
@@ -131,7 +131,7 @@ slop_string compiler_lines_to_string(slop_arena* arena, slop_list_string lines) 
                                 buf[pos] = 10;
                                 pos = (pos + 1);
                             }
-                        } else if (!_mv_1827.has_value) {
+                        } else if (!_mv_1833.has_value) {
                         }
                         j = (j + 1);
                     }
@@ -147,45 +147,46 @@ slop_string compiler_extract_module_name(slop_list_types_SExpr_ptr exprs) {
     if (((int64_t)((exprs).len)) < 1) {
         return SLOP_STR("unknown");
     } else {
-        __auto_type _mv_1828 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1828.has_value) {
-            __auto_type first_expr = _mv_1828.value;
-            __auto_type _mv_1829 = (*first_expr);
-            switch (_mv_1829.tag) {
+        __auto_type _mv_1834 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1834.has_value) {
+            __auto_type first_expr = _mv_1834.value;
+            __auto_type _mv_1835 = (*first_expr);
+            switch (_mv_1835.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type lst = _mv_1829.data.lst;
+                    __auto_type lst = _mv_1835.data.lst;
                     {
                         __auto_type items = lst.items;
                         if (((int64_t)((items).len)) < 2) {
                             return SLOP_STR("unknown");
                         } else {
-                            __auto_type _mv_1830 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1830.has_value) {
-                                __auto_type head = _mv_1830.value;
-                                __auto_type _mv_1831 = (*head);
-                                switch (_mv_1831.tag) {
+                            __auto_type _mv_1836 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1836.has_value) {
+                                __auto_type head = _mv_1836.value;
+                                __auto_type _mv_1837 = (*head);
+                                switch (_mv_1837.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1831.data.sym;
+                                        __auto_type sym = _mv_1837.data.sym;
                                         if (string_eq(sym.name, SLOP_STR("module"))) {
-                                            __auto_type _mv_1832 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1832.has_value) {
-                                                __auto_type name_expr = _mv_1832.value;
-                                                __auto_type _mv_1833 = (*name_expr);
-                                                switch (_mv_1833.tag) {
+                                            __auto_type _mv_1838 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1838.has_value) {
+                                                __auto_type name_expr = _mv_1838.value;
+                                                __auto_type _mv_1839 = (*name_expr);
+                                                switch (_mv_1839.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type name_sym = _mv_1833.data.sym;
+                                                        __auto_type name_sym = _mv_1839.data.sym;
                                                         return name_sym.name;
                                                     }
                                                     default: {
                                                         return SLOP_STR("unknown");
                                                     }
                                                 }
-                                            } else if (!_mv_1832.has_value) {
+                                            } else if (!_mv_1838.has_value) {
                                                 return SLOP_STR("unknown");
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else {
                                             return SLOP_STR("unknown");
                                         }
@@ -194,9 +195,10 @@ slop_string compiler_extract_module_name(slop_list_types_SExpr_ptr exprs) {
                                         return SLOP_STR("unknown");
                                     }
                                 }
-                            } else if (!_mv_1830.has_value) {
+                            } else if (!_mv_1836.has_value) {
                                 return SLOP_STR("unknown");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -204,9 +206,10 @@ slop_string compiler_extract_module_name(slop_list_types_SExpr_ptr exprs) {
                     return SLOP_STR("unknown");
                 }
             }
-        } else if (!_mv_1828.has_value) {
+        } else if (!_mv_1834.has_value) {
             return SLOP_STR("unknown");
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -230,9 +233,9 @@ void compiler_check_all_functions(env_TypeEnv* env, slop_list_types_SExpr_ptr as
     {
         __auto_type len = ((int64_t)((ast).len));
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_1834 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1834.has_value) {
-                __auto_type expr = _mv_1834.value;
+            __auto_type _mv_1840 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1840.has_value) {
+                __auto_type expr = _mv_1840.value;
                 if (parser_is_form(expr, SLOP_STR("fn"))) {
                     {
                         __auto_type _ = infer_infer_fn_body(env, expr);
@@ -241,7 +244,7 @@ void compiler_check_all_functions(env_TypeEnv* env, slop_list_types_SExpr_ptr as
                     compiler_check_module_functions(env, expr);
                 } else {
                 }
-            } else if (!_mv_1834.has_value) {
+            } else if (!_mv_1840.has_value) {
             }
         }
     }
@@ -249,13 +252,14 @@ void compiler_check_all_functions(env_TypeEnv* env, slop_list_types_SExpr_ptr as
 
 uint8_t compiler_is_annotation_form(types_SExpr* item) {
     if (parser_sexpr_is_list(item)) {
-        __auto_type _mv_1835 = parser_sexpr_list_get(item, 0);
-        if (_mv_1835.has_value) {
-            __auto_type head = _mv_1835.value;
+        __auto_type _mv_1841 = parser_sexpr_list_get(item, 0);
+        if (_mv_1841.has_value) {
+            __auto_type head = _mv_1841.value;
             return ((uint8_t)(({ __auto_type name = parser_sexpr_get_symbol_name(head); (((name.len > 0)) ? (name.data[0] == 64) : 0); })));
-        } else if (!_mv_1835.has_value) {
+        } else if (!_mv_1841.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     } else {
         return 0;
     }
@@ -285,13 +289,14 @@ uint8_t compiler_is_valid_toplevel_form(types_SExpr* item) {
 
 slop_string compiler_get_form_name(types_SExpr* item) {
     if (parser_sexpr_is_list(item)) {
-        __auto_type _mv_1836 = parser_sexpr_list_get(item, 0);
-        if (_mv_1836.has_value) {
-            __auto_type head = _mv_1836.value;
+        __auto_type _mv_1842 = parser_sexpr_list_get(item, 0);
+        if (_mv_1842.has_value) {
+            __auto_type head = _mv_1842.value;
             return parser_sexpr_get_symbol_name(head);
-        } else if (!_mv_1836.has_value) {
+        } else if (!_mv_1842.has_value) {
             return SLOP_STR("<empty>");
         }
+        SLOP_UNREACHABLE();
     } else {
         return SLOP_STR("<non-list>");
     }
@@ -301,23 +306,23 @@ void compiler_check_module_functions(env_TypeEnv* env, types_SExpr* module_form)
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((module_form != NULL)), "(!= module-form nil)");
     if (parser_sexpr_is_list(module_form)) {
-        __auto_type _mv_1837 = parser_sexpr_list_get(module_form, 1);
-        if (_mv_1837.has_value) {
-            __auto_type name_expr = _mv_1837.value;
+        __auto_type _mv_1843 = parser_sexpr_list_get(module_form, 1);
+        if (_mv_1843.has_value) {
+            __auto_type name_expr = _mv_1843.value;
             {
                 __auto_type mod_name = parser_sexpr_get_symbol_name(name_expr);
                 if (!(string_eq(mod_name, SLOP_STR("")))) {
                     env_env_set_module(env, (slop_option_string){.has_value = 1, .value = mod_name});
                 }
             }
-        } else if (!_mv_1837.has_value) {
+        } else if (!_mv_1843.has_value) {
         }
         {
             __auto_type len = parser_sexpr_list_len(module_form);
             for (int64_t i = 2; i < len; i++) {
-                __auto_type _mv_1838 = parser_sexpr_list_get(module_form, i);
-                if (_mv_1838.has_value) {
-                    __auto_type item = _mv_1838.value;
+                __auto_type _mv_1844 = parser_sexpr_list_get(module_form, i);
+                if (_mv_1844.has_value) {
+                    __auto_type item = _mv_1844.value;
                     if (parser_is_form(item, SLOP_STR("fn"))) {
                         {
                             __auto_type _ = infer_infer_fn_body(env, item);
@@ -330,7 +335,7 @@ void compiler_check_module_functions(env_TypeEnv* env, types_SExpr* module_form)
                             env_env_add_error(env, msg, parser_sexpr_line(item), parser_sexpr_col(item));
                         }
                     }
-                } else if (!_mv_1838.has_value) {
+                } else if (!_mv_1844.has_value) {
                 }
             }
         }
@@ -343,15 +348,15 @@ int64_t compiler_count_errors(slop_list_types_Diagnostic diagnostics) {
         int64_t errors = 0;
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1839 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1839.has_value) {
-                __auto_type diag = _mv_1839.value;
-                __auto_type _mv_1840 = diag.level;
-                if (_mv_1840 == types_DiagnosticLevel_diag_error) {
+            __auto_type _mv_1845 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1845.has_value) {
+                __auto_type diag = _mv_1845.value;
+                __auto_type _mv_1846 = diag.level;
+                if (_mv_1846 == types_DiagnosticLevel_diag_error) {
                     errors = (errors + 1);
-                } else if (_mv_1840 == types_DiagnosticLevel_diag_warning) {
+                } else if (_mv_1846 == types_DiagnosticLevel_diag_warning) {
                 }
-            } else if (!_mv_1839.has_value) {
+            } else if (!_mv_1845.has_value) {
             }
             i = (i + 1);
         }
@@ -366,10 +371,10 @@ void compiler_print_diagnostic(slop_arena* arena, slop_string filename, types_Di
     printf("%s", ":");
     printf("%lld", (long long)(diag.col));
     printf("%s", ": ");
-    __auto_type _mv_1841 = diag.level;
-    if (_mv_1841 == types_DiagnosticLevel_diag_warning) {
+    __auto_type _mv_1847 = diag.level;
+    if (_mv_1847 == types_DiagnosticLevel_diag_warning) {
         printf("%s", "warning: ");
-    } else if (_mv_1841 == types_DiagnosticLevel_diag_error) {
+    } else if (_mv_1847 == types_DiagnosticLevel_diag_error) {
         printf("%s", "error: ");
     }
     printf("%.*s\n", (int)(diag.message).len, (diag.message).data);
@@ -380,11 +385,11 @@ void compiler_output_diagnostics_text(slop_arena* arena, slop_string filename, s
         __auto_type len = ((int64_t)((diagnostics).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1842 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1842.has_value) {
-                __auto_type diag = _mv_1842.value;
+            __auto_type _mv_1848 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1848.has_value) {
+                __auto_type diag = _mv_1848.value;
                 compiler_print_diagnostic(arena, filename, diag);
-            } else if (!_mv_1842.has_value) {
+            } else if (!_mv_1848.has_value) {
             }
             i = (i + 1);
         }
@@ -400,11 +405,11 @@ void compiler_output_diagnostics_json(slop_arena* arena, slop_list_types_Diagnos
             if (i > 0) {
                 putchar(44);
             }
-            __auto_type _mv_1843 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1843.has_value) {
-                __auto_type diag = _mv_1843.value;
+            __auto_type _mv_1849 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1849.has_value) {
+                __auto_type diag = _mv_1849.value;
                 compiler_output_single_diagnostic_json(arena, diag);
-            } else if (!_mv_1843.has_value) {
+            } else if (!_mv_1849.has_value) {
             }
             i = (i + 1);
         }
@@ -415,10 +420,10 @@ void compiler_output_diagnostics_json(slop_arena* arena, slop_list_types_Diagnos
 void compiler_output_single_diagnostic_json(slop_arena* arena, types_Diagnostic diag) {
     putchar(123);
     compiler_print_str(((uint8_t*)(SLOP_STR("\"level\":").data)));
-    __auto_type _mv_1844 = diag.level;
-    if (_mv_1844 == types_DiagnosticLevel_diag_warning) {
+    __auto_type _mv_1850 = diag.level;
+    if (_mv_1850 == types_DiagnosticLevel_diag_warning) {
         compiler_print_str(((uint8_t*)(SLOP_STR("\"warning\"").data)));
-    } else if (_mv_1844 == types_DiagnosticLevel_diag_error) {
+    } else if (_mv_1850 == types_DiagnosticLevel_diag_error) {
         compiler_print_str(((uint8_t*)(SLOP_STR("\"error\"").data)));
     }
     putchar(44);
@@ -450,27 +455,27 @@ int64_t compiler_check_single_file(env_TypeEnv* env, slop_arena* arena, uint8_t*
     SLOP_PRE(((filename != NULL)), "(!= filename nil)");
     {
         __auto_type filename_str = strlib_cstring_to_string(filename);
-        __auto_type _mv_1845 = file_file_open(filename_str, file_FileMode_read);
-        if (!_mv_1845.is_ok) {
-            __auto_type e = _mv_1845.data.err;
+        __auto_type _mv_1851 = file_file_open(filename_str, file_FileMode_read);
+        if (!_mv_1851.is_ok) {
+            __auto_type e = _mv_1851.data.err;
             printf("%s", "Error: Could not open file: ");
             printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
             return 1;
-        } else if (_mv_1845.is_ok) {
-            __auto_type f = _mv_1845.data.ok;
-            __auto_type _mv_1846 = file_file_read_all(arena, (&f));
-            if (!_mv_1846.is_ok) {
-                __auto_type e = _mv_1846.data.err;
+        } else if (_mv_1851.is_ok) {
+            __auto_type f = _mv_1851.data.ok;
+            __auto_type _mv_1852 = file_file_read_all(arena, (&f));
+            if (!_mv_1852.is_ok) {
+                __auto_type e = _mv_1852.data.err;
                 file_file_close((&f));
                 printf("%s", "Error: Could not read file: ");
                 printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
                 return 1;
-            } else if (_mv_1846.is_ok) {
-                __auto_type source = _mv_1846.data.ok;
+            } else if (_mv_1852.is_ok) {
+                __auto_type source = _mv_1852.data.ok;
                 file_file_close((&f));
-                __auto_type _mv_1847 = parser_parse(arena, source);
-                if (_mv_1847.is_ok) {
-                    __auto_type ast = _mv_1847.data.ok;
+                __auto_type _mv_1853 = parser_parse(arena, source);
+                if (_mv_1853.is_ok) {
+                    __auto_type ast = _mv_1853.data.ok;
                     {
                         __auto_type mod_name = compiler_extract_module_name(ast);
                         env_env_clear_imports(env);
@@ -487,8 +492,8 @@ int64_t compiler_check_single_file(env_TypeEnv* env, slop_arena* arena, uint8_t*
                             return compiler_count_errors(diagnostics);
                         }
                     }
-                } else if (!_mv_1847.is_ok) {
-                    __auto_type parse_err = _mv_1847.data.err;
+                } else if (!_mv_1853.is_ok) {
+                    __auto_type parse_err = _mv_1853.data.err;
                     printf("%.*s", (int)(filename_str).len, (filename_str).data);
                     printf("%s", ":");
                     printf("%lld", (long long)(parse_err.line));
@@ -498,22 +503,25 @@ int64_t compiler_check_single_file(env_TypeEnv* env, slop_arena* arena, uint8_t*
                     printf("%.*s\n", (int)(parse_err.message).len, (parse_err.message).data);
                     return 1;
                 }
+                SLOP_UNREACHABLE();
             }
+            SLOP_UNREACHABLE();
         }
+        SLOP_UNREACHABLE();
     }
 }
 
 types_ResolvedType* compiler_resolve_type_string(env_TypeEnv* env, slop_arena* arena, slop_string type_str) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_1848 = parser_parse(arena, type_str);
-    if (_mv_1848.is_ok) {
-        __auto_type type_ast = _mv_1848.data.ok;
+    __auto_type _mv_1854 = parser_parse(arena, type_str);
+    if (_mv_1854.is_ok) {
+        __auto_type type_ast = _mv_1854.data.ok;
         if (((int64_t)((type_ast).len)) == 0) {
             return env_env_get_int_type(env);
         } else {
-            __auto_type _mv_1849 = ({ __auto_type _lst = type_ast; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1849.has_value) {
-                __auto_type type_expr = _mv_1849.value;
+            __auto_type _mv_1855 = ({ __auto_type _lst = type_ast; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1855.has_value) {
+                __auto_type type_expr = _mv_1855.value;
                 if (parser_sexpr_is_list(type_expr)) {
                     return infer_resolve_complex_type_expr(env, type_expr);
                 } else {
@@ -526,63 +534,65 @@ types_ResolvedType* compiler_resolve_type_string(env_TypeEnv* env, slop_arena* a
                         }
                     }
                 }
-            } else if (!_mv_1849.has_value) {
+            } else if (!_mv_1855.has_value) {
                 return env_env_get_int_type(env);
             }
+            SLOP_UNREACHABLE();
         }
-    } else if (!_mv_1848.is_ok) {
-        __auto_type _ = _mv_1848.data.err;
+    } else if (!_mv_1854.is_ok) {
+        __auto_type _ = _mv_1854.data.err;
         return env_env_get_int_type(env);
     }
+    SLOP_UNREACHABLE();
 }
 
 void compiler_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_string params_str) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_1850 = parser_parse(arena, params_str);
-    if (_mv_1850.is_ok) {
-        __auto_type params_ast = _mv_1850.data.ok;
+    __auto_type _mv_1856 = parser_parse(arena, params_str);
+    if (_mv_1856.is_ok) {
+        __auto_type params_ast = _mv_1856.data.ok;
         if (((int64_t)((params_ast).len)) > 0) {
-            __auto_type _mv_1851 = ({ __auto_type _lst = params_ast; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1851.has_value) {
-                __auto_type params_list = _mv_1851.value;
-                __auto_type _mv_1852 = (*params_list);
-                switch (_mv_1852.tag) {
+            __auto_type _mv_1857 = ({ __auto_type _lst = params_ast; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1857.has_value) {
+                __auto_type params_list = _mv_1857.value;
+                __auto_type _mv_1858 = (*params_list);
+                switch (_mv_1858.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type lst = _mv_1852.data.lst;
+                        __auto_type lst = _mv_1858.data.lst;
                         {
                             __auto_type items = lst.items;
                             __auto_type len = ((int64_t)((items).len));
                             for (int64_t i = 0; i < len; i++) {
-                                __auto_type _mv_1853 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1853.has_value) {
-                                    __auto_type param = _mv_1853.value;
-                                    __auto_type _mv_1854 = (*param);
-                                    switch (_mv_1854.tag) {
+                                __auto_type _mv_1859 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1859.has_value) {
+                                    __auto_type param = _mv_1859.value;
+                                    __auto_type _mv_1860 = (*param);
+                                    switch (_mv_1860.tag) {
                                         case types_SExpr_lst:
                                         {
-                                            __auto_type param_lst = _mv_1854.data.lst;
+                                            __auto_type param_lst = _mv_1860.data.lst;
                                             {
                                                 __auto_type param_items = param_lst.items;
                                                 if (((int64_t)((param_items).len)) >= 2) {
-                                                    __auto_type _mv_1855 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1855.has_value) {
-                                                        __auto_type name_expr = _mv_1855.value;
-                                                        __auto_type _mv_1856 = (*name_expr);
-                                                        switch (_mv_1856.tag) {
+                                                    __auto_type _mv_1861 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1861.has_value) {
+                                                        __auto_type name_expr = _mv_1861.value;
+                                                        __auto_type _mv_1862 = (*name_expr);
+                                                        switch (_mv_1862.tag) {
                                                             case types_SExpr_sym:
                                                             {
-                                                                __auto_type name_sym = _mv_1856.data.sym;
+                                                                __auto_type name_sym = _mv_1862.data.sym;
                                                                 {
                                                                     __auto_type param_name = name_sym.name;
-                                                                    __auto_type _mv_1857 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                    if (_mv_1857.has_value) {
-                                                                        __auto_type type_expr = _mv_1857.value;
-                                                                        __auto_type _mv_1858 = (*type_expr);
-                                                                        switch (_mv_1858.tag) {
+                                                                    __auto_type _mv_1863 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                    if (_mv_1863.has_value) {
+                                                                        __auto_type type_expr = _mv_1863.value;
+                                                                        __auto_type _mv_1864 = (*type_expr);
+                                                                        switch (_mv_1864.tag) {
                                                                             case types_SExpr_sym:
                                                                             {
-                                                                                __auto_type type_sym = _mv_1858.data.sym;
+                                                                                __auto_type type_sym = _mv_1864.data.sym;
                                                                                 {
                                                                                     __auto_type param_type = compiler_resolve_type_string(env, arena, type_sym.name);
                                                                                     env_env_bind_var(env, param_name, param_type);
@@ -591,7 +601,7 @@ void compiler_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_st
                                                                             }
                                                                             case types_SExpr_lst:
                                                                             {
-                                                                                __auto_type _ = _mv_1858.data.lst;
+                                                                                __auto_type _ = _mv_1864.data.lst;
                                                                                 {
                                                                                     __auto_type param_type = infer_resolve_complex_type_expr(env, type_expr);
                                                                                     env_env_bind_var(env, param_name, param_type);
@@ -603,7 +613,7 @@ void compiler_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_st
                                                                                 break;
                                                                             }
                                                                         }
-                                                                    } else if (!_mv_1857.has_value) {
+                                                                    } else if (!_mv_1863.has_value) {
                                                                     }
                                                                 }
                                                                 break;
@@ -612,7 +622,7 @@ void compiler_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_st
                                                                 break;
                                                             }
                                                         }
-                                                    } else if (!_mv_1855.has_value) {
+                                                    } else if (!_mv_1861.has_value) {
                                                     }
                                                 }
                                             }
@@ -622,7 +632,7 @@ void compiler_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_st
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1853.has_value) {
+                                } else if (!_mv_1859.has_value) {
                                 }
                             }
                         }
@@ -632,11 +642,11 @@ void compiler_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_st
                         break;
                     }
                 }
-            } else if (!_mv_1851.has_value) {
+            } else if (!_mv_1857.has_value) {
             }
         }
-    } else if (!_mv_1850.is_ok) {
-        __auto_type _ = _mv_1850.data.err;
+    } else if (!_mv_1856.is_ok) {
+        __auto_type _ = _mv_1856.data.err;
     }
 }
 
@@ -655,19 +665,21 @@ uint8_t compiler_types_names_equal(types_ResolvedType* a, types_ResolvedType* b)
         } else if (string_eq(a_name, SLOP_STR("Unknown")) || string_eq(b_name, SLOP_STR("Unknown"))) {
             return 1;
         } else if ((a_kind == types_ResolvedTypeKind_rk_option) && (b_kind == types_ResolvedTypeKind_rk_option)) {
-            __auto_type _mv_1859 = (*a).inner_type;
-            if (_mv_1859.has_value) {
-                __auto_type a_inner = _mv_1859.value;
-                __auto_type _mv_1860 = (*b).inner_type;
-                if (_mv_1860.has_value) {
-                    __auto_type b_inner = _mv_1860.value;
+            __auto_type _mv_1865 = (*a).inner_type;
+            if (_mv_1865.has_value) {
+                __auto_type a_inner = _mv_1865.value;
+                __auto_type _mv_1866 = (*b).inner_type;
+                if (_mv_1866.has_value) {
+                    __auto_type b_inner = _mv_1866.value;
                     return compiler_types_names_equal(a_inner, b_inner);
-                } else if (!_mv_1860.has_value) {
+                } else if (!_mv_1866.has_value) {
                     return 1;
                 }
-            } else if (!_mv_1859.has_value) {
+                SLOP_UNREACHABLE();
+            } else if (!_mv_1865.has_value) {
                 return 1;
             }
+            SLOP_UNREACHABLE();
         } else if ((a_kind == types_ResolvedTypeKind_rk_result) && (b_kind == types_ResolvedTypeKind_rk_result)) {
             {
                 __auto_type ok_match = ({ __auto_type _mv = (*a).inner_type; _mv.has_value ? ({ __auto_type a_inner = _mv.value; ({ __auto_type _mv = (*b).inner_type; _mv.has_value ? ({ __auto_type b_inner = _mv.value; compiler_types_names_equal(a_inner, b_inner); }) : (1); }); }) : (1); });
@@ -675,35 +687,39 @@ uint8_t compiler_types_names_equal(types_ResolvedType* a, types_ResolvedType* b)
                 return (ok_match && err_match);
             }
         } else if ((a_kind == types_ResolvedTypeKind_rk_ptr) && (b_kind == types_ResolvedTypeKind_rk_ptr)) {
-            __auto_type _mv_1861 = (*a).inner_type;
-            if (_mv_1861.has_value) {
-                __auto_type a_inner = _mv_1861.value;
-                __auto_type _mv_1862 = (*b).inner_type;
-                if (_mv_1862.has_value) {
-                    __auto_type b_inner = _mv_1862.value;
+            __auto_type _mv_1867 = (*a).inner_type;
+            if (_mv_1867.has_value) {
+                __auto_type a_inner = _mv_1867.value;
+                __auto_type _mv_1868 = (*b).inner_type;
+                if (_mv_1868.has_value) {
+                    __auto_type b_inner = _mv_1868.value;
                     return compiler_types_names_equal(a_inner, b_inner);
-                } else if (!_mv_1862.has_value) {
+                } else if (!_mv_1868.has_value) {
                     return 1;
                 }
-            } else if (!_mv_1861.has_value) {
+                SLOP_UNREACHABLE();
+            } else if (!_mv_1867.has_value) {
                 return 1;
             }
+            SLOP_UNREACHABLE();
         } else if (a_kind == types_ResolvedTypeKind_rk_range) {
-            __auto_type _mv_1863 = (*a).inner_type;
-            if (_mv_1863.has_value) {
-                __auto_type base = _mv_1863.value;
+            __auto_type _mv_1869 = (*a).inner_type;
+            if (_mv_1869.has_value) {
+                __auto_type base = _mv_1869.value;
                 return compiler_types_names_equal(base, b);
-            } else if (!_mv_1863.has_value) {
+            } else if (!_mv_1869.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         } else if (b_kind == types_ResolvedTypeKind_rk_range) {
-            __auto_type _mv_1864 = (*b).inner_type;
-            if (_mv_1864.has_value) {
-                __auto_type base = _mv_1864.value;
+            __auto_type _mv_1870 = (*b).inner_type;
+            if (_mv_1870.has_value) {
+                __auto_type base = _mv_1870.value;
                 return compiler_types_names_equal(a, base);
-            } else if (!_mv_1864.has_value) {
+            } else if (!_mv_1870.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         } else if ((a_kind == types_ResolvedTypeKind_rk_primitive) && (b_kind == types_ResolvedTypeKind_rk_primitive)) {
             {
                 __auto_type a_match = ({ __auto_type _mv = (*a).inner_type; _mv.has_value ? ({ __auto_type a_base = _mv.value; compiler_types_names_equal(a_base, b); }) : (0); });
@@ -711,21 +727,23 @@ uint8_t compiler_types_names_equal(types_ResolvedType* a, types_ResolvedType* b)
                 return (a_match || b_match);
             }
         } else if (a_kind == types_ResolvedTypeKind_rk_primitive) {
-            __auto_type _mv_1865 = (*a).inner_type;
-            if (_mv_1865.has_value) {
-                __auto_type a_base = _mv_1865.value;
+            __auto_type _mv_1871 = (*a).inner_type;
+            if (_mv_1871.has_value) {
+                __auto_type a_base = _mv_1871.value;
                 return compiler_types_names_equal(a_base, b);
-            } else if (!_mv_1865.has_value) {
+            } else if (!_mv_1871.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         } else if (b_kind == types_ResolvedTypeKind_rk_primitive) {
-            __auto_type _mv_1866 = (*b).inner_type;
-            if (_mv_1866.has_value) {
-                __auto_type b_base = _mv_1866.value;
+            __auto_type _mv_1872 = (*b).inner_type;
+            if (_mv_1872.has_value) {
+                __auto_type b_base = _mv_1872.value;
                 return compiler_types_names_equal(a, b_base);
-            } else if (!_mv_1866.has_value) {
+            } else if (!_mv_1872.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         } else {
             return 0;
         }
@@ -735,26 +753,26 @@ uint8_t compiler_types_names_equal(types_ResolvedType* a, types_ResolvedType* b)
 int64_t compiler_check_expr_mode(slop_arena* arena, env_TypeEnv* env, slop_string expr_str, slop_string type_str, slop_string context_file, slop_string params_str) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     if (string_len(context_file) > 0) {
-        __auto_type _mv_1867 = file_file_open(context_file, file_FileMode_read);
-        if (!_mv_1867.is_ok) {
-            __auto_type _ = _mv_1867.data.err;
-        } else if (_mv_1867.is_ok) {
-            __auto_type f = _mv_1867.data.ok;
-            __auto_type _mv_1868 = file_file_read_all(arena, (&f));
-            if (!_mv_1868.is_ok) {
-                __auto_type _ = _mv_1868.data.err;
+        __auto_type _mv_1873 = file_file_open(context_file, file_FileMode_read);
+        if (!_mv_1873.is_ok) {
+            __auto_type _ = _mv_1873.data.err;
+        } else if (_mv_1873.is_ok) {
+            __auto_type f = _mv_1873.data.ok;
+            __auto_type _mv_1874 = file_file_read_all(arena, (&f));
+            if (!_mv_1874.is_ok) {
+                __auto_type _ = _mv_1874.data.err;
                 file_file_close((&f));
-            } else if (_mv_1868.is_ok) {
-                __auto_type source = _mv_1868.data.ok;
+            } else if (_mv_1874.is_ok) {
+                __auto_type source = _mv_1874.data.ok;
                 file_file_close((&f));
-                __auto_type _mv_1869 = parser_parse(arena, source);
-                if (_mv_1869.is_ok) {
-                    __auto_type context_ast = _mv_1869.data.ok;
+                __auto_type _mv_1875 = parser_parse(arena, source);
+                if (_mv_1875.is_ok) {
+                    __auto_type context_ast = _mv_1875.data.ok;
                     collect_collect_module(env, context_ast);
                     resolve_resolve_imports(env, context_ast);
                     env_env_clear_diagnostics(env);
-                } else if (!_mv_1869.is_ok) {
-                    __auto_type _ = _mv_1869.data.err;
+                } else if (!_mv_1875.is_ok) {
+                    __auto_type _ = _mv_1875.data.err;
                 }
             }
         }
@@ -793,27 +811,27 @@ int64_t compiler_transpile_single_file(env_TypeEnv* env, context_TranspileContex
     {
         __auto_type filename_str = strlib_cstring_to_string(filename);
         context_ctx_set_file(ctx, filename_str);
-        __auto_type _mv_1870 = file_file_open(filename_str, file_FileMode_read);
-        if (!_mv_1870.is_ok) {
-            __auto_type e = _mv_1870.data.err;
+        __auto_type _mv_1876 = file_file_open(filename_str, file_FileMode_read);
+        if (!_mv_1876.is_ok) {
+            __auto_type e = _mv_1876.data.err;
             printf("%s", "Error: Could not open file: ");
             printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
             return 1;
-        } else if (_mv_1870.is_ok) {
-            __auto_type f = _mv_1870.data.ok;
-            __auto_type _mv_1871 = file_file_read_all(arena, (&f));
-            if (!_mv_1871.is_ok) {
-                __auto_type e = _mv_1871.data.err;
+        } else if (_mv_1876.is_ok) {
+            __auto_type f = _mv_1876.data.ok;
+            __auto_type _mv_1877 = file_file_read_all(arena, (&f));
+            if (!_mv_1877.is_ok) {
+                __auto_type e = _mv_1877.data.err;
                 file_file_close((&f));
                 printf("%s", "Error: Could not read file: ");
                 printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
                 return 1;
-            } else if (_mv_1871.is_ok) {
-                __auto_type source = _mv_1871.data.ok;
+            } else if (_mv_1877.is_ok) {
+                __auto_type source = _mv_1877.data.ok;
                 file_file_close((&f));
-                __auto_type _mv_1872 = parser_parse(arena, source);
-                if (_mv_1872.is_ok) {
-                    __auto_type ast = _mv_1872.data.ok;
+                __auto_type _mv_1878 = parser_parse(arena, source);
+                if (_mv_1878.is_ok) {
+                    __auto_type ast = _mv_1878.data.ok;
                     {
                         __auto_type mod_name = compiler_extract_module_name(ast);
                         env_env_clear_imports(env);
@@ -831,8 +849,8 @@ int64_t compiler_transpile_single_file(env_TypeEnv* env, context_TranspileContex
                         compiler_output_transpile_module_json(arena, ctx, mod_name, first);
                         return 0;
                     }
-                } else if (!_mv_1872.is_ok) {
-                    __auto_type parse_err = _mv_1872.data.err;
+                } else if (!_mv_1878.is_ok) {
+                    __auto_type parse_err = _mv_1878.data.err;
                     printf("%.*s", (int)(filename_str).len, (filename_str).data);
                     printf("%s", ":");
                     printf("%lld", (long long)(parse_err.line));
@@ -842,8 +860,11 @@ int64_t compiler_transpile_single_file(env_TypeEnv* env, context_TranspileContex
                     printf("%.*s\n", (int)(parse_err.message).len, (parse_err.message).data);
                     return 1;
                 }
+                SLOP_UNREACHABLE();
             }
+            SLOP_UNREACHABLE();
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -873,29 +894,30 @@ void compiler_output_transpile_module_json(slop_arena* arena, context_TranspileC
 
 slop_string compiler_emit_sexpr_inner(slop_arena* arena, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1873 = (*expr);
-    switch (_mv_1873.tag) {
+    __auto_type _mv_1879 = (*expr);
+    switch (_mv_1879.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1873.data.sym;
+            __auto_type sym = _mv_1879.data.sym;
             return sym.name;
         }
         case types_SExpr_str:
         {
-            __auto_type str = _mv_1873.data.str;
+            __auto_type str = _mv_1879.data.str;
             return string_concat(arena, SLOP_STR("\""), string_concat(arena, str.value, SLOP_STR("\"")));
         }
         case types_SExpr_num:
         {
-            __auto_type num = _mv_1873.data.num;
+            __auto_type num = _mv_1879.data.num;
             return num.raw;
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1873.data.lst;
+            __auto_type lst = _mv_1879.data.lst;
             return compiler_emit_typed_list(arena, lst.items);
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string compiler_emit_typed_sexpr(slop_arena* arena, types_SExpr* expr) {
@@ -903,16 +925,17 @@ slop_string compiler_emit_typed_sexpr(slop_arena* arena, types_SExpr* expr) {
     {
         __auto_type type_opt = ctype_get_node_resolved_type(expr);
         __auto_type inner = compiler_emit_sexpr_inner(arena, expr);
-        __auto_type _mv_1874 = type_opt;
-        if (_mv_1874.has_value) {
-            __auto_type rt = _mv_1874.value;
+        __auto_type _mv_1880 = type_opt;
+        if (_mv_1880.has_value) {
+            __auto_type rt = _mv_1880.value;
             {
                 __auto_type type_str = types_resolved_type_to_slop_string(arena, rt);
                 return string_concat(arena, SLOP_STR("(typed "), string_concat(arena, type_str, string_concat(arena, SLOP_STR(" "), string_concat(arena, inner, SLOP_STR(")")))));
             }
-        } else if (!_mv_1874.has_value) {
+        } else if (!_mv_1880.has_value) {
             return inner;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -922,9 +945,9 @@ slop_string compiler_emit_typed_list(slop_arena* arena, slop_list_types_SExpr_pt
         __auto_type result = SLOP_STR("(");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1875 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1875.has_value) {
-                __auto_type item = _mv_1875.value;
+            __auto_type _mv_1881 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1881.has_value) {
+                __auto_type item = _mv_1881.value;
                 {
                     __auto_type child_str = compiler_emit_typed_sexpr(arena, item);
                     if (i > 0) {
@@ -933,7 +956,7 @@ slop_string compiler_emit_typed_list(slop_arena* arena, slop_list_types_SExpr_pt
                         result = string_concat(arena, result, child_str);
                     }
                 }
-            } else if (!_mv_1875.has_value) {
+            } else if (!_mv_1881.has_value) {
             }
             i = (i + 1);
         }
@@ -960,9 +983,9 @@ slop_string compiler_emit_typed_module(slop_arena* arena, types_SExpr* module_fo
             __auto_type result = SLOP_STR("(");
             int64_t i = 0;
             while (i < len) {
-                __auto_type _mv_1876 = parser_sexpr_list_get(module_form, i);
-                if (_mv_1876.has_value) {
-                    __auto_type item = _mv_1876.value;
+                __auto_type _mv_1882 = parser_sexpr_list_get(module_form, i);
+                if (_mv_1882.has_value) {
+                    __auto_type item = _mv_1882.value;
                     {
                         __auto_type child_str = ((parser_is_form(item, SLOP_STR("fn"))) ? compiler_emit_typed_sexpr(arena, item) : compiler_emit_typed_sexpr(arena, item));
                         if (i > 0) {
@@ -971,7 +994,7 @@ slop_string compiler_emit_typed_module(slop_arena* arena, types_SExpr* module_fo
                             result = string_concat(arena, result, child_str);
                         }
                     }
-                } else if (!_mv_1876.has_value) {
+                } else if (!_mv_1882.has_value) {
                 }
                 i = (i + 1);
             }
@@ -988,9 +1011,9 @@ slop_string compiler_emit_typed_ast(slop_arena* arena, slop_list_types_SExpr_ptr
         __auto_type result = SLOP_STR("");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1877 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1877.has_value) {
-                __auto_type expr = _mv_1877.value;
+            __auto_type _mv_1883 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1883.has_value) {
+                __auto_type expr = _mv_1883.value;
                 {
                     __auto_type form_str = compiler_emit_typed_toplevel(arena, expr);
                     if (i > 0) {
@@ -999,7 +1022,7 @@ slop_string compiler_emit_typed_ast(slop_arena* arena, slop_list_types_SExpr_ptr
                         result = form_str;
                     }
                 }
-            } else if (!_mv_1877.has_value) {
+            } else if (!_mv_1883.has_value) {
             }
             i = (i + 1);
         }
@@ -1012,27 +1035,27 @@ int64_t compiler_typed_ast_single_file(env_TypeEnv* env, slop_arena* arena, uint
     SLOP_PRE(((filename != NULL)), "(!= filename nil)");
     {
         __auto_type filename_str = strlib_cstring_to_string(filename);
-        __auto_type _mv_1878 = file_file_open(filename_str, file_FileMode_read);
-        if (!_mv_1878.is_ok) {
-            __auto_type e = _mv_1878.data.err;
+        __auto_type _mv_1884 = file_file_open(filename_str, file_FileMode_read);
+        if (!_mv_1884.is_ok) {
+            __auto_type e = _mv_1884.data.err;
             printf("%s", "Error: Could not open file: ");
             printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
             return 1;
-        } else if (_mv_1878.is_ok) {
-            __auto_type f = _mv_1878.data.ok;
-            __auto_type _mv_1879 = file_file_read_all(arena, (&f));
-            if (!_mv_1879.is_ok) {
-                __auto_type e = _mv_1879.data.err;
+        } else if (_mv_1884.is_ok) {
+            __auto_type f = _mv_1884.data.ok;
+            __auto_type _mv_1885 = file_file_read_all(arena, (&f));
+            if (!_mv_1885.is_ok) {
+                __auto_type e = _mv_1885.data.err;
                 file_file_close((&f));
                 printf("%s", "Error: Could not read file: ");
                 printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
                 return 1;
-            } else if (_mv_1879.is_ok) {
-                __auto_type source = _mv_1879.data.ok;
+            } else if (_mv_1885.is_ok) {
+                __auto_type source = _mv_1885.data.ok;
                 file_file_close((&f));
-                __auto_type _mv_1880 = parser_parse(arena, source);
-                if (_mv_1880.is_ok) {
-                    __auto_type ast = _mv_1880.data.ok;
+                __auto_type _mv_1886 = parser_parse(arena, source);
+                if (_mv_1886.is_ok) {
+                    __auto_type ast = _mv_1886.data.ok;
                     {
                         __auto_type mod_name = compiler_extract_module_name(ast);
                         env_env_clear_imports(env);
@@ -1060,8 +1083,8 @@ int64_t compiler_typed_ast_single_file(env_TypeEnv* env, slop_arena* arena, uint
                             }
                         }
                     }
-                } else if (!_mv_1880.is_ok) {
-                    __auto_type parse_err = _mv_1880.data.err;
+                } else if (!_mv_1886.is_ok) {
+                    __auto_type parse_err = _mv_1886.data.err;
                     printf("%.*s", (int)(filename_str).len, (filename_str).data);
                     printf("%s", ":");
                     printf("%lld", (long long)(parse_err.line));
@@ -1071,8 +1094,11 @@ int64_t compiler_typed_ast_single_file(env_TypeEnv* env, slop_arena* arena, uint
                     printf("%.*s\n", (int)(parse_err.message).len, (parse_err.message).data);
                     return 1;
                 }
+                SLOP_UNREACHABLE();
             }
+            SLOP_UNREACHABLE();
         }
+        SLOP_UNREACHABLE();
     }
 }
 

--- a/bootstrap/compiler/slop_context.c
+++ b/bootstrap/compiler/slop_context.c
@@ -464,6 +464,7 @@ int64_t context_ctx_sexpr_line(types_SExpr* expr) {
                 return ((int64_t)(l.line));
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -494,6 +495,7 @@ int64_t context_ctx_sexpr_col(types_SExpr* expr) {
                 return ((int64_t)(l.col));
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -505,6 +507,7 @@ int64_t context_ctx_list_first_line(slop_list_types_SExpr_ptr items) {
     } else if (!_mv_53.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 int64_t context_ctx_list_first_col(slop_list_types_SExpr_ptr items) {
@@ -515,6 +518,7 @@ int64_t context_ctx_list_first_col(slop_list_types_SExpr_ptr items) {
     } else if (!_mv_54.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 void context_ctx_push_scope(context_TranspileContext* ctx) {
@@ -598,7 +602,9 @@ slop_option_context_VarEntry context_lookup_var_in_scope_chain(context_Scope* sc
                 } else if (!_mv_58.has_value) {
                     return (slop_option_context_VarEntry){.has_value = false};
                 }
+                SLOP_UNREACHABLE();
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -650,7 +656,9 @@ slop_option_context_VarEntry context_find_arena_in_scope_chain(context_Scope* sc
                 } else if (!_mv_61.has_value) {
                     return (slop_option_context_VarEntry){.has_value = false};
                 }
+                SLOP_UNREACHABLE();
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -723,6 +731,7 @@ slop_option_context_FuncEntry context_ctx_lookup_func(context_TranspileContext* 
         } else if (!_mv_64.has_value) {
             return self_entry;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -789,6 +798,7 @@ slop_string context_strip_module_prefix(slop_arena* arena, slop_string type_name
     } else if (!_mv_67.has_value) {
         return type_name;
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_option_string context_ctx_lookup_field_slop_type(context_TranspileContext* ctx, slop_string type_name, slop_string field_name) {
@@ -946,6 +956,7 @@ slop_string context_ctx_prefix_type(context_TranspileContext* ctx, slop_string t
             } else if (!_mv_73.has_value) {
                 return type_name;
             }
+            SLOP_UNREACHABLE();
         } else {
             return type_name;
         }
@@ -1548,6 +1559,7 @@ slop_string context_to_c_type_prefixed(context_TranspileContext* ctx, types_SExp
                         } else if (!_mv_91.has_value) {
                             return SLOP_STR("int64_t");
                         }
+                        SLOP_UNREACHABLE();
                     } else {
                         {
                             __auto_type base_c_type = ctype_to_c_type(arena, type_expr);
@@ -1561,6 +1573,7 @@ slop_string context_to_c_type_prefixed(context_TranspileContext* ctx, types_SExp
                                 } else if (!_mv_92.has_value) {
                                     return context_ctx_prefix_type(ctx, base_c_type);
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -1582,6 +1595,7 @@ slop_string context_to_c_type_prefixed(context_TranspileContext* ctx, types_SExp
                 return SLOP_STR("void*");
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -1610,6 +1624,7 @@ slop_option_string context_get_array_pointer_type(context_TranspileContext* ctx,
                 } else if (!_mv_94.has_value) {
                     return (slop_option_string){.has_value = false};
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {

--- a/bootstrap/compiler/slop_ctype.c
+++ b/bootstrap/compiler/slop_ctype.c
@@ -201,6 +201,7 @@ slop_string ctype_to_c_type(slop_arena* arena, types_SExpr* expr) {
                         return ctype_to_c_name(arena, name);
                     }
                 }
+                SLOP_UNREACHABLE();
             }
         }
         case types_SExpr_lst:
@@ -219,6 +220,7 @@ slop_string ctype_to_c_type(slop_arena* arena, types_SExpr* expr) {
             return SLOP_STR("void*");
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_ptr items) {
@@ -248,6 +250,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_23.has_value) {
                                         return SLOP_STR("void*");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("ScopedPtr"))) {
                                 if (len < 2) {
@@ -260,6 +263,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_24.has_value) {
                                         return SLOP_STR("void*");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("Option"))) {
                                 if (len < 2) {
@@ -276,6 +280,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_25.has_value) {
                                         return SLOP_STR("/* TRANSPILER_ERROR: Option requires inner type */");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("Result"))) {
                                 {
@@ -298,6 +303,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_26.has_value) {
                                         return SLOP_STR("slop_list_void");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("Map"))) {
                                 return SLOP_STR("slop_map*");
@@ -314,6 +320,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_27.has_value) {
                                         return SLOP_STR("void*");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("Chan"))) {
                                 if (len < 2) {
@@ -330,6 +337,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_28.has_value) {
                                         return SLOP_STR("slop_chan_void");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("Thread"))) {
                                 if (len < 2) {
@@ -346,6 +354,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_29.has_value) {
                                         return SLOP_STR("slop_thread_void");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("Fn"))) {
                                 return SLOP_STR("slop_closure_t");
@@ -359,6 +368,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                 } else if (!_mv_30.has_value) {
                                     return ctype_to_c_name(arena, head);
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -369,6 +379,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
             } else if (!_mv_21.has_value) {
                 return SLOP_STR("void*");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -547,6 +558,7 @@ slop_option_types_ResolvedType_ptr ctype_get_node_resolved_type(types_SExpr* exp
             return lst.resolved_type;
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) {
@@ -562,6 +574,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_40.has_value) {
                 return ctype_to_c_name(arena, name);
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_range) {
             return (*rt).c_name;
         } else if ((kind == types_ResolvedTypeKind_rk_record) || ((kind == types_ResolvedTypeKind_rk_union) || (kind == types_ResolvedTypeKind_rk_enum))) {
@@ -574,6 +587,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
                 } else if (!_mv_41.has_value) {
                     return c_name;
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (kind == types_ResolvedTypeKind_rk_ptr) {
             __auto_type _mv_42 = (*rt).inner_type;
@@ -590,6 +604,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_42.has_value) {
                 return SLOP_STR("void*");
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_option) {
             __auto_type _mv_43 = (*rt).inner_type;
             if (_mv_43.has_value) {
@@ -601,6 +616,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_43.has_value) {
                 return SLOP_STR("/* TRANSPILER_ERROR: Option requires inner type */");
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_list) {
             __auto_type _mv_44 = (*rt).inner_type;
             if (_mv_44.has_value) {
@@ -612,6 +628,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_44.has_value) {
                 return SLOP_STR("slop_list_void");
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_result) {
             {
                 __auto_type ok_id = ({ __auto_type _mv = (*rt).inner_type; _mv.has_value ? ({ __auto_type ok_t = _mv.value; ctype_type_to_identifier(arena, ctype_resolved_type_to_c(arena, ok_t)); }) : (SLOP_STR("void")); });
@@ -632,6 +649,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_45.has_value) {
                 return SLOP_STR("void*");
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_chan) {
             __auto_type _mv_46 = (*rt).inner_type;
             if (_mv_46.has_value) {
@@ -644,6 +662,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_46.has_value) {
                 return SLOP_STR("slop_chan_int*");
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_thread) {
             __auto_type _mv_47 = (*rt).inner_type;
             if (_mv_47.has_value) {
@@ -656,6 +675,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_47.has_value) {
                 return SLOP_STR("slop_thread_int*");
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_typevar) {
             return SLOP_STR("__typevar_error__");
         } else {

--- a/bootstrap/compiler/slop_defn.c
+++ b/bootstrap/compiler/slop_defn.c
@@ -113,6 +113,7 @@ uint8_t defn_is_type_form(types_SExpr* expr) {
                     } else if (!_mv_965.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -151,6 +152,7 @@ uint8_t defn_is_function_form(types_SExpr* expr) {
                     } else if (!_mv_968.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -189,6 +191,7 @@ uint8_t defn_is_const_form(types_SExpr* expr) {
                     } else if (!_mv_971.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -227,6 +230,7 @@ uint8_t defn_is_ffi_form(types_SExpr* expr) {
                     } else if (!_mv_974.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -265,6 +269,7 @@ uint8_t defn_is_ffi_struct_form(types_SExpr* expr) {
                     } else if (!_mv_977.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -356,6 +361,7 @@ uint8_t defn_is_pointer_type_expr(types_SExpr* type_expr) {
                     } else if (!_mv_984.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -522,6 +528,7 @@ slop_string defn_eval_const_value(context_TranspileContext* ctx, types_SExpr* ex
                 return expr_transpile_expr(ctx, expr);
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -600,6 +607,7 @@ uint8_t defn_is_string_expr(slop_list_types_SExpr_ptr items, int64_t idx) {
     } else if (!_mv_997.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t defn_ends_with_t(slop_string name) {
@@ -1269,6 +1277,7 @@ uint8_t defn_is_array_type(types_SExpr* type_expr) {
                     } else if (!_mv_1036.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1793,6 +1802,7 @@ uint8_t defn_is_pointer_type(types_SExpr* type_expr) {
                     } else if (!_mv_1061.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1868,6 +1878,7 @@ slop_string defn_get_param_c_type(context_TranspileContext* ctx, types_SExpr* pa
                             } else if (!_mv_1066.has_value) {
                                 return SLOP_STR("void*");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -1992,6 +2003,7 @@ uint8_t defn_is_spec_form(types_SExpr* expr) {
                     } else if (!_mv_1073.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2037,6 +2049,7 @@ slop_string defn_extract_spec_return_type(context_TranspileContext* ctx, types_S
                                             } else if (!_mv_1078.has_value) {
                                                 return SLOP_STR("void");
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 }
@@ -2047,6 +2060,7 @@ slop_string defn_extract_spec_return_type(context_TranspileContext* ctx, types_S
                         } else if (!_mv_1076.has_value) {
                             return SLOP_STR("void");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -2093,6 +2107,7 @@ slop_string defn_extract_spec_slop_return_type(context_TranspileContext* ctx, ty
                                             } else if (!_mv_1082.has_value) {
                                                 return SLOP_STR("");
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 }
@@ -2103,6 +2118,7 @@ slop_string defn_extract_spec_slop_return_type(context_TranspileContext* ctx, ty
                         } else if (!_mv_1080.has_value) {
                             return SLOP_STR("");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -2192,6 +2208,7 @@ slop_option_string defn_extract_result_type_name(context_TranspileContext* ctx, 
                                             } else if (!_mv_1088.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 }
@@ -2202,6 +2219,7 @@ slop_option_string defn_extract_result_type_name(context_TranspileContext* ctx, 
                         } else if (!_mv_1086.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -2236,7 +2254,9 @@ slop_option_string defn_check_result_type(context_TranspileContext* ctx, types_S
                         } else if (!_mv_1091.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             case types_SExpr_lst:
@@ -2271,9 +2291,11 @@ slop_option_string defn_check_result_type(context_TranspileContext* ctx, types_S
                                             } else if (!_mv_1095.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else if (!_mv_1094.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else {
                                         return (slop_option_string){.has_value = false};
                                     }
@@ -2285,6 +2307,7 @@ slop_option_string defn_check_result_type(context_TranspileContext* ctx, types_S
                         } else if (!_mv_1092.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -2385,6 +2408,7 @@ slop_string defn_build_single_param(context_TranspileContext* ctx, types_SExpr* 
                                         } else if (!_mv_1101.has_value) {
                                             return SLOP_STR("/* missing param type */");
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                     default: {
                                         return SLOP_STR("/* param name must be symbol */");
@@ -2393,6 +2417,7 @@ slop_string defn_build_single_param(context_TranspileContext* ctx, types_SExpr* 
                             } else if (!_mv_1099.has_value) {
                                 return SLOP_STR("/* missing param name */");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -2428,6 +2453,7 @@ uint8_t defn_is_param_mode(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_1102.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2459,6 +2485,7 @@ uint8_t defn_is_fn_type(types_SExpr* type_expr) {
                     } else if (!_mv_1105.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2498,6 +2525,7 @@ slop_string defn_emit_fn_param_type(context_TranspileContext* ctx, types_SExpr* 
                                 } else if (!_mv_1108.has_value) {
                                     return context_ctx_str(ctx, context_ctx_str(ctx, ret_type, SLOP_STR("(*")), context_ctx_str(ctx, param_name, SLOP_STR(")(void)")));
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -2636,6 +2664,7 @@ uint8_t defn_is_c_name_attr_at(slop_list_types_SExpr_ptr items, int64_t idx) {
     } else if (!_mv_1114.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 int64_t defn_find_body_start(slop_list_types_SExpr_ptr items) {
@@ -2692,6 +2721,7 @@ uint8_t defn_is_annotation(types_SExpr* expr) {
                     } else if (!_mv_1117.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2730,6 +2760,7 @@ uint8_t defn_is_pre_form(types_SExpr* expr) {
                     } else if (!_mv_1120.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2768,6 +2799,7 @@ uint8_t defn_is_post_form(types_SExpr* expr) {
                     } else if (!_mv_1123.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2806,6 +2838,7 @@ uint8_t defn_is_assume_form(types_SExpr* expr) {
                     } else if (!_mv_1126.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2904,6 +2937,7 @@ uint8_t defn_is_doc_form(types_SExpr* expr) {
                     } else if (!_mv_1133.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }

--- a/bootstrap/compiler/slop_env.c
+++ b/bootstrap/compiler/slop_env.c
@@ -293,6 +293,7 @@ uint8_t env_env_constant_matches_module(env_ConstBinding binding, slop_string mo
     } else if (!_mv_924.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t env_env_constant_is_builtin(env_ConstBinding binding) {
@@ -303,6 +304,7 @@ uint8_t env_env_constant_is_builtin(env_ConstBinding binding) {
         __auto_type _ = _mv_925.value;
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t env_env_lookup_constant_in_module(env_TypeEnv* env, slop_string mod_name, slop_string const_name) {
@@ -481,6 +483,7 @@ slop_option_types_ResolvedType_ptr env_env_lookup_type(env_TypeEnv* env, slop_st
             } else if (!_mv_934.has_value) {
                 return (slop_option_types_ResolvedType_ptr){.has_value = false};
             }
+            SLOP_UNREACHABLE();
         }
     } else if (!_mv_933.has_value) {
         __auto_type _mv_935 = env_env_resolve_import(env, name);
@@ -490,7 +493,9 @@ slop_option_types_ResolvedType_ptr env_env_lookup_type(env_TypeEnv* env, slop_st
         } else if (!_mv_935.has_value) {
             return (slop_option_types_ResolvedType_ptr){.has_value = false};
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_option_types_ResolvedType_ptr env_env_lookup_type_qualified(env_TypeEnv* env, slop_string module_name, slop_string type_name) {
@@ -537,7 +542,9 @@ uint8_t env_env_is_type_visible(env_TypeEnv* env, types_ResolvedType* t) {
         } else if (!_mv_939.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t env_env_is_function_visible(env_TypeEnv* env, types_FnSignature* sig) {
@@ -555,7 +562,9 @@ uint8_t env_env_is_function_visible(env_TypeEnv* env, types_FnSignature* sig) {
         } else if (!_mv_941.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 void env_env_register_function(env_TypeEnv* env, types_FnSignature* sig) {
@@ -609,7 +618,9 @@ slop_option_types_FnSignature_ptr env_env_lookup_function(env_TypeEnv* env, slop
                 } else if (!_mv_945.has_value) {
                     return (slop_option_types_FnSignature_ptr){.has_value = false};
                 }
+                SLOP_UNREACHABLE();
             }
+            SLOP_UNREACHABLE();
         }
     } else if (!_mv_943.has_value) {
         __auto_type _mv_946 = env_env_resolve_import(env, name);
@@ -627,8 +638,11 @@ slop_option_types_FnSignature_ptr env_env_lookup_function(env_TypeEnv* env, slop
             } else if (!_mv_947.has_value) {
                 return (slop_option_types_FnSignature_ptr){.has_value = false};
             }
+            SLOP_UNREACHABLE();
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 void env_env_add_import(env_TypeEnv* env, slop_string local_name, slop_string qualified_name) {
@@ -679,6 +693,7 @@ uint8_t env_env_variant_matches_module(env_VariantMapping v, slop_string mod_nam
     } else if (!_mv_949.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t env_env_variant_is_builtin(env_VariantMapping v) {
@@ -689,6 +704,7 @@ uint8_t env_env_variant_is_builtin(env_VariantMapping v) {
         __auto_type _ = _mv_950.value;
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_option_string env_env_lookup_variant(env_TypeEnv* env, slop_string variant_name) {
@@ -815,6 +831,7 @@ uint8_t env_env_same_module_opt(slop_option_string a, slop_option_string b) {
             __auto_type _ = _mv_960.value;
             return 0;
         }
+        SLOP_UNREACHABLE();
     } else if (_mv_959.has_value) {
         __auto_type amod = _mv_959.value;
         __auto_type _mv_961 = b;
@@ -824,7 +841,9 @@ uint8_t env_env_same_module_opt(slop_option_string a, slop_option_string b) {
             __auto_type bmod = _mv_961.value;
             return string_eq(amod, bmod);
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 void env_env_set_module(env_TypeEnv* env, slop_option_string module_name) {

--- a/bootstrap/compiler/slop_expr.c
+++ b/bootstrap/compiler/slop_expr.c
@@ -335,6 +335,7 @@ slop_option_string expr_extract_symbol_name(types_SExpr* expr) {
                                     } else if (!_mv_124.has_value) {
                                         return (slop_option_string){.has_value = false};
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else {
                                     return (slop_option_string){.has_value = false};
                                 }
@@ -346,6 +347,7 @@ slop_option_string expr_extract_symbol_name(types_SExpr* expr) {
                     } else if (!_mv_122.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -385,6 +387,7 @@ slop_string expr_transpile_literal(context_TranspileContext* ctx, types_SExpr* e
             return SLOP_STR("/* error: list is not a literal */");
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_transpile_symbol(context_TranspileContext* ctx, slop_string name) {
@@ -412,6 +415,7 @@ slop_string expr_transpile_symbol(context_TranspileContext* ctx, slop_string nam
                 } else if (!_mv_127.has_value) {
                     return ctype_to_c_name(arena, variant_name);
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (strlib_contains(name, SLOP_STR("."))) {
             __auto_type _mv_128 = strlib_index_of(name, SLOP_STR("."));
@@ -439,11 +443,14 @@ slop_string expr_transpile_symbol(context_TranspileContext* ctx, slop_string nam
                         } else if (!_mv_130.has_value) {
                             return context_ctx_str3(ctx, base_name, SLOP_STR("_"), c_rest);
                         }
+                        SLOP_UNREACHABLE();
                     }
+                    SLOP_UNREACHABLE();
                 }
             } else if (!_mv_128.has_value) {
                 return ctype_to_c_name(arena, name);
             }
+            SLOP_UNREACHABLE();
         } else {
             __auto_type _mv_131 = context_ctx_lookup_var(ctx, name);
             if (_mv_131.has_value) {
@@ -467,9 +474,12 @@ slop_string expr_transpile_symbol(context_TranspileContext* ctx, slop_string nam
                             }
                             return c_name;
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
+                SLOP_UNREACHABLE();
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -674,6 +684,7 @@ uint8_t expr_is_pointer_type_expr(types_SExpr* type_expr) {
                     } else if (!_mv_138.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -722,6 +733,7 @@ uint8_t expr_is_fn_type_expr(types_SExpr* type_expr) {
             } else if (!_mv_142.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         }
         default: {
             return 0;
@@ -762,6 +774,7 @@ uint8_t expr_is_closure_typed_expr(context_TranspileContext* ctx, types_SExpr* e
             } else if (!_mv_146.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         }
         default: {
             return 0;
@@ -922,6 +935,7 @@ slop_string expr_transpile_call(context_TranspileContext* ctx, slop_string fn_na
                             return context_ctx_str4(ctx, c_name, SLOP_STR("("), args, SLOP_STR(")"));
                         }
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1148,6 +1162,7 @@ slop_string expr_closure_type_to_c(context_TranspileContext* ctx, slop_string sl
         } else if (!_mv_151.has_value) {
             return SLOP_STR("int64_t");
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -1280,6 +1295,7 @@ slop_string expr_transpile_enum_variant(context_TranspileContext* ctx, slop_stri
         } else if (!_mv_152.has_value) {
             return ctype_to_c_name(arena, variant_name);
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -1292,6 +1308,7 @@ slop_string expr_transpile_ok(context_TranspileContext* ctx, slop_string value_c
     } else if (!_mv_153.has_value) {
         return context_ctx_str3(ctx, SLOP_STR("(slop_result){ .is_ok = true, .data.ok = "), value_c, SLOP_STR(" }"));
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_transpile_error(context_TranspileContext* ctx, slop_string value_c) {
@@ -1303,6 +1320,7 @@ slop_string expr_transpile_error(context_TranspileContext* ctx, slop_string valu
     } else if (!_mv_154.has_value) {
         return context_ctx_str3(ctx, SLOP_STR("(slop_result){ .is_ok = false, .data.err = "), value_c, SLOP_STR(" }"));
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_infer_option_type(context_TranspileContext* ctx, types_SExpr* val_expr) {
@@ -1377,8 +1395,10 @@ slop_string expr_infer_option_type(context_TranspileContext* ctx, types_SExpr* v
                         context_ctx_add_error_at(ctx, context_ctx_str3(ctx, SLOP_STR("Unknown variable '"), name, SLOP_STR("' for Option type inference")), context_ctx_sexpr_line(val_expr), context_ctx_sexpr_col(val_expr));
                         return SLOP_STR("__type_error__");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
+            SLOP_UNREACHABLE();
         }
         case types_SExpr_lst:
         {
@@ -1386,6 +1406,7 @@ slop_string expr_infer_option_type(context_TranspileContext* ctx, types_SExpr* v
             return expr_infer_list_expr_option_type(ctx, lst.items);
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_c_type_to_option_type_name(context_TranspileContext* ctx, slop_string c_type) {
@@ -1443,11 +1464,14 @@ slop_string expr_infer_field_c_type_from_items(context_TranspileContext* ctx, sl
                                             } else if (!_mv_163.has_value) {
                                                 return SLOP_STR("__auto_type");
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     } else if (!_mv_162.has_value) {
                                         return SLOP_STR("__auto_type");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                         default: {
@@ -1457,9 +1481,11 @@ slop_string expr_infer_field_c_type_from_items(context_TranspileContext* ctx, sl
                 } else if (!_mv_159.has_value) {
                     return SLOP_STR("__auto_type");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_158.has_value) {
                 return SLOP_STR("__auto_type");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -1544,6 +1570,7 @@ slop_string expr_infer_list_expr_option_type(context_TranspileContext* ctx, slop
                                                 context_ctx_add_error_at(ctx, SLOP_STR("Missing field for option type inference"), line, col);
                                                 return SLOP_STR("__type_error__");
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 }
@@ -1582,6 +1609,7 @@ slop_string expr_infer_list_expr_option_type(context_TranspileContext* ctx, slop
                                     context_ctx_add_error_at(ctx, context_ctx_str3(ctx, SLOP_STR("Unknown function '"), op, SLOP_STR("' for Option type inference")), line, col);
                                     return SLOP_STR("__type_error__");
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -1594,6 +1622,7 @@ slop_string expr_infer_list_expr_option_type(context_TranspileContext* ctx, slop
                 context_ctx_add_error_at(ctx, SLOP_STR("Missing list head in option type inference"), line, col);
                 return SLOP_STR("__type_error__");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -1643,10 +1672,12 @@ slop_string expr_infer_list_element_option_type(context_TranspileContext* ctx, t
             } else if (!_mv_170.has_value) {
                 return expr_infer_list_element_option_type_fallback(ctx, list_expr);
             }
+            SLOP_UNREACHABLE();
         } else if (!_mv_169.has_value) {
             context_ctx_warn_fallback(ctx, list_expr, SLOP_STR("infer-list-element-option-type"));
             return expr_infer_list_element_option_type_fallback(ctx, list_expr);
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -1677,6 +1708,7 @@ slop_string expr_infer_list_element_option_type_fallback(context_TranspileContex
                         } else if (!_mv_172.has_value) {
                             return SLOP_STR("");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
                 case types_SExpr_lst:
@@ -1703,6 +1735,7 @@ slop_string expr_infer_list_element_option_type_fallback(context_TranspileContex
                                             } else if (!_mv_175.has_value) {
                                                 return SLOP_STR("");
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else {
                                             return SLOP_STR("");
                                         }
@@ -1714,6 +1747,7 @@ slop_string expr_infer_list_element_option_type_fallback(context_TranspileContex
                             } else if (!_mv_173.has_value) {
                                 return SLOP_STR("");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -1794,6 +1828,7 @@ slop_string expr_prefix_list_element_type(context_TranspileContext* ctx, slop_st
                 } else if (!_mv_177.has_value) {
                     return elem_type;
                 }
+                SLOP_UNREACHABLE();
             }
         } else {
             __auto_type _mv_178 = context_ctx_lookup_type(ctx, elem_type);
@@ -1803,6 +1838,7 @@ slop_string expr_prefix_list_element_type(context_TranspileContext* ctx, slop_st
             } else if (!_mv_178.has_value) {
                 return elem_type;
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -1902,6 +1938,7 @@ slop_string expr_slop_value_type_to_c_type(context_TranspileContext* ctx, slop_s
             } else if (!_mv_179.has_value) {
                 return ctype_to_c_name(arena, slop_type);
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -1989,6 +2026,7 @@ slop_string expr_resolve_type_alias(context_TranspileContext* ctx, slop_string s
         } else if (!_mv_181.has_value) {
             return slop_type;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2011,6 +2049,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                     } else if (!_mv_183.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             case types_SExpr_lst:
@@ -2064,8 +2103,10 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                                             } else if (!_mv_190.has_value) {
                                                                                 return SLOP_STR("");
                                                                             }
+                                                                            SLOP_UNREACHABLE();
                                                                         }
                                                                     }
+                                                                    SLOP_UNREACHABLE();
                                                                 }
                                                             }
                                                         }
@@ -2076,9 +2117,11 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                 } else if (!_mv_187.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else if (!_mv_186.has_value) {
                                                 return SLOP_STR("");
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else if (string_eq(op, SLOP_STR("record-new"))) {
                                             if (len >= 2) {
                                                 __auto_type _mv_191 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
@@ -2098,6 +2141,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                 } else if (!_mv_191.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -2117,9 +2161,11 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                     } else if (!_mv_194.has_value) {
                                                         return SLOP_STR("");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 } else if (!_mv_193.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -2135,6 +2181,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                 } else if (!_mv_195.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -2150,6 +2197,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                 } else if (!_mv_196.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -2165,6 +2213,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                 } else if (!_mv_197.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -2180,6 +2229,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                 } else if (!_mv_198.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -2191,6 +2241,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                             } else if (!_mv_199.has_value) {
                                                 return SLOP_STR("");
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else {
                                             __auto_type _mv_200 = context_ctx_lookup_func(ctx, op);
                                             if (_mv_200.has_value) {
@@ -2199,6 +2250,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                             } else if (!_mv_200.has_value) {
                                                 return SLOP_STR("");
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 }
@@ -2209,6 +2261,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                         } else if (!_mv_184.has_value) {
                             return SLOP_STR("");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -2349,6 +2402,7 @@ slop_string expr_infer_map_key_c_type(context_TranspileContext* ctx, types_SExpr
                     } else if (!_mv_202.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             default: {
@@ -2426,6 +2480,7 @@ slop_string expr_infer_set_elem_c_type(context_TranspileContext* ctx, types_SExp
                     } else if (!_mv_204.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             default: {
@@ -2603,6 +2658,7 @@ slop_string expr_infer_map_value_option_type(context_TranspileContext* ctx, type
                     } else if (!_mv_206.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             default: {
@@ -2753,6 +2809,7 @@ slop_string expr_infer_option_inner_slop_type(context_TranspileContext* ctx, typ
                                                                             } else if (!_mv_212.has_value) {
                                                                                 return SLOP_STR("");
                                                                             }
+                                                                            SLOP_UNREACHABLE();
                                                                         }
                                                                     }
                                                                     default: {
@@ -2762,6 +2819,7 @@ slop_string expr_infer_option_inner_slop_type(context_TranspileContext* ctx, typ
                                                             } else if (!_mv_210.has_value) {
                                                                 return SLOP_STR("");
                                                             }
+                                                            SLOP_UNREACHABLE();
                                                         }
                                                     } else if (string_eq(op, SLOP_STR("list-get"))) {
                                                         if (len < 2) {
@@ -2798,6 +2856,7 @@ slop_string expr_infer_option_inner_slop_type(context_TranspileContext* ctx, typ
                                                                             } else if (!_mv_215.has_value) {
                                                                                 return SLOP_STR("");
                                                                             }
+                                                                            SLOP_UNREACHABLE();
                                                                         }
                                                                     }
                                                                     default: {
@@ -2807,6 +2866,7 @@ slop_string expr_infer_option_inner_slop_type(context_TranspileContext* ctx, typ
                                                             } else if (!_mv_213.has_value) {
                                                                 return SLOP_STR("");
                                                             }
+                                                            SLOP_UNREACHABLE();
                                                         }
                                                     } else {
                                                         return SLOP_STR("");
@@ -2820,6 +2880,7 @@ slop_string expr_infer_option_inner_slop_type(context_TranspileContext* ctx, typ
                                     } else if (!_mv_208.has_value) {
                                         return SLOP_STR("");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             }
                         }
@@ -2845,6 +2906,7 @@ slop_string expr_fix_ternary_none(context_TranspileContext* ctx, types_SExpr* ot
             } else if (!_mv_216.has_value) {
                 return this_branch;
             }
+            SLOP_UNREACHABLE();
         }
     } else {
         if (string_eq(this_branch, SLOP_STR("none"))) {
@@ -2912,6 +2974,7 @@ slop_string expr_transpile_array_index(context_TranspileContext* ctx, types_SExp
                 } else if (!_mv_218.has_value) {
                     return context_ctx_str4(ctx, arr_c, SLOP_STR("["), idx_c, SLOP_STR("]"));
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -2937,6 +3000,7 @@ uint8_t expr_is_pointer_expr(context_TranspileContext* ctx, types_SExpr* expr) {
                 } else if (!_mv_220.has_value) {
                     return 0;
                 }
+                SLOP_UNREACHABLE();
             }
         }
         case types_SExpr_lst:
@@ -2969,6 +3033,7 @@ uint8_t expr_is_pointer_expr(context_TranspileContext* ctx, types_SExpr* expr) {
                                         } else if (!_mv_223.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else {
                                         return 0;
                                     }
@@ -2981,6 +3046,7 @@ uint8_t expr_is_pointer_expr(context_TranspileContext* ctx, types_SExpr* expr) {
                     } else if (!_mv_221.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 } else {
                     return 0;
                 }
@@ -3024,6 +3090,7 @@ slop_string expr_extract_sizeof_type(context_TranspileContext* ctx, types_SExpr*
                                             } else if (!_mv_227.has_value) {
                                                 return SLOP_STR("uint8_t");
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else if (string_eq(op, SLOP_STR("*")) || (string_eq(op, SLOP_STR("+")) || (string_eq(op, SLOP_STR("-")) || string_eq(op, SLOP_STR("/"))))) {
                                             {
                                                 __auto_type i = 1;
@@ -3056,6 +3123,7 @@ slop_string expr_extract_sizeof_type(context_TranspileContext* ctx, types_SExpr*
                         } else if (!_mv_225.has_value) {
                             return SLOP_STR("uint8_t");
                         }
+                        SLOP_UNREACHABLE();
                     } else {
                         return SLOP_STR("uint8_t");
                     }
@@ -3094,6 +3162,7 @@ slop_string expr_transpile_expr(context_TranspileContext* ctx, types_SExpr* expr
             return expr_transpile_list_expr(ctx, lst.items);
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items) {
@@ -3137,10 +3206,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                             context_ctx_add_error_at(ctx, SLOP_STR("missing right operand"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                             return SLOP_STR("0");
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else if (!_mv_232.has_value) {
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing left operand"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (expr_is_comparison_op(op) && (len < 3)) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("comparison operator needs 2 operands"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
@@ -3176,10 +3247,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing right operand"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_234.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing left operand"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("not")) && (len < 2)) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("not needs an argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                 return SLOP_STR("0");
@@ -3192,6 +3265,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("if")) && (len < 4)) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("if expression needs condition, then, and else branches"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                 return SLOP_STR("0");
@@ -3219,14 +3293,17 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                             context_ctx_add_error_at(ctx, SLOP_STR("missing else"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                             return SLOP_STR("0");
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else if (!_mv_238.has_value) {
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing then"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_237.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing condition"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if ((string_eq(op, SLOP_STR("let")) || string_eq(op, SLOP_STR("let*"))) && (len >= 3)) {
                                 return expr_transpile_let_expr(ctx, items);
                             } else if (string_eq(op, SLOP_STR("while")) && (len >= 3)) {
@@ -3252,6 +3329,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR(".")) && (len >= 3)) {
                                 __auto_type _mv_241 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_241.has_value) {
@@ -3284,10 +3362,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing field"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_241.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing object"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("cast")) && (len >= 3)) {
                                 __auto_type _mv_244 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_244.has_value) {
@@ -3321,10 +3401,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing cast value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_244.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing cast type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("c-inline")) && (len >= 2)) {
                                 __auto_type _mv_246 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_246.has_value) {
@@ -3345,6 +3427,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing c-inline string"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("some")) && (len >= 2)) {
                                 __auto_type _mv_248 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_248.has_value) {
@@ -3366,6 +3449,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing some value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("sizeof")) && (len >= 2)) {
                                 __auto_type _mv_249 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_249.has_value) {
@@ -3378,6 +3462,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing sizeof type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("addr")) && (len >= 2)) {
                                 __auto_type _mv_250 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_250.has_value) {
@@ -3387,6 +3472,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing addr argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("@")) && (len >= 3)) {
                                 __auto_type _mv_251 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_251.has_value) {
@@ -3403,10 +3489,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing index"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_251.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing array"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("arena-alloc")) && (len >= 3)) {
                                 __auto_type _mv_253 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_253.has_value) {
@@ -3437,6 +3525,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                                                 return expr_wrap_arena_alloc_checked(ctx, context_ctx_str5(ctx, SLOP_STR("("), cast_type, SLOP_STR("*)slop_arena_alloc("), context_ctx_str3(ctx, arena_c, SLOP_STR(", "), size_c), SLOP_STR(")")));
                                                             }
                                                         }
+                                                        SLOP_UNREACHABLE();
                                                     }
                                                 }
                                                 default: {
@@ -3452,10 +3541,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing arena-alloc size"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("NULL");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_253.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("NULL");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("arena-new")) && (len >= 2)) {
                                 __auto_type _mv_257 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_257.has_value) {
@@ -3468,6 +3559,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("arena-new requires size argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("NULL");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("arena-free")) && (len >= 2)) {
                                 __auto_type _mv_258 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_258.has_value) {
@@ -3480,6 +3572,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("arena-free requires arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("(void)0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("quote")) && (len >= 2)) {
                                 __auto_type _mv_259 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_259.has_value) {
@@ -3503,6 +3596,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing quote argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("record-new")) && (len >= 2)) {
                                 return expr_transpile_record_new(ctx, items);
                             } else if (string_eq(op, SLOP_STR("list")) && (len >= 2)) {
@@ -3581,6 +3675,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing union value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                                                 return SLOP_STR("0");
                                                             }
+                                                            SLOP_UNREACHABLE();
                                                         } else {
                                                             return context_ctx_str3(ctx, SLOP_STR("(("), type_name, context_ctx_str3(ctx, SLOP_STR("){ .tag = "), tag_const, SLOP_STR(" })")));
                                                         }
@@ -3589,6 +3684,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                                     context_ctx_add_error_at(ctx, SLOP_STR("union-new tag must be symbol"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                                     return SLOP_STR("0");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                             default: {
                                                 context_ctx_add_error_at(ctx, SLOP_STR("union-new type must be symbol"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
@@ -3599,10 +3695,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing union tag"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_261.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing union type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("ok")) && (len >= 2)) {
                                 __auto_type _mv_267 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_267.has_value) {
@@ -3615,6 +3713,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing ok value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("error")) && (len >= 2)) {
                                 __auto_type _mv_268 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_268.has_value) {
@@ -3627,6 +3726,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing error value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("?")) && (len >= 2)) {
                                 __auto_type _mv_269 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_269.has_value) {
@@ -3640,11 +3740,13 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         } else if (!_mv_270.has_value) {
                                             return context_ctx_str3(ctx, SLOP_STR("({ __auto_type _tmp = "), result_c, SLOP_STR("; if (!_tmp.is_ok) return _tmp; _tmp.data.ok; })"));
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 } else if (!_mv_269.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing ? argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("list-len")) && (len >= 2)) {
                                 __auto_type _mv_271 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_271.has_value) {
@@ -3657,6 +3759,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing list-len argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("list-get")) && (len >= 3)) {
                                 __auto_type _mv_272 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_272.has_value) {
@@ -3678,10 +3781,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing list-get index"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_272.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing list-get list argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("list-pop")) && (len >= 2)) {
                                 __auto_type _mv_274 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_274.has_value) {
@@ -3699,6 +3804,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing list-pop list argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("list-new")) && (len >= 3)) {
                                 __auto_type _mv_275 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_275.has_value) {
@@ -3717,10 +3823,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing list-new type argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_275.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing list-new arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("list-push")) && (len >= 3)) {
                                 __auto_type _mv_277 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_277.has_value) {
@@ -3746,10 +3854,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing list-push item"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_277.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing list-push list"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("none")) && (len == 1)) {
                                 __auto_type _mv_279 = context_ctx_get_current_return_type(ctx);
                                 if (_mv_279.has_value) {
@@ -3762,6 +3872,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                 } else if (!_mv_279.has_value) {
                                     return SLOP_STR("none");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("cond"))) {
                                 return expr_transpile_cond_expr(ctx, items);
                             } else if (string_eq(op, SLOP_STR("for"))) {
@@ -3806,6 +3917,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                 context_ctx_add_error_at(ctx, SLOP_STR("empty list"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -3826,6 +3938,7 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                 } else if (!_mv_281.has_value) {
                     return SLOP_STR("printf(\"\\n\")");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("print"))) {
             if (len < 2) {
@@ -3840,6 +3953,7 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                     context_ctx_add_error_at(ctx, SLOP_STR("print: missing argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("printf"))) {
             return expr_transpile_printf_call(ctx, items);
@@ -3873,10 +3987,12 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                         context_ctx_add_error_at(ctx, SLOP_STR("min: missing second argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         return SLOP_STR("0");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_283.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("min: missing first argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("max"))) {
             if (len < 3) {
@@ -3906,10 +4022,12 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                         context_ctx_add_error_at(ctx, SLOP_STR("max: missing second argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         return SLOP_STR("0");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_285.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("max: missing first argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("spawn"))) {
             if (len < 3) {
@@ -3928,6 +4046,7 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                     context_ctx_add_error_at(ctx, SLOP_STR("spawn: missing function argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("chan-buffered")) || strlib_ends_with(fn_name, SLOP_STR(":chan-buffered"))) {
             if (len < 4) {
@@ -3959,14 +4078,17 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                             context_ctx_add_error_at(ctx, SLOP_STR("chan-buffered: missing capacity argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                             return SLOP_STR("NULL");
                         }
+                        SLOP_UNREACHABLE();
                     } else if (!_mv_289.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("chan-buffered: missing arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         return SLOP_STR("NULL");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_288.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("chan-buffered: missing type argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("chan")) || strlib_ends_with(fn_name, SLOP_STR(":chan"))) {
             if (len < 3) {
@@ -3994,10 +4116,12 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                         context_ctx_add_error_at(ctx, SLOP_STR("chan: missing arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         return SLOP_STR("NULL");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_291.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("chan: missing type argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("send"))) {
             if (len < 3) {
@@ -4032,10 +4156,12 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                         context_ctx_add_error_at(ctx, SLOP_STR("send: missing value argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         return SLOP_STR("0");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_293.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("send: missing channel argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("recv"))) {
             if (len < 2) {
@@ -4066,6 +4192,7 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                     context_ctx_add_error_at(ctx, SLOP_STR("recv: missing channel argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             }
         } else {
             {
@@ -4147,6 +4274,7 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                                     } else if (!_mv_300.has_value) {
                                         return context_ctx_str3(ctx, SLOP_STR("(("), type_name, context_ctx_str3(ctx, SLOP_STR("){ .tag = "), c_tag_enum, SLOP_STR(" })")));
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else {
                                     return context_ctx_str3(ctx, SLOP_STR("(("), type_name, context_ctx_str3(ctx, SLOP_STR("){ .tag = "), c_tag_enum, SLOP_STR(" })")));
                                 }
@@ -4209,9 +4337,12 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                                     }
                                     return expr_transpile_call(ctx, fn_name, args);
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
+                        SLOP_UNREACHABLE();
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -4258,6 +4389,7 @@ slop_string expr_transpile_print(context_TranspileContext* ctx, types_SExpr* arg
                     } else if (!_mv_305.has_value) {
                         return context_ctx_str5(ctx, SLOP_STR("printf(\"%lld"), nl, SLOP_STR("\", (long long)("), arg_c, SLOP_STR("))"));
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -4362,6 +4494,7 @@ slop_option_string expr_get_expr_type_hint(context_TranspileContext* ctx, types_
                     } else if (!_mv_309.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
                 case types_SExpr_lst:
                 {
@@ -4423,6 +4556,7 @@ slop_option_string expr_get_expr_type_hint(context_TranspileContext* ctx, types_
                                                                                 } else if (!_mv_315.has_value) {
                                                                                     return (slop_option_string){.has_value = false};
                                                                                 }
+                                                                                SLOP_UNREACHABLE();
                                                                             } else {
                                                                                 return (slop_option_string){.has_value = false};
                                                                             }
@@ -4435,9 +4569,11 @@ slop_option_string expr_get_expr_type_hint(context_TranspileContext* ctx, types_
                                                             } else if (!_mv_313.has_value) {
                                                                 return (slop_option_string){.has_value = false};
                                                             }
+                                                            SLOP_UNREACHABLE();
                                                         } else if (!_mv_312.has_value) {
                                                             return (slop_option_string){.has_value = false};
                                                         }
+                                                        SLOP_UNREACHABLE();
                                                     }
                                                 }
                                             } else if (string_eq(op, SLOP_STR("int-to-string")) || (string_eq(op, SLOP_STR("string-copy")) || (string_eq(op, SLOP_STR("string-concat")) || string_eq(op, SLOP_STR("pretty-print"))))) {
@@ -4454,6 +4590,7 @@ slop_option_string expr_get_expr_type_hint(context_TranspileContext* ctx, types_
                                                 } else if (!_mv_316.has_value) {
                                                     return (slop_option_string){.has_value = false};
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         }
                                     }
@@ -4464,6 +4601,7 @@ slop_option_string expr_get_expr_type_hint(context_TranspileContext* ctx, types_
                             } else if (!_mv_310.has_value) {
                                 return (slop_option_string){.has_value = false};
                             }
+                            SLOP_UNREACHABLE();
                         } else {
                             return (slop_option_string){.has_value = false};
                         }
@@ -4540,6 +4678,7 @@ slop_string expr_transpile_union_constructor(context_TranspileContext* ctx, slop
                                                     } else if (!_mv_322.has_value) {
                                                         return context_ctx_str(ctx, SLOP_STR("(("), context_ctx_str(ctx, c_type_name, context_ctx_str(ctx, SLOP_STR("){ .tag = "), context_ctx_str(ctx, c_tag_enum, SLOP_STR(" })")))));
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 } else {
                                                     return context_ctx_str(ctx, SLOP_STR("(("), context_ctx_str(ctx, c_type_name, context_ctx_str(ctx, SLOP_STR("){ .tag = "), context_ctx_str(ctx, c_tag_enum, SLOP_STR(" })")))));
                                                 }
@@ -4552,6 +4691,7 @@ slop_string expr_transpile_union_constructor(context_TranspileContext* ctx, slop
                                 } else if (!_mv_319.has_value) {
                                     return context_ctx_str3(ctx, SLOP_STR("(("), c_type_name, SLOP_STR("){})/* no tag */"));
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -4572,6 +4712,7 @@ slop_string expr_transpile_union_constructor(context_TranspileContext* ctx, slop
             } else if (!_mv_317.has_value) {
                 return context_ctx_str3(ctx, SLOP_STR("(("), c_type_name, SLOP_STR("){})/* no args */"));
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -4730,6 +4871,7 @@ slop_string expr_transpile_match_expr(context_TranspileContext* ctx, slop_list_t
                 context_ctx_add_error_at(ctx, SLOP_STR("missing match scrutinee"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -4804,6 +4946,7 @@ slop_string expr_get_expr_pattern_tag(types_SExpr* pat_expr) {
                     } else if (!_mv_335.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -4964,6 +5107,7 @@ slop_option_string expr_get_expr_binding_name(types_SExpr* pat_expr) {
                     } else if (!_mv_345.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -4987,6 +5131,7 @@ slop_string expr_get_match_branch_body(context_TranspileContext* ctx, slop_list_
             } else if (!_mv_347.has_value) {
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -5163,6 +5308,7 @@ slop_string expr_infer_cond_result_c_type(context_TranspileContext* ctx, slop_li
                                 } else if (!_mv_354.has_value) {
                                     return SLOP_STR("int64_t");
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -5173,6 +5319,7 @@ slop_string expr_infer_cond_result_c_type(context_TranspileContext* ctx, slop_li
             } else if (!_mv_352.has_value) {
                 return SLOP_STR("int64_t");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -5198,6 +5345,7 @@ slop_string expr_infer_match_branch_body_type(context_TranspileContext* ctx, typ
                     } else if (!_mv_356.has_value) {
                         return SLOP_STR("__type_error__");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -5274,6 +5422,7 @@ slop_string expr_slop_type_to_c_type(context_TranspileContext* ctx, slop_string 
                 return slop_type;
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -5326,6 +5475,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                         } else if (!_mv_360.has_value) {
                             return SLOP_STR("int64_t");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
                 case types_SExpr_lst:
@@ -5361,6 +5511,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_363.has_value) {
                                                         return SLOP_STR("int64_t");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("do"))) {
                                                 if (((int64_t)((items).len)) < 2) {
@@ -5373,6 +5524,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_364.has_value) {
                                                         return SLOP_STR("void");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("cond"))) {
                                                 return expr_infer_cond_result_c_type(ctx, items);
@@ -5387,6 +5539,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_365.has_value) {
                                                         return SLOP_STR("int64_t");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("match"))) {
                                                 return expr_infer_match_result_c_type(ctx, items);
@@ -5401,6 +5554,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_366.has_value) {
                                                         return SLOP_STR("int64_t");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("some"))) {
                                                 if (((int64_t)((items).len)) < 2) {
@@ -5432,6 +5586,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                         context_ctx_add_error_at(ctx, SLOP_STR("some constructor: missing value expression"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                                                         return SLOP_STR("__type_error__");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("none"))) {
                                                 __auto_type _mv_368 = context_ctx_get_current_return_type(ctx);
@@ -5445,6 +5600,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                 } else if (!_mv_368.has_value) {
                                                     return SLOP_STR("slop_option_int");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else if (string_eq(op, SLOP_STR("list-push"))) {
                                                 return SLOP_STR("void");
                                             } else if (string_eq(op, SLOP_STR("set!"))) {
@@ -5460,6 +5616,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_369.has_value) {
                                                         return SLOP_STR("void*");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("deref"))) {
                                                 if (((int64_t)((items).len)) < 2) {
@@ -5479,6 +5636,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_370.has_value) {
                                                         return SLOP_STR("int64_t");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("string-concat"))) {
                                                 return SLOP_STR("slop_string");
@@ -5499,6 +5657,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_371.has_value) {
                                                         return SLOP_STR("void*");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("send")) || strlib_ends_with(op, SLOP_STR(":send"))) {
                                                 return SLOP_STR("slop_result_void_thread_ChanError");
@@ -5524,6 +5683,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_372.has_value) {
                                                         return SLOP_STR("slop_result_int64_t_thread_ChanError");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("join")) || strlib_ends_with(op, SLOP_STR(":join"))) {
                                                 return SLOP_STR("int64_t");
@@ -5544,6 +5704,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_373.has_value) {
                                                         return SLOP_STR("slop_chan_int*");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("chan")) || strlib_ends_with(op, SLOP_STR(":chan"))) {
                                                 if (((int64_t)((items).len)) < 3) {
@@ -5560,6 +5721,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_374.has_value) {
                                                         return SLOP_STR("slop_chan_int*");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("arena-alloc"))) {
                                                 return SLOP_STR("void*");
@@ -5583,6 +5745,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                         context_ctx_add_error_at(ctx, SLOP_STR("Cannot infer list-new element type"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                                                         return SLOP_STR("__type_error__");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("list-get"))) {
                                                 if (((int64_t)((items).len)) < 2) {
@@ -5608,6 +5771,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                         context_ctx_add_error_at(ctx, SLOP_STR("Cannot infer list-get type: missing argument"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                                                         return SLOP_STR("__type_error__");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("int-to-string"))) {
                                                 return SLOP_STR("slop_string");
@@ -5649,7 +5813,9 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                         context_ctx_add_error_at(ctx, context_ctx_str3(ctx, SLOP_STR("unknown function or type '"), op, SLOP_STR("'")), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                                                         return SLOP_STR("__type_error__");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         }
                                     }
@@ -5662,6 +5828,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                 context_ctx_add_error_at(ctx, SLOP_STR("cannot infer type of empty list"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                                 return SLOP_STR("__type_error__");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -5838,6 +6005,7 @@ slop_string expr_build_enum_case_expr(context_TranspileContext* ctx, slop_arena*
                 context_ctx_add_error_at(ctx, context_ctx_str3(ctx, SLOP_STR("unknown enum variant '"), tag, SLOP_STR("' in match expression")), context_ctx_sexpr_line(pattern), context_ctx_sexpr_col(pattern));
                 return cases;
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -5942,6 +6110,7 @@ slop_string expr_wrap_fn_ref_as_closure(context_TranspileContext* ctx, slop_stri
                     } else if (!_mv_392.has_value) {
                         return arg_c;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             default: {
@@ -6051,10 +6220,12 @@ slop_string expr_build_union_case_expr(context_TranspileContext* ctx, slop_arena
                             return s5;
                         }
                     }
+                    SLOP_UNREACHABLE();
                 }
             } else if (!_mv_394.has_value) {
                 return cases;
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -6146,6 +6317,7 @@ uint8_t expr_discard_needs_void(types_SExpr* e) {
             } else if (!_mv_400.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         }
         default: {
             return 0;
@@ -6238,6 +6410,7 @@ slop_string expr_transpile_let_expr(context_TranspileContext* ctx, slop_list_typ
             } else if (!_mv_402.has_value) {
                 return SLOP_STR("({ (void)0; })");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -6344,6 +6517,7 @@ slop_string expr_transpile_binding_expr(context_TranspileContext* ctx, types_SEx
                                                         } else if (!_mv_414.has_value) {
                                                             return context_ctx_str5(ctx, c_type, SLOP_STR(" "), var_name, SLOP_STR(" = {0};"), SLOP_STR(""));
                                                         }
+                                                        SLOP_UNREACHABLE();
                                                     }
                                                 } else if (!_mv_413.has_value) {
                                                     __auto_type _mv_415 = ({ __auto_type _lst = items; size_t _idx = (size_t)init_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
@@ -6356,7 +6530,9 @@ slop_string expr_transpile_binding_expr(context_TranspileContext* ctx, types_SEx
                                                     } else if (!_mv_415.has_value) {
                                                         return context_ctx_str3(ctx, SLOP_STR("__auto_type "), var_name, SLOP_STR(" = 0;"));
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 __auto_type _mv_416 = ({ __auto_type _lst = items; size_t _idx = (size_t)init_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                                 if (_mv_416.has_value) {
@@ -6368,6 +6544,7 @@ slop_string expr_transpile_binding_expr(context_TranspileContext* ctx, types_SEx
                                                 } else if (!_mv_416.has_value) {
                                                     return context_ctx_str3(ctx, SLOP_STR("__auto_type "), var_name, SLOP_STR(" = 0;"));
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         }
                                     }
@@ -6378,6 +6555,7 @@ slop_string expr_transpile_binding_expr(context_TranspileContext* ctx, types_SEx
                             } else if (!_mv_411.has_value) {
                                 return SLOP_STR("");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -6410,6 +6588,7 @@ uint8_t expr_binding_has_mut(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_417.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -6450,6 +6629,7 @@ slop_string expr_transpile_typed_init(context_TranspileContext* ctx, types_SExpr
                                             } else if (!_mv_422.has_value) {
                                                 return expr_transpile_expr(ctx, init_expr);
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     } else if (string_eq(op, SLOP_STR("none"))) {
                                         return context_ctx_str3(ctx, SLOP_STR("("), target_type, SLOP_STR("){.has_value = false}"));
@@ -6465,6 +6645,7 @@ slop_string expr_transpile_typed_init(context_TranspileContext* ctx, types_SExpr
                     } else if (!_mv_420.has_value) {
                         return expr_transpile_expr(ctx, init_expr);
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6511,6 +6692,7 @@ slop_string expr_transpile_while_expr(context_TranspileContext* ctx, slop_list_t
             } else if (!_mv_423.has_value) {
                 return SLOP_STR("({ (void)0; })");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -6575,6 +6757,7 @@ slop_string expr_transpile_when_expr(context_TranspileContext* ctx, slop_list_ty
             } else if (!_mv_426.has_value) {
                 return SLOP_STR("({ (void)0; })");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -6606,6 +6789,7 @@ uint8_t expr_set_is_self_assign(slop_list_types_SExpr_ptr items) {
                     } else if (!_mv_430.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
                 default: {
                     return 0;
@@ -6614,6 +6798,7 @@ uint8_t expr_set_is_self_assign(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_428.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     } else {
         return 0;
     }
@@ -6676,9 +6861,11 @@ slop_string expr_transpile_set_expr(context_TranspileContext* ctx, slop_list_typ
                                                                         } else if (!_mv_438.has_value) {
                                                                             return SLOP_STR("({ (void)0; })");
                                                                         }
+                                                                        SLOP_UNREACHABLE();
                                                                     } else if (!_mv_437.has_value) {
                                                                         return SLOP_STR("({ (void)0; })");
                                                                     }
+                                                                    SLOP_UNREACHABLE();
                                                                 }
                                                             } else if (string_eq(op, SLOP_STR("."))) {
                                                                 {
@@ -6703,6 +6890,7 @@ slop_string expr_transpile_set_expr(context_TranspileContext* ctx, slop_list_typ
                                             } else if (!_mv_435.has_value) {
                                                 return SLOP_STR("({ (void)0; })");
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 }
@@ -6726,9 +6914,11 @@ slop_string expr_transpile_set_expr(context_TranspileContext* ctx, slop_list_typ
                     } else if (!_mv_433.has_value) {
                         return SLOP_STR("({ (void)0; })");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_432.has_value) {
                     return SLOP_STR("({ (void)0; })");
                 }
+                SLOP_UNREACHABLE();
             }
         }
     }
@@ -6749,7 +6939,9 @@ slop_string expr_resolve_arena_c_name(context_TranspileContext* ctx, slop_string
             context_ctx_add_error_at(ctx, context_ctx_str(ctx, op, SLOP_STR(": no arena in scope")), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             return SLOP_STR("arena");
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_get_arena_for_list_push_expr(context_TranspileContext* ctx, types_SExpr* list_expr, slop_string list_c) {
@@ -6777,10 +6969,13 @@ slop_string expr_get_arena_for_list_push_expr(context_TranspileContext* ctx, typ
                     } else if (!_mv_443.has_value) {
                         return SLOP_STR("arena");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_get_arena_from_field_access(context_TranspileContext* ctx, types_SExpr* expr) {
@@ -6813,6 +7008,7 @@ slop_string expr_get_arena_from_field_access(context_TranspileContext* ctx, type
                                     } else if (!_mv_447.has_value) {
                                         return SLOP_STR("");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else {
                                     return SLOP_STR("");
                                 }
@@ -6824,6 +7020,7 @@ slop_string expr_get_arena_from_field_access(context_TranspileContext* ctx, type
                     } else if (!_mv_445.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6858,6 +7055,7 @@ slop_string expr_get_arena_from_base(context_TranspileContext* ctx, types_SExpr*
                         return context_ctx_str(ctx, c_name, SLOP_STR("->arena"));
                     }
                 }
+                SLOP_UNREACHABLE();
             }
         }
         case types_SExpr_lst:
@@ -6887,6 +7085,7 @@ slop_string expr_get_arena_from_base(context_TranspileContext* ctx, types_SExpr*
                                     } else if (!_mv_452.has_value) {
                                         return SLOP_STR("arena");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else {
                                     return SLOP_STR("arena");
                                 }
@@ -6898,6 +7097,7 @@ slop_string expr_get_arena_from_base(context_TranspileContext* ctx, types_SExpr*
                     } else if (!_mv_450.has_value) {
                         return SLOP_STR("arena");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6932,6 +7132,7 @@ uint8_t expr_is_ptr_to_ptr_map(context_TranspileContext* ctx, types_SExpr* expr)
                 } else if (!_mv_454.has_value) {
                     return 0;
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -7024,6 +7225,7 @@ slop_string expr_transpile_record_new(context_TranspileContext* ctx, slop_list_t
                                     context_ctx_add_error_at(ctx, SLOP_STR("record-new: empty type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -7036,6 +7238,7 @@ slop_string expr_transpile_record_new(context_TranspileContext* ctx, slop_list_t
                 context_ctx_add_error_at(ctx, SLOP_STR("record-new: missing type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7316,6 +7519,7 @@ slop_string expr_transpile_list_literal(context_TranspileContext* ctx, slop_list
                                     return context_ctx_str(ctx, result, context_ctx_str(ctx, data_part, SLOP_STR("}})")));
                                 }
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -7323,6 +7527,7 @@ slop_string expr_transpile_list_literal(context_TranspileContext* ctx, slop_list
                 context_ctx_add_error_at(ctx, SLOP_STR("list: missing type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7403,6 +7608,7 @@ slop_string expr_get_map_key_c_info(context_TranspileContext* ctx, types_SExpr* 
                     } else if (!_mv_480.has_value) {
                         return SLOP_STR("sizeof(void*), slop_hash_ptr, slop_eq_ptr");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -7439,11 +7645,14 @@ slop_string expr_get_struct_key_info_by_name(context_TranspileContext* ctx, slop
                 } else if (!_mv_484.has_value) {
                     return SLOP_STR("");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (!_mv_483.has_value) {
             return SLOP_STR("");
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_transpile_map_new(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items) {
@@ -7466,6 +7675,7 @@ slop_string expr_transpile_map_new(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("map-new: missing arena"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             }
         } else {
             __auto_type _mv_486 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
@@ -7483,10 +7693,12 @@ slop_string expr_transpile_map_new(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("map-new: missing KeyType"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_486.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("map-new: missing arena"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7598,14 +7810,17 @@ slop_string expr_transpile_map_put(context_TranspileContext* ctx, slop_list_type
                         context_ctx_add_error_at(ctx, SLOP_STR("map-put: missing val"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         return SLOP_STR("0");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_489.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("map-put: missing key"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_488.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("map-put: missing map"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7645,10 +7860,12 @@ slop_string expr_transpile_map_get(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("map-get: missing key"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_491.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("map-get: missing map"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7677,10 +7894,12 @@ slop_string expr_transpile_map_has(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("map-has: missing key"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("false");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_493.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("map-has: missing map"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("false");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7709,10 +7928,12 @@ slop_string expr_transpile_map_remove(context_TranspileContext* ctx, slop_list_t
                     context_ctx_add_error_at(ctx, SLOP_STR("map-remove: missing key"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_495.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("map-remove: missing map"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7752,6 +7973,7 @@ slop_string expr_transpile_map_keys(context_TranspileContext* ctx, slop_list_typ
                 context_ctx_add_error_at(ctx, SLOP_STR("map-keys: missing map"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7779,10 +8001,12 @@ slop_string expr_transpile_set_new(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("set-new: missing ElementType"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_498.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("set-new: missing arena"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7812,10 +8036,12 @@ slop_string expr_transpile_set_put(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("set-put: missing element"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_500.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("set-put: missing set"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7844,10 +8070,12 @@ slop_string expr_transpile_set_has(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("set-has: missing element"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("false");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_502.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("set-has: missing set"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("false");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7876,10 +8104,12 @@ slop_string expr_transpile_set_remove(context_TranspileContext* ctx, slop_list_t
                     context_ctx_add_error_at(ctx, SLOP_STR("set-remove: missing element"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_504.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("set-remove: missing set"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7919,6 +8149,7 @@ slop_string expr_transpile_set_elements(context_TranspileContext* ctx, slop_list
                 context_ctx_add_error_at(ctx, SLOP_STR("set-elements: missing set"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7963,6 +8194,7 @@ slop_string expr_transpile_set_literal(context_TranspileContext* ctx, slop_list_
                 context_ctx_add_error_at(ctx, SLOP_STR("set: missing type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -8032,9 +8264,11 @@ slop_string expr_transpile_for_as_expr(context_TranspileContext* ctx, slop_list_
                                                     } else if (!_mv_514.has_value) {
                                                         return SLOP_STR("({ /* for: missing end */ 0; })");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 } else if (!_mv_513.has_value) {
                                                     return SLOP_STR("({ /* for: missing start */ 0; })");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         }
                                         default: {
@@ -8044,6 +8278,7 @@ slop_string expr_transpile_for_as_expr(context_TranspileContext* ctx, slop_list_
                                 } else if (!_mv_511.has_value) {
                                     return SLOP_STR("({ /* for: missing var */ 0; })");
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -8054,6 +8289,7 @@ slop_string expr_transpile_for_as_expr(context_TranspileContext* ctx, slop_list_
             } else if (!_mv_509.has_value) {
                 return SLOP_STR("({ /* for: missing binding */ 0; })");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -8112,6 +8348,7 @@ slop_string expr_transpile_for_each_as_expr(context_TranspileContext* ctx, slop_
                                                 } else if (!_mv_520.has_value) {
                                                     return SLOP_STR("({ /* for-each: missing collection */ 0; })");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         }
                                         default: {
@@ -8121,6 +8358,7 @@ slop_string expr_transpile_for_each_as_expr(context_TranspileContext* ctx, slop_
                                 } else if (!_mv_518.has_value) {
                                     return SLOP_STR("({ /* for-each: missing var */ 0; })");
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -8131,6 +8369,7 @@ slop_string expr_transpile_for_each_as_expr(context_TranspileContext* ctx, slop_
             } else if (!_mv_516.has_value) {
                 return SLOP_STR("({ /* for-each: missing binding */ 0; })");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -8335,12 +8574,15 @@ slop_string expr_transpile_for_each_map_kv_as_expr(context_TranspileContext* ctx
                                     } else if (!_mv_528.has_value) {
                                         return SLOP_STR("({ /* for-each: missing map expression */ 0; })");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_527.has_value) {
                                     return SLOP_STR("({ /* for-each: missing value binding */ 0; })");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (!_mv_526.has_value) {
                                 return SLOP_STR("({ /* for-each: missing key binding */ 0; })");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -8351,6 +8593,7 @@ slop_string expr_transpile_for_each_map_kv_as_expr(context_TranspileContext* ctx
         } else if (!_mv_524.has_value) {
             return SLOP_STR("({ /* for-each: missing binding */ 0; })");
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -8418,6 +8661,7 @@ slop_string expr_transpile_lambda_expr(context_TranspileContext* ctx, slop_list_
                 context_ctx_add_error_at(ctx, SLOP_STR("lambda missing params"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -8685,7 +8929,9 @@ slop_string expr_find_arena_ptr_expr(context_TranspileContext* ctx) {
         } else if (!_mv_542.has_value) {
             return SLOP_STR("");
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_build_closure_instance(context_TranspileContext* ctx, slop_string lambda_name, slop_string env_name, slop_string env_type, slop_list_string free_vars, slop_list_string captured_accesses) {
@@ -8892,6 +9138,7 @@ uint8_t expr_is_pointer_type_sexpr(types_SExpr* type_expr) {
                     } else if (!_mv_555.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -8993,6 +9240,7 @@ uint8_t expr_is_capturing_lambda(types_SExpr* expr) {
                                     } else if (!_mv_561.has_value) {
                                         return 0;
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             }
                             default: {
@@ -9002,6 +9250,7 @@ uint8_t expr_is_capturing_lambda(types_SExpr* expr) {
                     } else if (!_mv_559.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -9035,6 +9284,7 @@ slop_string expr_transpile_spawn_closure(context_TranspileContext* ctx, slop_lis
             context_ctx_add_error_at(ctx, SLOP_STR("spawn: missing arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             return SLOP_STR("NULL");
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -9075,6 +9325,7 @@ uint8_t expr_lambda_has_captures(context_TranspileContext* ctx, types_SExpr* fn_
                     } else if (!_mv_565.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -9140,6 +9391,7 @@ slop_string expr_infer_generic_type_binding(context_TranspileContext* ctx, slop_
             } else if (!_mv_568.has_value) {
                 return SLOP_STR("");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -9477,6 +9729,7 @@ uint8_t expr_is_mut_binding(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_580.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -9660,6 +9913,7 @@ slop_list_string expr_extract_for_loop_var_pending(slop_arena* arena, slop_list_
         } else if (!_mv_592.has_value) {
             return pending;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -9753,8 +10007,11 @@ uint8_t expr_is_free_var(context_TranspileContext* ctx, slop_list_string param_n
                         } else if (!_mv_600.has_value) {
                             return 0;
                         }
+                        SLOP_UNREACHABLE();
                     }
+                    SLOP_UNREACHABLE();
                 }
+                SLOP_UNREACHABLE();
             }
         }
     }
@@ -9939,6 +10196,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                                 } else if (!_mv_607.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         } else if (string_eq(op, SLOP_STR("set-elements"))) {
                                             if (((int64_t)((items).len)) < 2) {
@@ -9961,6 +10219,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                                 } else if (!_mv_608.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         } else if (string_eq(op, SLOP_STR("map-values"))) {
                                             if (((int64_t)((items).len)) < 2) {
@@ -9983,6 +10242,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                                 } else if (!_mv_609.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         } else {
                                             return expr_infer_elem_from_type(ctx, coll_expr);
@@ -9996,6 +10256,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                         } else if (!_mv_605.has_value) {
                             return SLOP_STR("");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }

--- a/bootstrap/compiler/slop_infer.c
+++ b/bootstrap/compiler/slop_infer.c
@@ -36,6 +36,11 @@ types_ResolvedType* infer_infer_field_access(env_TypeEnv* env, types_SExpr* expr
 types_ResolvedType* infer_check_field_exists(env_TypeEnv* env, types_ResolvedType* obj_type, slop_string field_name, int64_t line, int64_t col);
 types_ResolvedType* infer_infer_cond_expr(env_TypeEnv* env, types_SExpr* expr, types_SExprList lst);
 void infer_bind_match_pattern(env_TypeEnv* env, types_ResolvedType* scrutinee_type, types_SExpr* pattern);
+slop_string infer_match_pattern_head(types_SExpr* pattern);
+uint8_t infer_is_wildcard_head(slop_string head);
+uint8_t infer_string_list_contains(slop_list_string names, slop_string name);
+slop_list_string infer_match_expected_variants(slop_arena* arena, types_ResolvedType* scrutinee_type);
+void infer_check_match_exhaustive(env_TypeEnv* env, types_ResolvedType* scrutinee_type, slop_list_string covered, uint8_t has_wildcard, int64_t line, int64_t col);
 types_ResolvedType* infer_infer_match_expr(env_TypeEnv* env, types_SExpr* expr, types_SExprList lst);
 void infer_check_return_type(env_TypeEnv* env, types_SExpr* fn_form, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col);
 void infer_check_spec_return_type(env_TypeEnv* env, types_SExpr* spec_form, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col);
@@ -378,6 +383,7 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
                 } else if (!_mv_1650.has_value) {
                     return t;
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (kind == types_ResolvedTypeKind_rk_ptr) {
             __auto_type _mv_1651 = (*t).inner_type;
@@ -394,6 +400,7 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
             } else if (!_mv_1651.has_value) {
                 return t;
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_chan) {
             __auto_type _mv_1652 = (*t).inner_type;
             if (_mv_1652.has_value) {
@@ -407,6 +414,7 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
             } else if (!_mv_1652.has_value) {
                 return t;
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_thread) {
             __auto_type _mv_1653 = (*t).inner_type;
             if (_mv_1653.has_value) {
@@ -420,6 +428,7 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
             } else if (!_mv_1653.has_value) {
                 return t;
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_list) {
             __auto_type _mv_1654 = (*t).inner_type;
             if (_mv_1654.has_value) {
@@ -433,6 +442,7 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
             } else if (!_mv_1654.has_value) {
                 return t;
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_option) {
             __auto_type _mv_1655 = (*t).inner_type;
             if (_mv_1655.has_value) {
@@ -448,6 +458,7 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
             } else if (!_mv_1655.has_value) {
                 return t;
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_result) {
             {
                 __auto_type new_ok = ({ __auto_type _mv = (*t).inner_type; _mv.has_value ? ({ __auto_type ok = _mv.value; infer_substitute_type_vars(arena, ok, bind_names, bind_types); }) : (NULL); });
@@ -568,6 +579,7 @@ uint8_t infer_types_compatible_with_range(types_ResolvedType* a, types_ResolvedT
             } else if (!_mv_1658.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         } else if (b_kind == types_ResolvedTypeKind_rk_range) {
             __auto_type _mv_1659 = (*b).inner_type;
             if (_mv_1659.has_value) {
@@ -576,6 +588,7 @@ uint8_t infer_types_compatible_with_range(types_ResolvedType* a, types_ResolvedT
             } else if (!_mv_1659.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         } else {
             return 0;
         }
@@ -706,7 +719,9 @@ types_ResolvedType* infer_infer_expr_inner(env_TypeEnv* env, types_SExpr* expr) 
                                                         return env_env_get_int_type(env);
                                                     }
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     } else {
                                         __auto_type _mv_1667 = env_env_lookup_type(env, name);
@@ -724,6 +739,7 @@ types_ResolvedType* infer_infer_expr_inner(env_TypeEnv* env, types_SExpr* expr) 
                                                 } else if (!_mv_1669.has_value) {
                                                     return env_env_get_int_type(env);
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else if (!_mv_1668.has_value) {
                                                 {
                                                     __auto_type arena = env_env_arena(env);
@@ -732,11 +748,16 @@ types_ResolvedType* infer_infer_expr_inner(env_TypeEnv* env, types_SExpr* expr) 
                                                     return env_env_get_int_type(env);
                                                 }
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
+                                SLOP_UNREACHABLE();
                             }
+                            SLOP_UNREACHABLE();
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -756,6 +777,7 @@ types_ResolvedType* infer_infer_expr_inner(env_TypeEnv* env, types_SExpr* expr) 
                 return infer_infer_list_expr(env, expr, lst);
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -788,6 +810,7 @@ types_ResolvedType* infer_infer_list_expr(env_TypeEnv* env, types_SExpr* expr, t
                     }
                 }
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -824,10 +847,12 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                         } else if (!_mv_1674.has_value) {
                             return then_type;
                         }
+                        SLOP_UNREACHABLE();
                     }
                 } else if (!_mv_1673.has_value) {
                     return env_env_get_unit_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_unit_type(env);
             }
@@ -845,6 +870,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                 } else if (!_mv_1675.has_value) {
                     return env_env_get_unit_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_unit_type(env);
             }
@@ -955,11 +981,13 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                             } else if (!_mv_1683.has_value) {
                                                 return env_env_get_unit_type(env);
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 } else if (!_mv_1682.has_value) {
                                     return env_env_get_unit_type(env);
                                 }
+                                SLOP_UNREACHABLE();
                             } else {
                                 return env_env_get_unit_type(env);
                             }
@@ -970,6 +998,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                 } else if (!_mv_1681.has_value) {
                     return env_env_get_unit_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_unit_type(env);
             }
@@ -1068,6 +1097,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             } else if (!_mv_1691.has_value) {
                                 return env_env_get_unit_type(env);
                             }
+                            SLOP_UNREACHABLE();
                         } else {
                             return ptr_type;
                         }
@@ -1075,6 +1105,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                 } else if (!_mv_1690.has_value) {
                     return env_env_get_unit_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_unit_type(env);
             }
@@ -1090,6 +1121,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                 } else if (!_mv_1692.has_value) {
                     return env_env_get_unit_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_unit_type(env);
             }
@@ -1137,6 +1169,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                 } else if (!_mv_1694.has_value) {
                                     return env_env_get_unknown_type(env);
                                 }
+                                SLOP_UNREACHABLE();
                             } else {
                                 return env_env_get_unknown_type(env);
                             }
@@ -1158,11 +1191,13 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                     return env_env_get_unknown_type(env);
                                 }
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 } else if (!_mv_1693.has_value) {
                     return env_env_get_unknown_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_unknown_type(env);
             }
@@ -1186,14 +1221,17 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                 } else if (!_mv_1698.has_value) {
                                     return env_env_get_unknown_type(env);
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (!_mv_1697.has_value) {
                                 return env_env_get_unknown_type(env);
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 } else if (!_mv_1696.has_value) {
                     return env_env_get_unknown_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_unknown_type(env);
             }
@@ -1211,6 +1249,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                 } else if (!_mv_1699.has_value) {
                     return env_env_make_option_type(env, NULL);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_make_option_type(env, NULL);
             }
@@ -1250,11 +1289,13 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             } else if (!_mv_1703.has_value) {
                                 return env_env_get_unit_type(env);
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 } else if (!_mv_1702.has_value) {
                     return env_env_get_unit_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_unit_type(env);
             }
@@ -1285,11 +1326,13 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             } else if (!_mv_1706.has_value) {
                                 return env_env_get_unit_type(env);
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 } else if (!_mv_1705.has_value) {
                     return env_env_get_unit_type(env);
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return env_env_get_unit_type(env);
             }
@@ -1379,17 +1422,20 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                                                 } else if (!_mv_1714.has_value) {
                                                                     return env_env_get_int_type(env);
                                                                 }
+                                                                SLOP_UNREACHABLE();
                                                             }
                                                         }
                                                     } else if (!_mv_1713.has_value) {
                                                         return env_env_get_int_type(env);
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 } else {
                                                     return env_env_get_int_type(env);
                                                 }
                                             } else if (!_mv_1712.has_value) {
                                                 return env_env_get_int_type(env);
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else {
                                             return env_env_get_int_type(env);
                                         }
@@ -1405,11 +1451,13 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                             }
                                             return env_env_get_int_type(env);
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             } else if (!_mv_1711.has_value) {
                                 return env_env_get_int_type(env);
                             }
+                            SLOP_UNREACHABLE();
                         }
                     } else if (string_eq(op, SLOP_STR("arena-new"))) {
                         infer_check_builtin_args(env, SLOP_STR("arena-new"), 1, (len - 1), line, col);
@@ -1513,6 +1561,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                         } else if (!_mv_1720.has_value) {
                                             return env_env_get_int_type(env);
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else {
                                         return env_env_get_int_type(env);
                                     }
@@ -1520,6 +1569,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             } else if (!_mv_1719.has_value) {
                                 return env_env_get_int_type(env);
                             }
+                            SLOP_UNREACHABLE();
                         } else {
                             return env_env_get_int_type(env);
                         }
@@ -1771,12 +1821,16 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                             return env_env_get_unknown_type(env);
                                         }
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
+                SLOP_UNREACHABLE();
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -1948,8 +2002,10 @@ types_ResolvedType* infer_infer_field_access(env_TypeEnv* env, types_SExpr* expr
                             }
                         }
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -1972,6 +2028,7 @@ types_ResolvedType* infer_check_field_exists(env_TypeEnv* env, types_ResolvedTyp
                     return env_env_get_unit_type(env);
                 }
             }
+            SLOP_UNREACHABLE();
         } else {
             if (string_eq(type_name, SLOP_STR("T"))) {
                 return env_env_get_generic_type(env);
@@ -1996,6 +2053,7 @@ types_ResolvedType* infer_check_field_exists(env_TypeEnv* env, types_ResolvedTyp
                             } else if (!_mv_1744.has_value) {
                                 return env_env_get_unknown_type(env);
                             }
+                            SLOP_UNREACHABLE();
                         } else {
                             if (string_eq(type_name, SLOP_STR("Chan")) || string_eq(type_name, SLOP_STR("Thread"))) {
                                 return env_env_get_unknown_type(env);
@@ -2199,6 +2257,143 @@ void infer_bind_match_pattern(env_TypeEnv* env, types_ResolvedType* scrutinee_ty
     }
 }
 
+slop_string infer_match_pattern_head(types_SExpr* pattern) {
+    SLOP_PRE(((pattern != NULL)), "(!= pattern nil)");
+    if (parser_sexpr_is_list(pattern)) {
+        if (parser_sexpr_list_len(pattern) > 0) {
+            __auto_type _mv_1757 = parser_sexpr_list_get(pattern, 0);
+            if (_mv_1757.has_value) {
+                __auto_type head = _mv_1757.value;
+                return parser_sexpr_get_symbol_name(head);
+            } else if (!_mv_1757.has_value) {
+                return SLOP_STR("");
+            }
+            SLOP_UNREACHABLE();
+        } else {
+            return SLOP_STR("");
+        }
+    } else {
+        return parser_sexpr_get_symbol_name(pattern);
+    }
+}
+
+uint8_t infer_is_wildcard_head(slop_string head) {
+    return (string_eq(head, SLOP_STR("_")) || string_eq(head, SLOP_STR("else")));
+}
+
+uint8_t infer_string_list_contains(slop_list_string names, slop_string name) {
+    {
+        __auto_type n = ((int64_t)((names).len));
+        int64_t i = 0;
+        uint8_t found = 0;
+        while ((i < n) && !(found)) {
+            __auto_type _mv_1758 = ({ __auto_type _lst = names; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1758.has_value) {
+                __auto_type existing = _mv_1758.value;
+                if (string_eq(existing, name)) {
+                    found = 1;
+                }
+            } else if (!_mv_1758.has_value) {
+            }
+            i = (i + 1);
+        }
+        return found;
+    }
+}
+
+slop_list_string infer_match_expected_variants(slop_arena* arena, types_ResolvedType* scrutinee_type) {
+    SLOP_PRE(((scrutinee_type != NULL)), "(!= scrutinee-type nil)");
+    {
+        __auto_type kind = (*scrutinee_type).kind;
+        __auto_type result = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
+        if ((kind == types_ResolvedTypeKind_rk_union) || (kind == types_ResolvedTypeKind_rk_enum)) {
+            {
+                __auto_type variants = (*scrutinee_type).variants;
+                __auto_type n = ((int64_t)((variants).len));
+                int64_t i = 0;
+                while (i < n) {
+                    __auto_type _mv_1759 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_types_ResolvedVariant _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1759.has_value) {
+                        __auto_type v = _mv_1759.value;
+                        ({ __auto_type _lst_p = &(result); __auto_type _item = (v.name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+                    } else if (!_mv_1759.has_value) {
+                    }
+                    i = (i + 1);
+                }
+                return result;
+            }
+        } else if (kind == types_ResolvedTypeKind_rk_option) {
+            ({ __auto_type _lst_p = &(result); __auto_type _item = (SLOP_STR("some")); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+            ({ __auto_type _lst_p = &(result); __auto_type _item = (SLOP_STR("none")); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+            return result;
+        } else if (kind == types_ResolvedTypeKind_rk_result) {
+            ({ __auto_type _lst_p = &(result); __auto_type _item = (SLOP_STR("ok")); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+            ({ __auto_type _lst_p = &(result); __auto_type _item = (SLOP_STR("error")); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+            return result;
+        } else {
+            return result;
+        }
+    }
+}
+
+void infer_check_match_exhaustive(env_TypeEnv* env, types_ResolvedType* scrutinee_type, slop_list_string covered, uint8_t has_wildcard, int64_t line, int64_t col) {
+    SLOP_PRE(((env != NULL)), "(!= env nil)");
+    SLOP_PRE(((scrutinee_type != NULL)), "(!= scrutinee-type nil)");
+    if (!(has_wildcard)) {
+        {
+            __auto_type arena = env_env_arena(env);
+            __auto_type type_name = (*scrutinee_type).name;
+            __auto_type expected = infer_match_expected_variants(arena, scrutinee_type);
+            if ((((int64_t)((expected).len)) > 0) && !(string_eq(type_name, SLOP_STR("T")))) {
+                {
+                    __auto_type n = ((int64_t)((covered).len));
+                    int64_t i = 0;
+                    uint8_t all_known = 1;
+                    __auto_type missing = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
+                    while (i < n) {
+                        __auto_type _mv_1760 = ({ __auto_type _lst = covered; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1760.has_value) {
+                            __auto_type head = _mv_1760.value;
+                            if (!(infer_string_list_contains(expected, head))) {
+                                all_known = 0;
+                            }
+                        } else if (!_mv_1760.has_value) {
+                        }
+                        i = (i + 1);
+                    }
+                    if (all_known) {
+                        {
+                            __auto_type e_len = ((int64_t)((expected).len));
+                            int64_t j = 0;
+                            while (j < e_len) {
+                                __auto_type _mv_1761 = ({ __auto_type _lst = expected; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1761.has_value) {
+                                    __auto_type want = _mv_1761.value;
+                                    if (!(infer_string_list_contains(covered, want))) {
+                                        ({ __auto_type _lst_p = &(missing); __auto_type _item = (want); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+                                    }
+                                } else if (!_mv_1761.has_value) {
+                                }
+                                j = (j + 1);
+                            }
+                            if (((int64_t)((missing).len)) > 0) {
+                                {
+                                    __auto_type parts = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
+                                    ({ __auto_type _lst_p = &(parts); __auto_type _item = (SLOP_STR("non-exhaustive match on ")); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+                                    ({ __auto_type _lst_p = &(parts); __auto_type _item = (type_name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+                                    ({ __auto_type _lst_p = &(parts); __auto_type _item = (SLOP_STR(": missing ")); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+                                    ({ __auto_type _lst_p = &(parts); __auto_type _item = (strlib_join(arena, missing, SLOP_STR(", "))); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+                                    env_env_add_warning(env, strlib_string_build(arena, parts), line, col);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 types_ResolvedType* infer_infer_match_expr(env_TypeEnv* env, types_SExpr* expr, types_SExprList lst) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     {
@@ -2207,42 +2402,60 @@ types_ResolvedType* infer_infer_match_expr(env_TypeEnv* env, types_SExpr* expr, 
         __auto_type line = parser_sexpr_line(expr);
         __auto_type col = parser_sexpr_col(expr);
         uint8_t has_result = 0;
+        uint8_t has_wildcard = 0;
+        __auto_type match_arena = env_env_arena(env);
+        __auto_type covered = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(match_arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
         types_ResolvedType* result_type = env_env_get_unit_type(env);
         __auto_type scrutinee_type = (((len >= 2)) ? ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type scrutinee = _mv.value; infer_infer_expr(env, scrutinee); }) : (env_env_get_unit_type(env)); }) : env_env_get_unit_type(env));
         int64_t i = 2;
         while (i < len) {
-            __auto_type _mv_1757 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1757.has_value) {
-                __auto_type clause = _mv_1757.value;
-                __auto_type _mv_1758 = (*clause);
-                switch (_mv_1758.tag) {
+            __auto_type _mv_1762 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1762.has_value) {
+                __auto_type clause = _mv_1762.value;
+                __auto_type _mv_1763 = (*clause);
+                switch (_mv_1763.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type clause_lst = _mv_1758.data.lst;
+                        __auto_type clause_lst = _mv_1763.data.lst;
                         {
                             __auto_type clause_items = clause_lst.items;
                             __auto_type clause_len = ((int64_t)((clause_items).len));
+                            if (clause_len > 0) {
+                                __auto_type _mv_1764 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1764.has_value) {
+                                    __auto_type pattern = _mv_1764.value;
+                                    {
+                                        __auto_type head = infer_match_pattern_head(pattern);
+                                        if (infer_is_wildcard_head(head)) {
+                                            has_wildcard = 1;
+                                        } else {
+                                            ({ __auto_type _lst_p = &(covered); __auto_type _item = (head); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(match_arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
+                                        }
+                                    }
+                                } else if (!_mv_1764.has_value) {
+                                }
+                            }
                             if (clause_len > 1) {
                                 env_env_push_scope(env);
-                                __auto_type _mv_1759 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1759.has_value) {
-                                    __auto_type pattern = _mv_1759.value;
+                                __auto_type _mv_1765 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1765.has_value) {
+                                    __auto_type pattern = _mv_1765.value;
                                     infer_bind_match_pattern(env, scrutinee_type, pattern);
-                                } else if (!_mv_1759.has_value) {
+                                } else if (!_mv_1765.has_value) {
                                 }
                                 for (int64_t bi = 1; bi < (clause_len - 1); bi++) {
-                                    __auto_type _mv_1760 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_1760.has_value) {
-                                        __auto_type body_expr = _mv_1760.value;
+                                    __auto_type _mv_1766 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_1766.has_value) {
+                                        __auto_type body_expr = _mv_1766.value;
                                         {
                                             __auto_type _ = infer_infer_expr(env, body_expr);
                                         }
-                                    } else if (!_mv_1760.has_value) {
+                                    } else if (!_mv_1766.has_value) {
                                     }
                                 }
-                                __auto_type _mv_1761 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)(clause_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1761.has_value) {
-                                    __auto_type body = _mv_1761.value;
+                                __auto_type _mv_1767 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)(clause_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1767.has_value) {
+                                    __auto_type body = _mv_1767.value;
                                     {
                                         __auto_type body_type = infer_infer_expr(env, body);
                                         if (!(has_result)) {
@@ -2252,7 +2465,7 @@ types_ResolvedType* infer_infer_match_expr(env_TypeEnv* env, types_SExpr* expr, 
                                             result_type = infer_unify_branch_types(env, result_type, body_type, line, col);
                                         }
                                     }
-                                } else if (!_mv_1761.has_value) {
+                                } else if (!_mv_1767.has_value) {
                                 }
                                 env_env_pop_scope(env);
                             }
@@ -2263,10 +2476,11 @@ types_ResolvedType* infer_infer_match_expr(env_TypeEnv* env, types_SExpr* expr, 
                         break;
                     }
                 }
-            } else if (!_mv_1757.has_value) {
+            } else if (!_mv_1762.has_value) {
             }
             i = (i + 1);
         }
+        infer_check_match_exhaustive(env, scrutinee_type, covered, has_wildcard, line, col);
         return result_type;
     }
 }
@@ -2275,22 +2489,22 @@ void infer_check_return_type(env_TypeEnv* env, types_SExpr* fn_form, slop_string
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((fn_form != NULL)), "(!= fn-form nil)");
     SLOP_PRE(((inferred_type != NULL)), "(!= inferred-type nil)");
-    __auto_type _mv_1762 = (*fn_form);
-    switch (_mv_1762.tag) {
+    __auto_type _mv_1768 = (*fn_form);
+    switch (_mv_1768.tag) {
         case types_SExpr_lst:
         {
-            __auto_type fn_lst = _mv_1762.data.lst;
+            __auto_type fn_lst = _mv_1768.data.lst;
             {
                 __auto_type items = fn_lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 for (int64_t i = 3; i < len; i++) {
-                    __auto_type _mv_1763 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1763.has_value) {
-                        __auto_type item = _mv_1763.value;
+                    __auto_type _mv_1769 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1769.has_value) {
+                        __auto_type item = _mv_1769.value;
                         if (parser_is_form(item, SLOP_STR("@spec"))) {
                             infer_check_spec_return_type(env, item, fn_name, inferred_type, fn_line, fn_col);
                         }
-                    } else if (!_mv_1763.has_value) {
+                    } else if (!_mv_1769.has_value) {
                     }
                 }
             }
@@ -2305,18 +2519,18 @@ void infer_check_return_type(env_TypeEnv* env, types_SExpr* fn_form, slop_string
 void infer_check_spec_return_type(env_TypeEnv* env, types_SExpr* spec_form, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((spec_form != NULL)), "(!= spec-form nil)");
-    __auto_type _mv_1764 = (*spec_form);
-    switch (_mv_1764.tag) {
+    __auto_type _mv_1770 = (*spec_form);
+    switch (_mv_1770.tag) {
         case types_SExpr_lst:
         {
-            __auto_type spec_lst = _mv_1764.data.lst;
+            __auto_type spec_lst = _mv_1770.data.lst;
             {
                 __auto_type spec_items = spec_lst.items;
-                __auto_type _mv_1765 = ({ __auto_type _lst = spec_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1765.has_value) {
-                    __auto_type spec_body = _mv_1765.value;
+                __auto_type _mv_1771 = ({ __auto_type _lst = spec_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1771.has_value) {
+                    __auto_type spec_body = _mv_1771.value;
                     infer_check_spec_body_return(env, spec_body, fn_name, inferred_type, fn_line, fn_col);
-                } else if (!_mv_1765.has_value) {
+                } else if (!_mv_1771.has_value) {
                 }
             }
             break;
@@ -2330,19 +2544,19 @@ void infer_check_spec_return_type(env_TypeEnv* env, types_SExpr* spec_form, slop
 void infer_check_spec_body_return(env_TypeEnv* env, types_SExpr* spec_body, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((spec_body != NULL)), "(!= spec-body nil)");
-    __auto_type _mv_1766 = (*spec_body);
-    switch (_mv_1766.tag) {
+    __auto_type _mv_1772 = (*spec_body);
+    switch (_mv_1772.tag) {
         case types_SExpr_lst:
         {
-            __auto_type body_lst = _mv_1766.data.lst;
+            __auto_type body_lst = _mv_1772.data.lst;
             {
                 __auto_type body_items = body_lst.items;
                 __auto_type body_len = ((int64_t)((body_items).len));
-                __auto_type _mv_1767 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1767.has_value) {
-                    __auto_type ret_expr = _mv_1767.value;
+                __auto_type _mv_1773 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1773.has_value) {
+                    __auto_type ret_expr = _mv_1773.value;
                     infer_check_return_expr(env, ret_expr, fn_name, inferred_type, fn_line, fn_col);
-                } else if (!_mv_1767.has_value) {
+                } else if (!_mv_1773.has_value) {
                 }
             }
             break;
@@ -2364,11 +2578,11 @@ uint8_t infer_is_integer_type(slop_string name) {
 void infer_check_return_expr(env_TypeEnv* env, types_SExpr* ret_expr, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((ret_expr != NULL)), "(!= ret-expr nil)");
-    __auto_type _mv_1768 = (*ret_expr);
-    switch (_mv_1768.tag) {
+    __auto_type _mv_1774 = (*ret_expr);
+    switch (_mv_1774.tag) {
         case types_SExpr_sym:
         {
-            __auto_type ret_sym = _mv_1768.data.sym;
+            __auto_type ret_sym = _mv_1774.data.sym;
             {
                 __auto_type declared_name = ret_sym.name;
                 __auto_type inferred_name = (*inferred_type).name;
@@ -2392,16 +2606,16 @@ void infer_bind_param_from_form(env_TypeEnv* env, types_SExpr* param_form) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((param_form != NULL)), "(!= param-form nil)");
     if (parser_sexpr_is_list(param_form) && (parser_sexpr_list_len(param_form) >= 2)) {
-        __auto_type _mv_1769 = parser_sexpr_list_get(param_form, 0);
-        if (_mv_1769.has_value) {
-            __auto_type first_expr = _mv_1769.value;
+        __auto_type _mv_1775 = parser_sexpr_list_get(param_form, 0);
+        if (_mv_1775.has_value) {
+            __auto_type first_expr = _mv_1775.value;
             {
                 __auto_type first_name = parser_sexpr_get_symbol_name(first_expr);
                 if ((string_eq(first_name, SLOP_STR("in"))) || (string_eq(first_name, SLOP_STR("out"))) || (string_eq(first_name, SLOP_STR("mut")))) {
                     if (parser_sexpr_list_len(param_form) >= 3) {
-                        __auto_type _mv_1770 = parser_sexpr_list_get(param_form, 1);
-                        if (_mv_1770.has_value) {
-                            __auto_type name_expr = _mv_1770.value;
+                        __auto_type _mv_1776 = parser_sexpr_list_get(param_form, 1);
+                        if (_mv_1776.has_value) {
+                            __auto_type name_expr = _mv_1776.value;
                             {
                                 __auto_type param_name = parser_sexpr_get_symbol_name(name_expr);
                                 if (!(string_eq(param_name, SLOP_STR("")))) {
@@ -2411,7 +2625,7 @@ void infer_bind_param_from_form(env_TypeEnv* env, types_SExpr* param_form) {
                                     }
                                 }
                             }
-                        } else if (!_mv_1770.has_value) {
+                        } else if (!_mv_1776.has_value) {
                         }
                     }
                 } else {
@@ -2423,7 +2637,7 @@ void infer_bind_param_from_form(env_TypeEnv* env, types_SExpr* param_form) {
                     }
                 }
             }
-        } else if (!_mv_1769.has_value) {
+        } else if (!_mv_1775.has_value) {
         }
     }
 }
@@ -2433,9 +2647,9 @@ types_ResolvedType* infer_get_param_type_from_form(env_TypeEnv* env, types_SExpr
     SLOP_PRE(((param_form != NULL)), "(!= param-form nil)");
     {
         __auto_type type_pos = ({ __auto_type _mv = parser_sexpr_list_get(param_form, 0); _mv.has_value ? ({ __auto_type first_expr = _mv.value; ({ __auto_type first_name = parser_sexpr_get_symbol_name(first_expr); ((((string_eq(first_name, SLOP_STR("in"))) || (string_eq(first_name, SLOP_STR("out"))) || (string_eq(first_name, SLOP_STR("mut"))))) ? 2 : 1); }); }) : (1); });
-        __auto_type _mv_1771 = parser_sexpr_list_get(param_form, type_pos);
-        if (_mv_1771.has_value) {
-            __auto_type type_expr = _mv_1771.value;
+        __auto_type _mv_1777 = parser_sexpr_list_get(param_form, type_pos);
+        if (_mv_1777.has_value) {
+            __auto_type type_expr = _mv_1777.value;
             {
                 __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                 if (string_eq(type_name, SLOP_STR(""))) {
@@ -2448,18 +2662,19 @@ types_ResolvedType* infer_get_param_type_from_form(env_TypeEnv* env, types_SExpr
                     return infer_resolve_simple_type(env, type_name);
                 }
             }
-        } else if (!_mv_1771.has_value) {
+        } else if (!_mv_1777.has_value) {
             return env_env_get_unknown_type(env);
         }
+        SLOP_UNREACHABLE();
     }
 }
 
 types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExpr* type_expr) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_1772 = parser_sexpr_list_get(type_expr, 0);
-    if (_mv_1772.has_value) {
-        __auto_type head_expr = _mv_1772.value;
+    __auto_type _mv_1778 = parser_sexpr_list_get(type_expr, 0);
+    if (_mv_1778.has_value) {
+        __auto_type head_expr = _mv_1778.value;
         {
             __auto_type head_name = parser_sexpr_get_symbol_name(head_expr);
             if (string_eq(head_name, SLOP_STR("Option"))) {
@@ -2487,16 +2702,16 @@ types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExp
                     __auto_type map_type = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_map, SLOP_STR("Map"), ((slop_option_string){.has_value = false}), SLOP_STR("slop_map*"));
                     types_resolved_type_set_inner(map_type, key_type);
                     if (parser_sexpr_list_len(type_expr) >= 3) {
-                        __auto_type _mv_1773 = parser_sexpr_list_get(type_expr, 2);
-                        if (_mv_1773.has_value) {
-                            __auto_type val_expr = _mv_1773.value;
+                        __auto_type _mv_1779 = parser_sexpr_list_get(type_expr, 2);
+                        if (_mv_1779.has_value) {
+                            __auto_type val_expr = _mv_1779.value;
                             {
                                 __auto_type val_type = infer_resolve_simple_type(env, parser_sexpr_get_symbol_name(val_expr));
                                 if (val_type != NULL) {
                                     types_resolved_type_set_inner2(map_type, val_type);
                                 }
                             }
-                        } else if (!_mv_1773.has_value) {
+                        } else if (!_mv_1779.has_value) {
                         }
                     }
                     return map_type;
@@ -2530,9 +2745,9 @@ types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExp
                     __auto_type arena = env_env_arena(env);
                     __auto_type result_type = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_result, SLOP_STR("Result"), ((slop_option_string){.has_value = false}), SLOP_STR("Result"));
                     if (parser_sexpr_list_len(type_expr) >= 2) {
-                        __auto_type _mv_1774 = parser_sexpr_list_get(type_expr, 1);
-                        if (_mv_1774.has_value) {
-                            __auto_type ok_expr = _mv_1774.value;
+                        __auto_type _mv_1780 = parser_sexpr_list_get(type_expr, 1);
+                        if (_mv_1780.has_value) {
+                            __auto_type ok_expr = _mv_1780.value;
                             {
                                 __auto_type ok_name = parser_sexpr_get_symbol_name(ok_expr);
                                 {
@@ -2540,13 +2755,13 @@ types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExp
                                     types_resolved_type_set_inner(result_type, ok_type);
                                 }
                             }
-                        } else if (!_mv_1774.has_value) {
+                        } else if (!_mv_1780.has_value) {
                         }
                     }
                     if (parser_sexpr_list_len(type_expr) >= 3) {
-                        __auto_type _mv_1775 = parser_sexpr_list_get(type_expr, 2);
-                        if (_mv_1775.has_value) {
-                            __auto_type err_expr = _mv_1775.value;
+                        __auto_type _mv_1781 = parser_sexpr_list_get(type_expr, 2);
+                        if (_mv_1781.has_value) {
+                            __auto_type err_expr = _mv_1781.value;
                             {
                                 __auto_type err_name = parser_sexpr_get_symbol_name(err_expr);
                                 {
@@ -2554,24 +2769,26 @@ types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExp
                                     types_resolved_type_set_inner2(result_type, err_type);
                                 }
                             }
-                        } else if (!_mv_1775.has_value) {
+                        } else if (!_mv_1781.has_value) {
                         }
                     }
                     return result_type;
                 }
             } else {
-                __auto_type _mv_1776 = env_env_lookup_type(env, head_name);
-                if (_mv_1776.has_value) {
-                    __auto_type t = _mv_1776.value;
+                __auto_type _mv_1782 = env_env_lookup_type(env, head_name);
+                if (_mv_1782.has_value) {
+                    __auto_type t = _mv_1782.value;
                     return t;
-                } else if (!_mv_1776.has_value) {
+                } else if (!_mv_1782.has_value) {
                     return env_env_get_unknown_type(env);
                 }
+                SLOP_UNREACHABLE();
             }
         }
-    } else if (!_mv_1772.has_value) {
+    } else if (!_mv_1778.has_value) {
         return env_env_get_unknown_type(env);
     }
+    SLOP_UNREACHABLE();
 }
 
 types_ResolvedType* infer_resolve_option_inner_type(env_TypeEnv* env, types_SExpr* type_expr) {
@@ -2579,9 +2796,9 @@ types_ResolvedType* infer_resolve_option_inner_type(env_TypeEnv* env, types_SExp
     if (parser_sexpr_list_len(type_expr) < 2) {
         return env_env_get_unknown_type(env);
     } else {
-        __auto_type _mv_1777 = parser_sexpr_list_get(type_expr, 1);
-        if (_mv_1777.has_value) {
-            __auto_type inner_expr = _mv_1777.value;
+        __auto_type _mv_1783 = parser_sexpr_list_get(type_expr, 1);
+        if (_mv_1783.has_value) {
+            __auto_type inner_expr = _mv_1783.value;
             {
                 __auto_type inner_name = parser_sexpr_get_symbol_name(inner_expr);
                 if (string_eq(inner_name, SLOP_STR(""))) {
@@ -2590,9 +2807,10 @@ types_ResolvedType* infer_resolve_option_inner_type(env_TypeEnv* env, types_SExp
                     return infer_resolve_simple_type(env, inner_name);
                 }
             }
-        } else if (!_mv_1777.has_value) {
+        } else if (!_mv_1783.has_value) {
             return env_env_get_unknown_type(env);
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2601,9 +2819,9 @@ types_ResolvedType* infer_resolve_ptr_inner_type(env_TypeEnv* env, types_SExpr* 
     if (parser_sexpr_list_len(type_expr) < 2) {
         return env_env_get_unit_type(env);
     } else {
-        __auto_type _mv_1778 = parser_sexpr_list_get(type_expr, 1);
-        if (_mv_1778.has_value) {
-            __auto_type inner_expr = _mv_1778.value;
+        __auto_type _mv_1784 = parser_sexpr_list_get(type_expr, 1);
+        if (_mv_1784.has_value) {
+            __auto_type inner_expr = _mv_1784.value;
             {
                 __auto_type inner_name = parser_sexpr_get_symbol_name(inner_expr);
                 if (string_eq(inner_name, SLOP_STR(""))) {
@@ -2616,19 +2834,20 @@ types_ResolvedType* infer_resolve_ptr_inner_type(env_TypeEnv* env, types_SExpr* 
                     return infer_resolve_simple_type(env, inner_name);
                 }
             }
-        } else if (!_mv_1778.has_value) {
+        } else if (!_mv_1784.has_value) {
             return env_env_get_unit_type(env);
         }
+        SLOP_UNREACHABLE();
     }
 }
 
 types_ResolvedType* infer_resolve_type_lenient(env_TypeEnv* env, slop_string type_name) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_1779 = env_env_lookup_type(env, type_name);
-    if (_mv_1779.has_value) {
-        __auto_type t = _mv_1779.value;
+    __auto_type _mv_1785 = env_env_lookup_type(env, type_name);
+    if (_mv_1785.has_value) {
+        __auto_type t = _mv_1785.value;
         return t;
-    } else if (!_mv_1779.has_value) {
+    } else if (!_mv_1785.has_value) {
         {
             __auto_type arena = env_env_arena(env);
             if (string_eq(type_name, SLOP_STR("Int"))) {
@@ -2646,15 +2865,16 @@ types_ResolvedType* infer_resolve_type_lenient(env_TypeEnv* env, slop_string typ
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 types_ResolvedType* infer_resolve_simple_type(env_TypeEnv* env, slop_string type_name) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_1780 = env_env_lookup_type(env, type_name);
-    if (_mv_1780.has_value) {
-        __auto_type t = _mv_1780.value;
+    __auto_type _mv_1786 = env_env_lookup_type(env, type_name);
+    if (_mv_1786.has_value) {
+        __auto_type t = _mv_1786.value;
         return t;
-    } else if (!_mv_1780.has_value) {
+    } else if (!_mv_1786.has_value) {
         {
             __auto_type arena = env_env_arena(env);
             if (string_eq(type_name, SLOP_STR("Int"))) {
@@ -2705,30 +2925,31 @@ types_ResolvedType* infer_resolve_simple_type(env_TypeEnv* env, slop_string type
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 void infer_bind_let_binding(env_TypeEnv* env, types_SExpr* binding_form) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((binding_form != NULL)), "(!= binding-form nil)");
     if (parser_sexpr_is_list(binding_form) && (parser_sexpr_list_len(binding_form) >= 2)) {
-        __auto_type _mv_1781 = parser_sexpr_list_get(binding_form, 0);
-        if (_mv_1781.has_value) {
-            __auto_type first_expr = _mv_1781.value;
+        __auto_type _mv_1787 = parser_sexpr_list_get(binding_form, 0);
+        if (_mv_1787.has_value) {
+            __auto_type first_expr = _mv_1787.value;
             {
                 __auto_type first_name = parser_sexpr_get_symbol_name(first_expr);
                 if (string_eq(first_name, SLOP_STR("mut"))) {
                     if (parser_sexpr_list_len(binding_form) >= 3) {
-                        __auto_type _mv_1782 = parser_sexpr_list_get(binding_form, 1);
-                        if (_mv_1782.has_value) {
-                            __auto_type name_expr = _mv_1782.value;
+                        __auto_type _mv_1788 = parser_sexpr_list_get(binding_form, 1);
+                        if (_mv_1788.has_value) {
+                            __auto_type name_expr = _mv_1788.value;
                             {
                                 __auto_type var_name = parser_sexpr_get_symbol_name(name_expr);
                                 if (!(string_eq(var_name, SLOP_STR("")))) {
                                     {
                                         __auto_type binding_len = parser_sexpr_list_len(binding_form);
-                                        __auto_type _mv_1783 = parser_sexpr_list_get(binding_form, (binding_len - 1));
-                                        if (_mv_1783.has_value) {
-                                            __auto_type val_expr = _mv_1783.value;
+                                        __auto_type _mv_1789 = parser_sexpr_list_get(binding_form, (binding_len - 1));
+                                        if (_mv_1789.has_value) {
+                                            __auto_type val_expr = _mv_1789.value;
                                             {
                                                 __auto_type val_type = infer_infer_expr(env, val_expr);
                                                 __auto_type val_type_name = (*val_type).name;
@@ -2750,12 +2971,12 @@ void infer_bind_let_binding(env_TypeEnv* env, types_SExpr* binding_form) {
                                                     env_env_bind_var(env, var_name, val_type);
                                                 }
                                             }
-                                        } else if (!_mv_1783.has_value) {
+                                        } else if (!_mv_1789.has_value) {
                                         }
                                     }
                                 }
                             }
-                        } else if (!_mv_1782.has_value) {
+                        } else if (!_mv_1788.has_value) {
                         }
                     }
                 } else {
@@ -2763,31 +2984,31 @@ void infer_bind_let_binding(env_TypeEnv* env, types_SExpr* binding_form) {
                         {
                             __auto_type binding_len = parser_sexpr_list_len(binding_form);
                             if (binding_len == 3) {
-                                __auto_type _mv_1784 = parser_sexpr_list_get(binding_form, 2);
-                                if (_mv_1784.has_value) {
-                                    __auto_type val_expr = _mv_1784.value;
+                                __auto_type _mv_1790 = parser_sexpr_list_get(binding_form, 2);
+                                if (_mv_1790.has_value) {
+                                    __auto_type val_expr = _mv_1790.value;
                                     {
                                         __auto_type val_type = infer_infer_expr(env, val_expr);
                                         env_env_bind_var(env, first_name, val_type);
                                     }
-                                } else if (!_mv_1784.has_value) {
+                                } else if (!_mv_1790.has_value) {
                                 }
                             } else {
-                                __auto_type _mv_1785 = parser_sexpr_list_get(binding_form, 1);
-                                if (_mv_1785.has_value) {
-                                    __auto_type val_expr = _mv_1785.value;
+                                __auto_type _mv_1791 = parser_sexpr_list_get(binding_form, 1);
+                                if (_mv_1791.has_value) {
+                                    __auto_type val_expr = _mv_1791.value;
                                     {
                                         __auto_type val_type = infer_infer_expr(env, val_expr);
                                         env_env_bind_var(env, first_name, val_type);
                                     }
-                                } else if (!_mv_1785.has_value) {
+                                } else if (!_mv_1791.has_value) {
                                 }
                             }
                         }
                     }
                 }
             }
-        } else if (!_mv_1781.has_value) {
+        } else if (!_mv_1787.has_value) {
         }
     }
 }
@@ -2797,23 +3018,23 @@ types_ResolvedType* infer_infer_let_expr(env_TypeEnv* env, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     env_env_push_scope(env);
     if (parser_sexpr_is_list(expr)) {
-        __auto_type _mv_1786 = parser_sexpr_list_get(expr, 1);
-        if (_mv_1786.has_value) {
-            __auto_type bindings_expr = _mv_1786.value;
+        __auto_type _mv_1792 = parser_sexpr_list_get(expr, 1);
+        if (_mv_1792.has_value) {
+            __auto_type bindings_expr = _mv_1792.value;
             if (parser_sexpr_is_list(bindings_expr)) {
                 {
                     __auto_type num_bindings = parser_sexpr_list_len(bindings_expr);
                     for (int64_t i = 0; i < num_bindings; i++) {
-                        __auto_type _mv_1787 = parser_sexpr_list_get(bindings_expr, i);
-                        if (_mv_1787.has_value) {
-                            __auto_type binding = _mv_1787.value;
+                        __auto_type _mv_1793 = parser_sexpr_list_get(bindings_expr, i);
+                        if (_mv_1793.has_value) {
+                            __auto_type binding = _mv_1793.value;
                             infer_bind_let_binding(env, binding);
-                        } else if (!_mv_1787.has_value) {
+                        } else if (!_mv_1793.has_value) {
                         }
                     }
                 }
             }
-        } else if (!_mv_1786.has_value) {
+        } else if (!_mv_1792.has_value) {
         }
     }
     {
@@ -2841,14 +3062,14 @@ types_ResolvedType* infer_infer_with_arena_expr(env_TypeEnv* env, types_SExpr* e
                     env_env_add_error(env, SLOP_STR("with-arena :as requires name and size"), parser_sexpr_line(expr), parser_sexpr_col(expr));
                     return env_env_get_unit_type(env);
                 } else {
-                    __auto_type _mv_1788 = parser_sexpr_list_get(expr, size_idx);
-                    if (_mv_1788.has_value) {
-                        __auto_type size_expr = _mv_1788.value;
-                        __auto_type _mv_1789 = (*size_expr);
-                        switch (_mv_1789.tag) {
+                    __auto_type _mv_1794 = parser_sexpr_list_get(expr, size_idx);
+                    if (_mv_1794.has_value) {
+                        __auto_type size_expr = _mv_1794.value;
+                        __auto_type _mv_1795 = (*size_expr);
+                        switch (_mv_1795.tag) {
                             case types_SExpr_num:
                             {
-                                __auto_type num = _mv_1789.data.num;
+                                __auto_type num = _mv_1795.data.num;
                                 if (num.int_value <= 0) {
                                     env_env_add_error(env, SLOP_STR("with-arena size must be positive"), num.line, num.col);
                                 } else {
@@ -2859,18 +3080,18 @@ types_ResolvedType* infer_infer_with_arena_expr(env_TypeEnv* env, types_SExpr* e
                                 break;
                             }
                         }
-                    } else if (!_mv_1788.has_value) {
+                    } else if (!_mv_1794.has_value) {
                     }
                     env_env_push_scope(env);
                     env_env_bind_var(env, arena_name, env_env_get_arena_type(env));
                     {
                         types_ResolvedType* result_type = env_env_get_unit_type(env);
                         for (int64_t i = body_start; i < len; i++) {
-                            __auto_type _mv_1790 = parser_sexpr_list_get(expr, i);
-                            if (_mv_1790.has_value) {
-                                __auto_type body_expr = _mv_1790.value;
+                            __auto_type _mv_1796 = parser_sexpr_list_get(expr, i);
+                            if (_mv_1796.has_value) {
+                                __auto_type body_expr = _mv_1796.value;
                                 result_type = infer_infer_expr(env, body_expr);
-                            } else if (!_mv_1790.has_value) {
+                            } else if (!_mv_1796.has_value) {
                             }
                         }
                         env_env_pop_scope(env);
@@ -2890,9 +3111,9 @@ slop_string infer_get_fn_name(types_SExpr* fn_form) {
         if (parser_sexpr_list_len(fn_form) < 2) {
             return SLOP_STR("unknown");
         } else {
-            __auto_type _mv_1791 = parser_sexpr_list_get(fn_form, 1);
-            if (_mv_1791.has_value) {
-                __auto_type name_expr = _mv_1791.value;
+            __auto_type _mv_1797 = parser_sexpr_list_get(fn_form, 1);
+            if (_mv_1797.has_value) {
+                __auto_type name_expr = _mv_1797.value;
                 {
                     __auto_type name = parser_sexpr_get_symbol_name(name_expr);
                     if (string_eq(name, SLOP_STR(""))) {
@@ -2901,9 +3122,10 @@ slop_string infer_get_fn_name(types_SExpr* fn_form) {
                         return name;
                     }
                 }
-            } else if (!_mv_1791.has_value) {
+            } else if (!_mv_1797.has_value) {
                 return SLOP_STR("unknown");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -2913,19 +3135,19 @@ types_ResolvedType* infer_resolve_hole_type(env_TypeEnv* env, slop_list_types_SE
     if (len < 2) {
         return env_env_get_unit_type(env);
     } else {
-        __auto_type _mv_1792 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1792.has_value) {
-            __auto_type type_expr = _mv_1792.value;
+        __auto_type _mv_1798 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1798.has_value) {
+            __auto_type type_expr = _mv_1798.value;
             {
                 __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                 if (string_eq(type_name, SLOP_STR(""))) {
                     return env_env_get_unit_type(env);
                 } else {
-                    __auto_type _mv_1793 = env_env_lookup_type(env, type_name);
-                    if (_mv_1793.has_value) {
-                        __auto_type t = _mv_1793.value;
+                    __auto_type _mv_1799 = env_env_lookup_type(env, type_name);
+                    if (_mv_1799.has_value) {
+                        __auto_type t = _mv_1799.value;
                         return t;
-                    } else if (!_mv_1793.has_value) {
+                    } else if (!_mv_1799.has_value) {
                         if (string_eq(type_name, SLOP_STR("Int"))) {
                             return env_env_get_int_type(env);
                         } else if (string_eq(type_name, SLOP_STR("Bool"))) {
@@ -2938,11 +3160,13 @@ types_ResolvedType* infer_resolve_hole_type(env_TypeEnv* env, slop_list_types_SE
                             return env_env_get_unit_type(env);
                         }
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
-        } else if (!_mv_1792.has_value) {
+        } else if (!_mv_1798.has_value) {
             return env_env_get_unit_type(env);
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2950,23 +3174,24 @@ slop_string infer_get_hole_prompt(slop_list_types_SExpr_ptr items, int64_t len) 
     if (len < 3) {
         return SLOP_STR("(no description)");
     } else {
-        __auto_type _mv_1794 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1794.has_value) {
-            __auto_type prompt_expr = _mv_1794.value;
-            __auto_type _mv_1795 = (*prompt_expr);
-            switch (_mv_1795.tag) {
+        __auto_type _mv_1800 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1800.has_value) {
+            __auto_type prompt_expr = _mv_1800.value;
+            __auto_type _mv_1801 = (*prompt_expr);
+            switch (_mv_1801.tag) {
                 case types_SExpr_str:
                 {
-                    __auto_type str = _mv_1795.data.str;
+                    __auto_type str = _mv_1801.data.str;
                     return str.value;
                 }
                 default: {
                     return SLOP_STR("(no description)");
                 }
             }
-        } else if (!_mv_1794.has_value) {
+        } else if (!_mv_1800.has_value) {
             return SLOP_STR("(no description)");
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2982,37 +3207,38 @@ int64_t infer_find_last_body_idx(slop_list_types_SExpr_ptr items) {
 }
 
 uint8_t infer_is_c_name_related(slop_list_types_SExpr_ptr items, int64_t idx) {
-    __auto_type _mv_1796 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-    if (_mv_1796.has_value) {
-        __auto_type item = _mv_1796.value;
-        __auto_type _mv_1797 = (*item);
-        switch (_mv_1797.tag) {
+    __auto_type _mv_1802 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+    if (_mv_1802.has_value) {
+        __auto_type item = _mv_1802.value;
+        __auto_type _mv_1803 = (*item);
+        switch (_mv_1803.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1797.data.sym;
+                __auto_type sym = _mv_1803.data.sym;
                 return string_eq(sym.name, SLOP_STR(":c-name"));
             }
             case types_SExpr_str:
             {
-                __auto_type _ = _mv_1797.data.str;
+                __auto_type _ = _mv_1803.data.str;
                 if (idx > 0) {
-                    __auto_type _mv_1798 = ({ __auto_type _lst = items; size_t _idx = (size_t)(idx - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1798.has_value) {
-                        __auto_type prev = _mv_1798.value;
-                        __auto_type _mv_1799 = (*prev);
-                        switch (_mv_1799.tag) {
+                    __auto_type _mv_1804 = ({ __auto_type _lst = items; size_t _idx = (size_t)(idx - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1804.has_value) {
+                        __auto_type prev = _mv_1804.value;
+                        __auto_type _mv_1805 = (*prev);
+                        switch (_mv_1805.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1799.data.sym;
+                                __auto_type sym = _mv_1805.data.sym;
                                 return string_eq(sym.name, SLOP_STR(":c-name"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1798.has_value) {
+                    } else if (!_mv_1804.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 } else {
                     return 0;
                 }
@@ -3021,31 +3247,33 @@ uint8_t infer_is_c_name_related(slop_list_types_SExpr_ptr items, int64_t idx) {
                 return 0;
             }
         }
-    } else if (!_mv_1796.has_value) {
+    } else if (!_mv_1802.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t infer_is_annotation_expr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     if (parser_sexpr_is_list(expr)) {
-        __auto_type _mv_1800 = parser_sexpr_list_get(expr, 0);
-        if (_mv_1800.has_value) {
-            __auto_type head = _mv_1800.value;
-            __auto_type _mv_1801 = (*head);
-            switch (_mv_1801.tag) {
+        __auto_type _mv_1806 = parser_sexpr_list_get(expr, 0);
+        if (_mv_1806.has_value) {
+            __auto_type head = _mv_1806.value;
+            __auto_type _mv_1807 = (*head);
+            switch (_mv_1807.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_1801.data.sym;
+                    __auto_type sym = _mv_1807.data.sym;
                     return strlib_starts_with(sym.name, SLOP_STR("@"));
                 }
                 default: {
                     return 0;
                 }
             }
-        } else if (!_mv_1800.has_value) {
+        } else if (!_mv_1806.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     } else {
         return 0;
     }
@@ -3053,14 +3281,14 @@ uint8_t infer_is_annotation_expr(types_SExpr* expr) {
 
 uint8_t infer_is_checkable_annotation(types_SExpr* expr) {
     if (parser_sexpr_is_list(expr)) {
-        __auto_type _mv_1802 = parser_sexpr_list_get(expr, 0);
-        if (_mv_1802.has_value) {
-            __auto_type head = _mv_1802.value;
-            __auto_type _mv_1803 = (*head);
-            switch (_mv_1803.tag) {
+        __auto_type _mv_1808 = parser_sexpr_list_get(expr, 0);
+        if (_mv_1808.has_value) {
+            __auto_type head = _mv_1808.value;
+            __auto_type _mv_1809 = (*head);
+            switch (_mv_1809.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_1803.data.sym;
+                    __auto_type sym = _mv_1809.data.sym;
                     {
                         __auto_type name = sym.name;
                         return ((string_eq(name, SLOP_STR("@pre"))) || (string_eq(name, SLOP_STR("@post"))) || (string_eq(name, SLOP_STR("@assume"))) || (string_eq(name, SLOP_STR("@assert"))));
@@ -3070,9 +3298,10 @@ uint8_t infer_is_checkable_annotation(types_SExpr* expr) {
                     return 0;
                 }
             }
-        } else if (!_mv_1802.has_value) {
+        } else if (!_mv_1808.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     } else {
         return 0;
     }
@@ -3093,23 +3322,23 @@ types_ResolvedType* infer_infer_fn_body(env_TypeEnv* env, types_SExpr* fn_form) 
             {
                 __auto_type params_len = parser_sexpr_list_len(fn_form);
                 if (params_len > 2) {
-                    __auto_type _mv_1804 = parser_sexpr_list_get(fn_form, 2);
-                    if (_mv_1804.has_value) {
-                        __auto_type params_expr = _mv_1804.value;
+                    __auto_type _mv_1810 = parser_sexpr_list_get(fn_form, 2);
+                    if (_mv_1810.has_value) {
+                        __auto_type params_expr = _mv_1810.value;
                         if (parser_sexpr_is_list(params_expr)) {
                             {
                                 __auto_type num_params = parser_sexpr_list_len(params_expr);
                                 for (int64_t k = 0; k < num_params; k++) {
-                                    __auto_type _mv_1805 = parser_sexpr_list_get(params_expr, k);
-                                    if (_mv_1805.has_value) {
-                                        __auto_type param_form = _mv_1805.value;
+                                    __auto_type _mv_1811 = parser_sexpr_list_get(params_expr, k);
+                                    if (_mv_1811.has_value) {
+                                        __auto_type param_form = _mv_1811.value;
                                         infer_bind_param_from_form(env, param_form);
-                                    } else if (!_mv_1805.has_value) {
+                                    } else if (!_mv_1811.has_value) {
                                     }
                                 }
                             }
                         }
-                    } else if (!_mv_1804.has_value) {
+                    } else if (!_mv_1810.has_value) {
                     }
                 }
             }
@@ -3131,34 +3360,34 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
         {
             __auto_type num_patterns = ((int64_t)((patterns).len));
             for (int64_t i = 0; i < num_patterns; i++) {
-                __auto_type _mv_1806 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1806.has_value) {
-                    __auto_type pattern_case = _mv_1806.value;
-                    __auto_type _mv_1807 = (*pattern_case);
-                    switch (_mv_1807.tag) {
+                __auto_type _mv_1812 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1812.has_value) {
+                    __auto_type pattern_case = _mv_1812.value;
+                    __auto_type _mv_1813 = (*pattern_case);
+                    switch (_mv_1813.tag) {
                         case types_SExpr_lst:
                         {
-                            __auto_type pattern_list = _mv_1807.data.lst;
+                            __auto_type pattern_list = _mv_1813.data.lst;
                             if (((int64_t)((pattern_list.items).len)) > 0) {
-                                __auto_type _mv_1808 = ({ __auto_type _lst = pattern_list.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1808.has_value) {
-                                    __auto_type pattern_expr = _mv_1808.value;
-                                    __auto_type _mv_1809 = (*pattern_expr);
-                                    switch (_mv_1809.tag) {
+                                __auto_type _mv_1814 = ({ __auto_type _lst = pattern_list.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1814.has_value) {
+                                    __auto_type pattern_expr = _mv_1814.value;
+                                    __auto_type _mv_1815 = (*pattern_expr);
+                                    switch (_mv_1815.tag) {
                                         case types_SExpr_lst:
                                         {
-                                            __auto_type variant_list = _mv_1809.data.lst;
+                                            __auto_type variant_list = _mv_1815.data.lst;
                                             {
                                                 __auto_type variant_items = variant_list.items;
                                                 if (((int64_t)((variant_items).len)) > 0) {
-                                                    __auto_type _mv_1810 = ({ __auto_type _lst = variant_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1810.has_value) {
-                                                        __auto_type variant_name_expr = _mv_1810.value;
-                                                        __auto_type _mv_1811 = (*variant_name_expr);
-                                                        switch (_mv_1811.tag) {
+                                                    __auto_type _mv_1816 = ({ __auto_type _lst = variant_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1816.has_value) {
+                                                        __auto_type variant_name_expr = _mv_1816.value;
+                                                        __auto_type _mv_1817 = (*variant_name_expr);
+                                                        switch (_mv_1817.tag) {
                                                             case types_SExpr_sym:
                                                             {
-                                                                __auto_type variant_sym = _mv_1811.data.sym;
+                                                                __auto_type variant_sym = _mv_1817.data.sym;
                                                                 {
                                                                     __auto_type variant_name = variant_sym.name;
                                                                     {
@@ -3168,24 +3397,24 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                                                                             {
                                                                                 __auto_type num_vt = ((int64_t)((variant_items).len));
                                                                                 for (int64_t vi = 1; vi < num_vt; vi++) {
-                                                                                    __auto_type _mv_1812 = ({ __auto_type _lst = variant_items; size_t _idx = (size_t)vi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                                    if (_mv_1812.has_value) {
-                                                                                        __auto_type binding_expr = _mv_1812.value;
-                                                                                        __auto_type _mv_1813 = (*binding_expr);
-                                                                                        switch (_mv_1813.tag) {
+                                                                                    __auto_type _mv_1818 = ({ __auto_type _lst = variant_items; size_t _idx = (size_t)vi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                                    if (_mv_1818.has_value) {
+                                                                                        __auto_type binding_expr = _mv_1818.value;
+                                                                                        __auto_type _mv_1819 = (*binding_expr);
+                                                                                        switch (_mv_1819.tag) {
                                                                                             case types_SExpr_sym:
                                                                                             {
-                                                                                                __auto_type binding_sym = _mv_1813.data.sym;
+                                                                                                __auto_type binding_sym = _mv_1819.data.sym;
                                                                                                 {
                                                                                                     __auto_type bname = binding_sym.name;
                                                                                                     __auto_type type_idx = (vi - 1);
                                                                                                     if (!(string_eq(bname, SLOP_STR("_"))) && !(string_eq(bname, SLOP_STR("")))) {
                                                                                                         if (type_idx < num_pt) {
-                                                                                                            __auto_type _mv_1814 = ({ __auto_type _lst = payload_types; size_t _idx = (size_t)type_idx; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                                                            if (_mv_1814.has_value) {
-                                                                                                                __auto_type pt = _mv_1814.value;
+                                                                                                            __auto_type _mv_1820 = ({ __auto_type _lst = payload_types; size_t _idx = (size_t)type_idx; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                                                            if (_mv_1820.has_value) {
+                                                                                                                __auto_type pt = _mv_1820.value;
                                                                                                                 env_env_bind_var(env, bname, pt);
-                                                                                                            } else if (!_mv_1814.has_value) {
+                                                                                                            } else if (!_mv_1820.has_value) {
                                                                                                                 env_env_bind_var(env, bname, env_env_get_generic_type(env));
                                                                                                             }
                                                                                                         } else {
@@ -3199,15 +3428,15 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                                                                                                 break;
                                                                                             }
                                                                                         }
-                                                                                    } else if (!_mv_1812.has_value) {
+                                                                                    } else if (!_mv_1818.has_value) {
                                                                                     }
                                                                                 }
                                                                             }
                                                                         } else {
-                                                                            __auto_type _mv_1815 = types_resolved_type_get_variant_index(scrutinee_type, variant_name);
-                                                                            if (_mv_1815.has_value) {
-                                                                                __auto_type _ = _mv_1815.value;
-                                                                            } else if (!_mv_1815.has_value) {
+                                                                            __auto_type _mv_1821 = types_resolved_type_get_variant_index(scrutinee_type, variant_name);
+                                                                            if (_mv_1821.has_value) {
+                                                                                __auto_type _ = _mv_1821.value;
+                                                                            } else if (!_mv_1821.has_value) {
                                                                             }
                                                                         }
                                                                     }
@@ -3218,7 +3447,7 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                                                                 break;
                                                             }
                                                         }
-                                                    } else if (!_mv_1810.has_value) {
+                                                    } else if (!_mv_1816.has_value) {
                                                     }
                                                 }
                                             }
@@ -3228,7 +3457,7 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1808.has_value) {
+                                } else if (!_mv_1814.has_value) {
                                 }
                             }
                             break;
@@ -3237,7 +3466,7 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                             break;
                         }
                     }
-                } else if (!_mv_1806.has_value) {
+                } else if (!_mv_1812.has_value) {
                 }
             }
         }

--- a/bootstrap/compiler/slop_infer.h
+++ b/bootstrap/compiler/slop_infer.h
@@ -65,6 +65,11 @@ types_ResolvedType* infer_infer_field_access(env_TypeEnv* env, types_SExpr* expr
 types_ResolvedType* infer_check_field_exists(env_TypeEnv* env, types_ResolvedType* obj_type, slop_string field_name, int64_t line, int64_t col);
 types_ResolvedType* infer_infer_cond_expr(env_TypeEnv* env, types_SExpr* expr, types_SExprList lst);
 void infer_bind_match_pattern(env_TypeEnv* env, types_ResolvedType* scrutinee_type, types_SExpr* pattern);
+slop_string infer_match_pattern_head(types_SExpr* pattern);
+uint8_t infer_is_wildcard_head(slop_string head);
+uint8_t infer_string_list_contains(slop_list_string names, slop_string name);
+slop_list_string infer_match_expected_variants(slop_arena* arena, types_ResolvedType* scrutinee_type);
+void infer_check_match_exhaustive(env_TypeEnv* env, types_ResolvedType* scrutinee_type, slop_list_string covered, uint8_t has_wildcard, int64_t line, int64_t col);
 types_ResolvedType* infer_infer_match_expr(env_TypeEnv* env, types_SExpr* expr, types_SExprList lst);
 void infer_check_return_type(env_TypeEnv* env, types_SExpr* fn_form, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col);
 void infer_check_spec_return_type(env_TypeEnv* env, types_SExpr* spec_form, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col);

--- a/bootstrap/compiler/slop_match.c
+++ b/bootstrap/compiler/slop_match.c
@@ -24,6 +24,7 @@ void match_emit_literal_case(context_TranspileContext* ctx, slop_string scrutine
 void match_transpile_union_match(context_TranspileContext* ctx, slop_string scrutinee_c, slop_list_types_SExpr_ptr patterns, slop_list_types_SExpr_ptr items, uint8_t is_return);
 void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_c, types_SExpr* pattern, slop_string tag, slop_string union_type_name, slop_list_types_SExpr_ptr branch_items, uint8_t is_return);
 void match_transpile_generic_match(context_TranspileContext* ctx, slop_string scrutinee_c, slop_list_types_SExpr_ptr items, uint8_t is_return);
+void match_emit_match_fallthrough_trap(context_TranspileContext* ctx, uint8_t is_return, uint8_t has_else);
 void match_emit_else_branch(context_TranspileContext* ctx, slop_list_types_SExpr_ptr branch_items, uint8_t is_return, uint8_t first);
 void match_emit_branch_body(context_TranspileContext* ctx, slop_list_types_SExpr_ptr branch_items, uint8_t is_return);
 void match_emit_branch_body_item(context_TranspileContext* ctx, types_SExpr* body_expr, uint8_t is_return, uint8_t is_last);
@@ -242,6 +243,7 @@ slop_string match_get_pattern_tag(types_SExpr* pat_expr) {
                     } else if (!_mv_655.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -285,6 +287,7 @@ slop_option_string match_extract_binding_name(types_SExpr* pat_expr) {
                     } else if (!_mv_658.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -431,6 +434,7 @@ void match_transpile_option_match(context_TranspileContext* ctx, slop_string scr
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 2;
         uint8_t first = 1;
+        uint8_t has_else = 0;
         while (i < len) {
             __auto_type _mv_666 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_666.has_value) {
@@ -456,6 +460,7 @@ void match_transpile_option_match(context_TranspileContext* ctx, slop_string scr
                                             first = 0;
                                         } else if (string_eq(tag, SLOP_STR("else"))) {
                                             match_emit_else_branch(ctx, branch_items, is_return, first);
+                                            has_else = 1;
                                             first = 0;
                                         } else {
                                         }
@@ -477,6 +482,7 @@ void match_transpile_option_match(context_TranspileContext* ctx, slop_string scr
         if (!(first)) {
             context_ctx_emit(ctx, SLOP_STR("}"));
         }
+        match_emit_match_fallthrough_trap(ctx, is_return, has_else);
     }
 }
 
@@ -531,6 +537,7 @@ void match_transpile_result_match(context_TranspileContext* ctx, slop_string scr
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 2;
         uint8_t first = 1;
+        uint8_t has_else = 0;
         while (i < len) {
             __auto_type _mv_670 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_670.has_value) {
@@ -556,6 +563,7 @@ void match_transpile_result_match(context_TranspileContext* ctx, slop_string scr
                                             first = 0;
                                         } else if (string_eq(tag, SLOP_STR("else"))) {
                                             match_emit_else_branch(ctx, branch_items, is_return, first);
+                                            has_else = 1;
                                             first = 0;
                                         } else {
                                         }
@@ -577,6 +585,7 @@ void match_transpile_result_match(context_TranspileContext* ctx, slop_string scr
         if (!(first)) {
             context_ctx_emit(ctx, SLOP_STR("}"));
         }
+        match_emit_match_fallthrough_trap(ctx, is_return, has_else);
     }
 }
 
@@ -650,6 +659,7 @@ void match_transpile_enum_match(context_TranspileContext* ctx, slop_string scrut
         __auto_type arena = (*ctx).arena;
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 2;
+        uint8_t has_else = 0;
         context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("switch ("), scrutinee_c, SLOP_STR(") {")));
         context_ctx_indent(ctx);
         while (i < len) {
@@ -667,6 +677,12 @@ void match_transpile_enum_match(context_TranspileContext* ctx, slop_string scrut
                                 __auto_type _mv_677 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_677.has_value) {
                                     __auto_type pattern = _mv_677.value;
+                                    {
+                                        __auto_type tag = match_get_pattern_tag(pattern);
+                                        if (string_eq(tag, SLOP_STR("else")) || string_eq(tag, SLOP_STR("_"))) {
+                                            has_else = 1;
+                                        }
+                                    }
                                     match_emit_enum_case(ctx, pattern, branch_items, is_return);
                                 } else if (!_mv_677.has_value) {
                                 }
@@ -684,6 +700,7 @@ void match_transpile_enum_match(context_TranspileContext* ctx, slop_string scrut
         }
         context_ctx_dedent(ctx);
         context_ctx_emit(ctx, SLOP_STR("}"));
+        match_emit_match_fallthrough_trap(ctx, is_return, has_else);
     }
 }
 
@@ -728,6 +745,7 @@ void match_transpile_literal_match(context_TranspileContext* ctx, slop_string sc
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 2;
         uint8_t first = 1;
+        uint8_t has_else = 0;
         while (i < len) {
             __auto_type _mv_679 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_679.has_value) {
@@ -743,6 +761,9 @@ void match_transpile_literal_match(context_TranspileContext* ctx, slop_string sc
                                 __auto_type _mv_681 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_681.has_value) {
                                     __auto_type pattern = _mv_681.value;
+                                    if (string_eq(match_get_pattern_tag(pattern), SLOP_STR("else"))) {
+                                        has_else = 1;
+                                    }
                                     match_emit_literal_case(ctx, scrutinee_c, pattern, branch_items, is_return, first);
                                     first = 0;
                                 } else if (!_mv_681.has_value) {
@@ -762,6 +783,7 @@ void match_transpile_literal_match(context_TranspileContext* ctx, slop_string sc
         if (!(first)) {
             context_ctx_emit(ctx, SLOP_STR("}"));
         }
+        match_emit_match_fallthrough_trap(ctx, is_return, has_else);
     }
 }
 
@@ -806,6 +828,7 @@ void match_transpile_union_match(context_TranspileContext* ctx, slop_string scru
             __auto_type len = ((int64_t)((items).len));
             int64_t i = 2;
             uint8_t first = 1;
+            uint8_t has_else = 0;
             context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("switch ("), scrutinee_c, SLOP_STR(".tag) {")));
             context_ctx_indent(ctx);
             while (i < len) {
@@ -826,6 +849,7 @@ void match_transpile_union_match(context_TranspileContext* ctx, slop_string scru
                                         {
                                             __auto_type tag = match_get_pattern_tag(pattern);
                                             if (string_eq(tag, SLOP_STR("else")) || string_eq(tag, SLOP_STR("_"))) {
+                                                has_else = 1;
                                                 context_ctx_emit(ctx, SLOP_STR("default: {"));
                                                 context_ctx_indent(ctx);
                                                 match_emit_branch_body(ctx, branch_items, is_return);
@@ -860,6 +884,7 @@ void match_transpile_union_match(context_TranspileContext* ctx, slop_string scru
             }
             context_ctx_dedent(ctx);
             context_ctx_emit(ctx, SLOP_STR("}"));
+            match_emit_match_fallthrough_trap(ctx, is_return, has_else);
         }
     }
 }
@@ -945,6 +970,13 @@ void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_
 void match_transpile_generic_match(context_TranspileContext* ctx, slop_string scrutinee_c, slop_list_types_SExpr_ptr items, uint8_t is_return) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     match_transpile_literal_match(ctx, scrutinee_c, items, is_return);
+}
+
+void match_emit_match_fallthrough_trap(context_TranspileContext* ctx, uint8_t is_return, uint8_t has_else) {
+    SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
+    if (is_return && !(has_else)) {
+        context_ctx_emit(ctx, SLOP_STR("SLOP_UNREACHABLE();"));
+    }
 }
 
 void match_emit_else_branch(context_TranspileContext* ctx, slop_list_types_SExpr_ptr branch_items, uint8_t is_return, uint8_t first) {
@@ -1299,6 +1331,7 @@ uint8_t match_binding_starts_with_mut(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_706.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -1364,6 +1397,7 @@ uint8_t match_is_none_form_inline(types_SExpr* expr) {
                     } else if (!_mv_710.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 } else {
                     return 0;
                 }
@@ -1409,6 +1443,7 @@ slop_option_string match_get_arena_alloc_ptr_type_inline(context_TranspileContex
                                         } else if (!_mv_715.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else {
                                         return (slop_option_string){.has_value = false};
                                     }
@@ -1420,6 +1455,7 @@ slop_option_string match_get_arena_alloc_ptr_type_inline(context_TranspileContex
                         } else if (!_mv_713.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     } else {
                         return (slop_option_string){.has_value = false};
                     }
@@ -1451,6 +1487,7 @@ slop_option_string match_extract_sizeof_type_inline(context_TranspileContext* ct
                     } else if (!_mv_717.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             case types_SExpr_lst:
@@ -1478,6 +1515,7 @@ slop_option_string match_extract_sizeof_type_inline(context_TranspileContext* ct
                                         } else if (!_mv_720.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else {
                                         return (slop_option_string){.has_value = false};
                                     }
@@ -1489,6 +1527,7 @@ slop_option_string match_extract_sizeof_type_inline(context_TranspileContext* ct
                         } else if (!_mv_718.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     } else {
                         return (slop_option_string){.has_value = false};
                     }
@@ -1607,6 +1646,7 @@ slop_option_string match_get_var_c_type_inline(context_TranspileContext* ctx, ty
                 } else if (!_mv_727.has_value) {
                     return (slop_option_string){.has_value = false};
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -1881,6 +1921,7 @@ uint8_t match_is_deref_inline(types_SExpr* expr) {
                     } else if (!_mv_747.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1906,6 +1947,7 @@ slop_string match_get_deref_inner_inline(context_TranspileContext* ctx, types_SE
                 } else if (!_mv_750.has_value) {
                     return SLOP_STR("/* missing deref arg */");
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -1966,6 +2008,7 @@ void match_emit_inline_cond(context_TranspileContext* ctx, slop_list_types_SExpr
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 1;
         uint8_t first = 1;
+        uint8_t has_else = 0;
         while (i < len) {
             __auto_type _mv_753 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_753.has_value) {
@@ -1990,6 +2033,7 @@ void match_emit_inline_cond(context_TranspileContext* ctx, slop_list_types_SExpr
                                         {
                                             __auto_type sym = _mv_756.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("else"))) {
+                                                has_else = 1;
                                                 context_ctx_emit(ctx, SLOP_STR("} else {"));
                                                 context_ctx_indent(ctx);
                                                 match_emit_inline_cond_body(ctx, clause_items, 1, is_return, is_last);
@@ -2045,6 +2089,7 @@ void match_emit_inline_cond(context_TranspileContext* ctx, slop_list_types_SExpr
         if (!(first)) {
             context_ctx_emit(ctx, SLOP_STR("}"));
         }
+        match_emit_match_fallthrough_trap(ctx, is_return, has_else);
     }
 }
 
@@ -2848,6 +2893,7 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 2;
         uint8_t first = 1;
+        uint8_t has_else = 0;
         while (i < len) {
             __auto_type _mv_796 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_796.has_value) {
@@ -2866,6 +2912,7 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
                                     {
                                         __auto_type tag = match_get_pattern_tag(pattern);
                                         if (string_eq(tag, SLOP_STR("else")) || string_eq(tag, SLOP_STR("_"))) {
+                                            has_else = 1;
                                             if (first) {
                                                 context_ctx_emit(ctx, SLOP_STR("{"));
                                             } else {
@@ -2921,6 +2968,7 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
         if (!(first)) {
             context_ctx_emit(ctx, SLOP_STR("}"));
         }
+        match_emit_match_fallthrough_trap(ctx, is_return, has_else);
     }
 }
 

--- a/bootstrap/compiler/slop_match.h
+++ b/bootstrap/compiler/slop_match.h
@@ -44,6 +44,7 @@ void match_emit_literal_case(context_TranspileContext* ctx, slop_string scrutine
 void match_transpile_union_match(context_TranspileContext* ctx, slop_string scrutinee_c, slop_list_types_SExpr_ptr patterns, slop_list_types_SExpr_ptr items, uint8_t is_return);
 void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_c, types_SExpr* pattern, slop_string tag, slop_string union_type_name, slop_list_types_SExpr_ptr branch_items, uint8_t is_return);
 void match_transpile_generic_match(context_TranspileContext* ctx, slop_string scrutinee_c, slop_list_types_SExpr_ptr items, uint8_t is_return);
+void match_emit_match_fallthrough_trap(context_TranspileContext* ctx, uint8_t is_return, uint8_t has_else);
 void match_emit_else_branch(context_TranspileContext* ctx, slop_list_types_SExpr_ptr branch_items, uint8_t is_return, uint8_t first);
 void match_emit_branch_body(context_TranspileContext* ctx, slop_list_types_SExpr_ptr branch_items, uint8_t is_return);
 void match_emit_branch_body_item(context_TranspileContext* ctx, types_SExpr* body_expr, uint8_t is_return, uint8_t is_last);

--- a/bootstrap/compiler/slop_parser.c
+++ b/bootstrap/compiler/slop_parser.c
@@ -383,6 +383,7 @@ parser_Token parser_parser_peek(parser_ParserState* state) {
     } else if (!_mv_611.has_value) {
         return (parser_Token){parser_TokenType_tok_eof, SLOP_STR(""), 1, 1};
     }
+    SLOP_UNREACHABLE();
 }
 
 void parser_parser_advance(parser_ParserState* state) {
@@ -447,6 +448,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_expr(slop_arena* aren
                 __auto_type e = _mv_612.data.err;
                 return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
             }
+            SLOP_UNREACHABLE();
         } else if (tok.kind == parser_TokenType_tok_symbol) {
             parser_parser_advance(state);
             {
@@ -592,7 +594,9 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_paren_group(slo
             __auto_type _ = _mv_615.data.ok;
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = expr });
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_arena* arena, parser_ParserState* state) {
@@ -629,6 +633,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                         return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = node });
                     }
                 }
+                SLOP_UNREACHABLE();
             } else {
                 parser_parser_advance(state);
                 {
@@ -659,6 +664,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                     return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = node });
                 }
             }
+            SLOP_UNREACHABLE();
         } else if (tok.kind == parser_TokenType_tok_operator) {
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = (parser_ParseError){SLOP_STR("Unexpected operator in expression"), tok.line, tok.col} });
         } else if (tok.kind == parser_TokenType_tok_lparen) {
@@ -683,6 +689,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                         }
                     }
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (tok.kind == parser_TokenType_tok_quote) {
             parser_parser_advance(state);
@@ -703,6 +710,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                     return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = node });
                 }
             }
+            SLOP_UNREACHABLE();
         } else {
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = (parser_ParseError){SLOP_STR("Expected expression in infix"), tok.line, tok.col} });
         }
@@ -767,6 +775,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_prec(slop_arena
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix(slop_arena* arena, parser_ParserState* state) {
@@ -794,6 +803,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix(slop_arena* are
                     }
                 }
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -836,6 +846,7 @@ slop_result_list_types_SExpr_ptr_parser_ParseError parser_parse(slop_arena* aren
         __auto_type e = _mv_623.data.err;
         return ((slop_result_list_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
     }
+    SLOP_UNREACHABLE();
 }
 
 int64_t parser_sexpr_line(types_SExpr* expr) {
@@ -862,6 +873,7 @@ int64_t parser_sexpr_line(types_SExpr* expr) {
             return l.line;
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 int64_t parser_sexpr_col(types_SExpr* expr) {
@@ -888,6 +900,7 @@ int64_t parser_sexpr_col(types_SExpr* expr) {
             return l.col;
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t parser_sexpr_is_symbol_with_name(types_SExpr* expr, slop_string name) {
@@ -920,6 +933,7 @@ uint8_t parser_is_form(types_SExpr* expr, slop_string keyword) {
                 } else if (!_mv_629.has_value) {
                     return 0;
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -1197,6 +1211,7 @@ slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string parser_json_escape_string(slop_arena* arena, slop_string s) {
@@ -1324,5 +1339,6 @@ slop_string parser_json_print(slop_arena* arena, types_SExpr* expr) {
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 

--- a/bootstrap/compiler/slop_path.c
+++ b/bootstrap/compiler/slop_path.c
@@ -23,6 +23,7 @@ slop_string path_path_dirname(slop_arena* arena, slop_string path) {
             } else if (!_mv_1251.has_value) {
                 return SLOP_STR(".");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -65,6 +66,7 @@ slop_string path_path_basename(slop_arena* arena, slop_string path) {
             } else if (!_mv_1252.has_value) {
                 return path;
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -89,6 +91,7 @@ slop_string path_path_extension(slop_arena* arena, slop_string path) {
             } else if (!_mv_1253.has_value) {
                 return SLOP_STR("");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }

--- a/bootstrap/compiler/slop_resolve.c
+++ b/bootstrap/compiler/slop_resolve.c
@@ -12,16 +12,16 @@ void resolve_resolve_imports(env_TypeEnv* env, slop_list_types_SExpr_ptr ast) {
     {
         __auto_type len = ((int64_t)((ast).len));
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_1816 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1816.has_value) {
-                __auto_type expr = _mv_1816.value;
+            __auto_type _mv_1822 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1822.has_value) {
+                __auto_type expr = _mv_1822.value;
                 if (parser_is_form(expr, SLOP_STR("import"))) {
                     resolve_resolve_import_stmt(env, expr);
                 } else if (parser_is_form(expr, SLOP_STR("module"))) {
                     resolve_resolve_module_imports(env, expr);
                 } else {
                 }
-            } else if (!_mv_1816.has_value) {
+            } else if (!_mv_1822.has_value) {
             }
         }
     }
@@ -34,13 +34,13 @@ void resolve_resolve_module_imports(env_TypeEnv* env, types_SExpr* module_form) 
         {
             __auto_type len = parser_sexpr_list_len(module_form);
             for (int64_t i = 2; i < len; i++) {
-                __auto_type _mv_1817 = parser_sexpr_list_get(module_form, i);
-                if (_mv_1817.has_value) {
-                    __auto_type item = _mv_1817.value;
+                __auto_type _mv_1823 = parser_sexpr_list_get(module_form, i);
+                if (_mv_1823.has_value) {
+                    __auto_type item = _mv_1823.value;
                     if (parser_is_form(item, SLOP_STR("import"))) {
                         resolve_resolve_import_stmt(env, item);
                     }
-                } else if (!_mv_1817.has_value) {
+                } else if (!_mv_1823.has_value) {
                 }
             }
         }
@@ -53,41 +53,41 @@ void resolve_resolve_import_stmt(env_TypeEnv* env, types_SExpr* import_form) {
     SLOP_PRE((parser_is_form(import_form, SLOP_STR("import"))), "(is-form import-form \"import\")");
     {
         __auto_type arena = env_env_arena(env);
-        __auto_type _mv_1818 = (*import_form);
-        switch (_mv_1818.tag) {
+        __auto_type _mv_1824 = (*import_form);
+        switch (_mv_1824.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1818.data.lst;
+                __auto_type lst = _mv_1824.data.lst;
                 {
                     __auto_type items = lst.items;
-                    __auto_type _mv_1819 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1819.has_value) {
-                        __auto_type mod_name_expr = _mv_1819.value;
-                        __auto_type _mv_1820 = (*mod_name_expr);
-                        switch (_mv_1820.tag) {
+                    __auto_type _mv_1825 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1825.has_value) {
+                        __auto_type mod_name_expr = _mv_1825.value;
+                        __auto_type _mv_1826 = (*mod_name_expr);
+                        switch (_mv_1826.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type mod_sym = _mv_1820.data.sym;
-                                __auto_type _mv_1821 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1821.has_value) {
-                                    __auto_type names_expr = _mv_1821.value;
-                                    __auto_type _mv_1822 = (*names_expr);
-                                    switch (_mv_1822.tag) {
+                                __auto_type mod_sym = _mv_1826.data.sym;
+                                __auto_type _mv_1827 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1827.has_value) {
+                                    __auto_type names_expr = _mv_1827.value;
+                                    __auto_type _mv_1828 = (*names_expr);
+                                    switch (_mv_1828.tag) {
                                         case types_SExpr_lst:
                                         {
-                                            __auto_type names_lst = _mv_1822.data.lst;
+                                            __auto_type names_lst = _mv_1828.data.lst;
                                             {
                                                 __auto_type name_items = names_lst.items;
                                                 __auto_type name_len = ((int64_t)((name_items).len));
                                                 for (int64_t j = 0; j < name_len; j++) {
-                                                    __auto_type _mv_1823 = ({ __auto_type _lst = name_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1823.has_value) {
-                                                        __auto_type name_expr = _mv_1823.value;
-                                                        __auto_type _mv_1824 = (*name_expr);
-                                                        switch (_mv_1824.tag) {
+                                                    __auto_type _mv_1829 = ({ __auto_type _lst = name_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1829.has_value) {
+                                                        __auto_type name_expr = _mv_1829.value;
+                                                        __auto_type _mv_1830 = (*name_expr);
+                                                        switch (_mv_1830.tag) {
                                                             case types_SExpr_sym:
                                                             {
-                                                                __auto_type name_sym = _mv_1824.data.sym;
+                                                                __auto_type name_sym = _mv_1830.data.sym;
                                                                 {
                                                                     __auto_type local_name = name_sym.name;
                                                                     __auto_type actual_module = ({ __auto_type _mv = env_env_lookup_type_direct(env, local_name); _mv.has_value ? ({ __auto_type t = _mv.value; ({ __auto_type _mv = (*t).module_name; _mv.has_value ? ({ __auto_type mod = _mv.value; mod; }) : (mod_sym.name); }); }) : (mod_sym.name); });
@@ -103,7 +103,7 @@ void resolve_resolve_import_stmt(env_TypeEnv* env, types_SExpr* import_form) {
                                                                 break;
                                                             }
                                                         }
-                                                    } else if (!_mv_1823.has_value) {
+                                                    } else if (!_mv_1829.has_value) {
                                                     }
                                                 }
                                             }
@@ -113,7 +113,7 @@ void resolve_resolve_import_stmt(env_TypeEnv* env, types_SExpr* import_form) {
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1821.has_value) {
+                                } else if (!_mv_1827.has_value) {
                                 }
                                 break;
                             }
@@ -121,7 +121,7 @@ void resolve_resolve_import_stmt(env_TypeEnv* env, types_SExpr* import_form) {
                                 break;
                             }
                         }
-                    } else if (!_mv_1819.has_value) {
+                    } else if (!_mv_1825.has_value) {
                     }
                 }
                 break;
@@ -150,9 +150,9 @@ slop_option_string resolve_resolve_module_file(slop_arena* arena, slop_string mo
     if (!(resolve_contains_slash(module_name))) {
         return (slop_option_string){.has_value = false};
     } else {
-        __auto_type _mv_1825 = from_file;
-        if (_mv_1825.has_value) {
-            __auto_type current_path = _mv_1825.value;
+        __auto_type _mv_1831 = from_file;
+        if (_mv_1831.has_value) {
+            __auto_type current_path = _mv_1831.value;
             {
                 __auto_type dir = path_path_dirname(arena, current_path);
                 __auto_type rel_path = string_concat(arena, module_name, SLOP_STR(".slop"));
@@ -163,9 +163,10 @@ slop_option_string resolve_resolve_module_file(slop_arena* arena, slop_string mo
                     return (slop_option_string){.has_value = false};
                 }
             }
-        } else if (!_mv_1825.has_value) {
+        } else if (!_mv_1831.has_value) {
             return (slop_option_string){.has_value = false};
         }
+        SLOP_UNREACHABLE();
     }
 }
 

--- a/bootstrap/compiler/slop_stmt.c
+++ b/bootstrap/compiler/slop_stmt.c
@@ -109,6 +109,7 @@ slop_option_string stmt_get_arena_alloc_ptr_type(context_TranspileContext* ctx, 
                                             } else if (!_mv_805.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else if (string_eq(op, SLOP_STR("cast")) && (((int64_t)((items).len)) >= 3)) {
                                             __auto_type _mv_806 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                             if (_mv_806.has_value) {
@@ -117,6 +118,7 @@ slop_option_string stmt_get_arena_alloc_ptr_type(context_TranspileContext* ctx, 
                                             } else if (!_mv_806.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else {
                                             return (slop_option_string){.has_value = false};
                                         }
@@ -129,6 +131,7 @@ slop_option_string stmt_get_arena_alloc_ptr_type(context_TranspileContext* ctx, 
                         } else if (!_mv_803.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     } else {
                         return (slop_option_string){.has_value = false};
                     }
@@ -160,6 +163,7 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
                     } else if (!_mv_808.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             case types_SExpr_lst:
@@ -187,6 +191,7 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
                                         } else if (!_mv_811.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else {
                                         return (slop_option_string){.has_value = false};
                                     }
@@ -198,6 +203,7 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
                         } else if (!_mv_809.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     } else {
                         return (slop_option_string){.has_value = false};
                     }
@@ -242,6 +248,7 @@ uint8_t stmt_is_stmt_form(types_SExpr* expr) {
                     } else if (!_mv_813.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -470,6 +477,7 @@ uint8_t stmt_binding_has_mut(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_827.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -585,6 +593,7 @@ uint8_t stmt_is_none_form(types_SExpr* expr) {
                     } else if (!_mv_834.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 } else {
                     return 0;
                 }
@@ -888,6 +897,7 @@ slop_option_string stmt_get_var_c_type(context_TranspileContext* ctx, types_SExp
                 } else if (!_mv_854.has_value) {
                     return (slop_option_string){.has_value = false};
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -913,6 +923,7 @@ uint8_t stmt_is_pointer_target(context_TranspileContext* ctx, types_SExpr* expr)
                 } else if (!_mv_856.has_value) {
                     return 0;
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -1058,6 +1069,7 @@ uint8_t stmt_is_deref_expr(types_SExpr* expr) {
                     } else if (!_mv_866.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1083,6 +1095,7 @@ types_SExpr* stmt_get_deref_inner(types_SExpr* expr) {
                 } else if (!_mv_869.has_value) {
                     return expr;
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {

--- a/bootstrap/compiler/slop_strlib.c
+++ b/bootstrap/compiler/slop_strlib.c
@@ -183,6 +183,7 @@ uint8_t strlib_contains(slop_string haystack, slop_string needle) {
     } else if (!_mv_0.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t strlib_starts_with(slop_string s, slop_string prefix) {
@@ -602,6 +603,7 @@ slop_string strlib_join(slop_arena* arena, slop_list_string strings, slop_string
                 } else if (!_mv_1.has_value) {
                     return (slop_string){.len = ((uint64_t)(0)), .data = ((uint8_t*)(({ __auto_type _alloc = (uint8_t*)slop_arena_alloc(arena, 1); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })))};
                 }
+                SLOP_UNREACHABLE();
             } else {
                 {
                     int64_t total_len = 0;
@@ -679,6 +681,7 @@ slop_string strlib_replace(slop_arena* arena, slop_string s, slop_string old, sl
             return (slop_string){.len = ((uint64_t)(result_len)), .data = ((uint8_t*)(buf))};
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string strlib_replace_all(slop_arena* arena, slop_string s, slop_string old, slop_string new) {

--- a/bootstrap/compiler/slop_transpiler.c
+++ b/bootstrap/compiler/slop_transpiler.c
@@ -1025,6 +1025,7 @@ slop_string transpiler_prescan_get_param_c_type(context_TranspileContext* ctx, t
                             } else if (!_mv_1313.has_value) {
                                 return SLOP_STR("void*");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -1070,6 +1071,7 @@ uint8_t transpiler_prescan_is_param_mode(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_1314.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -1122,6 +1124,7 @@ uint8_t transpiler_is_spec_annotation(types_SExpr* expr) {
                     } else if (!_mv_1318.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1947,6 +1950,7 @@ slop_string transpiler_get_ffi_struct_c_name(slop_arena* arena, slop_list_types_
                             } else if (!_mv_1375.has_value) {
                                 return transpiler_apply_struct_prefix_heuristic(arena, default_name);
                             }
+                            SLOP_UNREACHABLE();
                         } else {
                             return transpiler_apply_struct_prefix_heuristic(arena, default_name);
                         }
@@ -1958,6 +1962,7 @@ slop_string transpiler_get_ffi_struct_c_name(slop_arena* arena, slop_list_types_
             } else if (!_mv_1373.has_value) {
                 return transpiler_apply_struct_prefix_heuristic(arena, default_name);
             }
+            SLOP_UNREACHABLE();
         } else {
             return transpiler_apply_struct_prefix_heuristic(arena, default_name);
         }
@@ -2017,6 +2022,7 @@ uint8_t transpiler_is_ffi_string_item(slop_list_types_SExpr_ptr items, int64_t i
     } else if (!_mv_1377.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t transpiler_is_enum_def(slop_list_types_SExpr_ptr items) {
@@ -2053,6 +2059,7 @@ uint8_t transpiler_is_enum_def(slop_list_types_SExpr_ptr items) {
                             } else if (!_mv_1381.has_value) {
                                 return 0;
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -2063,6 +2070,7 @@ uint8_t transpiler_is_enum_def(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_1379.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2100,6 +2108,7 @@ uint8_t transpiler_is_record_def(slop_list_types_SExpr_ptr items) {
                             } else if (!_mv_1385.has_value) {
                                 return 0;
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -2110,6 +2119,7 @@ uint8_t transpiler_is_record_def(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_1383.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2147,6 +2157,7 @@ uint8_t transpiler_is_union_def(slop_list_types_SExpr_ptr items) {
                             } else if (!_mv_1389.has_value) {
                                 return 0;
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -2157,6 +2168,7 @@ uint8_t transpiler_is_union_def(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_1387.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2197,6 +2209,7 @@ slop_string transpiler_get_array_c_type(context_TranspileContext* ctx, slop_list
                                             } else if (!_mv_1395.has_value) {
                                                 return default_c_type;
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else {
                                             return default_c_type;
                                         }
@@ -2208,6 +2221,7 @@ slop_string transpiler_get_array_c_type(context_TranspileContext* ctx, slop_list
                             } else if (!_mv_1393.has_value) {
                                 return default_c_type;
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -2218,6 +2232,7 @@ slop_string transpiler_get_array_c_type(context_TranspileContext* ctx, slop_list
         } else if (!_mv_1391.has_value) {
             return default_c_type;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2305,6 +2320,7 @@ uint8_t transpiler_is_union_type_def(types_SExpr* item) {
                                         } else if (!_mv_1401.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -2315,6 +2331,7 @@ uint8_t transpiler_is_union_type_def(types_SExpr* item) {
                     } else if (!_mv_1399.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2353,6 +2370,7 @@ uint8_t transpiler_is_type_def(types_SExpr* item) {
                     } else if (!_mv_1404.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2410,6 +2428,7 @@ uint8_t transpiler_is_fn_def(types_SExpr* item) {
                     } else if (!_mv_1408.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2539,6 +2558,7 @@ int64_t transpiler_get_body_start(slop_list_types_SExpr_ptr items) {
                             } else if (!_mv_1415.has_value) {
                                 return 2;
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -2549,6 +2569,7 @@ int64_t transpiler_get_body_start(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_1413.has_value) {
             return 2;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -3059,6 +3080,7 @@ uint8_t transpiler_is_struct_type_def(types_SExpr* item) {
                                         } else if (!_mv_1450.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -3069,6 +3091,7 @@ uint8_t transpiler_is_struct_type_def(types_SExpr* item) {
                     } else if (!_mv_1448.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -3157,6 +3180,7 @@ uint8_t transpiler_is_type_alias_def(types_SExpr* item) {
                                         } else if (!_mv_1457.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -3167,6 +3191,7 @@ uint8_t transpiler_is_type_alias_def(types_SExpr* item) {
                     } else if (!_mv_1455.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -3218,6 +3243,7 @@ uint8_t transpiler_is_result_type_alias_def(types_SExpr* item) {
                                         } else if (!_mv_1462.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -3228,6 +3254,7 @@ uint8_t transpiler_is_result_type_alias_def(types_SExpr* item) {
                     } else if (!_mv_1460.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -3328,6 +3355,7 @@ uint8_t transpiler_is_array_type_body(types_SExpr* body_expr) {
                     } else if (!_mv_1469.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -3785,6 +3813,7 @@ slop_option_string transpiler_get_type_name(types_SExpr* item) {
                     } else if (!_mv_1491.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -4444,6 +4473,7 @@ uint8_t transpiler_is_range_type_alias(context_TranspileContext* ctx, slop_strin
     } else if (!_mv_1514.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t transpiler_is_unsigned_payload_type(slop_string slop_type) {
@@ -4464,6 +4494,7 @@ slop_string transpiler_resolve_payload_slop_type(context_TranspileContext* ctx, 
         } else if (!_mv_1515.has_value) {
             return slop_type;
         }
+        SLOP_UNREACHABLE();
     } else {
         return slop_type;
     }
@@ -5268,6 +5299,7 @@ uint8_t transpiler_is_simple_enum_def(types_SExpr* item) {
                                         } else if (!_mv_1531.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -5278,6 +5310,7 @@ uint8_t transpiler_is_simple_enum_def(types_SExpr* item) {
                     } else if (!_mv_1529.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -5872,6 +5905,7 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                     } else if (!_mv_1563.has_value) {
                         return ctype_to_c_type(arena, type_expr);
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             case types_SExpr_lst:
@@ -5910,6 +5944,7 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                                                 } else if (!_mv_1566.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -5929,6 +5964,7 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                                                 } else if (!_mv_1567.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -5944,6 +5980,7 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                         } else if (!_mv_1564.has_value) {
                             return SLOP_STR("");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -5996,6 +6033,7 @@ slop_string transpiler_get_type_c_name(context_TranspileContext* ctx, types_SExp
                                     } else if (!_mv_1571.has_value) {
                                         return SLOP_STR("");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             }
                             default: {
@@ -6005,6 +6043,7 @@ slop_string transpiler_get_type_c_name(context_TranspileContext* ctx, types_SExp
                     } else if (!_mv_1569.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6225,6 +6264,7 @@ uint8_t transpiler_is_imported_type(context_TranspileContext* ctx, slop_string t
         } else if (!_mv_1580.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -6311,6 +6351,7 @@ uint8_t transpiler_struct_uses_list_type(context_TranspileContext* ctx, types_SE
                         } else if (!_mv_1584.has_value) {
                             return 0;
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -6386,6 +6427,7 @@ uint8_t transpiler_field_uses_typename(context_TranspileContext* ctx, types_SExp
                     } else if (!_mv_1588.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6650,6 +6692,7 @@ uint8_t transpiler_is_pointer_type_expr_header(types_SExpr* type_expr) {
                     } else if (!_mv_1604.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6745,6 +6788,7 @@ slop_string transpiler_get_variant_name(types_SExpr* variant_expr) {
                     } else if (!_mv_1609.has_value) {
                         return SLOP_STR("unknown");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6894,6 +6938,7 @@ slop_string transpiler_get_const_name(types_SExpr* item) {
                     } else if (!_mv_1618.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6962,6 +7007,7 @@ uint8_t transpiler_emit_const_header_if_exported(context_TranspileContext* ctx, 
                                         } else if (!_mv_1624.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -6972,6 +7018,7 @@ uint8_t transpiler_emit_const_header_if_exported(context_TranspileContext* ctx, 
                     } else if (!_mv_1622.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -7134,6 +7181,7 @@ uint8_t transpiler_is_module_expr(slop_list_types_SExpr_ptr exprs) {
                             } else if (!_mv_1631.has_value) {
                                 return 0;
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -7144,6 +7192,7 @@ uint8_t transpiler_is_module_expr(slop_list_types_SExpr_ptr exprs) {
         } else if (!_mv_1629.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 

--- a/bootstrap/compiler/slop_types.c
+++ b/bootstrap/compiler/slop_types.c
@@ -347,6 +347,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_11.has_value) {
                     return SLOP_STR("Option");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_ptr) {
                 __auto_type _mv_12 = (*t).inner_type;
                 if (_mv_12.has_value) {
@@ -355,6 +356,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_12.has_value) {
                     return SLOP_STR("Ptr");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_list) {
                 __auto_type _mv_13 = (*t).inner_type;
                 if (_mv_13.has_value) {
@@ -363,6 +365,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_13.has_value) {
                     return SLOP_STR("List");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_map) {
                 __auto_type _mv_14 = (*t).inner_type;
                 if (_mv_14.has_value) {
@@ -374,9 +377,11 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                     } else if (!_mv_15.has_value) {
                         return string_concat(arena, SLOP_STR("(Map "), string_concat(arena, types_resolved_type_to_slop_string(arena, key_type), SLOP_STR(")")));
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_14.has_value) {
                     return SLOP_STR("Map");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_result) {
                 __auto_type _mv_16 = (*t).inner_type;
                 if (_mv_16.has_value) {
@@ -388,9 +393,11 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                     } else if (!_mv_17.has_value) {
                         return string_concat(arena, SLOP_STR("(Result "), string_concat(arena, types_resolved_type_to_slop_string(arena, ok_type), SLOP_STR(")")));
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_16.has_value) {
                     return SLOP_STR("Result");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_array) {
                 __auto_type _mv_18 = (*t).inner_type;
                 if (_mv_18.has_value) {
@@ -399,6 +406,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_18.has_value) {
                     return SLOP_STR("Array");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_typevar) {
                 return name;
             } else {

--- a/bootstrap/parser/slop_parser.c
+++ b/bootstrap/parser/slop_parser.c
@@ -383,6 +383,7 @@ parser_Token parser_parser_peek(parser_ParserState* state) {
     } else if (!_mv_20.has_value) {
         return (parser_Token){parser_TokenType_tok_eof, SLOP_STR(""), 1, 1};
     }
+    SLOP_UNREACHABLE();
 }
 
 void parser_parser_advance(parser_ParserState* state) {
@@ -447,6 +448,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_expr(slop_arena* aren
                 __auto_type e = _mv_21.data.err;
                 return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
             }
+            SLOP_UNREACHABLE();
         } else if (tok.kind == parser_TokenType_tok_symbol) {
             parser_parser_advance(state);
             {
@@ -592,7 +594,9 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_paren_group(slo
             __auto_type _ = _mv_24.data.ok;
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = expr });
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_arena* arena, parser_ParserState* state) {
@@ -629,6 +633,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                         return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = node });
                     }
                 }
+                SLOP_UNREACHABLE();
             } else {
                 parser_parser_advance(state);
                 {
@@ -659,6 +664,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                     return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = node });
                 }
             }
+            SLOP_UNREACHABLE();
         } else if (tok.kind == parser_TokenType_tok_operator) {
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = (parser_ParseError){SLOP_STR("Unexpected operator in expression"), tok.line, tok.col} });
         } else if (tok.kind == parser_TokenType_tok_lparen) {
@@ -683,6 +689,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                         }
                     }
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (tok.kind == parser_TokenType_tok_quote) {
             parser_parser_advance(state);
@@ -703,6 +710,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                     return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = node });
                 }
             }
+            SLOP_UNREACHABLE();
         } else {
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = (parser_ParseError){SLOP_STR("Expected expression in infix"), tok.line, tok.col} });
         }
@@ -767,6 +775,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_prec(slop_arena
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix(slop_arena* arena, parser_ParserState* state) {
@@ -794,6 +803,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix(slop_arena* are
                     }
                 }
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -836,6 +846,7 @@ slop_result_list_types_SExpr_ptr_parser_ParseError parser_parse(slop_arena* aren
         __auto_type e = _mv_32.data.err;
         return ((slop_result_list_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
     }
+    SLOP_UNREACHABLE();
 }
 
 int64_t parser_sexpr_line(types_SExpr* expr) {
@@ -862,6 +873,7 @@ int64_t parser_sexpr_line(types_SExpr* expr) {
             return l.line;
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 int64_t parser_sexpr_col(types_SExpr* expr) {
@@ -888,6 +900,7 @@ int64_t parser_sexpr_col(types_SExpr* expr) {
             return l.col;
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t parser_sexpr_is_symbol_with_name(types_SExpr* expr, slop_string name) {
@@ -920,6 +933,7 @@ uint8_t parser_is_form(types_SExpr* expr, slop_string keyword) {
                 } else if (!_mv_38.has_value) {
                     return 0;
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -1197,6 +1211,7 @@ slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string parser_json_escape_string(slop_arena* arena, slop_string s) {
@@ -1324,5 +1339,6 @@ slop_string parser_json_print(slop_arena* arena, types_SExpr* expr) {
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 

--- a/bootstrap/parser/slop_parser_cli.c
+++ b/bootstrap/parser/slop_parser_cli.c
@@ -128,8 +128,11 @@ int main(int argc, char** _c_argv) {
                                     return 0;
                                 }
                             }
+                            SLOP_UNREACHABLE();
                         }
+                        SLOP_UNREACHABLE();
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             slop_arena_free(arena);

--- a/bootstrap/parser/slop_strlib.c
+++ b/bootstrap/parser/slop_strlib.c
@@ -183,6 +183,7 @@ uint8_t strlib_contains(slop_string haystack, slop_string needle) {
     } else if (!_mv_0.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t strlib_starts_with(slop_string s, slop_string prefix) {
@@ -602,6 +603,7 @@ slop_string strlib_join(slop_arena* arena, slop_list_string strings, slop_string
                 } else if (!_mv_1.has_value) {
                     return (slop_string){.len = ((uint64_t)(0)), .data = ((uint8_t*)(({ __auto_type _alloc = (uint8_t*)slop_arena_alloc(arena, 1); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })))};
                 }
+                SLOP_UNREACHABLE();
             } else {
                 {
                     int64_t total_len = 0;
@@ -679,6 +681,7 @@ slop_string strlib_replace(slop_arena* arena, slop_string s, slop_string old, sl
             return (slop_string){.len = ((uint64_t)(result_len)), .data = ((uint8_t*)(buf))};
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string strlib_replace_all(slop_arena* arena, slop_string s, slop_string old, slop_string new) {

--- a/bootstrap/parser/slop_types.c
+++ b/bootstrap/parser/slop_types.c
@@ -347,6 +347,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_11.has_value) {
                     return SLOP_STR("Option");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_ptr) {
                 __auto_type _mv_12 = (*t).inner_type;
                 if (_mv_12.has_value) {
@@ -355,6 +356,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_12.has_value) {
                     return SLOP_STR("Ptr");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_list) {
                 __auto_type _mv_13 = (*t).inner_type;
                 if (_mv_13.has_value) {
@@ -363,6 +365,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_13.has_value) {
                     return SLOP_STR("List");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_map) {
                 __auto_type _mv_14 = (*t).inner_type;
                 if (_mv_14.has_value) {
@@ -374,9 +377,11 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                     } else if (!_mv_15.has_value) {
                         return string_concat(arena, SLOP_STR("(Map "), string_concat(arena, types_resolved_type_to_slop_string(arena, key_type), SLOP_STR(")")));
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_14.has_value) {
                     return SLOP_STR("Map");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_result) {
                 __auto_type _mv_16 = (*t).inner_type;
                 if (_mv_16.has_value) {
@@ -388,9 +393,11 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                     } else if (!_mv_17.has_value) {
                         return string_concat(arena, SLOP_STR("(Result "), string_concat(arena, types_resolved_type_to_slop_string(arena, ok_type), SLOP_STR(")")));
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_16.has_value) {
                     return SLOP_STR("Result");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_array) {
                 __auto_type _mv_18 = (*t).inner_type;
                 if (_mv_18.has_value) {
@@ -399,6 +406,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_18.has_value) {
                     return SLOP_STR("Array");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_typevar) {
                 return name;
             } else {

--- a/bootstrap/runtime/slop_runtime.h
+++ b/bootstrap/runtime/slop_runtime.h
@@ -75,6 +75,23 @@ _Atomic size_t slop_global_allocated __attribute__((weak)) = 0;
     #define SLOP_ASSERT(cond, msg) ((void)0)
 #endif
 
+/* Reached when a match in return position matched none of its arms.
+ *
+ * Deliberately NOT gated on SLOP_DEBUG, unlike the contracts above. The checker
+ * warns about a non-exhaustive match but does not yet reject one, so this path is
+ * genuinely reachable -- and __builtin_unreachable() on a path that actually runs
+ * licenses the optimiser to do considerably worse than the fall-off-the-end this
+ * replaces. One cold branch at the tail of a match is the cheaper mistake.
+ *
+ * Emitted AFTER the closed if-chain or switch rather than as a final else/default,
+ * so -Wswitch still fires on a missing enum case. */
+#define SLOP_UNREACHABLE() \
+    do { \
+        fprintf(stderr, "SLOP: non-exhaustive match reached\n  at %s:%d\n", \
+                __FILE__, __LINE__); \
+        abort(); \
+    } while(0)
+
 /* Expression-form range check - returns value after checking bounds.
  * Unlike SLOP_PRE, this can be used in expression contexts like return statements. */
 #ifdef SLOP_DEBUG

--- a/bootstrap/tester/slop_context.c
+++ b/bootstrap/tester/slop_context.c
@@ -464,6 +464,7 @@ int64_t context_ctx_sexpr_line(types_SExpr* expr) {
                 return ((int64_t)(l.line));
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -494,6 +495,7 @@ int64_t context_ctx_sexpr_col(types_SExpr* expr) {
                 return ((int64_t)(l.col));
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -505,6 +507,7 @@ int64_t context_ctx_list_first_line(slop_list_types_SExpr_ptr items) {
     } else if (!_mv_53.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 int64_t context_ctx_list_first_col(slop_list_types_SExpr_ptr items) {
@@ -515,6 +518,7 @@ int64_t context_ctx_list_first_col(slop_list_types_SExpr_ptr items) {
     } else if (!_mv_54.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 void context_ctx_push_scope(context_TranspileContext* ctx) {
@@ -598,7 +602,9 @@ slop_option_context_VarEntry context_lookup_var_in_scope_chain(context_Scope* sc
                 } else if (!_mv_58.has_value) {
                     return (slop_option_context_VarEntry){.has_value = false};
                 }
+                SLOP_UNREACHABLE();
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -650,7 +656,9 @@ slop_option_context_VarEntry context_find_arena_in_scope_chain(context_Scope* sc
                 } else if (!_mv_61.has_value) {
                     return (slop_option_context_VarEntry){.has_value = false};
                 }
+                SLOP_UNREACHABLE();
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -723,6 +731,7 @@ slop_option_context_FuncEntry context_ctx_lookup_func(context_TranspileContext* 
         } else if (!_mv_64.has_value) {
             return self_entry;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -789,6 +798,7 @@ slop_string context_strip_module_prefix(slop_arena* arena, slop_string type_name
     } else if (!_mv_67.has_value) {
         return type_name;
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_option_string context_ctx_lookup_field_slop_type(context_TranspileContext* ctx, slop_string type_name, slop_string field_name) {
@@ -946,6 +956,7 @@ slop_string context_ctx_prefix_type(context_TranspileContext* ctx, slop_string t
             } else if (!_mv_73.has_value) {
                 return type_name;
             }
+            SLOP_UNREACHABLE();
         } else {
             return type_name;
         }
@@ -1548,6 +1559,7 @@ slop_string context_to_c_type_prefixed(context_TranspileContext* ctx, types_SExp
                         } else if (!_mv_91.has_value) {
                             return SLOP_STR("int64_t");
                         }
+                        SLOP_UNREACHABLE();
                     } else {
                         {
                             __auto_type base_c_type = ctype_to_c_type(arena, type_expr);
@@ -1561,6 +1573,7 @@ slop_string context_to_c_type_prefixed(context_TranspileContext* ctx, types_SExp
                                 } else if (!_mv_92.has_value) {
                                     return context_ctx_prefix_type(ctx, base_c_type);
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -1582,6 +1595,7 @@ slop_string context_to_c_type_prefixed(context_TranspileContext* ctx, types_SExp
                 return SLOP_STR("void*");
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -1610,6 +1624,7 @@ slop_option_string context_get_array_pointer_type(context_TranspileContext* ctx,
                 } else if (!_mv_94.has_value) {
                     return (slop_option_string){.has_value = false};
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {

--- a/bootstrap/tester/slop_ctype.c
+++ b/bootstrap/tester/slop_ctype.c
@@ -201,6 +201,7 @@ slop_string ctype_to_c_type(slop_arena* arena, types_SExpr* expr) {
                         return ctype_to_c_name(arena, name);
                     }
                 }
+                SLOP_UNREACHABLE();
             }
         }
         case types_SExpr_lst:
@@ -219,6 +220,7 @@ slop_string ctype_to_c_type(slop_arena* arena, types_SExpr* expr) {
             return SLOP_STR("void*");
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_ptr items) {
@@ -248,6 +250,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_23.has_value) {
                                         return SLOP_STR("void*");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("ScopedPtr"))) {
                                 if (len < 2) {
@@ -260,6 +263,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_24.has_value) {
                                         return SLOP_STR("void*");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("Option"))) {
                                 if (len < 2) {
@@ -276,6 +280,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_25.has_value) {
                                         return SLOP_STR("/* TRANSPILER_ERROR: Option requires inner type */");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("Result"))) {
                                 {
@@ -298,6 +303,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_26.has_value) {
                                         return SLOP_STR("slop_list_void");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("Map"))) {
                                 return SLOP_STR("slop_map*");
@@ -314,6 +320,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_27.has_value) {
                                         return SLOP_STR("void*");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("Chan"))) {
                                 if (len < 2) {
@@ -330,6 +337,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_28.has_value) {
                                         return SLOP_STR("slop_chan_void");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("Thread"))) {
                                 if (len < 2) {
@@ -346,6 +354,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_29.has_value) {
                                         return SLOP_STR("slop_thread_void");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("Fn"))) {
                                 return SLOP_STR("slop_closure_t");
@@ -359,6 +368,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                 } else if (!_mv_30.has_value) {
                                     return ctype_to_c_name(arena, head);
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -369,6 +379,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
             } else if (!_mv_21.has_value) {
                 return SLOP_STR("void*");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -547,6 +558,7 @@ slop_option_types_ResolvedType_ptr ctype_get_node_resolved_type(types_SExpr* exp
             return lst.resolved_type;
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) {
@@ -562,6 +574,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_40.has_value) {
                 return ctype_to_c_name(arena, name);
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_range) {
             return (*rt).c_name;
         } else if ((kind == types_ResolvedTypeKind_rk_record) || ((kind == types_ResolvedTypeKind_rk_union) || (kind == types_ResolvedTypeKind_rk_enum))) {
@@ -574,6 +587,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
                 } else if (!_mv_41.has_value) {
                     return c_name;
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (kind == types_ResolvedTypeKind_rk_ptr) {
             __auto_type _mv_42 = (*rt).inner_type;
@@ -590,6 +604,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_42.has_value) {
                 return SLOP_STR("void*");
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_option) {
             __auto_type _mv_43 = (*rt).inner_type;
             if (_mv_43.has_value) {
@@ -601,6 +616,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_43.has_value) {
                 return SLOP_STR("/* TRANSPILER_ERROR: Option requires inner type */");
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_list) {
             __auto_type _mv_44 = (*rt).inner_type;
             if (_mv_44.has_value) {
@@ -612,6 +628,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_44.has_value) {
                 return SLOP_STR("slop_list_void");
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_result) {
             {
                 __auto_type ok_id = ({ __auto_type _mv = (*rt).inner_type; _mv.has_value ? ({ __auto_type ok_t = _mv.value; ctype_type_to_identifier(arena, ctype_resolved_type_to_c(arena, ok_t)); }) : (SLOP_STR("void")); });
@@ -632,6 +649,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_45.has_value) {
                 return SLOP_STR("void*");
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_chan) {
             __auto_type _mv_46 = (*rt).inner_type;
             if (_mv_46.has_value) {
@@ -644,6 +662,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_46.has_value) {
                 return SLOP_STR("slop_chan_int*");
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_thread) {
             __auto_type _mv_47 = (*rt).inner_type;
             if (_mv_47.has_value) {
@@ -656,6 +675,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_47.has_value) {
                 return SLOP_STR("slop_thread_int*");
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_typevar) {
             return SLOP_STR("__typevar_error__");
         } else {

--- a/bootstrap/tester/slop_defn.c
+++ b/bootstrap/tester/slop_defn.c
@@ -113,6 +113,7 @@ uint8_t defn_is_type_form(types_SExpr* expr) {
                     } else if (!_mv_921.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -151,6 +152,7 @@ uint8_t defn_is_function_form(types_SExpr* expr) {
                     } else if (!_mv_924.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -189,6 +191,7 @@ uint8_t defn_is_const_form(types_SExpr* expr) {
                     } else if (!_mv_927.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -227,6 +230,7 @@ uint8_t defn_is_ffi_form(types_SExpr* expr) {
                     } else if (!_mv_930.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -265,6 +269,7 @@ uint8_t defn_is_ffi_struct_form(types_SExpr* expr) {
                     } else if (!_mv_933.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -356,6 +361,7 @@ uint8_t defn_is_pointer_type_expr(types_SExpr* type_expr) {
                     } else if (!_mv_940.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -522,6 +528,7 @@ slop_string defn_eval_const_value(context_TranspileContext* ctx, types_SExpr* ex
                 return expr_transpile_expr(ctx, expr);
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -600,6 +607,7 @@ uint8_t defn_is_string_expr(slop_list_types_SExpr_ptr items, int64_t idx) {
     } else if (!_mv_953.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t defn_ends_with_t(slop_string name) {
@@ -1269,6 +1277,7 @@ uint8_t defn_is_array_type(types_SExpr* type_expr) {
                     } else if (!_mv_992.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1793,6 +1802,7 @@ uint8_t defn_is_pointer_type(types_SExpr* type_expr) {
                     } else if (!_mv_1017.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1868,6 +1878,7 @@ slop_string defn_get_param_c_type(context_TranspileContext* ctx, types_SExpr* pa
                             } else if (!_mv_1022.has_value) {
                                 return SLOP_STR("void*");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -1992,6 +2003,7 @@ uint8_t defn_is_spec_form(types_SExpr* expr) {
                     } else if (!_mv_1029.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2037,6 +2049,7 @@ slop_string defn_extract_spec_return_type(context_TranspileContext* ctx, types_S
                                             } else if (!_mv_1034.has_value) {
                                                 return SLOP_STR("void");
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 }
@@ -2047,6 +2060,7 @@ slop_string defn_extract_spec_return_type(context_TranspileContext* ctx, types_S
                         } else if (!_mv_1032.has_value) {
                             return SLOP_STR("void");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -2093,6 +2107,7 @@ slop_string defn_extract_spec_slop_return_type(context_TranspileContext* ctx, ty
                                             } else if (!_mv_1038.has_value) {
                                                 return SLOP_STR("");
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 }
@@ -2103,6 +2118,7 @@ slop_string defn_extract_spec_slop_return_type(context_TranspileContext* ctx, ty
                         } else if (!_mv_1036.has_value) {
                             return SLOP_STR("");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -2192,6 +2208,7 @@ slop_option_string defn_extract_result_type_name(context_TranspileContext* ctx, 
                                             } else if (!_mv_1044.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 }
@@ -2202,6 +2219,7 @@ slop_option_string defn_extract_result_type_name(context_TranspileContext* ctx, 
                         } else if (!_mv_1042.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -2236,7 +2254,9 @@ slop_option_string defn_check_result_type(context_TranspileContext* ctx, types_S
                         } else if (!_mv_1047.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             case types_SExpr_lst:
@@ -2271,9 +2291,11 @@ slop_option_string defn_check_result_type(context_TranspileContext* ctx, types_S
                                             } else if (!_mv_1051.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else if (!_mv_1050.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else {
                                         return (slop_option_string){.has_value = false};
                                     }
@@ -2285,6 +2307,7 @@ slop_option_string defn_check_result_type(context_TranspileContext* ctx, types_S
                         } else if (!_mv_1048.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -2385,6 +2408,7 @@ slop_string defn_build_single_param(context_TranspileContext* ctx, types_SExpr* 
                                         } else if (!_mv_1057.has_value) {
                                             return SLOP_STR("/* missing param type */");
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                     default: {
                                         return SLOP_STR("/* param name must be symbol */");
@@ -2393,6 +2417,7 @@ slop_string defn_build_single_param(context_TranspileContext* ctx, types_SExpr* 
                             } else if (!_mv_1055.has_value) {
                                 return SLOP_STR("/* missing param name */");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -2428,6 +2453,7 @@ uint8_t defn_is_param_mode(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_1058.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2459,6 +2485,7 @@ uint8_t defn_is_fn_type(types_SExpr* type_expr) {
                     } else if (!_mv_1061.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2498,6 +2525,7 @@ slop_string defn_emit_fn_param_type(context_TranspileContext* ctx, types_SExpr* 
                                 } else if (!_mv_1064.has_value) {
                                     return context_ctx_str(ctx, context_ctx_str(ctx, ret_type, SLOP_STR("(*")), context_ctx_str(ctx, param_name, SLOP_STR(")(void)")));
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -2636,6 +2664,7 @@ uint8_t defn_is_c_name_attr_at(slop_list_types_SExpr_ptr items, int64_t idx) {
     } else if (!_mv_1070.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 int64_t defn_find_body_start(slop_list_types_SExpr_ptr items) {
@@ -2692,6 +2721,7 @@ uint8_t defn_is_annotation(types_SExpr* expr) {
                     } else if (!_mv_1073.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2730,6 +2760,7 @@ uint8_t defn_is_pre_form(types_SExpr* expr) {
                     } else if (!_mv_1076.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2768,6 +2799,7 @@ uint8_t defn_is_post_form(types_SExpr* expr) {
                     } else if (!_mv_1079.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2806,6 +2838,7 @@ uint8_t defn_is_assume_form(types_SExpr* expr) {
                     } else if (!_mv_1082.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2904,6 +2937,7 @@ uint8_t defn_is_doc_form(types_SExpr* expr) {
                     } else if (!_mv_1089.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }

--- a/bootstrap/tester/slop_expr.c
+++ b/bootstrap/tester/slop_expr.c
@@ -335,6 +335,7 @@ slop_option_string expr_extract_symbol_name(types_SExpr* expr) {
                                     } else if (!_mv_124.has_value) {
                                         return (slop_option_string){.has_value = false};
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else {
                                     return (slop_option_string){.has_value = false};
                                 }
@@ -346,6 +347,7 @@ slop_option_string expr_extract_symbol_name(types_SExpr* expr) {
                     } else if (!_mv_122.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -385,6 +387,7 @@ slop_string expr_transpile_literal(context_TranspileContext* ctx, types_SExpr* e
             return SLOP_STR("/* error: list is not a literal */");
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_transpile_symbol(context_TranspileContext* ctx, slop_string name) {
@@ -412,6 +415,7 @@ slop_string expr_transpile_symbol(context_TranspileContext* ctx, slop_string nam
                 } else if (!_mv_127.has_value) {
                     return ctype_to_c_name(arena, variant_name);
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (strlib_contains(name, SLOP_STR("."))) {
             __auto_type _mv_128 = strlib_index_of(name, SLOP_STR("."));
@@ -439,11 +443,14 @@ slop_string expr_transpile_symbol(context_TranspileContext* ctx, slop_string nam
                         } else if (!_mv_130.has_value) {
                             return context_ctx_str3(ctx, base_name, SLOP_STR("_"), c_rest);
                         }
+                        SLOP_UNREACHABLE();
                     }
+                    SLOP_UNREACHABLE();
                 }
             } else if (!_mv_128.has_value) {
                 return ctype_to_c_name(arena, name);
             }
+            SLOP_UNREACHABLE();
         } else {
             __auto_type _mv_131 = context_ctx_lookup_var(ctx, name);
             if (_mv_131.has_value) {
@@ -467,9 +474,12 @@ slop_string expr_transpile_symbol(context_TranspileContext* ctx, slop_string nam
                             }
                             return c_name;
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
+                SLOP_UNREACHABLE();
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -674,6 +684,7 @@ uint8_t expr_is_pointer_type_expr(types_SExpr* type_expr) {
                     } else if (!_mv_138.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -722,6 +733,7 @@ uint8_t expr_is_fn_type_expr(types_SExpr* type_expr) {
             } else if (!_mv_142.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         }
         default: {
             return 0;
@@ -762,6 +774,7 @@ uint8_t expr_is_closure_typed_expr(context_TranspileContext* ctx, types_SExpr* e
             } else if (!_mv_146.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         }
         default: {
             return 0;
@@ -922,6 +935,7 @@ slop_string expr_transpile_call(context_TranspileContext* ctx, slop_string fn_na
                             return context_ctx_str4(ctx, c_name, SLOP_STR("("), args, SLOP_STR(")"));
                         }
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1148,6 +1162,7 @@ slop_string expr_closure_type_to_c(context_TranspileContext* ctx, slop_string sl
         } else if (!_mv_151.has_value) {
             return SLOP_STR("int64_t");
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -1280,6 +1295,7 @@ slop_string expr_transpile_enum_variant(context_TranspileContext* ctx, slop_stri
         } else if (!_mv_152.has_value) {
             return ctype_to_c_name(arena, variant_name);
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -1292,6 +1308,7 @@ slop_string expr_transpile_ok(context_TranspileContext* ctx, slop_string value_c
     } else if (!_mv_153.has_value) {
         return context_ctx_str3(ctx, SLOP_STR("(slop_result){ .is_ok = true, .data.ok = "), value_c, SLOP_STR(" }"));
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_transpile_error(context_TranspileContext* ctx, slop_string value_c) {
@@ -1303,6 +1320,7 @@ slop_string expr_transpile_error(context_TranspileContext* ctx, slop_string valu
     } else if (!_mv_154.has_value) {
         return context_ctx_str3(ctx, SLOP_STR("(slop_result){ .is_ok = false, .data.err = "), value_c, SLOP_STR(" }"));
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_infer_option_type(context_TranspileContext* ctx, types_SExpr* val_expr) {
@@ -1377,8 +1395,10 @@ slop_string expr_infer_option_type(context_TranspileContext* ctx, types_SExpr* v
                         context_ctx_add_error_at(ctx, context_ctx_str3(ctx, SLOP_STR("Unknown variable '"), name, SLOP_STR("' for Option type inference")), context_ctx_sexpr_line(val_expr), context_ctx_sexpr_col(val_expr));
                         return SLOP_STR("__type_error__");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
+            SLOP_UNREACHABLE();
         }
         case types_SExpr_lst:
         {
@@ -1386,6 +1406,7 @@ slop_string expr_infer_option_type(context_TranspileContext* ctx, types_SExpr* v
             return expr_infer_list_expr_option_type(ctx, lst.items);
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_c_type_to_option_type_name(context_TranspileContext* ctx, slop_string c_type) {
@@ -1443,11 +1464,14 @@ slop_string expr_infer_field_c_type_from_items(context_TranspileContext* ctx, sl
                                             } else if (!_mv_163.has_value) {
                                                 return SLOP_STR("__auto_type");
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     } else if (!_mv_162.has_value) {
                                         return SLOP_STR("__auto_type");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                         default: {
@@ -1457,9 +1481,11 @@ slop_string expr_infer_field_c_type_from_items(context_TranspileContext* ctx, sl
                 } else if (!_mv_159.has_value) {
                     return SLOP_STR("__auto_type");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_158.has_value) {
                 return SLOP_STR("__auto_type");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -1544,6 +1570,7 @@ slop_string expr_infer_list_expr_option_type(context_TranspileContext* ctx, slop
                                                 context_ctx_add_error_at(ctx, SLOP_STR("Missing field for option type inference"), line, col);
                                                 return SLOP_STR("__type_error__");
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 }
@@ -1582,6 +1609,7 @@ slop_string expr_infer_list_expr_option_type(context_TranspileContext* ctx, slop
                                     context_ctx_add_error_at(ctx, context_ctx_str3(ctx, SLOP_STR("Unknown function '"), op, SLOP_STR("' for Option type inference")), line, col);
                                     return SLOP_STR("__type_error__");
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -1594,6 +1622,7 @@ slop_string expr_infer_list_expr_option_type(context_TranspileContext* ctx, slop
                 context_ctx_add_error_at(ctx, SLOP_STR("Missing list head in option type inference"), line, col);
                 return SLOP_STR("__type_error__");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -1643,10 +1672,12 @@ slop_string expr_infer_list_element_option_type(context_TranspileContext* ctx, t
             } else if (!_mv_170.has_value) {
                 return expr_infer_list_element_option_type_fallback(ctx, list_expr);
             }
+            SLOP_UNREACHABLE();
         } else if (!_mv_169.has_value) {
             context_ctx_warn_fallback(ctx, list_expr, SLOP_STR("infer-list-element-option-type"));
             return expr_infer_list_element_option_type_fallback(ctx, list_expr);
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -1677,6 +1708,7 @@ slop_string expr_infer_list_element_option_type_fallback(context_TranspileContex
                         } else if (!_mv_172.has_value) {
                             return SLOP_STR("");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
                 case types_SExpr_lst:
@@ -1703,6 +1735,7 @@ slop_string expr_infer_list_element_option_type_fallback(context_TranspileContex
                                             } else if (!_mv_175.has_value) {
                                                 return SLOP_STR("");
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else {
                                             return SLOP_STR("");
                                         }
@@ -1714,6 +1747,7 @@ slop_string expr_infer_list_element_option_type_fallback(context_TranspileContex
                             } else if (!_mv_173.has_value) {
                                 return SLOP_STR("");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -1794,6 +1828,7 @@ slop_string expr_prefix_list_element_type(context_TranspileContext* ctx, slop_st
                 } else if (!_mv_177.has_value) {
                     return elem_type;
                 }
+                SLOP_UNREACHABLE();
             }
         } else {
             __auto_type _mv_178 = context_ctx_lookup_type(ctx, elem_type);
@@ -1803,6 +1838,7 @@ slop_string expr_prefix_list_element_type(context_TranspileContext* ctx, slop_st
             } else if (!_mv_178.has_value) {
                 return elem_type;
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -1902,6 +1938,7 @@ slop_string expr_slop_value_type_to_c_type(context_TranspileContext* ctx, slop_s
             } else if (!_mv_179.has_value) {
                 return ctype_to_c_name(arena, slop_type);
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -1989,6 +2026,7 @@ slop_string expr_resolve_type_alias(context_TranspileContext* ctx, slop_string s
         } else if (!_mv_181.has_value) {
             return slop_type;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2011,6 +2049,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                     } else if (!_mv_183.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             case types_SExpr_lst:
@@ -2064,8 +2103,10 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                                             } else if (!_mv_190.has_value) {
                                                                                 return SLOP_STR("");
                                                                             }
+                                                                            SLOP_UNREACHABLE();
                                                                         }
                                                                     }
+                                                                    SLOP_UNREACHABLE();
                                                                 }
                                                             }
                                                         }
@@ -2076,9 +2117,11 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                 } else if (!_mv_187.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else if (!_mv_186.has_value) {
                                                 return SLOP_STR("");
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else if (string_eq(op, SLOP_STR("record-new"))) {
                                             if (len >= 2) {
                                                 __auto_type _mv_191 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
@@ -2098,6 +2141,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                 } else if (!_mv_191.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -2117,9 +2161,11 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                     } else if (!_mv_194.has_value) {
                                                         return SLOP_STR("");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 } else if (!_mv_193.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -2135,6 +2181,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                 } else if (!_mv_195.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -2150,6 +2197,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                 } else if (!_mv_196.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -2165,6 +2213,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                 } else if (!_mv_197.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -2180,6 +2229,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                 } else if (!_mv_198.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -2191,6 +2241,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                             } else if (!_mv_199.has_value) {
                                                 return SLOP_STR("");
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else {
                                             __auto_type _mv_200 = context_ctx_lookup_func(ctx, op);
                                             if (_mv_200.has_value) {
@@ -2199,6 +2250,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                             } else if (!_mv_200.has_value) {
                                                 return SLOP_STR("");
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 }
@@ -2209,6 +2261,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                         } else if (!_mv_184.has_value) {
                             return SLOP_STR("");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -2349,6 +2402,7 @@ slop_string expr_infer_map_key_c_type(context_TranspileContext* ctx, types_SExpr
                     } else if (!_mv_202.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             default: {
@@ -2426,6 +2480,7 @@ slop_string expr_infer_set_elem_c_type(context_TranspileContext* ctx, types_SExp
                     } else if (!_mv_204.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             default: {
@@ -2603,6 +2658,7 @@ slop_string expr_infer_map_value_option_type(context_TranspileContext* ctx, type
                     } else if (!_mv_206.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             default: {
@@ -2753,6 +2809,7 @@ slop_string expr_infer_option_inner_slop_type(context_TranspileContext* ctx, typ
                                                                             } else if (!_mv_212.has_value) {
                                                                                 return SLOP_STR("");
                                                                             }
+                                                                            SLOP_UNREACHABLE();
                                                                         }
                                                                     }
                                                                     default: {
@@ -2762,6 +2819,7 @@ slop_string expr_infer_option_inner_slop_type(context_TranspileContext* ctx, typ
                                                             } else if (!_mv_210.has_value) {
                                                                 return SLOP_STR("");
                                                             }
+                                                            SLOP_UNREACHABLE();
                                                         }
                                                     } else if (string_eq(op, SLOP_STR("list-get"))) {
                                                         if (len < 2) {
@@ -2798,6 +2856,7 @@ slop_string expr_infer_option_inner_slop_type(context_TranspileContext* ctx, typ
                                                                             } else if (!_mv_215.has_value) {
                                                                                 return SLOP_STR("");
                                                                             }
+                                                                            SLOP_UNREACHABLE();
                                                                         }
                                                                     }
                                                                     default: {
@@ -2807,6 +2866,7 @@ slop_string expr_infer_option_inner_slop_type(context_TranspileContext* ctx, typ
                                                             } else if (!_mv_213.has_value) {
                                                                 return SLOP_STR("");
                                                             }
+                                                            SLOP_UNREACHABLE();
                                                         }
                                                     } else {
                                                         return SLOP_STR("");
@@ -2820,6 +2880,7 @@ slop_string expr_infer_option_inner_slop_type(context_TranspileContext* ctx, typ
                                     } else if (!_mv_208.has_value) {
                                         return SLOP_STR("");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             }
                         }
@@ -2845,6 +2906,7 @@ slop_string expr_fix_ternary_none(context_TranspileContext* ctx, types_SExpr* ot
             } else if (!_mv_216.has_value) {
                 return this_branch;
             }
+            SLOP_UNREACHABLE();
         }
     } else {
         if (string_eq(this_branch, SLOP_STR("none"))) {
@@ -2912,6 +2974,7 @@ slop_string expr_transpile_array_index(context_TranspileContext* ctx, types_SExp
                 } else if (!_mv_218.has_value) {
                     return context_ctx_str4(ctx, arr_c, SLOP_STR("["), idx_c, SLOP_STR("]"));
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -2937,6 +3000,7 @@ uint8_t expr_is_pointer_expr(context_TranspileContext* ctx, types_SExpr* expr) {
                 } else if (!_mv_220.has_value) {
                     return 0;
                 }
+                SLOP_UNREACHABLE();
             }
         }
         case types_SExpr_lst:
@@ -2969,6 +3033,7 @@ uint8_t expr_is_pointer_expr(context_TranspileContext* ctx, types_SExpr* expr) {
                                         } else if (!_mv_223.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else {
                                         return 0;
                                     }
@@ -2981,6 +3046,7 @@ uint8_t expr_is_pointer_expr(context_TranspileContext* ctx, types_SExpr* expr) {
                     } else if (!_mv_221.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 } else {
                     return 0;
                 }
@@ -3024,6 +3090,7 @@ slop_string expr_extract_sizeof_type(context_TranspileContext* ctx, types_SExpr*
                                             } else if (!_mv_227.has_value) {
                                                 return SLOP_STR("uint8_t");
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else if (string_eq(op, SLOP_STR("*")) || (string_eq(op, SLOP_STR("+")) || (string_eq(op, SLOP_STR("-")) || string_eq(op, SLOP_STR("/"))))) {
                                             {
                                                 __auto_type i = 1;
@@ -3056,6 +3123,7 @@ slop_string expr_extract_sizeof_type(context_TranspileContext* ctx, types_SExpr*
                         } else if (!_mv_225.has_value) {
                             return SLOP_STR("uint8_t");
                         }
+                        SLOP_UNREACHABLE();
                     } else {
                         return SLOP_STR("uint8_t");
                     }
@@ -3094,6 +3162,7 @@ slop_string expr_transpile_expr(context_TranspileContext* ctx, types_SExpr* expr
             return expr_transpile_list_expr(ctx, lst.items);
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items) {
@@ -3137,10 +3206,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                             context_ctx_add_error_at(ctx, SLOP_STR("missing right operand"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                             return SLOP_STR("0");
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else if (!_mv_232.has_value) {
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing left operand"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (expr_is_comparison_op(op) && (len < 3)) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("comparison operator needs 2 operands"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
@@ -3176,10 +3247,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing right operand"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_234.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing left operand"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("not")) && (len < 2)) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("not needs an argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                 return SLOP_STR("0");
@@ -3192,6 +3265,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("if")) && (len < 4)) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("if expression needs condition, then, and else branches"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                 return SLOP_STR("0");
@@ -3219,14 +3293,17 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                             context_ctx_add_error_at(ctx, SLOP_STR("missing else"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                             return SLOP_STR("0");
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else if (!_mv_238.has_value) {
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing then"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_237.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing condition"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if ((string_eq(op, SLOP_STR("let")) || string_eq(op, SLOP_STR("let*"))) && (len >= 3)) {
                                 return expr_transpile_let_expr(ctx, items);
                             } else if (string_eq(op, SLOP_STR("while")) && (len >= 3)) {
@@ -3252,6 +3329,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR(".")) && (len >= 3)) {
                                 __auto_type _mv_241 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_241.has_value) {
@@ -3284,10 +3362,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing field"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_241.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing object"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("cast")) && (len >= 3)) {
                                 __auto_type _mv_244 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_244.has_value) {
@@ -3321,10 +3401,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing cast value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_244.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing cast type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("c-inline")) && (len >= 2)) {
                                 __auto_type _mv_246 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_246.has_value) {
@@ -3345,6 +3427,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing c-inline string"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("some")) && (len >= 2)) {
                                 __auto_type _mv_248 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_248.has_value) {
@@ -3366,6 +3449,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing some value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("sizeof")) && (len >= 2)) {
                                 __auto_type _mv_249 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_249.has_value) {
@@ -3378,6 +3462,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing sizeof type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("addr")) && (len >= 2)) {
                                 __auto_type _mv_250 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_250.has_value) {
@@ -3387,6 +3472,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing addr argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("@")) && (len >= 3)) {
                                 __auto_type _mv_251 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_251.has_value) {
@@ -3403,10 +3489,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing index"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_251.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing array"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("arena-alloc")) && (len >= 3)) {
                                 __auto_type _mv_253 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_253.has_value) {
@@ -3437,6 +3525,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                                                 return expr_wrap_arena_alloc_checked(ctx, context_ctx_str5(ctx, SLOP_STR("("), cast_type, SLOP_STR("*)slop_arena_alloc("), context_ctx_str3(ctx, arena_c, SLOP_STR(", "), size_c), SLOP_STR(")")));
                                                             }
                                                         }
+                                                        SLOP_UNREACHABLE();
                                                     }
                                                 }
                                                 default: {
@@ -3452,10 +3541,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing arena-alloc size"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("NULL");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_253.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("NULL");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("arena-new")) && (len >= 2)) {
                                 __auto_type _mv_257 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_257.has_value) {
@@ -3468,6 +3559,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("arena-new requires size argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("NULL");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("arena-free")) && (len >= 2)) {
                                 __auto_type _mv_258 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_258.has_value) {
@@ -3480,6 +3572,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("arena-free requires arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("(void)0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("quote")) && (len >= 2)) {
                                 __auto_type _mv_259 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_259.has_value) {
@@ -3503,6 +3596,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing quote argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("record-new")) && (len >= 2)) {
                                 return expr_transpile_record_new(ctx, items);
                             } else if (string_eq(op, SLOP_STR("list")) && (len >= 2)) {
@@ -3581,6 +3675,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing union value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                                                 return SLOP_STR("0");
                                                             }
+                                                            SLOP_UNREACHABLE();
                                                         } else {
                                                             return context_ctx_str3(ctx, SLOP_STR("(("), type_name, context_ctx_str3(ctx, SLOP_STR("){ .tag = "), tag_const, SLOP_STR(" })")));
                                                         }
@@ -3589,6 +3684,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                                     context_ctx_add_error_at(ctx, SLOP_STR("union-new tag must be symbol"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                                     return SLOP_STR("0");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                             default: {
                                                 context_ctx_add_error_at(ctx, SLOP_STR("union-new type must be symbol"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
@@ -3599,10 +3695,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing union tag"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_261.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing union type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("ok")) && (len >= 2)) {
                                 __auto_type _mv_267 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_267.has_value) {
@@ -3615,6 +3713,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing ok value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("error")) && (len >= 2)) {
                                 __auto_type _mv_268 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_268.has_value) {
@@ -3627,6 +3726,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing error value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("?")) && (len >= 2)) {
                                 __auto_type _mv_269 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_269.has_value) {
@@ -3640,11 +3740,13 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         } else if (!_mv_270.has_value) {
                                             return context_ctx_str3(ctx, SLOP_STR("({ __auto_type _tmp = "), result_c, SLOP_STR("; if (!_tmp.is_ok) return _tmp; _tmp.data.ok; })"));
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 } else if (!_mv_269.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing ? argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("list-len")) && (len >= 2)) {
                                 __auto_type _mv_271 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_271.has_value) {
@@ -3657,6 +3759,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing list-len argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("list-get")) && (len >= 3)) {
                                 __auto_type _mv_272 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_272.has_value) {
@@ -3678,10 +3781,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing list-get index"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_272.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing list-get list argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("list-pop")) && (len >= 2)) {
                                 __auto_type _mv_274 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_274.has_value) {
@@ -3699,6 +3804,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing list-pop list argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("list-new")) && (len >= 3)) {
                                 __auto_type _mv_275 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_275.has_value) {
@@ -3717,10 +3823,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing list-new type argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_275.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing list-new arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("list-push")) && (len >= 3)) {
                                 __auto_type _mv_277 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_277.has_value) {
@@ -3746,10 +3854,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing list-push item"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_277.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing list-push list"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("none")) && (len == 1)) {
                                 __auto_type _mv_279 = context_ctx_get_current_return_type(ctx);
                                 if (_mv_279.has_value) {
@@ -3762,6 +3872,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                 } else if (!_mv_279.has_value) {
                                     return SLOP_STR("none");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("cond"))) {
                                 return expr_transpile_cond_expr(ctx, items);
                             } else if (string_eq(op, SLOP_STR("for"))) {
@@ -3806,6 +3917,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                 context_ctx_add_error_at(ctx, SLOP_STR("empty list"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -3826,6 +3938,7 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                 } else if (!_mv_281.has_value) {
                     return SLOP_STR("printf(\"\\n\")");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("print"))) {
             if (len < 2) {
@@ -3840,6 +3953,7 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                     context_ctx_add_error_at(ctx, SLOP_STR("print: missing argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("printf"))) {
             return expr_transpile_printf_call(ctx, items);
@@ -3873,10 +3987,12 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                         context_ctx_add_error_at(ctx, SLOP_STR("min: missing second argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         return SLOP_STR("0");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_283.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("min: missing first argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("max"))) {
             if (len < 3) {
@@ -3906,10 +4022,12 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                         context_ctx_add_error_at(ctx, SLOP_STR("max: missing second argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         return SLOP_STR("0");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_285.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("max: missing first argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("spawn"))) {
             if (len < 3) {
@@ -3928,6 +4046,7 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                     context_ctx_add_error_at(ctx, SLOP_STR("spawn: missing function argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("chan-buffered")) || strlib_ends_with(fn_name, SLOP_STR(":chan-buffered"))) {
             if (len < 4) {
@@ -3959,14 +4078,17 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                             context_ctx_add_error_at(ctx, SLOP_STR("chan-buffered: missing capacity argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                             return SLOP_STR("NULL");
                         }
+                        SLOP_UNREACHABLE();
                     } else if (!_mv_289.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("chan-buffered: missing arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         return SLOP_STR("NULL");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_288.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("chan-buffered: missing type argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("chan")) || strlib_ends_with(fn_name, SLOP_STR(":chan"))) {
             if (len < 3) {
@@ -3994,10 +4116,12 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                         context_ctx_add_error_at(ctx, SLOP_STR("chan: missing arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         return SLOP_STR("NULL");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_291.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("chan: missing type argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("send"))) {
             if (len < 3) {
@@ -4032,10 +4156,12 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                         context_ctx_add_error_at(ctx, SLOP_STR("send: missing value argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         return SLOP_STR("0");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_293.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("send: missing channel argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("recv"))) {
             if (len < 2) {
@@ -4066,6 +4192,7 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                     context_ctx_add_error_at(ctx, SLOP_STR("recv: missing channel argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             }
         } else {
             {
@@ -4147,6 +4274,7 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                                     } else if (!_mv_300.has_value) {
                                         return context_ctx_str3(ctx, SLOP_STR("(("), type_name, context_ctx_str3(ctx, SLOP_STR("){ .tag = "), c_tag_enum, SLOP_STR(" })")));
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else {
                                     return context_ctx_str3(ctx, SLOP_STR("(("), type_name, context_ctx_str3(ctx, SLOP_STR("){ .tag = "), c_tag_enum, SLOP_STR(" })")));
                                 }
@@ -4209,9 +4337,12 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                                     }
                                     return expr_transpile_call(ctx, fn_name, args);
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
+                        SLOP_UNREACHABLE();
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -4258,6 +4389,7 @@ slop_string expr_transpile_print(context_TranspileContext* ctx, types_SExpr* arg
                     } else if (!_mv_305.has_value) {
                         return context_ctx_str5(ctx, SLOP_STR("printf(\"%lld"), nl, SLOP_STR("\", (long long)("), arg_c, SLOP_STR("))"));
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -4362,6 +4494,7 @@ slop_option_string expr_get_expr_type_hint(context_TranspileContext* ctx, types_
                     } else if (!_mv_309.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
                 case types_SExpr_lst:
                 {
@@ -4423,6 +4556,7 @@ slop_option_string expr_get_expr_type_hint(context_TranspileContext* ctx, types_
                                                                                 } else if (!_mv_315.has_value) {
                                                                                     return (slop_option_string){.has_value = false};
                                                                                 }
+                                                                                SLOP_UNREACHABLE();
                                                                             } else {
                                                                                 return (slop_option_string){.has_value = false};
                                                                             }
@@ -4435,9 +4569,11 @@ slop_option_string expr_get_expr_type_hint(context_TranspileContext* ctx, types_
                                                             } else if (!_mv_313.has_value) {
                                                                 return (slop_option_string){.has_value = false};
                                                             }
+                                                            SLOP_UNREACHABLE();
                                                         } else if (!_mv_312.has_value) {
                                                             return (slop_option_string){.has_value = false};
                                                         }
+                                                        SLOP_UNREACHABLE();
                                                     }
                                                 }
                                             } else if (string_eq(op, SLOP_STR("int-to-string")) || (string_eq(op, SLOP_STR("string-copy")) || (string_eq(op, SLOP_STR("string-concat")) || string_eq(op, SLOP_STR("pretty-print"))))) {
@@ -4454,6 +4590,7 @@ slop_option_string expr_get_expr_type_hint(context_TranspileContext* ctx, types_
                                                 } else if (!_mv_316.has_value) {
                                                     return (slop_option_string){.has_value = false};
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         }
                                     }
@@ -4464,6 +4601,7 @@ slop_option_string expr_get_expr_type_hint(context_TranspileContext* ctx, types_
                             } else if (!_mv_310.has_value) {
                                 return (slop_option_string){.has_value = false};
                             }
+                            SLOP_UNREACHABLE();
                         } else {
                             return (slop_option_string){.has_value = false};
                         }
@@ -4540,6 +4678,7 @@ slop_string expr_transpile_union_constructor(context_TranspileContext* ctx, slop
                                                     } else if (!_mv_322.has_value) {
                                                         return context_ctx_str(ctx, SLOP_STR("(("), context_ctx_str(ctx, c_type_name, context_ctx_str(ctx, SLOP_STR("){ .tag = "), context_ctx_str(ctx, c_tag_enum, SLOP_STR(" })")))));
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 } else {
                                                     return context_ctx_str(ctx, SLOP_STR("(("), context_ctx_str(ctx, c_type_name, context_ctx_str(ctx, SLOP_STR("){ .tag = "), context_ctx_str(ctx, c_tag_enum, SLOP_STR(" })")))));
                                                 }
@@ -4552,6 +4691,7 @@ slop_string expr_transpile_union_constructor(context_TranspileContext* ctx, slop
                                 } else if (!_mv_319.has_value) {
                                     return context_ctx_str3(ctx, SLOP_STR("(("), c_type_name, SLOP_STR("){})/* no tag */"));
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -4572,6 +4712,7 @@ slop_string expr_transpile_union_constructor(context_TranspileContext* ctx, slop
             } else if (!_mv_317.has_value) {
                 return context_ctx_str3(ctx, SLOP_STR("(("), c_type_name, SLOP_STR("){})/* no args */"));
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -4730,6 +4871,7 @@ slop_string expr_transpile_match_expr(context_TranspileContext* ctx, slop_list_t
                 context_ctx_add_error_at(ctx, SLOP_STR("missing match scrutinee"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -4804,6 +4946,7 @@ slop_string expr_get_expr_pattern_tag(types_SExpr* pat_expr) {
                     } else if (!_mv_335.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -4964,6 +5107,7 @@ slop_option_string expr_get_expr_binding_name(types_SExpr* pat_expr) {
                     } else if (!_mv_345.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -4987,6 +5131,7 @@ slop_string expr_get_match_branch_body(context_TranspileContext* ctx, slop_list_
             } else if (!_mv_347.has_value) {
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -5163,6 +5308,7 @@ slop_string expr_infer_cond_result_c_type(context_TranspileContext* ctx, slop_li
                                 } else if (!_mv_354.has_value) {
                                     return SLOP_STR("int64_t");
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -5173,6 +5319,7 @@ slop_string expr_infer_cond_result_c_type(context_TranspileContext* ctx, slop_li
             } else if (!_mv_352.has_value) {
                 return SLOP_STR("int64_t");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -5198,6 +5345,7 @@ slop_string expr_infer_match_branch_body_type(context_TranspileContext* ctx, typ
                     } else if (!_mv_356.has_value) {
                         return SLOP_STR("__type_error__");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -5274,6 +5422,7 @@ slop_string expr_slop_type_to_c_type(context_TranspileContext* ctx, slop_string 
                 return slop_type;
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -5326,6 +5475,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                         } else if (!_mv_360.has_value) {
                             return SLOP_STR("int64_t");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
                 case types_SExpr_lst:
@@ -5361,6 +5511,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_363.has_value) {
                                                         return SLOP_STR("int64_t");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("do"))) {
                                                 if (((int64_t)((items).len)) < 2) {
@@ -5373,6 +5524,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_364.has_value) {
                                                         return SLOP_STR("void");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("cond"))) {
                                                 return expr_infer_cond_result_c_type(ctx, items);
@@ -5387,6 +5539,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_365.has_value) {
                                                         return SLOP_STR("int64_t");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("match"))) {
                                                 return expr_infer_match_result_c_type(ctx, items);
@@ -5401,6 +5554,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_366.has_value) {
                                                         return SLOP_STR("int64_t");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("some"))) {
                                                 if (((int64_t)((items).len)) < 2) {
@@ -5432,6 +5586,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                         context_ctx_add_error_at(ctx, SLOP_STR("some constructor: missing value expression"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                                                         return SLOP_STR("__type_error__");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("none"))) {
                                                 __auto_type _mv_368 = context_ctx_get_current_return_type(ctx);
@@ -5445,6 +5600,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                 } else if (!_mv_368.has_value) {
                                                     return SLOP_STR("slop_option_int");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else if (string_eq(op, SLOP_STR("list-push"))) {
                                                 return SLOP_STR("void");
                                             } else if (string_eq(op, SLOP_STR("set!"))) {
@@ -5460,6 +5616,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_369.has_value) {
                                                         return SLOP_STR("void*");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("deref"))) {
                                                 if (((int64_t)((items).len)) < 2) {
@@ -5479,6 +5636,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_370.has_value) {
                                                         return SLOP_STR("int64_t");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("string-concat"))) {
                                                 return SLOP_STR("slop_string");
@@ -5499,6 +5657,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_371.has_value) {
                                                         return SLOP_STR("void*");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("send")) || strlib_ends_with(op, SLOP_STR(":send"))) {
                                                 return SLOP_STR("slop_result_void_thread_ChanError");
@@ -5524,6 +5683,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_372.has_value) {
                                                         return SLOP_STR("slop_result_int64_t_thread_ChanError");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("join")) || strlib_ends_with(op, SLOP_STR(":join"))) {
                                                 return SLOP_STR("int64_t");
@@ -5544,6 +5704,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_373.has_value) {
                                                         return SLOP_STR("slop_chan_int*");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("chan")) || strlib_ends_with(op, SLOP_STR(":chan"))) {
                                                 if (((int64_t)((items).len)) < 3) {
@@ -5560,6 +5721,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_374.has_value) {
                                                         return SLOP_STR("slop_chan_int*");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("arena-alloc"))) {
                                                 return SLOP_STR("void*");
@@ -5583,6 +5745,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                         context_ctx_add_error_at(ctx, SLOP_STR("Cannot infer list-new element type"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                                                         return SLOP_STR("__type_error__");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("list-get"))) {
                                                 if (((int64_t)((items).len)) < 2) {
@@ -5608,6 +5771,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                         context_ctx_add_error_at(ctx, SLOP_STR("Cannot infer list-get type: missing argument"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                                                         return SLOP_STR("__type_error__");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("int-to-string"))) {
                                                 return SLOP_STR("slop_string");
@@ -5649,7 +5813,9 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                         context_ctx_add_error_at(ctx, context_ctx_str3(ctx, SLOP_STR("unknown function or type '"), op, SLOP_STR("'")), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                                                         return SLOP_STR("__type_error__");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         }
                                     }
@@ -5662,6 +5828,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                 context_ctx_add_error_at(ctx, SLOP_STR("cannot infer type of empty list"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                                 return SLOP_STR("__type_error__");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -5838,6 +6005,7 @@ slop_string expr_build_enum_case_expr(context_TranspileContext* ctx, slop_arena*
                 context_ctx_add_error_at(ctx, context_ctx_str3(ctx, SLOP_STR("unknown enum variant '"), tag, SLOP_STR("' in match expression")), context_ctx_sexpr_line(pattern), context_ctx_sexpr_col(pattern));
                 return cases;
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -5942,6 +6110,7 @@ slop_string expr_wrap_fn_ref_as_closure(context_TranspileContext* ctx, slop_stri
                     } else if (!_mv_392.has_value) {
                         return arg_c;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             default: {
@@ -6051,10 +6220,12 @@ slop_string expr_build_union_case_expr(context_TranspileContext* ctx, slop_arena
                             return s5;
                         }
                     }
+                    SLOP_UNREACHABLE();
                 }
             } else if (!_mv_394.has_value) {
                 return cases;
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -6146,6 +6317,7 @@ uint8_t expr_discard_needs_void(types_SExpr* e) {
             } else if (!_mv_400.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         }
         default: {
             return 0;
@@ -6238,6 +6410,7 @@ slop_string expr_transpile_let_expr(context_TranspileContext* ctx, slop_list_typ
             } else if (!_mv_402.has_value) {
                 return SLOP_STR("({ (void)0; })");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -6344,6 +6517,7 @@ slop_string expr_transpile_binding_expr(context_TranspileContext* ctx, types_SEx
                                                         } else if (!_mv_414.has_value) {
                                                             return context_ctx_str5(ctx, c_type, SLOP_STR(" "), var_name, SLOP_STR(" = {0};"), SLOP_STR(""));
                                                         }
+                                                        SLOP_UNREACHABLE();
                                                     }
                                                 } else if (!_mv_413.has_value) {
                                                     __auto_type _mv_415 = ({ __auto_type _lst = items; size_t _idx = (size_t)init_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
@@ -6356,7 +6530,9 @@ slop_string expr_transpile_binding_expr(context_TranspileContext* ctx, types_SEx
                                                     } else if (!_mv_415.has_value) {
                                                         return context_ctx_str3(ctx, SLOP_STR("__auto_type "), var_name, SLOP_STR(" = 0;"));
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 __auto_type _mv_416 = ({ __auto_type _lst = items; size_t _idx = (size_t)init_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                                 if (_mv_416.has_value) {
@@ -6368,6 +6544,7 @@ slop_string expr_transpile_binding_expr(context_TranspileContext* ctx, types_SEx
                                                 } else if (!_mv_416.has_value) {
                                                     return context_ctx_str3(ctx, SLOP_STR("__auto_type "), var_name, SLOP_STR(" = 0;"));
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         }
                                     }
@@ -6378,6 +6555,7 @@ slop_string expr_transpile_binding_expr(context_TranspileContext* ctx, types_SEx
                             } else if (!_mv_411.has_value) {
                                 return SLOP_STR("");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -6410,6 +6588,7 @@ uint8_t expr_binding_has_mut(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_417.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -6450,6 +6629,7 @@ slop_string expr_transpile_typed_init(context_TranspileContext* ctx, types_SExpr
                                             } else if (!_mv_422.has_value) {
                                                 return expr_transpile_expr(ctx, init_expr);
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     } else if (string_eq(op, SLOP_STR("none"))) {
                                         return context_ctx_str3(ctx, SLOP_STR("("), target_type, SLOP_STR("){.has_value = false}"));
@@ -6465,6 +6645,7 @@ slop_string expr_transpile_typed_init(context_TranspileContext* ctx, types_SExpr
                     } else if (!_mv_420.has_value) {
                         return expr_transpile_expr(ctx, init_expr);
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6511,6 +6692,7 @@ slop_string expr_transpile_while_expr(context_TranspileContext* ctx, slop_list_t
             } else if (!_mv_423.has_value) {
                 return SLOP_STR("({ (void)0; })");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -6575,6 +6757,7 @@ slop_string expr_transpile_when_expr(context_TranspileContext* ctx, slop_list_ty
             } else if (!_mv_426.has_value) {
                 return SLOP_STR("({ (void)0; })");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -6606,6 +6789,7 @@ uint8_t expr_set_is_self_assign(slop_list_types_SExpr_ptr items) {
                     } else if (!_mv_430.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
                 default: {
                     return 0;
@@ -6614,6 +6798,7 @@ uint8_t expr_set_is_self_assign(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_428.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     } else {
         return 0;
     }
@@ -6676,9 +6861,11 @@ slop_string expr_transpile_set_expr(context_TranspileContext* ctx, slop_list_typ
                                                                         } else if (!_mv_438.has_value) {
                                                                             return SLOP_STR("({ (void)0; })");
                                                                         }
+                                                                        SLOP_UNREACHABLE();
                                                                     } else if (!_mv_437.has_value) {
                                                                         return SLOP_STR("({ (void)0; })");
                                                                     }
+                                                                    SLOP_UNREACHABLE();
                                                                 }
                                                             } else if (string_eq(op, SLOP_STR("."))) {
                                                                 {
@@ -6703,6 +6890,7 @@ slop_string expr_transpile_set_expr(context_TranspileContext* ctx, slop_list_typ
                                             } else if (!_mv_435.has_value) {
                                                 return SLOP_STR("({ (void)0; })");
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 }
@@ -6726,9 +6914,11 @@ slop_string expr_transpile_set_expr(context_TranspileContext* ctx, slop_list_typ
                     } else if (!_mv_433.has_value) {
                         return SLOP_STR("({ (void)0; })");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_432.has_value) {
                     return SLOP_STR("({ (void)0; })");
                 }
+                SLOP_UNREACHABLE();
             }
         }
     }
@@ -6749,7 +6939,9 @@ slop_string expr_resolve_arena_c_name(context_TranspileContext* ctx, slop_string
             context_ctx_add_error_at(ctx, context_ctx_str(ctx, op, SLOP_STR(": no arena in scope")), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             return SLOP_STR("arena");
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_get_arena_for_list_push_expr(context_TranspileContext* ctx, types_SExpr* list_expr, slop_string list_c) {
@@ -6777,10 +6969,13 @@ slop_string expr_get_arena_for_list_push_expr(context_TranspileContext* ctx, typ
                     } else if (!_mv_443.has_value) {
                         return SLOP_STR("arena");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_get_arena_from_field_access(context_TranspileContext* ctx, types_SExpr* expr) {
@@ -6813,6 +7008,7 @@ slop_string expr_get_arena_from_field_access(context_TranspileContext* ctx, type
                                     } else if (!_mv_447.has_value) {
                                         return SLOP_STR("");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else {
                                     return SLOP_STR("");
                                 }
@@ -6824,6 +7020,7 @@ slop_string expr_get_arena_from_field_access(context_TranspileContext* ctx, type
                     } else if (!_mv_445.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6858,6 +7055,7 @@ slop_string expr_get_arena_from_base(context_TranspileContext* ctx, types_SExpr*
                         return context_ctx_str(ctx, c_name, SLOP_STR("->arena"));
                     }
                 }
+                SLOP_UNREACHABLE();
             }
         }
         case types_SExpr_lst:
@@ -6887,6 +7085,7 @@ slop_string expr_get_arena_from_base(context_TranspileContext* ctx, types_SExpr*
                                     } else if (!_mv_452.has_value) {
                                         return SLOP_STR("arena");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else {
                                     return SLOP_STR("arena");
                                 }
@@ -6898,6 +7097,7 @@ slop_string expr_get_arena_from_base(context_TranspileContext* ctx, types_SExpr*
                     } else if (!_mv_450.has_value) {
                         return SLOP_STR("arena");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6932,6 +7132,7 @@ uint8_t expr_is_ptr_to_ptr_map(context_TranspileContext* ctx, types_SExpr* expr)
                 } else if (!_mv_454.has_value) {
                     return 0;
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -7024,6 +7225,7 @@ slop_string expr_transpile_record_new(context_TranspileContext* ctx, slop_list_t
                                     context_ctx_add_error_at(ctx, SLOP_STR("record-new: empty type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -7036,6 +7238,7 @@ slop_string expr_transpile_record_new(context_TranspileContext* ctx, slop_list_t
                 context_ctx_add_error_at(ctx, SLOP_STR("record-new: missing type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7316,6 +7519,7 @@ slop_string expr_transpile_list_literal(context_TranspileContext* ctx, slop_list
                                     return context_ctx_str(ctx, result, context_ctx_str(ctx, data_part, SLOP_STR("}})")));
                                 }
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -7323,6 +7527,7 @@ slop_string expr_transpile_list_literal(context_TranspileContext* ctx, slop_list
                 context_ctx_add_error_at(ctx, SLOP_STR("list: missing type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7403,6 +7608,7 @@ slop_string expr_get_map_key_c_info(context_TranspileContext* ctx, types_SExpr* 
                     } else if (!_mv_480.has_value) {
                         return SLOP_STR("sizeof(void*), slop_hash_ptr, slop_eq_ptr");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -7439,11 +7645,14 @@ slop_string expr_get_struct_key_info_by_name(context_TranspileContext* ctx, slop
                 } else if (!_mv_484.has_value) {
                     return SLOP_STR("");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (!_mv_483.has_value) {
             return SLOP_STR("");
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_transpile_map_new(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items) {
@@ -7466,6 +7675,7 @@ slop_string expr_transpile_map_new(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("map-new: missing arena"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             }
         } else {
             __auto_type _mv_486 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
@@ -7483,10 +7693,12 @@ slop_string expr_transpile_map_new(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("map-new: missing KeyType"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_486.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("map-new: missing arena"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7598,14 +7810,17 @@ slop_string expr_transpile_map_put(context_TranspileContext* ctx, slop_list_type
                         context_ctx_add_error_at(ctx, SLOP_STR("map-put: missing val"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         return SLOP_STR("0");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_489.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("map-put: missing key"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_488.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("map-put: missing map"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7645,10 +7860,12 @@ slop_string expr_transpile_map_get(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("map-get: missing key"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_491.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("map-get: missing map"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7677,10 +7894,12 @@ slop_string expr_transpile_map_has(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("map-has: missing key"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("false");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_493.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("map-has: missing map"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("false");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7709,10 +7928,12 @@ slop_string expr_transpile_map_remove(context_TranspileContext* ctx, slop_list_t
                     context_ctx_add_error_at(ctx, SLOP_STR("map-remove: missing key"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_495.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("map-remove: missing map"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7752,6 +7973,7 @@ slop_string expr_transpile_map_keys(context_TranspileContext* ctx, slop_list_typ
                 context_ctx_add_error_at(ctx, SLOP_STR("map-keys: missing map"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7779,10 +8001,12 @@ slop_string expr_transpile_set_new(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("set-new: missing ElementType"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_498.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("set-new: missing arena"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7812,10 +8036,12 @@ slop_string expr_transpile_set_put(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("set-put: missing element"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_500.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("set-put: missing set"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7844,10 +8070,12 @@ slop_string expr_transpile_set_has(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("set-has: missing element"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("false");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_502.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("set-has: missing set"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("false");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7876,10 +8104,12 @@ slop_string expr_transpile_set_remove(context_TranspileContext* ctx, slop_list_t
                     context_ctx_add_error_at(ctx, SLOP_STR("set-remove: missing element"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_504.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("set-remove: missing set"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7919,6 +8149,7 @@ slop_string expr_transpile_set_elements(context_TranspileContext* ctx, slop_list
                 context_ctx_add_error_at(ctx, SLOP_STR("set-elements: missing set"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7963,6 +8194,7 @@ slop_string expr_transpile_set_literal(context_TranspileContext* ctx, slop_list_
                 context_ctx_add_error_at(ctx, SLOP_STR("set: missing type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -8032,9 +8264,11 @@ slop_string expr_transpile_for_as_expr(context_TranspileContext* ctx, slop_list_
                                                     } else if (!_mv_514.has_value) {
                                                         return SLOP_STR("({ /* for: missing end */ 0; })");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 } else if (!_mv_513.has_value) {
                                                     return SLOP_STR("({ /* for: missing start */ 0; })");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         }
                                         default: {
@@ -8044,6 +8278,7 @@ slop_string expr_transpile_for_as_expr(context_TranspileContext* ctx, slop_list_
                                 } else if (!_mv_511.has_value) {
                                     return SLOP_STR("({ /* for: missing var */ 0; })");
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -8054,6 +8289,7 @@ slop_string expr_transpile_for_as_expr(context_TranspileContext* ctx, slop_list_
             } else if (!_mv_509.has_value) {
                 return SLOP_STR("({ /* for: missing binding */ 0; })");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -8112,6 +8348,7 @@ slop_string expr_transpile_for_each_as_expr(context_TranspileContext* ctx, slop_
                                                 } else if (!_mv_520.has_value) {
                                                     return SLOP_STR("({ /* for-each: missing collection */ 0; })");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         }
                                         default: {
@@ -8121,6 +8358,7 @@ slop_string expr_transpile_for_each_as_expr(context_TranspileContext* ctx, slop_
                                 } else if (!_mv_518.has_value) {
                                     return SLOP_STR("({ /* for-each: missing var */ 0; })");
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -8131,6 +8369,7 @@ slop_string expr_transpile_for_each_as_expr(context_TranspileContext* ctx, slop_
             } else if (!_mv_516.has_value) {
                 return SLOP_STR("({ /* for-each: missing binding */ 0; })");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -8335,12 +8574,15 @@ slop_string expr_transpile_for_each_map_kv_as_expr(context_TranspileContext* ctx
                                     } else if (!_mv_528.has_value) {
                                         return SLOP_STR("({ /* for-each: missing map expression */ 0; })");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_527.has_value) {
                                     return SLOP_STR("({ /* for-each: missing value binding */ 0; })");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (!_mv_526.has_value) {
                                 return SLOP_STR("({ /* for-each: missing key binding */ 0; })");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -8351,6 +8593,7 @@ slop_string expr_transpile_for_each_map_kv_as_expr(context_TranspileContext* ctx
         } else if (!_mv_524.has_value) {
             return SLOP_STR("({ /* for-each: missing binding */ 0; })");
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -8418,6 +8661,7 @@ slop_string expr_transpile_lambda_expr(context_TranspileContext* ctx, slop_list_
                 context_ctx_add_error_at(ctx, SLOP_STR("lambda missing params"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -8685,7 +8929,9 @@ slop_string expr_find_arena_ptr_expr(context_TranspileContext* ctx) {
         } else if (!_mv_542.has_value) {
             return SLOP_STR("");
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_build_closure_instance(context_TranspileContext* ctx, slop_string lambda_name, slop_string env_name, slop_string env_type, slop_list_string free_vars, slop_list_string captured_accesses) {
@@ -8892,6 +9138,7 @@ uint8_t expr_is_pointer_type_sexpr(types_SExpr* type_expr) {
                     } else if (!_mv_555.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -8993,6 +9240,7 @@ uint8_t expr_is_capturing_lambda(types_SExpr* expr) {
                                     } else if (!_mv_561.has_value) {
                                         return 0;
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             }
                             default: {
@@ -9002,6 +9250,7 @@ uint8_t expr_is_capturing_lambda(types_SExpr* expr) {
                     } else if (!_mv_559.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -9035,6 +9284,7 @@ slop_string expr_transpile_spawn_closure(context_TranspileContext* ctx, slop_lis
             context_ctx_add_error_at(ctx, SLOP_STR("spawn: missing arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             return SLOP_STR("NULL");
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -9075,6 +9325,7 @@ uint8_t expr_lambda_has_captures(context_TranspileContext* ctx, types_SExpr* fn_
                     } else if (!_mv_565.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -9140,6 +9391,7 @@ slop_string expr_infer_generic_type_binding(context_TranspileContext* ctx, slop_
             } else if (!_mv_568.has_value) {
                 return SLOP_STR("");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -9477,6 +9729,7 @@ uint8_t expr_is_mut_binding(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_580.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -9660,6 +9913,7 @@ slop_list_string expr_extract_for_loop_var_pending(slop_arena* arena, slop_list_
         } else if (!_mv_592.has_value) {
             return pending;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -9753,8 +10007,11 @@ uint8_t expr_is_free_var(context_TranspileContext* ctx, slop_list_string param_n
                         } else if (!_mv_600.has_value) {
                             return 0;
                         }
+                        SLOP_UNREACHABLE();
                     }
+                    SLOP_UNREACHABLE();
                 }
+                SLOP_UNREACHABLE();
             }
         }
     }
@@ -9939,6 +10196,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                                 } else if (!_mv_607.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         } else if (string_eq(op, SLOP_STR("set-elements"))) {
                                             if (((int64_t)((items).len)) < 2) {
@@ -9961,6 +10219,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                                 } else if (!_mv_608.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         } else if (string_eq(op, SLOP_STR("map-values"))) {
                                             if (((int64_t)((items).len)) < 2) {
@@ -9983,6 +10242,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                                 } else if (!_mv_609.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         } else {
                                             return expr_infer_elem_from_type(ctx, coll_expr);
@@ -9996,6 +10256,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                         } else if (!_mv_605.has_value) {
                             return SLOP_STR("");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }

--- a/bootstrap/tester/slop_extract.c
+++ b/bootstrap/tester/slop_extract.c
@@ -133,11 +133,13 @@ slop_option_string extract_extract_return_type(slop_arena* arena, types_SExpr* s
                     } else if (!_mv_1515.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         } else if (!_mv_1514.has_value) {
             return (slop_option_string){.has_value = false};
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -228,10 +230,12 @@ slop_list_extract_TestCase_ptr extract_extract_fn_examples(slop_arena* arena, ty
                                         return result;
                                     }
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
                 }
+                SLOP_UNREACHABLE();
             }
         }
     }
@@ -307,6 +311,7 @@ slop_option_extract_TestCase_ptr extract_parse_example(slop_arena* arena, types_
                                         } else if (!_mv_1526.has_value) {
                                             return (slop_option_extract_TestCase_ptr){.has_value = false};
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -428,6 +433,7 @@ slop_list_extract_TestCase_ptr extract_extract_examples_from_module(slop_arena* 
                         return result;
                     }
                 }
+                SLOP_UNREACHABLE();
             }
         }
     }

--- a/bootstrap/tester/slop_match.c
+++ b/bootstrap/tester/slop_match.c
@@ -24,6 +24,7 @@ void match_emit_literal_case(context_TranspileContext* ctx, slop_string scrutine
 void match_transpile_union_match(context_TranspileContext* ctx, slop_string scrutinee_c, slop_list_types_SExpr_ptr patterns, slop_list_types_SExpr_ptr items, uint8_t is_return);
 void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_c, types_SExpr* pattern, slop_string tag, slop_string union_type_name, slop_list_types_SExpr_ptr branch_items, uint8_t is_return);
 void match_transpile_generic_match(context_TranspileContext* ctx, slop_string scrutinee_c, slop_list_types_SExpr_ptr items, uint8_t is_return);
+void match_emit_match_fallthrough_trap(context_TranspileContext* ctx, uint8_t is_return, uint8_t has_else);
 void match_emit_else_branch(context_TranspileContext* ctx, slop_list_types_SExpr_ptr branch_items, uint8_t is_return, uint8_t first);
 void match_emit_branch_body(context_TranspileContext* ctx, slop_list_types_SExpr_ptr branch_items, uint8_t is_return);
 void match_emit_branch_body_item(context_TranspileContext* ctx, types_SExpr* body_expr, uint8_t is_return, uint8_t is_last);
@@ -242,6 +243,7 @@ slop_string match_get_pattern_tag(types_SExpr* pat_expr) {
                     } else if (!_mv_655.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -285,6 +287,7 @@ slop_option_string match_extract_binding_name(types_SExpr* pat_expr) {
                     } else if (!_mv_658.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -431,6 +434,7 @@ void match_transpile_option_match(context_TranspileContext* ctx, slop_string scr
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 2;
         uint8_t first = 1;
+        uint8_t has_else = 0;
         while (i < len) {
             __auto_type _mv_666 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_666.has_value) {
@@ -456,6 +460,7 @@ void match_transpile_option_match(context_TranspileContext* ctx, slop_string scr
                                             first = 0;
                                         } else if (string_eq(tag, SLOP_STR("else"))) {
                                             match_emit_else_branch(ctx, branch_items, is_return, first);
+                                            has_else = 1;
                                             first = 0;
                                         } else {
                                         }
@@ -477,6 +482,7 @@ void match_transpile_option_match(context_TranspileContext* ctx, slop_string scr
         if (!(first)) {
             context_ctx_emit(ctx, SLOP_STR("}"));
         }
+        match_emit_match_fallthrough_trap(ctx, is_return, has_else);
     }
 }
 
@@ -531,6 +537,7 @@ void match_transpile_result_match(context_TranspileContext* ctx, slop_string scr
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 2;
         uint8_t first = 1;
+        uint8_t has_else = 0;
         while (i < len) {
             __auto_type _mv_670 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_670.has_value) {
@@ -556,6 +563,7 @@ void match_transpile_result_match(context_TranspileContext* ctx, slop_string scr
                                             first = 0;
                                         } else if (string_eq(tag, SLOP_STR("else"))) {
                                             match_emit_else_branch(ctx, branch_items, is_return, first);
+                                            has_else = 1;
                                             first = 0;
                                         } else {
                                         }
@@ -577,6 +585,7 @@ void match_transpile_result_match(context_TranspileContext* ctx, slop_string scr
         if (!(first)) {
             context_ctx_emit(ctx, SLOP_STR("}"));
         }
+        match_emit_match_fallthrough_trap(ctx, is_return, has_else);
     }
 }
 
@@ -650,6 +659,7 @@ void match_transpile_enum_match(context_TranspileContext* ctx, slop_string scrut
         __auto_type arena = (*ctx).arena;
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 2;
+        uint8_t has_else = 0;
         context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("switch ("), scrutinee_c, SLOP_STR(") {")));
         context_ctx_indent(ctx);
         while (i < len) {
@@ -667,6 +677,12 @@ void match_transpile_enum_match(context_TranspileContext* ctx, slop_string scrut
                                 __auto_type _mv_677 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_677.has_value) {
                                     __auto_type pattern = _mv_677.value;
+                                    {
+                                        __auto_type tag = match_get_pattern_tag(pattern);
+                                        if (string_eq(tag, SLOP_STR("else")) || string_eq(tag, SLOP_STR("_"))) {
+                                            has_else = 1;
+                                        }
+                                    }
                                     match_emit_enum_case(ctx, pattern, branch_items, is_return);
                                 } else if (!_mv_677.has_value) {
                                 }
@@ -684,6 +700,7 @@ void match_transpile_enum_match(context_TranspileContext* ctx, slop_string scrut
         }
         context_ctx_dedent(ctx);
         context_ctx_emit(ctx, SLOP_STR("}"));
+        match_emit_match_fallthrough_trap(ctx, is_return, has_else);
     }
 }
 
@@ -728,6 +745,7 @@ void match_transpile_literal_match(context_TranspileContext* ctx, slop_string sc
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 2;
         uint8_t first = 1;
+        uint8_t has_else = 0;
         while (i < len) {
             __auto_type _mv_679 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_679.has_value) {
@@ -743,6 +761,9 @@ void match_transpile_literal_match(context_TranspileContext* ctx, slop_string sc
                                 __auto_type _mv_681 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_681.has_value) {
                                     __auto_type pattern = _mv_681.value;
+                                    if (string_eq(match_get_pattern_tag(pattern), SLOP_STR("else"))) {
+                                        has_else = 1;
+                                    }
                                     match_emit_literal_case(ctx, scrutinee_c, pattern, branch_items, is_return, first);
                                     first = 0;
                                 } else if (!_mv_681.has_value) {
@@ -762,6 +783,7 @@ void match_transpile_literal_match(context_TranspileContext* ctx, slop_string sc
         if (!(first)) {
             context_ctx_emit(ctx, SLOP_STR("}"));
         }
+        match_emit_match_fallthrough_trap(ctx, is_return, has_else);
     }
 }
 
@@ -806,6 +828,7 @@ void match_transpile_union_match(context_TranspileContext* ctx, slop_string scru
             __auto_type len = ((int64_t)((items).len));
             int64_t i = 2;
             uint8_t first = 1;
+            uint8_t has_else = 0;
             context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("switch ("), scrutinee_c, SLOP_STR(".tag) {")));
             context_ctx_indent(ctx);
             while (i < len) {
@@ -826,6 +849,7 @@ void match_transpile_union_match(context_TranspileContext* ctx, slop_string scru
                                         {
                                             __auto_type tag = match_get_pattern_tag(pattern);
                                             if (string_eq(tag, SLOP_STR("else")) || string_eq(tag, SLOP_STR("_"))) {
+                                                has_else = 1;
                                                 context_ctx_emit(ctx, SLOP_STR("default: {"));
                                                 context_ctx_indent(ctx);
                                                 match_emit_branch_body(ctx, branch_items, is_return);
@@ -860,6 +884,7 @@ void match_transpile_union_match(context_TranspileContext* ctx, slop_string scru
             }
             context_ctx_dedent(ctx);
             context_ctx_emit(ctx, SLOP_STR("}"));
+            match_emit_match_fallthrough_trap(ctx, is_return, has_else);
         }
     }
 }
@@ -945,6 +970,13 @@ void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_
 void match_transpile_generic_match(context_TranspileContext* ctx, slop_string scrutinee_c, slop_list_types_SExpr_ptr items, uint8_t is_return) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     match_transpile_literal_match(ctx, scrutinee_c, items, is_return);
+}
+
+void match_emit_match_fallthrough_trap(context_TranspileContext* ctx, uint8_t is_return, uint8_t has_else) {
+    SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
+    if (is_return && !(has_else)) {
+        context_ctx_emit(ctx, SLOP_STR("SLOP_UNREACHABLE();"));
+    }
 }
 
 void match_emit_else_branch(context_TranspileContext* ctx, slop_list_types_SExpr_ptr branch_items, uint8_t is_return, uint8_t first) {
@@ -1299,6 +1331,7 @@ uint8_t match_binding_starts_with_mut(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_706.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -1364,6 +1397,7 @@ uint8_t match_is_none_form_inline(types_SExpr* expr) {
                     } else if (!_mv_710.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 } else {
                     return 0;
                 }
@@ -1409,6 +1443,7 @@ slop_option_string match_get_arena_alloc_ptr_type_inline(context_TranspileContex
                                         } else if (!_mv_715.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else {
                                         return (slop_option_string){.has_value = false};
                                     }
@@ -1420,6 +1455,7 @@ slop_option_string match_get_arena_alloc_ptr_type_inline(context_TranspileContex
                         } else if (!_mv_713.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     } else {
                         return (slop_option_string){.has_value = false};
                     }
@@ -1451,6 +1487,7 @@ slop_option_string match_extract_sizeof_type_inline(context_TranspileContext* ct
                     } else if (!_mv_717.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             case types_SExpr_lst:
@@ -1478,6 +1515,7 @@ slop_option_string match_extract_sizeof_type_inline(context_TranspileContext* ct
                                         } else if (!_mv_720.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else {
                                         return (slop_option_string){.has_value = false};
                                     }
@@ -1489,6 +1527,7 @@ slop_option_string match_extract_sizeof_type_inline(context_TranspileContext* ct
                         } else if (!_mv_718.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     } else {
                         return (slop_option_string){.has_value = false};
                     }
@@ -1607,6 +1646,7 @@ slop_option_string match_get_var_c_type_inline(context_TranspileContext* ctx, ty
                 } else if (!_mv_727.has_value) {
                     return (slop_option_string){.has_value = false};
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -1881,6 +1921,7 @@ uint8_t match_is_deref_inline(types_SExpr* expr) {
                     } else if (!_mv_747.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1906,6 +1947,7 @@ slop_string match_get_deref_inner_inline(context_TranspileContext* ctx, types_SE
                 } else if (!_mv_750.has_value) {
                     return SLOP_STR("/* missing deref arg */");
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -1966,6 +2008,7 @@ void match_emit_inline_cond(context_TranspileContext* ctx, slop_list_types_SExpr
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 1;
         uint8_t first = 1;
+        uint8_t has_else = 0;
         while (i < len) {
             __auto_type _mv_753 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_753.has_value) {
@@ -1990,6 +2033,7 @@ void match_emit_inline_cond(context_TranspileContext* ctx, slop_list_types_SExpr
                                         {
                                             __auto_type sym = _mv_756.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("else"))) {
+                                                has_else = 1;
                                                 context_ctx_emit(ctx, SLOP_STR("} else {"));
                                                 context_ctx_indent(ctx);
                                                 match_emit_inline_cond_body(ctx, clause_items, 1, is_return, is_last);
@@ -2045,6 +2089,7 @@ void match_emit_inline_cond(context_TranspileContext* ctx, slop_list_types_SExpr
         if (!(first)) {
             context_ctx_emit(ctx, SLOP_STR("}"));
         }
+        match_emit_match_fallthrough_trap(ctx, is_return, has_else);
     }
 }
 
@@ -2848,6 +2893,7 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 2;
         uint8_t first = 1;
+        uint8_t has_else = 0;
         while (i < len) {
             __auto_type _mv_796 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_796.has_value) {
@@ -2866,6 +2912,7 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
                                     {
                                         __auto_type tag = match_get_pattern_tag(pattern);
                                         if (string_eq(tag, SLOP_STR("else")) || string_eq(tag, SLOP_STR("_"))) {
+                                            has_else = 1;
                                             if (first) {
                                                 context_ctx_emit(ctx, SLOP_STR("{"));
                                             } else {
@@ -2921,6 +2968,7 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
         if (!(first)) {
             context_ctx_emit(ctx, SLOP_STR("}"));
         }
+        match_emit_match_fallthrough_trap(ctx, is_return, has_else);
     }
 }
 

--- a/bootstrap/tester/slop_match.h
+++ b/bootstrap/tester/slop_match.h
@@ -44,6 +44,7 @@ void match_emit_literal_case(context_TranspileContext* ctx, slop_string scrutine
 void match_transpile_union_match(context_TranspileContext* ctx, slop_string scrutinee_c, slop_list_types_SExpr_ptr patterns, slop_list_types_SExpr_ptr items, uint8_t is_return);
 void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_c, types_SExpr* pattern, slop_string tag, slop_string union_type_name, slop_list_types_SExpr_ptr branch_items, uint8_t is_return);
 void match_transpile_generic_match(context_TranspileContext* ctx, slop_string scrutinee_c, slop_list_types_SExpr_ptr items, uint8_t is_return);
+void match_emit_match_fallthrough_trap(context_TranspileContext* ctx, uint8_t is_return, uint8_t has_else);
 void match_emit_else_branch(context_TranspileContext* ctx, slop_list_types_SExpr_ptr branch_items, uint8_t is_return, uint8_t first);
 void match_emit_branch_body(context_TranspileContext* ctx, slop_list_types_SExpr_ptr branch_items, uint8_t is_return);
 void match_emit_branch_body_item(context_TranspileContext* ctx, types_SExpr* body_expr, uint8_t is_return, uint8_t is_last);

--- a/bootstrap/tester/slop_parser.c
+++ b/bootstrap/tester/slop_parser.c
@@ -383,6 +383,7 @@ parser_Token parser_parser_peek(parser_ParserState* state) {
     } else if (!_mv_611.has_value) {
         return (parser_Token){parser_TokenType_tok_eof, SLOP_STR(""), 1, 1};
     }
+    SLOP_UNREACHABLE();
 }
 
 void parser_parser_advance(parser_ParserState* state) {
@@ -447,6 +448,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_expr(slop_arena* aren
                 __auto_type e = _mv_612.data.err;
                 return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
             }
+            SLOP_UNREACHABLE();
         } else if (tok.kind == parser_TokenType_tok_symbol) {
             parser_parser_advance(state);
             {
@@ -592,7 +594,9 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_paren_group(slo
             __auto_type _ = _mv_615.data.ok;
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = expr });
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_arena* arena, parser_ParserState* state) {
@@ -629,6 +633,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                         return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = node });
                     }
                 }
+                SLOP_UNREACHABLE();
             } else {
                 parser_parser_advance(state);
                 {
@@ -659,6 +664,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                     return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = node });
                 }
             }
+            SLOP_UNREACHABLE();
         } else if (tok.kind == parser_TokenType_tok_operator) {
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = (parser_ParseError){SLOP_STR("Unexpected operator in expression"), tok.line, tok.col} });
         } else if (tok.kind == parser_TokenType_tok_lparen) {
@@ -683,6 +689,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                         }
                     }
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (tok.kind == parser_TokenType_tok_quote) {
             parser_parser_advance(state);
@@ -703,6 +710,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                     return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = node });
                 }
             }
+            SLOP_UNREACHABLE();
         } else {
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = (parser_ParseError){SLOP_STR("Expected expression in infix"), tok.line, tok.col} });
         }
@@ -767,6 +775,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_prec(slop_arena
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix(slop_arena* arena, parser_ParserState* state) {
@@ -794,6 +803,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix(slop_arena* are
                     }
                 }
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -836,6 +846,7 @@ slop_result_list_types_SExpr_ptr_parser_ParseError parser_parse(slop_arena* aren
         __auto_type e = _mv_623.data.err;
         return ((slop_result_list_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
     }
+    SLOP_UNREACHABLE();
 }
 
 int64_t parser_sexpr_line(types_SExpr* expr) {
@@ -862,6 +873,7 @@ int64_t parser_sexpr_line(types_SExpr* expr) {
             return l.line;
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 int64_t parser_sexpr_col(types_SExpr* expr) {
@@ -888,6 +900,7 @@ int64_t parser_sexpr_col(types_SExpr* expr) {
             return l.col;
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t parser_sexpr_is_symbol_with_name(types_SExpr* expr, slop_string name) {
@@ -920,6 +933,7 @@ uint8_t parser_is_form(types_SExpr* expr, slop_string keyword) {
                 } else if (!_mv_629.has_value) {
                     return 0;
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -1197,6 +1211,7 @@ slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string parser_json_escape_string(slop_arena* arena, slop_string s) {
@@ -1324,5 +1339,6 @@ slop_string parser_json_print(slop_arena* arena, types_SExpr* expr) {
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 

--- a/bootstrap/tester/slop_stmt.c
+++ b/bootstrap/tester/slop_stmt.c
@@ -109,6 +109,7 @@ slop_option_string stmt_get_arena_alloc_ptr_type(context_TranspileContext* ctx, 
                                             } else if (!_mv_805.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else if (string_eq(op, SLOP_STR("cast")) && (((int64_t)((items).len)) >= 3)) {
                                             __auto_type _mv_806 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                             if (_mv_806.has_value) {
@@ -117,6 +118,7 @@ slop_option_string stmt_get_arena_alloc_ptr_type(context_TranspileContext* ctx, 
                                             } else if (!_mv_806.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else {
                                             return (slop_option_string){.has_value = false};
                                         }
@@ -129,6 +131,7 @@ slop_option_string stmt_get_arena_alloc_ptr_type(context_TranspileContext* ctx, 
                         } else if (!_mv_803.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     } else {
                         return (slop_option_string){.has_value = false};
                     }
@@ -160,6 +163,7 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
                     } else if (!_mv_808.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             case types_SExpr_lst:
@@ -187,6 +191,7 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
                                         } else if (!_mv_811.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else {
                                         return (slop_option_string){.has_value = false};
                                     }
@@ -198,6 +203,7 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
                         } else if (!_mv_809.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     } else {
                         return (slop_option_string){.has_value = false};
                     }
@@ -242,6 +248,7 @@ uint8_t stmt_is_stmt_form(types_SExpr* expr) {
                     } else if (!_mv_813.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -470,6 +477,7 @@ uint8_t stmt_binding_has_mut(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_827.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -585,6 +593,7 @@ uint8_t stmt_is_none_form(types_SExpr* expr) {
                     } else if (!_mv_834.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 } else {
                     return 0;
                 }
@@ -888,6 +897,7 @@ slop_option_string stmt_get_var_c_type(context_TranspileContext* ctx, types_SExp
                 } else if (!_mv_854.has_value) {
                     return (slop_option_string){.has_value = false};
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -913,6 +923,7 @@ uint8_t stmt_is_pointer_target(context_TranspileContext* ctx, types_SExpr* expr)
                 } else if (!_mv_856.has_value) {
                     return 0;
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -1058,6 +1069,7 @@ uint8_t stmt_is_deref_expr(types_SExpr* expr) {
                     } else if (!_mv_866.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1083,6 +1095,7 @@ types_SExpr* stmt_get_deref_inner(types_SExpr* expr) {
                 } else if (!_mv_869.has_value) {
                     return expr;
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {

--- a/bootstrap/tester/slop_strlib.c
+++ b/bootstrap/tester/slop_strlib.c
@@ -183,6 +183,7 @@ uint8_t strlib_contains(slop_string haystack, slop_string needle) {
     } else if (!_mv_0.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t strlib_starts_with(slop_string s, slop_string prefix) {
@@ -602,6 +603,7 @@ slop_string strlib_join(slop_arena* arena, slop_list_string strings, slop_string
                 } else if (!_mv_1.has_value) {
                     return (slop_string){.len = ((uint64_t)(0)), .data = ((uint8_t*)(({ __auto_type _alloc = (uint8_t*)slop_arena_alloc(arena, 1); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })))};
                 }
+                SLOP_UNREACHABLE();
             } else {
                 {
                     int64_t total_len = 0;
@@ -679,6 +681,7 @@ slop_string strlib_replace(slop_arena* arena, slop_string s, slop_string old, sl
             return (slop_string){.len = ((uint64_t)(result_len)), .data = ((uint8_t*)(buf))};
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string strlib_replace_all(slop_arena* arena, slop_string s, slop_string old, slop_string new) {

--- a/bootstrap/tester/slop_test_emit.c
+++ b/bootstrap/tester/slop_test_emit.c
@@ -137,6 +137,7 @@ uint8_t test_emit_has_ellipsis(types_SExpr* expr) {
             return 0;
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t test_emit_args_have_ellipsis(slop_list_types_SExpr_ptr args) {
@@ -212,6 +213,7 @@ uint8_t test_emit_contains_wildcard(types_SExpr* expr) {
             return 0;
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 types_SExpr* test_emit_replace_wildcards(slop_arena* arena, types_SExpr* expr) {
@@ -280,6 +282,7 @@ types_SExpr* test_emit_replace_wildcards(slop_arena* arena, types_SExpr* expr) {
             return expr;
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string test_emit_transpile_expr_safe(slop_arena* arena, context_TranspileContext* tctx, types_SExpr* expr) {
@@ -301,6 +304,7 @@ slop_string test_emit_prefix_symbol(slop_arena* arena, slop_string name, slop_st
                 return ctype_to_c_name(arena, name);
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -495,6 +499,7 @@ uint8_t test_emit_expr_mentions_arena(types_SExpr* expr) {
             return 0;
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t test_emit_test_mentions_arena(extract_TestCase tc) {
@@ -568,11 +573,13 @@ slop_string test_emit_param_name_at(types_SExpr* params, int64_t idx) {
                 } else if (!_mv_1554.has_value) {
                     return SLOP_STR("");
                 }
+                SLOP_UNREACHABLE();
             }
         }
     } else if (!_mv_1553.has_value) {
         return SLOP_STR("");
     }
+    SLOP_UNREACHABLE();
 }
 
 types_SExpr* test_emit_substitute_symbol(slop_arena* arena, types_SExpr* expr, slop_string name, types_SExpr* replacement) {
@@ -625,6 +632,7 @@ types_SExpr* test_emit_substitute_symbol(slop_arena* arena, types_SExpr* expr, s
             return expr;
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 types_SExpr* test_emit_bind_precondition_args(slop_arena* arena, extract_TestCase tc, types_SExpr* cond_expr) {
@@ -731,6 +739,7 @@ slop_option_string test_emit_first_error_since(slop_arena* arena, context_Transp
             } else if (!_mv_1560.has_value) {
                 return (slop_option_string){.has_value = false};
             }
+            SLOP_UNREACHABLE();
         } else {
             return (slop_option_string){.has_value = false};
         }
@@ -747,6 +756,7 @@ types_SExpr* test_emit_example_anchor(extract_TestCase tc) {
     } else if (!_mv_1561.has_value) {
         return tc.expected;
     }
+    SLOP_UNREACHABLE();
     SLOP_POST(((_retval != NULL)), "(!= $result nil)");
     return _retval;
 }
@@ -859,6 +869,7 @@ slop_string test_emit_make_c_fn_name(slop_arena* arena, slop_string fn_name, slo
                 return c_name;
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -925,6 +936,7 @@ test_emit_CompareInfo test_emit_build_comparison_typed(slop_arena* arena, types_
                                         } else if (!_mv_1565.has_value) {
                                             return (test_emit_CompareInfo){string_concat(arena, SLOP_STR("({ typeof(result.value) expected_value = "), string_concat(arena, inner_expected, SLOP_STR("; result.has_value && memcmp(&result.value, &expected_value, sizeof(result.value)) == 0; })"))), SLOP_STR("%s"), SLOP_STR("result.has_value ? \"some(...)\" : \"none\""), SLOP_STR("%s"), SLOP_STR("\"some(...)\"")};
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 } else {
                                     return (test_emit_CompareInfo){string_concat(arena, SLOP_STR("result.has_value && result.value == "), inner_expected), SLOP_STR("%s"), SLOP_STR("result.has_value ? \"some(...)\" : \"none\""), SLOP_STR("%s"), SLOP_STR("\"some(...)\"")};
@@ -971,6 +983,7 @@ test_emit_CompareInfo test_emit_build_comparison_typed(slop_arena* arena, types_
                                                     } else if (!_mv_1566.has_value) {
                                                         return (test_emit_CompareInfo){string_concat(arena, SLOP_STR("({ typeof(result.data.ok) expected_ok = "), string_concat(arena, inner_expected, SLOP_STR("; result.is_ok && memcmp(&result.data.ok, &expected_ok, sizeof(result.data.ok)) == 0; })"))), SLOP_STR("%s"), SLOP_STR("result.is_ok ? \"ok(...)\" : \"error(...)\""), SLOP_STR("%s"), SLOP_STR("\"ok(...)\"")};
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else {
                                                 {
@@ -1095,6 +1108,7 @@ test_emit_CompareInfo test_emit_build_record_comparison_inner(slop_arena* arena,
             return (test_emit_CompareInfo){string_concat(arena, SLOP_STR("({ typeof(result) "), string_concat(arena, expected_var_name, string_concat(arena, SLOP_STR(" = "), string_concat(arena, c_expected, string_concat(arena, SLOP_STR("; memcmp(&result, &"), string_concat(arena, expected_var_name, SLOP_STR(", sizeof(result)) == 0; })"))))))), SLOP_STR("%s"), SLOP_STR("\"<record>\""), SLOP_STR("%s"), SLOP_STR("\"<expected>\"")};
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string test_emit_get_record_decl_type(slop_arena* arena, type_extract_TypeRegistry types, slop_string record_name) {
@@ -1105,6 +1119,7 @@ slop_string test_emit_get_record_decl_type(slop_arena* arena, type_extract_TypeR
     } else if (!_mv_1568.has_value) {
         return SLOP_STR("");
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string test_emit_get_record_name_from_expr(types_SExpr* expr) {
@@ -1130,6 +1145,7 @@ slop_string test_emit_get_record_name_from_expr(types_SExpr* expr) {
                     } else if (!_mv_1570.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1357,9 +1373,11 @@ slop_string test_emit_get_first_symbol_name(types_SExpr* expr) {
                             return SLOP_STR("");
                         }
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_1577.has_value) {
                     return SLOP_STR("");
                 }
+                SLOP_UNREACHABLE();
             } else {
                 return SLOP_STR("");
             }
@@ -1375,6 +1393,7 @@ slop_string test_emit_get_first_symbol_name(types_SExpr* expr) {
             return SLOP_STR("");
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 test_emit_CompareInfo test_emit_build_union_comparison_typed(slop_arena* arena, types_SExpr* expected, slop_string prefix, type_extract_TypeRegistry types, slop_string ret_type_str, context_TranspileContext* tctx) {
@@ -1413,6 +1432,7 @@ slop_string test_emit_build_union_payload_comparison(slop_arena* arena, slop_str
                     return string_concat(arena, SLOP_STR("memcmp(&result.data."), string_concat(arena, c_variant, string_concat(arena, SLOP_STR(", &"), string_concat(arena, expected_var, string_concat(arena, SLOP_STR(".data."), string_concat(arena, c_variant, string_concat(arena, SLOP_STR(", sizeof(result.data."), string_concat(arena, c_variant, SLOP_STR("))")))))))));
                 }
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -1506,6 +1526,7 @@ uint8_t test_emit_is_union_constructor_typed(types_SExpr* expr, type_extract_Typ
                                         } else if (!_mv_1583.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -1515,6 +1536,7 @@ uint8_t test_emit_is_union_constructor_typed(types_SExpr* expr, type_extract_Typ
                     } else if (!_mv_1582.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1554,6 +1576,7 @@ slop_string test_emit_get_union_variant_name(types_SExpr* expr) {
                                     } else if (!_mv_1586.has_value) {
                                         return SLOP_STR("");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else {
                                     return name;
                                 }
@@ -1564,6 +1587,7 @@ slop_string test_emit_get_union_variant_name(types_SExpr* expr) {
                     } else if (!_mv_1585.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1592,6 +1616,7 @@ uint8_t test_emit_is_enum_value_typed(types_SExpr* expr, type_extract_TypeRegist
                         } else if (!_mv_1588.has_value) {
                             return 0;
                         }
+                        SLOP_UNREACHABLE();
                     }
                 } else {
                     return 0;
@@ -1621,18 +1646,21 @@ uint8_t test_emit_is_enum_value_typed(types_SExpr* expr, type_extract_TypeRegist
                                     } else if (!_mv_1591.has_value) {
                                         return 0;
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else {
                                     return 0;
                                 }
                             } else if (!_mv_1590.has_value) {
                                 return 0;
                             }
+                            SLOP_UNREACHABLE();
                         } else {
                             return 0;
                         }
                     } else if (!_mv_1589.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1670,6 +1698,7 @@ uint8_t test_emit_is_record_constructor_typed(types_SExpr* expr, type_extract_Ty
                                     } else if (!_mv_1594.has_value) {
                                         return 0;
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             }
                         } else {
@@ -1678,6 +1707,7 @@ uint8_t test_emit_is_record_constructor_typed(types_SExpr* expr, type_extract_Ty
                     } else if (!_mv_1593.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1704,6 +1734,7 @@ slop_string test_emit_get_some_inner_typed(slop_arena* arena, types_SExpr* expr,
         } else if (!_mv_1595.has_value) {
             return SLOP_STR("0");
         }
+        SLOP_UNREACHABLE();
     } else {
         return SLOP_STR("0");
     }
@@ -1734,6 +1765,7 @@ types_SExpr* test_emit_get_some_inner_expr(types_SExpr* expected) {
                     } else if (!_mv_1597.has_value) {
                         return expected;
                     }
+                    SLOP_UNREACHABLE();
                 } else {
                     return expected;
                 }
@@ -1762,6 +1794,7 @@ types_SExpr* test_emit_get_ok_inner_expr(types_SExpr* expected) {
                     } else if (!_mv_1599.has_value) {
                         return expected;
                     }
+                    SLOP_UNREACHABLE();
                 } else {
                     return expected;
                 }
@@ -1872,6 +1905,7 @@ slop_string test_emit_build_eq_function_name(slop_arena* arena, slop_string type
                 }
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 

--- a/bootstrap/tester/slop_tester.c
+++ b/bootstrap/tester/slop_tester.c
@@ -36,6 +36,7 @@ slop_string tester_extract_module_name(slop_list_types_SExpr_ptr exprs) {
                     } else if (!_mv_1621.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 } else {
                     return SLOP_STR("");
                 }
@@ -45,6 +46,7 @@ slop_string tester_extract_module_name(slop_list_types_SExpr_ptr exprs) {
         } else if (!_mv_1620.has_value) {
             return SLOP_STR("");
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -144,6 +146,7 @@ tester_TestResult tester_generate_tests(slop_arena* arena, slop_string source, s
             return (tester_TestResult){0, ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 }), 0, SLOP_STR(""), error_msg};
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 tester_TestResult tester_generate_tests_with_imports(slop_arena* arena, slop_string source, slop_list_string import_sources, slop_string file_name) {
@@ -205,6 +208,7 @@ tester_TestResult tester_generate_tests_with_imports(slop_arena* arena, slop_str
             return (tester_TestResult){0, ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 }), 0, SLOP_STR(""), error_msg};
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 void tester_extract_types_from_module_ast(slop_arena* arena, slop_list_types_SExpr_ptr ast, type_extract_TypeRegistry* types, slop_string prefix) {
@@ -475,5 +479,6 @@ slop_string tester_sexpr_to_string_simple(slop_arena* arena, types_SExpr* expr) 
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 

--- a/bootstrap/tester/slop_tester_main.c
+++ b/bootstrap/tester/slop_tester_main.c
@@ -229,6 +229,7 @@ int main(int argc, char** _c_argv) {
                 tester_main_print_str(((char*)(SLOP_STR("{\"error\":\"Could not read file\"}\n").data)));
                 return 1;
             }
+            SLOP_UNREACHABLE();
             slop_arena_free(arena);
         }
     }

--- a/bootstrap/tester/slop_transpiler.c
+++ b/bootstrap/tester/slop_transpiler.c
@@ -1025,6 +1025,7 @@ slop_string transpiler_prescan_get_param_c_type(context_TranspileContext* ctx, t
                             } else if (!_mv_1166.has_value) {
                                 return SLOP_STR("void*");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -1070,6 +1071,7 @@ uint8_t transpiler_prescan_is_param_mode(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_1167.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -1122,6 +1124,7 @@ uint8_t transpiler_is_spec_annotation(types_SExpr* expr) {
                     } else if (!_mv_1171.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1947,6 +1950,7 @@ slop_string transpiler_get_ffi_struct_c_name(slop_arena* arena, slop_list_types_
                             } else if (!_mv_1228.has_value) {
                                 return transpiler_apply_struct_prefix_heuristic(arena, default_name);
                             }
+                            SLOP_UNREACHABLE();
                         } else {
                             return transpiler_apply_struct_prefix_heuristic(arena, default_name);
                         }
@@ -1958,6 +1962,7 @@ slop_string transpiler_get_ffi_struct_c_name(slop_arena* arena, slop_list_types_
             } else if (!_mv_1226.has_value) {
                 return transpiler_apply_struct_prefix_heuristic(arena, default_name);
             }
+            SLOP_UNREACHABLE();
         } else {
             return transpiler_apply_struct_prefix_heuristic(arena, default_name);
         }
@@ -2017,6 +2022,7 @@ uint8_t transpiler_is_ffi_string_item(slop_list_types_SExpr_ptr items, int64_t i
     } else if (!_mv_1230.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t transpiler_is_enum_def(slop_list_types_SExpr_ptr items) {
@@ -2053,6 +2059,7 @@ uint8_t transpiler_is_enum_def(slop_list_types_SExpr_ptr items) {
                             } else if (!_mv_1234.has_value) {
                                 return 0;
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -2063,6 +2070,7 @@ uint8_t transpiler_is_enum_def(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_1232.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2100,6 +2108,7 @@ uint8_t transpiler_is_record_def(slop_list_types_SExpr_ptr items) {
                             } else if (!_mv_1238.has_value) {
                                 return 0;
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -2110,6 +2119,7 @@ uint8_t transpiler_is_record_def(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_1236.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2147,6 +2157,7 @@ uint8_t transpiler_is_union_def(slop_list_types_SExpr_ptr items) {
                             } else if (!_mv_1242.has_value) {
                                 return 0;
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -2157,6 +2168,7 @@ uint8_t transpiler_is_union_def(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_1240.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2197,6 +2209,7 @@ slop_string transpiler_get_array_c_type(context_TranspileContext* ctx, slop_list
                                             } else if (!_mv_1248.has_value) {
                                                 return default_c_type;
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else {
                                             return default_c_type;
                                         }
@@ -2208,6 +2221,7 @@ slop_string transpiler_get_array_c_type(context_TranspileContext* ctx, slop_list
                             } else if (!_mv_1246.has_value) {
                                 return default_c_type;
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -2218,6 +2232,7 @@ slop_string transpiler_get_array_c_type(context_TranspileContext* ctx, slop_list
         } else if (!_mv_1244.has_value) {
             return default_c_type;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2305,6 +2320,7 @@ uint8_t transpiler_is_union_type_def(types_SExpr* item) {
                                         } else if (!_mv_1254.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -2315,6 +2331,7 @@ uint8_t transpiler_is_union_type_def(types_SExpr* item) {
                     } else if (!_mv_1252.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2353,6 +2370,7 @@ uint8_t transpiler_is_type_def(types_SExpr* item) {
                     } else if (!_mv_1257.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2410,6 +2428,7 @@ uint8_t transpiler_is_fn_def(types_SExpr* item) {
                     } else if (!_mv_1261.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2539,6 +2558,7 @@ int64_t transpiler_get_body_start(slop_list_types_SExpr_ptr items) {
                             } else if (!_mv_1268.has_value) {
                                 return 2;
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -2549,6 +2569,7 @@ int64_t transpiler_get_body_start(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_1266.has_value) {
             return 2;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -3059,6 +3080,7 @@ uint8_t transpiler_is_struct_type_def(types_SExpr* item) {
                                         } else if (!_mv_1303.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -3069,6 +3091,7 @@ uint8_t transpiler_is_struct_type_def(types_SExpr* item) {
                     } else if (!_mv_1301.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -3157,6 +3180,7 @@ uint8_t transpiler_is_type_alias_def(types_SExpr* item) {
                                         } else if (!_mv_1310.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -3167,6 +3191,7 @@ uint8_t transpiler_is_type_alias_def(types_SExpr* item) {
                     } else if (!_mv_1308.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -3218,6 +3243,7 @@ uint8_t transpiler_is_result_type_alias_def(types_SExpr* item) {
                                         } else if (!_mv_1315.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -3228,6 +3254,7 @@ uint8_t transpiler_is_result_type_alias_def(types_SExpr* item) {
                     } else if (!_mv_1313.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -3328,6 +3355,7 @@ uint8_t transpiler_is_array_type_body(types_SExpr* body_expr) {
                     } else if (!_mv_1322.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -3785,6 +3813,7 @@ slop_option_string transpiler_get_type_name(types_SExpr* item) {
                     } else if (!_mv_1344.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -4444,6 +4473,7 @@ uint8_t transpiler_is_range_type_alias(context_TranspileContext* ctx, slop_strin
     } else if (!_mv_1367.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t transpiler_is_unsigned_payload_type(slop_string slop_type) {
@@ -4464,6 +4494,7 @@ slop_string transpiler_resolve_payload_slop_type(context_TranspileContext* ctx, 
         } else if (!_mv_1368.has_value) {
             return slop_type;
         }
+        SLOP_UNREACHABLE();
     } else {
         return slop_type;
     }
@@ -5268,6 +5299,7 @@ uint8_t transpiler_is_simple_enum_def(types_SExpr* item) {
                                         } else if (!_mv_1384.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -5278,6 +5310,7 @@ uint8_t transpiler_is_simple_enum_def(types_SExpr* item) {
                     } else if (!_mv_1382.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -5872,6 +5905,7 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                     } else if (!_mv_1416.has_value) {
                         return ctype_to_c_type(arena, type_expr);
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             case types_SExpr_lst:
@@ -5910,6 +5944,7 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                                                 } else if (!_mv_1419.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -5929,6 +5964,7 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                                                 } else if (!_mv_1420.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -5944,6 +5980,7 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                         } else if (!_mv_1417.has_value) {
                             return SLOP_STR("");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -5996,6 +6033,7 @@ slop_string transpiler_get_type_c_name(context_TranspileContext* ctx, types_SExp
                                     } else if (!_mv_1424.has_value) {
                                         return SLOP_STR("");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             }
                             default: {
@@ -6005,6 +6043,7 @@ slop_string transpiler_get_type_c_name(context_TranspileContext* ctx, types_SExp
                     } else if (!_mv_1422.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6225,6 +6264,7 @@ uint8_t transpiler_is_imported_type(context_TranspileContext* ctx, slop_string t
         } else if (!_mv_1433.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -6311,6 +6351,7 @@ uint8_t transpiler_struct_uses_list_type(context_TranspileContext* ctx, types_SE
                         } else if (!_mv_1437.has_value) {
                             return 0;
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -6386,6 +6427,7 @@ uint8_t transpiler_field_uses_typename(context_TranspileContext* ctx, types_SExp
                     } else if (!_mv_1441.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6650,6 +6692,7 @@ uint8_t transpiler_is_pointer_type_expr_header(types_SExpr* type_expr) {
                     } else if (!_mv_1457.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6745,6 +6788,7 @@ slop_string transpiler_get_variant_name(types_SExpr* variant_expr) {
                     } else if (!_mv_1462.has_value) {
                         return SLOP_STR("unknown");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6894,6 +6938,7 @@ slop_string transpiler_get_const_name(types_SExpr* item) {
                     } else if (!_mv_1471.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6962,6 +7007,7 @@ uint8_t transpiler_emit_const_header_if_exported(context_TranspileContext* ctx, 
                                         } else if (!_mv_1477.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -6972,6 +7018,7 @@ uint8_t transpiler_emit_const_header_if_exported(context_TranspileContext* ctx, 
                     } else if (!_mv_1475.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -7134,6 +7181,7 @@ uint8_t transpiler_is_module_expr(slop_list_types_SExpr_ptr exprs) {
                             } else if (!_mv_1484.has_value) {
                                 return 0;
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -7144,6 +7192,7 @@ uint8_t transpiler_is_module_expr(slop_list_types_SExpr_ptr exprs) {
         } else if (!_mv_1482.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 

--- a/bootstrap/tester/slop_type_extract.c
+++ b/bootstrap/tester/slop_type_extract.c
@@ -398,6 +398,7 @@ uint8_t type_extract_registry_is_union(type_extract_TypeRegistry reg, slop_strin
     } else if (!_mv_1503.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t type_extract_registry_is_record(type_extract_TypeRegistry reg, slop_string name) {
@@ -408,6 +409,7 @@ uint8_t type_extract_registry_is_record(type_extract_TypeRegistry reg, slop_stri
     } else if (!_mv_1504.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t type_extract_registry_is_enum(type_extract_TypeRegistry reg, slop_string name) {
@@ -418,6 +420,7 @@ uint8_t type_extract_registry_is_enum(type_extract_TypeRegistry reg, slop_string
     } else if (!_mv_1505.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_option_type_extract_VariantEntry type_extract_registry_get_variant_info(type_extract_TypeRegistry reg, slop_string variant_name) {
@@ -445,6 +448,7 @@ slop_option_type_extract_VariantEntry type_extract_registry_get_variant_info(typ
     } else if (!_mv_1506.has_value) {
         return (slop_option_type_extract_VariantEntry){.has_value = false};
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_option_list_type_extract_TstFieldEntry type_extract_registry_get_record_fields(type_extract_TypeRegistry reg, slop_string name) {
@@ -459,6 +463,7 @@ slop_option_list_type_extract_TstFieldEntry type_extract_registry_get_record_fie
     } else if (!_mv_1508.has_value) {
         return (slop_option_list_type_extract_TstFieldEntry){.has_value = false};
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string type_extract_make_c_type_name(slop_arena* arena, slop_string prefix, slop_string name) {

--- a/bootstrap/tester/slop_types.c
+++ b/bootstrap/tester/slop_types.c
@@ -347,6 +347,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_11.has_value) {
                     return SLOP_STR("Option");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_ptr) {
                 __auto_type _mv_12 = (*t).inner_type;
                 if (_mv_12.has_value) {
@@ -355,6 +356,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_12.has_value) {
                     return SLOP_STR("Ptr");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_list) {
                 __auto_type _mv_13 = (*t).inner_type;
                 if (_mv_13.has_value) {
@@ -363,6 +365,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_13.has_value) {
                     return SLOP_STR("List");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_map) {
                 __auto_type _mv_14 = (*t).inner_type;
                 if (_mv_14.has_value) {
@@ -374,9 +377,11 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                     } else if (!_mv_15.has_value) {
                         return string_concat(arena, SLOP_STR("(Map "), string_concat(arena, types_resolved_type_to_slop_string(arena, key_type), SLOP_STR(")")));
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_14.has_value) {
                     return SLOP_STR("Map");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_result) {
                 __auto_type _mv_16 = (*t).inner_type;
                 if (_mv_16.has_value) {
@@ -388,9 +393,11 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                     } else if (!_mv_17.has_value) {
                         return string_concat(arena, SLOP_STR("(Result "), string_concat(arena, types_resolved_type_to_slop_string(arena, ok_type), SLOP_STR(")")));
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_16.has_value) {
                     return SLOP_STR("Result");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_array) {
                 __auto_type _mv_18 = (*t).inner_type;
                 if (_mv_18.has_value) {
@@ -399,6 +406,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_18.has_value) {
                     return SLOP_STR("Array");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_typevar) {
                 return name;
             } else {

--- a/bootstrap/transpiler/slop_context.c
+++ b/bootstrap/transpiler/slop_context.c
@@ -464,6 +464,7 @@ int64_t context_ctx_sexpr_line(types_SExpr* expr) {
                 return ((int64_t)(l.line));
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -494,6 +495,7 @@ int64_t context_ctx_sexpr_col(types_SExpr* expr) {
                 return ((int64_t)(l.col));
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -505,6 +507,7 @@ int64_t context_ctx_list_first_line(slop_list_types_SExpr_ptr items) {
     } else if (!_mv_53.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 int64_t context_ctx_list_first_col(slop_list_types_SExpr_ptr items) {
@@ -515,6 +518,7 @@ int64_t context_ctx_list_first_col(slop_list_types_SExpr_ptr items) {
     } else if (!_mv_54.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 void context_ctx_push_scope(context_TranspileContext* ctx) {
@@ -598,7 +602,9 @@ slop_option_context_VarEntry context_lookup_var_in_scope_chain(context_Scope* sc
                 } else if (!_mv_58.has_value) {
                     return (slop_option_context_VarEntry){.has_value = false};
                 }
+                SLOP_UNREACHABLE();
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -650,7 +656,9 @@ slop_option_context_VarEntry context_find_arena_in_scope_chain(context_Scope* sc
                 } else if (!_mv_61.has_value) {
                     return (slop_option_context_VarEntry){.has_value = false};
                 }
+                SLOP_UNREACHABLE();
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -723,6 +731,7 @@ slop_option_context_FuncEntry context_ctx_lookup_func(context_TranspileContext* 
         } else if (!_mv_64.has_value) {
             return self_entry;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -789,6 +798,7 @@ slop_string context_strip_module_prefix(slop_arena* arena, slop_string type_name
     } else if (!_mv_67.has_value) {
         return type_name;
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_option_string context_ctx_lookup_field_slop_type(context_TranspileContext* ctx, slop_string type_name, slop_string field_name) {
@@ -946,6 +956,7 @@ slop_string context_ctx_prefix_type(context_TranspileContext* ctx, slop_string t
             } else if (!_mv_73.has_value) {
                 return type_name;
             }
+            SLOP_UNREACHABLE();
         } else {
             return type_name;
         }
@@ -1548,6 +1559,7 @@ slop_string context_to_c_type_prefixed(context_TranspileContext* ctx, types_SExp
                         } else if (!_mv_91.has_value) {
                             return SLOP_STR("int64_t");
                         }
+                        SLOP_UNREACHABLE();
                     } else {
                         {
                             __auto_type base_c_type = ctype_to_c_type(arena, type_expr);
@@ -1561,6 +1573,7 @@ slop_string context_to_c_type_prefixed(context_TranspileContext* ctx, types_SExp
                                 } else if (!_mv_92.has_value) {
                                     return context_ctx_prefix_type(ctx, base_c_type);
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -1582,6 +1595,7 @@ slop_string context_to_c_type_prefixed(context_TranspileContext* ctx, types_SExp
                 return SLOP_STR("void*");
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -1610,6 +1624,7 @@ slop_option_string context_get_array_pointer_type(context_TranspileContext* ctx,
                 } else if (!_mv_94.has_value) {
                     return (slop_option_string){.has_value = false};
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {

--- a/bootstrap/transpiler/slop_ctype.c
+++ b/bootstrap/transpiler/slop_ctype.c
@@ -201,6 +201,7 @@ slop_string ctype_to_c_type(slop_arena* arena, types_SExpr* expr) {
                         return ctype_to_c_name(arena, name);
                     }
                 }
+                SLOP_UNREACHABLE();
             }
         }
         case types_SExpr_lst:
@@ -219,6 +220,7 @@ slop_string ctype_to_c_type(slop_arena* arena, types_SExpr* expr) {
             return SLOP_STR("void*");
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_ptr items) {
@@ -248,6 +250,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_23.has_value) {
                                         return SLOP_STR("void*");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("ScopedPtr"))) {
                                 if (len < 2) {
@@ -260,6 +263,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_24.has_value) {
                                         return SLOP_STR("void*");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("Option"))) {
                                 if (len < 2) {
@@ -276,6 +280,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_25.has_value) {
                                         return SLOP_STR("/* TRANSPILER_ERROR: Option requires inner type */");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("Result"))) {
                                 {
@@ -298,6 +303,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_26.has_value) {
                                         return SLOP_STR("slop_list_void");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("Map"))) {
                                 return SLOP_STR("slop_map*");
@@ -314,6 +320,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_27.has_value) {
                                         return SLOP_STR("void*");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("Chan"))) {
                                 if (len < 2) {
@@ -330,6 +337,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_28.has_value) {
                                         return SLOP_STR("slop_chan_void");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("Thread"))) {
                                 if (len < 2) {
@@ -346,6 +354,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                     } else if (!_mv_29.has_value) {
                                         return SLOP_STR("slop_thread_void");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (string_eq(head, SLOP_STR("Fn"))) {
                                 return SLOP_STR("slop_closure_t");
@@ -359,6 +368,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
                                 } else if (!_mv_30.has_value) {
                                     return ctype_to_c_name(arena, head);
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -369,6 +379,7 @@ slop_string ctype_to_c_type_compound(slop_arena* arena, slop_list_types_SExpr_pt
             } else if (!_mv_21.has_value) {
                 return SLOP_STR("void*");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -547,6 +558,7 @@ slop_option_types_ResolvedType_ptr ctype_get_node_resolved_type(types_SExpr* exp
             return lst.resolved_type;
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) {
@@ -562,6 +574,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_40.has_value) {
                 return ctype_to_c_name(arena, name);
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_range) {
             return (*rt).c_name;
         } else if ((kind == types_ResolvedTypeKind_rk_record) || ((kind == types_ResolvedTypeKind_rk_union) || (kind == types_ResolvedTypeKind_rk_enum))) {
@@ -574,6 +587,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
                 } else if (!_mv_41.has_value) {
                     return c_name;
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (kind == types_ResolvedTypeKind_rk_ptr) {
             __auto_type _mv_42 = (*rt).inner_type;
@@ -590,6 +604,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_42.has_value) {
                 return SLOP_STR("void*");
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_option) {
             __auto_type _mv_43 = (*rt).inner_type;
             if (_mv_43.has_value) {
@@ -601,6 +616,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_43.has_value) {
                 return SLOP_STR("/* TRANSPILER_ERROR: Option requires inner type */");
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_list) {
             __auto_type _mv_44 = (*rt).inner_type;
             if (_mv_44.has_value) {
@@ -612,6 +628,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_44.has_value) {
                 return SLOP_STR("slop_list_void");
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_result) {
             {
                 __auto_type ok_id = ({ __auto_type _mv = (*rt).inner_type; _mv.has_value ? ({ __auto_type ok_t = _mv.value; ctype_type_to_identifier(arena, ctype_resolved_type_to_c(arena, ok_t)); }) : (SLOP_STR("void")); });
@@ -632,6 +649,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_45.has_value) {
                 return SLOP_STR("void*");
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_chan) {
             __auto_type _mv_46 = (*rt).inner_type;
             if (_mv_46.has_value) {
@@ -644,6 +662,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_46.has_value) {
                 return SLOP_STR("slop_chan_int*");
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_thread) {
             __auto_type _mv_47 = (*rt).inner_type;
             if (_mv_47.has_value) {
@@ -656,6 +675,7 @@ slop_string ctype_resolved_type_to_c(slop_arena* arena, types_ResolvedType* rt) 
             } else if (!_mv_47.has_value) {
                 return SLOP_STR("slop_thread_int*");
             }
+            SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_typevar) {
             return SLOP_STR("__typevar_error__");
         } else {

--- a/bootstrap/transpiler/slop_defn.c
+++ b/bootstrap/transpiler/slop_defn.c
@@ -113,6 +113,7 @@ uint8_t defn_is_type_form(types_SExpr* expr) {
                     } else if (!_mv_921.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -151,6 +152,7 @@ uint8_t defn_is_function_form(types_SExpr* expr) {
                     } else if (!_mv_924.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -189,6 +191,7 @@ uint8_t defn_is_const_form(types_SExpr* expr) {
                     } else if (!_mv_927.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -227,6 +230,7 @@ uint8_t defn_is_ffi_form(types_SExpr* expr) {
                     } else if (!_mv_930.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -265,6 +269,7 @@ uint8_t defn_is_ffi_struct_form(types_SExpr* expr) {
                     } else if (!_mv_933.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -356,6 +361,7 @@ uint8_t defn_is_pointer_type_expr(types_SExpr* type_expr) {
                     } else if (!_mv_940.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -522,6 +528,7 @@ slop_string defn_eval_const_value(context_TranspileContext* ctx, types_SExpr* ex
                 return expr_transpile_expr(ctx, expr);
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -600,6 +607,7 @@ uint8_t defn_is_string_expr(slop_list_types_SExpr_ptr items, int64_t idx) {
     } else if (!_mv_953.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t defn_ends_with_t(slop_string name) {
@@ -1269,6 +1277,7 @@ uint8_t defn_is_array_type(types_SExpr* type_expr) {
                     } else if (!_mv_992.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1793,6 +1802,7 @@ uint8_t defn_is_pointer_type(types_SExpr* type_expr) {
                     } else if (!_mv_1017.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1868,6 +1878,7 @@ slop_string defn_get_param_c_type(context_TranspileContext* ctx, types_SExpr* pa
                             } else if (!_mv_1022.has_value) {
                                 return SLOP_STR("void*");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -1992,6 +2003,7 @@ uint8_t defn_is_spec_form(types_SExpr* expr) {
                     } else if (!_mv_1029.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2037,6 +2049,7 @@ slop_string defn_extract_spec_return_type(context_TranspileContext* ctx, types_S
                                             } else if (!_mv_1034.has_value) {
                                                 return SLOP_STR("void");
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 }
@@ -2047,6 +2060,7 @@ slop_string defn_extract_spec_return_type(context_TranspileContext* ctx, types_S
                         } else if (!_mv_1032.has_value) {
                             return SLOP_STR("void");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -2093,6 +2107,7 @@ slop_string defn_extract_spec_slop_return_type(context_TranspileContext* ctx, ty
                                             } else if (!_mv_1038.has_value) {
                                                 return SLOP_STR("");
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 }
@@ -2103,6 +2118,7 @@ slop_string defn_extract_spec_slop_return_type(context_TranspileContext* ctx, ty
                         } else if (!_mv_1036.has_value) {
                             return SLOP_STR("");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -2192,6 +2208,7 @@ slop_option_string defn_extract_result_type_name(context_TranspileContext* ctx, 
                                             } else if (!_mv_1044.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 }
@@ -2202,6 +2219,7 @@ slop_option_string defn_extract_result_type_name(context_TranspileContext* ctx, 
                         } else if (!_mv_1042.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -2236,7 +2254,9 @@ slop_option_string defn_check_result_type(context_TranspileContext* ctx, types_S
                         } else if (!_mv_1047.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             case types_SExpr_lst:
@@ -2271,9 +2291,11 @@ slop_option_string defn_check_result_type(context_TranspileContext* ctx, types_S
                                             } else if (!_mv_1051.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else if (!_mv_1050.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else {
                                         return (slop_option_string){.has_value = false};
                                     }
@@ -2285,6 +2307,7 @@ slop_option_string defn_check_result_type(context_TranspileContext* ctx, types_S
                         } else if (!_mv_1048.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -2385,6 +2408,7 @@ slop_string defn_build_single_param(context_TranspileContext* ctx, types_SExpr* 
                                         } else if (!_mv_1057.has_value) {
                                             return SLOP_STR("/* missing param type */");
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                     default: {
                                         return SLOP_STR("/* param name must be symbol */");
@@ -2393,6 +2417,7 @@ slop_string defn_build_single_param(context_TranspileContext* ctx, types_SExpr* 
                             } else if (!_mv_1055.has_value) {
                                 return SLOP_STR("/* missing param name */");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -2428,6 +2453,7 @@ uint8_t defn_is_param_mode(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_1058.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2459,6 +2485,7 @@ uint8_t defn_is_fn_type(types_SExpr* type_expr) {
                     } else if (!_mv_1061.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2498,6 +2525,7 @@ slop_string defn_emit_fn_param_type(context_TranspileContext* ctx, types_SExpr* 
                                 } else if (!_mv_1064.has_value) {
                                     return context_ctx_str(ctx, context_ctx_str(ctx, ret_type, SLOP_STR("(*")), context_ctx_str(ctx, param_name, SLOP_STR(")(void)")));
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -2636,6 +2664,7 @@ uint8_t defn_is_c_name_attr_at(slop_list_types_SExpr_ptr items, int64_t idx) {
     } else if (!_mv_1070.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 int64_t defn_find_body_start(slop_list_types_SExpr_ptr items) {
@@ -2692,6 +2721,7 @@ uint8_t defn_is_annotation(types_SExpr* expr) {
                     } else if (!_mv_1073.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2730,6 +2760,7 @@ uint8_t defn_is_pre_form(types_SExpr* expr) {
                     } else if (!_mv_1076.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2768,6 +2799,7 @@ uint8_t defn_is_post_form(types_SExpr* expr) {
                     } else if (!_mv_1079.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2806,6 +2838,7 @@ uint8_t defn_is_assume_form(types_SExpr* expr) {
                     } else if (!_mv_1082.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2904,6 +2937,7 @@ uint8_t defn_is_doc_form(types_SExpr* expr) {
                     } else if (!_mv_1089.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }

--- a/bootstrap/transpiler/slop_expr.c
+++ b/bootstrap/transpiler/slop_expr.c
@@ -335,6 +335,7 @@ slop_option_string expr_extract_symbol_name(types_SExpr* expr) {
                                     } else if (!_mv_124.has_value) {
                                         return (slop_option_string){.has_value = false};
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else {
                                     return (slop_option_string){.has_value = false};
                                 }
@@ -346,6 +347,7 @@ slop_option_string expr_extract_symbol_name(types_SExpr* expr) {
                     } else if (!_mv_122.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -385,6 +387,7 @@ slop_string expr_transpile_literal(context_TranspileContext* ctx, types_SExpr* e
             return SLOP_STR("/* error: list is not a literal */");
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_transpile_symbol(context_TranspileContext* ctx, slop_string name) {
@@ -412,6 +415,7 @@ slop_string expr_transpile_symbol(context_TranspileContext* ctx, slop_string nam
                 } else if (!_mv_127.has_value) {
                     return ctype_to_c_name(arena, variant_name);
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (strlib_contains(name, SLOP_STR("."))) {
             __auto_type _mv_128 = strlib_index_of(name, SLOP_STR("."));
@@ -439,11 +443,14 @@ slop_string expr_transpile_symbol(context_TranspileContext* ctx, slop_string nam
                         } else if (!_mv_130.has_value) {
                             return context_ctx_str3(ctx, base_name, SLOP_STR("_"), c_rest);
                         }
+                        SLOP_UNREACHABLE();
                     }
+                    SLOP_UNREACHABLE();
                 }
             } else if (!_mv_128.has_value) {
                 return ctype_to_c_name(arena, name);
             }
+            SLOP_UNREACHABLE();
         } else {
             __auto_type _mv_131 = context_ctx_lookup_var(ctx, name);
             if (_mv_131.has_value) {
@@ -467,9 +474,12 @@ slop_string expr_transpile_symbol(context_TranspileContext* ctx, slop_string nam
                             }
                             return c_name;
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
+                SLOP_UNREACHABLE();
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -674,6 +684,7 @@ uint8_t expr_is_pointer_type_expr(types_SExpr* type_expr) {
                     } else if (!_mv_138.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -722,6 +733,7 @@ uint8_t expr_is_fn_type_expr(types_SExpr* type_expr) {
             } else if (!_mv_142.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         }
         default: {
             return 0;
@@ -762,6 +774,7 @@ uint8_t expr_is_closure_typed_expr(context_TranspileContext* ctx, types_SExpr* e
             } else if (!_mv_146.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         }
         default: {
             return 0;
@@ -922,6 +935,7 @@ slop_string expr_transpile_call(context_TranspileContext* ctx, slop_string fn_na
                             return context_ctx_str4(ctx, c_name, SLOP_STR("("), args, SLOP_STR(")"));
                         }
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1148,6 +1162,7 @@ slop_string expr_closure_type_to_c(context_TranspileContext* ctx, slop_string sl
         } else if (!_mv_151.has_value) {
             return SLOP_STR("int64_t");
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -1280,6 +1295,7 @@ slop_string expr_transpile_enum_variant(context_TranspileContext* ctx, slop_stri
         } else if (!_mv_152.has_value) {
             return ctype_to_c_name(arena, variant_name);
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -1292,6 +1308,7 @@ slop_string expr_transpile_ok(context_TranspileContext* ctx, slop_string value_c
     } else if (!_mv_153.has_value) {
         return context_ctx_str3(ctx, SLOP_STR("(slop_result){ .is_ok = true, .data.ok = "), value_c, SLOP_STR(" }"));
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_transpile_error(context_TranspileContext* ctx, slop_string value_c) {
@@ -1303,6 +1320,7 @@ slop_string expr_transpile_error(context_TranspileContext* ctx, slop_string valu
     } else if (!_mv_154.has_value) {
         return context_ctx_str3(ctx, SLOP_STR("(slop_result){ .is_ok = false, .data.err = "), value_c, SLOP_STR(" }"));
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_infer_option_type(context_TranspileContext* ctx, types_SExpr* val_expr) {
@@ -1377,8 +1395,10 @@ slop_string expr_infer_option_type(context_TranspileContext* ctx, types_SExpr* v
                         context_ctx_add_error_at(ctx, context_ctx_str3(ctx, SLOP_STR("Unknown variable '"), name, SLOP_STR("' for Option type inference")), context_ctx_sexpr_line(val_expr), context_ctx_sexpr_col(val_expr));
                         return SLOP_STR("__type_error__");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
+            SLOP_UNREACHABLE();
         }
         case types_SExpr_lst:
         {
@@ -1386,6 +1406,7 @@ slop_string expr_infer_option_type(context_TranspileContext* ctx, types_SExpr* v
             return expr_infer_list_expr_option_type(ctx, lst.items);
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_c_type_to_option_type_name(context_TranspileContext* ctx, slop_string c_type) {
@@ -1443,11 +1464,14 @@ slop_string expr_infer_field_c_type_from_items(context_TranspileContext* ctx, sl
                                             } else if (!_mv_163.has_value) {
                                                 return SLOP_STR("__auto_type");
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     } else if (!_mv_162.has_value) {
                                         return SLOP_STR("__auto_type");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                         default: {
@@ -1457,9 +1481,11 @@ slop_string expr_infer_field_c_type_from_items(context_TranspileContext* ctx, sl
                 } else if (!_mv_159.has_value) {
                     return SLOP_STR("__auto_type");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_158.has_value) {
                 return SLOP_STR("__auto_type");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -1544,6 +1570,7 @@ slop_string expr_infer_list_expr_option_type(context_TranspileContext* ctx, slop
                                                 context_ctx_add_error_at(ctx, SLOP_STR("Missing field for option type inference"), line, col);
                                                 return SLOP_STR("__type_error__");
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 }
@@ -1582,6 +1609,7 @@ slop_string expr_infer_list_expr_option_type(context_TranspileContext* ctx, slop
                                     context_ctx_add_error_at(ctx, context_ctx_str3(ctx, SLOP_STR("Unknown function '"), op, SLOP_STR("' for Option type inference")), line, col);
                                     return SLOP_STR("__type_error__");
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -1594,6 +1622,7 @@ slop_string expr_infer_list_expr_option_type(context_TranspileContext* ctx, slop
                 context_ctx_add_error_at(ctx, SLOP_STR("Missing list head in option type inference"), line, col);
                 return SLOP_STR("__type_error__");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -1643,10 +1672,12 @@ slop_string expr_infer_list_element_option_type(context_TranspileContext* ctx, t
             } else if (!_mv_170.has_value) {
                 return expr_infer_list_element_option_type_fallback(ctx, list_expr);
             }
+            SLOP_UNREACHABLE();
         } else if (!_mv_169.has_value) {
             context_ctx_warn_fallback(ctx, list_expr, SLOP_STR("infer-list-element-option-type"));
             return expr_infer_list_element_option_type_fallback(ctx, list_expr);
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -1677,6 +1708,7 @@ slop_string expr_infer_list_element_option_type_fallback(context_TranspileContex
                         } else if (!_mv_172.has_value) {
                             return SLOP_STR("");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
                 case types_SExpr_lst:
@@ -1703,6 +1735,7 @@ slop_string expr_infer_list_element_option_type_fallback(context_TranspileContex
                                             } else if (!_mv_175.has_value) {
                                                 return SLOP_STR("");
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else {
                                             return SLOP_STR("");
                                         }
@@ -1714,6 +1747,7 @@ slop_string expr_infer_list_element_option_type_fallback(context_TranspileContex
                             } else if (!_mv_173.has_value) {
                                 return SLOP_STR("");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -1794,6 +1828,7 @@ slop_string expr_prefix_list_element_type(context_TranspileContext* ctx, slop_st
                 } else if (!_mv_177.has_value) {
                     return elem_type;
                 }
+                SLOP_UNREACHABLE();
             }
         } else {
             __auto_type _mv_178 = context_ctx_lookup_type(ctx, elem_type);
@@ -1803,6 +1838,7 @@ slop_string expr_prefix_list_element_type(context_TranspileContext* ctx, slop_st
             } else if (!_mv_178.has_value) {
                 return elem_type;
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -1902,6 +1938,7 @@ slop_string expr_slop_value_type_to_c_type(context_TranspileContext* ctx, slop_s
             } else if (!_mv_179.has_value) {
                 return ctype_to_c_name(arena, slop_type);
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -1989,6 +2026,7 @@ slop_string expr_resolve_type_alias(context_TranspileContext* ctx, slop_string s
         } else if (!_mv_181.has_value) {
             return slop_type;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2011,6 +2049,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                     } else if (!_mv_183.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             case types_SExpr_lst:
@@ -2064,8 +2103,10 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                                             } else if (!_mv_190.has_value) {
                                                                                 return SLOP_STR("");
                                                                             }
+                                                                            SLOP_UNREACHABLE();
                                                                         }
                                                                     }
+                                                                    SLOP_UNREACHABLE();
                                                                 }
                                                             }
                                                         }
@@ -2076,9 +2117,11 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                 } else if (!_mv_187.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else if (!_mv_186.has_value) {
                                                 return SLOP_STR("");
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else if (string_eq(op, SLOP_STR("record-new"))) {
                                             if (len >= 2) {
                                                 __auto_type _mv_191 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
@@ -2098,6 +2141,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                 } else if (!_mv_191.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -2117,9 +2161,11 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                     } else if (!_mv_194.has_value) {
                                                         return SLOP_STR("");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 } else if (!_mv_193.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -2135,6 +2181,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                 } else if (!_mv_195.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -2150,6 +2197,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                 } else if (!_mv_196.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -2165,6 +2213,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                 } else if (!_mv_197.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -2180,6 +2229,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                                 } else if (!_mv_198.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -2191,6 +2241,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                             } else if (!_mv_199.has_value) {
                                                 return SLOP_STR("");
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else {
                                             __auto_type _mv_200 = context_ctx_lookup_func(ctx, op);
                                             if (_mv_200.has_value) {
@@ -2199,6 +2250,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                                             } else if (!_mv_200.has_value) {
                                                 return SLOP_STR("");
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 }
@@ -2209,6 +2261,7 @@ slop_string expr_infer_expr_slop_type(context_TranspileContext* ctx, types_SExpr
                         } else if (!_mv_184.has_value) {
                             return SLOP_STR("");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -2349,6 +2402,7 @@ slop_string expr_infer_map_key_c_type(context_TranspileContext* ctx, types_SExpr
                     } else if (!_mv_202.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             default: {
@@ -2426,6 +2480,7 @@ slop_string expr_infer_set_elem_c_type(context_TranspileContext* ctx, types_SExp
                     } else if (!_mv_204.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             default: {
@@ -2603,6 +2658,7 @@ slop_string expr_infer_map_value_option_type(context_TranspileContext* ctx, type
                     } else if (!_mv_206.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             default: {
@@ -2753,6 +2809,7 @@ slop_string expr_infer_option_inner_slop_type(context_TranspileContext* ctx, typ
                                                                             } else if (!_mv_212.has_value) {
                                                                                 return SLOP_STR("");
                                                                             }
+                                                                            SLOP_UNREACHABLE();
                                                                         }
                                                                     }
                                                                     default: {
@@ -2762,6 +2819,7 @@ slop_string expr_infer_option_inner_slop_type(context_TranspileContext* ctx, typ
                                                             } else if (!_mv_210.has_value) {
                                                                 return SLOP_STR("");
                                                             }
+                                                            SLOP_UNREACHABLE();
                                                         }
                                                     } else if (string_eq(op, SLOP_STR("list-get"))) {
                                                         if (len < 2) {
@@ -2798,6 +2856,7 @@ slop_string expr_infer_option_inner_slop_type(context_TranspileContext* ctx, typ
                                                                             } else if (!_mv_215.has_value) {
                                                                                 return SLOP_STR("");
                                                                             }
+                                                                            SLOP_UNREACHABLE();
                                                                         }
                                                                     }
                                                                     default: {
@@ -2807,6 +2866,7 @@ slop_string expr_infer_option_inner_slop_type(context_TranspileContext* ctx, typ
                                                             } else if (!_mv_213.has_value) {
                                                                 return SLOP_STR("");
                                                             }
+                                                            SLOP_UNREACHABLE();
                                                         }
                                                     } else {
                                                         return SLOP_STR("");
@@ -2820,6 +2880,7 @@ slop_string expr_infer_option_inner_slop_type(context_TranspileContext* ctx, typ
                                     } else if (!_mv_208.has_value) {
                                         return SLOP_STR("");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             }
                         }
@@ -2845,6 +2906,7 @@ slop_string expr_fix_ternary_none(context_TranspileContext* ctx, types_SExpr* ot
             } else if (!_mv_216.has_value) {
                 return this_branch;
             }
+            SLOP_UNREACHABLE();
         }
     } else {
         if (string_eq(this_branch, SLOP_STR("none"))) {
@@ -2912,6 +2974,7 @@ slop_string expr_transpile_array_index(context_TranspileContext* ctx, types_SExp
                 } else if (!_mv_218.has_value) {
                     return context_ctx_str4(ctx, arr_c, SLOP_STR("["), idx_c, SLOP_STR("]"));
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -2937,6 +3000,7 @@ uint8_t expr_is_pointer_expr(context_TranspileContext* ctx, types_SExpr* expr) {
                 } else if (!_mv_220.has_value) {
                     return 0;
                 }
+                SLOP_UNREACHABLE();
             }
         }
         case types_SExpr_lst:
@@ -2969,6 +3033,7 @@ uint8_t expr_is_pointer_expr(context_TranspileContext* ctx, types_SExpr* expr) {
                                         } else if (!_mv_223.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else {
                                         return 0;
                                     }
@@ -2981,6 +3046,7 @@ uint8_t expr_is_pointer_expr(context_TranspileContext* ctx, types_SExpr* expr) {
                     } else if (!_mv_221.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 } else {
                     return 0;
                 }
@@ -3024,6 +3090,7 @@ slop_string expr_extract_sizeof_type(context_TranspileContext* ctx, types_SExpr*
                                             } else if (!_mv_227.has_value) {
                                                 return SLOP_STR("uint8_t");
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else if (string_eq(op, SLOP_STR("*")) || (string_eq(op, SLOP_STR("+")) || (string_eq(op, SLOP_STR("-")) || string_eq(op, SLOP_STR("/"))))) {
                                             {
                                                 __auto_type i = 1;
@@ -3056,6 +3123,7 @@ slop_string expr_extract_sizeof_type(context_TranspileContext* ctx, types_SExpr*
                         } else if (!_mv_225.has_value) {
                             return SLOP_STR("uint8_t");
                         }
+                        SLOP_UNREACHABLE();
                     } else {
                         return SLOP_STR("uint8_t");
                     }
@@ -3094,6 +3162,7 @@ slop_string expr_transpile_expr(context_TranspileContext* ctx, types_SExpr* expr
             return expr_transpile_list_expr(ctx, lst.items);
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items) {
@@ -3137,10 +3206,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                             context_ctx_add_error_at(ctx, SLOP_STR("missing right operand"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                             return SLOP_STR("0");
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else if (!_mv_232.has_value) {
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing left operand"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             } else if (expr_is_comparison_op(op) && (len < 3)) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("comparison operator needs 2 operands"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
@@ -3176,10 +3247,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing right operand"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_234.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing left operand"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("not")) && (len < 2)) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("not needs an argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                 return SLOP_STR("0");
@@ -3192,6 +3265,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("if")) && (len < 4)) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("if expression needs condition, then, and else branches"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                 return SLOP_STR("0");
@@ -3219,14 +3293,17 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                             context_ctx_add_error_at(ctx, SLOP_STR("missing else"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                             return SLOP_STR("0");
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else if (!_mv_238.has_value) {
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing then"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_237.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing condition"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if ((string_eq(op, SLOP_STR("let")) || string_eq(op, SLOP_STR("let*"))) && (len >= 3)) {
                                 return expr_transpile_let_expr(ctx, items);
                             } else if (string_eq(op, SLOP_STR("while")) && (len >= 3)) {
@@ -3252,6 +3329,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR(".")) && (len >= 3)) {
                                 __auto_type _mv_241 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_241.has_value) {
@@ -3284,10 +3362,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing field"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_241.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing object"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("cast")) && (len >= 3)) {
                                 __auto_type _mv_244 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_244.has_value) {
@@ -3321,10 +3401,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing cast value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_244.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing cast type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("c-inline")) && (len >= 2)) {
                                 __auto_type _mv_246 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_246.has_value) {
@@ -3345,6 +3427,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing c-inline string"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("some")) && (len >= 2)) {
                                 __auto_type _mv_248 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_248.has_value) {
@@ -3366,6 +3449,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing some value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("sizeof")) && (len >= 2)) {
                                 __auto_type _mv_249 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_249.has_value) {
@@ -3378,6 +3462,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing sizeof type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("addr")) && (len >= 2)) {
                                 __auto_type _mv_250 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_250.has_value) {
@@ -3387,6 +3472,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing addr argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("@")) && (len >= 3)) {
                                 __auto_type _mv_251 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_251.has_value) {
@@ -3403,10 +3489,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing index"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_251.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing array"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("arena-alloc")) && (len >= 3)) {
                                 __auto_type _mv_253 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_253.has_value) {
@@ -3437,6 +3525,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                                                 return expr_wrap_arena_alloc_checked(ctx, context_ctx_str5(ctx, SLOP_STR("("), cast_type, SLOP_STR("*)slop_arena_alloc("), context_ctx_str3(ctx, arena_c, SLOP_STR(", "), size_c), SLOP_STR(")")));
                                                             }
                                                         }
+                                                        SLOP_UNREACHABLE();
                                                     }
                                                 }
                                                 default: {
@@ -3452,10 +3541,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing arena-alloc size"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("NULL");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_253.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("NULL");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("arena-new")) && (len >= 2)) {
                                 __auto_type _mv_257 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_257.has_value) {
@@ -3468,6 +3559,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("arena-new requires size argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("NULL");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("arena-free")) && (len >= 2)) {
                                 __auto_type _mv_258 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_258.has_value) {
@@ -3480,6 +3572,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("arena-free requires arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("(void)0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("quote")) && (len >= 2)) {
                                 __auto_type _mv_259 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_259.has_value) {
@@ -3503,6 +3596,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing quote argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("record-new")) && (len >= 2)) {
                                 return expr_transpile_record_new(ctx, items);
                             } else if (string_eq(op, SLOP_STR("list")) && (len >= 2)) {
@@ -3581,6 +3675,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing union value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                                                 return SLOP_STR("0");
                                                             }
+                                                            SLOP_UNREACHABLE();
                                                         } else {
                                                             return context_ctx_str3(ctx, SLOP_STR("(("), type_name, context_ctx_str3(ctx, SLOP_STR("){ .tag = "), tag_const, SLOP_STR(" })")));
                                                         }
@@ -3589,6 +3684,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                                     context_ctx_add_error_at(ctx, SLOP_STR("union-new tag must be symbol"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                                     return SLOP_STR("0");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                             default: {
                                                 context_ctx_add_error_at(ctx, SLOP_STR("union-new type must be symbol"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
@@ -3599,10 +3695,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing union tag"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_261.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing union type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("ok")) && (len >= 2)) {
                                 __auto_type _mv_267 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_267.has_value) {
@@ -3615,6 +3713,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing ok value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("error")) && (len >= 2)) {
                                 __auto_type _mv_268 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_268.has_value) {
@@ -3627,6 +3726,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing error value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("?")) && (len >= 2)) {
                                 __auto_type _mv_269 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_269.has_value) {
@@ -3640,11 +3740,13 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         } else if (!_mv_270.has_value) {
                                             return context_ctx_str3(ctx, SLOP_STR("({ __auto_type _tmp = "), result_c, SLOP_STR("; if (!_tmp.is_ok) return _tmp; _tmp.data.ok; })"));
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 } else if (!_mv_269.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing ? argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("list-len")) && (len >= 2)) {
                                 __auto_type _mv_271 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_271.has_value) {
@@ -3657,6 +3759,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing list-len argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("list-get")) && (len >= 3)) {
                                 __auto_type _mv_272 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_272.has_value) {
@@ -3678,10 +3781,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing list-get index"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_272.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing list-get list argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("list-pop")) && (len >= 2)) {
                                 __auto_type _mv_274 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_274.has_value) {
@@ -3699,6 +3804,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing list-pop list argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("list-new")) && (len >= 3)) {
                                 __auto_type _mv_275 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_275.has_value) {
@@ -3717,10 +3823,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing list-new type argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_275.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing list-new arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("list-push")) && (len >= 3)) {
                                 __auto_type _mv_277 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_277.has_value) {
@@ -3746,10 +3854,12 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                         context_ctx_add_error_at(ctx, SLOP_STR("missing list-push item"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                         return SLOP_STR("0");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_277.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing list-push list"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("none")) && (len == 1)) {
                                 __auto_type _mv_279 = context_ctx_get_current_return_type(ctx);
                                 if (_mv_279.has_value) {
@@ -3762,6 +3872,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                                 } else if (!_mv_279.has_value) {
                                     return SLOP_STR("none");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (string_eq(op, SLOP_STR("cond"))) {
                                 return expr_transpile_cond_expr(ctx, items);
                             } else if (string_eq(op, SLOP_STR("for"))) {
@@ -3806,6 +3917,7 @@ slop_string expr_transpile_list_expr(context_TranspileContext* ctx, slop_list_ty
                 context_ctx_add_error_at(ctx, SLOP_STR("empty list"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -3826,6 +3938,7 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                 } else if (!_mv_281.has_value) {
                     return SLOP_STR("printf(\"\\n\")");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("print"))) {
             if (len < 2) {
@@ -3840,6 +3953,7 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                     context_ctx_add_error_at(ctx, SLOP_STR("print: missing argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("printf"))) {
             return expr_transpile_printf_call(ctx, items);
@@ -3873,10 +3987,12 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                         context_ctx_add_error_at(ctx, SLOP_STR("min: missing second argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         return SLOP_STR("0");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_283.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("min: missing first argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("max"))) {
             if (len < 3) {
@@ -3906,10 +4022,12 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                         context_ctx_add_error_at(ctx, SLOP_STR("max: missing second argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         return SLOP_STR("0");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_285.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("max: missing first argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("spawn"))) {
             if (len < 3) {
@@ -3928,6 +4046,7 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                     context_ctx_add_error_at(ctx, SLOP_STR("spawn: missing function argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("chan-buffered")) || strlib_ends_with(fn_name, SLOP_STR(":chan-buffered"))) {
             if (len < 4) {
@@ -3959,14 +4078,17 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                             context_ctx_add_error_at(ctx, SLOP_STR("chan-buffered: missing capacity argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                             return SLOP_STR("NULL");
                         }
+                        SLOP_UNREACHABLE();
                     } else if (!_mv_289.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("chan-buffered: missing arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         return SLOP_STR("NULL");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_288.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("chan-buffered: missing type argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("chan")) || strlib_ends_with(fn_name, SLOP_STR(":chan"))) {
             if (len < 3) {
@@ -3994,10 +4116,12 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                         context_ctx_add_error_at(ctx, SLOP_STR("chan: missing arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         return SLOP_STR("NULL");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_291.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("chan: missing type argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("send"))) {
             if (len < 3) {
@@ -4032,10 +4156,12 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                         context_ctx_add_error_at(ctx, SLOP_STR("send: missing value argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         return SLOP_STR("0");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_293.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("send: missing channel argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (string_eq(fn_name, SLOP_STR("recv"))) {
             if (len < 2) {
@@ -4066,6 +4192,7 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                     context_ctx_add_error_at(ctx, SLOP_STR("recv: missing channel argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             }
         } else {
             {
@@ -4147,6 +4274,7 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                                     } else if (!_mv_300.has_value) {
                                         return context_ctx_str3(ctx, SLOP_STR("(("), type_name, context_ctx_str3(ctx, SLOP_STR("){ .tag = "), c_tag_enum, SLOP_STR(" })")));
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else {
                                     return context_ctx_str3(ctx, SLOP_STR("(("), type_name, context_ctx_str3(ctx, SLOP_STR("){ .tag = "), c_tag_enum, SLOP_STR(" })")));
                                 }
@@ -4209,9 +4337,12 @@ slop_string expr_transpile_fn_call(context_TranspileContext* ctx, slop_string fn
                                     }
                                     return expr_transpile_call(ctx, fn_name, args);
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
+                        SLOP_UNREACHABLE();
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -4258,6 +4389,7 @@ slop_string expr_transpile_print(context_TranspileContext* ctx, types_SExpr* arg
                     } else if (!_mv_305.has_value) {
                         return context_ctx_str5(ctx, SLOP_STR("printf(\"%lld"), nl, SLOP_STR("\", (long long)("), arg_c, SLOP_STR("))"));
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -4362,6 +4494,7 @@ slop_option_string expr_get_expr_type_hint(context_TranspileContext* ctx, types_
                     } else if (!_mv_309.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
                 case types_SExpr_lst:
                 {
@@ -4423,6 +4556,7 @@ slop_option_string expr_get_expr_type_hint(context_TranspileContext* ctx, types_
                                                                                 } else if (!_mv_315.has_value) {
                                                                                     return (slop_option_string){.has_value = false};
                                                                                 }
+                                                                                SLOP_UNREACHABLE();
                                                                             } else {
                                                                                 return (slop_option_string){.has_value = false};
                                                                             }
@@ -4435,9 +4569,11 @@ slop_option_string expr_get_expr_type_hint(context_TranspileContext* ctx, types_
                                                             } else if (!_mv_313.has_value) {
                                                                 return (slop_option_string){.has_value = false};
                                                             }
+                                                            SLOP_UNREACHABLE();
                                                         } else if (!_mv_312.has_value) {
                                                             return (slop_option_string){.has_value = false};
                                                         }
+                                                        SLOP_UNREACHABLE();
                                                     }
                                                 }
                                             } else if (string_eq(op, SLOP_STR("int-to-string")) || (string_eq(op, SLOP_STR("string-copy")) || (string_eq(op, SLOP_STR("string-concat")) || string_eq(op, SLOP_STR("pretty-print"))))) {
@@ -4454,6 +4590,7 @@ slop_option_string expr_get_expr_type_hint(context_TranspileContext* ctx, types_
                                                 } else if (!_mv_316.has_value) {
                                                     return (slop_option_string){.has_value = false};
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         }
                                     }
@@ -4464,6 +4601,7 @@ slop_option_string expr_get_expr_type_hint(context_TranspileContext* ctx, types_
                             } else if (!_mv_310.has_value) {
                                 return (slop_option_string){.has_value = false};
                             }
+                            SLOP_UNREACHABLE();
                         } else {
                             return (slop_option_string){.has_value = false};
                         }
@@ -4540,6 +4678,7 @@ slop_string expr_transpile_union_constructor(context_TranspileContext* ctx, slop
                                                     } else if (!_mv_322.has_value) {
                                                         return context_ctx_str(ctx, SLOP_STR("(("), context_ctx_str(ctx, c_type_name, context_ctx_str(ctx, SLOP_STR("){ .tag = "), context_ctx_str(ctx, c_tag_enum, SLOP_STR(" })")))));
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 } else {
                                                     return context_ctx_str(ctx, SLOP_STR("(("), context_ctx_str(ctx, c_type_name, context_ctx_str(ctx, SLOP_STR("){ .tag = "), context_ctx_str(ctx, c_tag_enum, SLOP_STR(" })")))));
                                                 }
@@ -4552,6 +4691,7 @@ slop_string expr_transpile_union_constructor(context_TranspileContext* ctx, slop
                                 } else if (!_mv_319.has_value) {
                                     return context_ctx_str3(ctx, SLOP_STR("(("), c_type_name, SLOP_STR("){})/* no tag */"));
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -4572,6 +4712,7 @@ slop_string expr_transpile_union_constructor(context_TranspileContext* ctx, slop
             } else if (!_mv_317.has_value) {
                 return context_ctx_str3(ctx, SLOP_STR("(("), c_type_name, SLOP_STR("){})/* no args */"));
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -4730,6 +4871,7 @@ slop_string expr_transpile_match_expr(context_TranspileContext* ctx, slop_list_t
                 context_ctx_add_error_at(ctx, SLOP_STR("missing match scrutinee"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -4804,6 +4946,7 @@ slop_string expr_get_expr_pattern_tag(types_SExpr* pat_expr) {
                     } else if (!_mv_335.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -4964,6 +5107,7 @@ slop_option_string expr_get_expr_binding_name(types_SExpr* pat_expr) {
                     } else if (!_mv_345.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -4987,6 +5131,7 @@ slop_string expr_get_match_branch_body(context_TranspileContext* ctx, slop_list_
             } else if (!_mv_347.has_value) {
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -5163,6 +5308,7 @@ slop_string expr_infer_cond_result_c_type(context_TranspileContext* ctx, slop_li
                                 } else if (!_mv_354.has_value) {
                                     return SLOP_STR("int64_t");
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -5173,6 +5319,7 @@ slop_string expr_infer_cond_result_c_type(context_TranspileContext* ctx, slop_li
             } else if (!_mv_352.has_value) {
                 return SLOP_STR("int64_t");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -5198,6 +5345,7 @@ slop_string expr_infer_match_branch_body_type(context_TranspileContext* ctx, typ
                     } else if (!_mv_356.has_value) {
                         return SLOP_STR("__type_error__");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -5274,6 +5422,7 @@ slop_string expr_slop_type_to_c_type(context_TranspileContext* ctx, slop_string 
                 return slop_type;
             }
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -5326,6 +5475,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                         } else if (!_mv_360.has_value) {
                             return SLOP_STR("int64_t");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
                 case types_SExpr_lst:
@@ -5361,6 +5511,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_363.has_value) {
                                                         return SLOP_STR("int64_t");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("do"))) {
                                                 if (((int64_t)((items).len)) < 2) {
@@ -5373,6 +5524,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_364.has_value) {
                                                         return SLOP_STR("void");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("cond"))) {
                                                 return expr_infer_cond_result_c_type(ctx, items);
@@ -5387,6 +5539,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_365.has_value) {
                                                         return SLOP_STR("int64_t");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("match"))) {
                                                 return expr_infer_match_result_c_type(ctx, items);
@@ -5401,6 +5554,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_366.has_value) {
                                                         return SLOP_STR("int64_t");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("some"))) {
                                                 if (((int64_t)((items).len)) < 2) {
@@ -5432,6 +5586,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                         context_ctx_add_error_at(ctx, SLOP_STR("some constructor: missing value expression"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                                                         return SLOP_STR("__type_error__");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("none"))) {
                                                 __auto_type _mv_368 = context_ctx_get_current_return_type(ctx);
@@ -5445,6 +5600,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                 } else if (!_mv_368.has_value) {
                                                     return SLOP_STR("slop_option_int");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else if (string_eq(op, SLOP_STR("list-push"))) {
                                                 return SLOP_STR("void");
                                             } else if (string_eq(op, SLOP_STR("set!"))) {
@@ -5460,6 +5616,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_369.has_value) {
                                                         return SLOP_STR("void*");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("deref"))) {
                                                 if (((int64_t)((items).len)) < 2) {
@@ -5479,6 +5636,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_370.has_value) {
                                                         return SLOP_STR("int64_t");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("string-concat"))) {
                                                 return SLOP_STR("slop_string");
@@ -5499,6 +5657,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_371.has_value) {
                                                         return SLOP_STR("void*");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("send")) || strlib_ends_with(op, SLOP_STR(":send"))) {
                                                 return SLOP_STR("slop_result_void_thread_ChanError");
@@ -5524,6 +5683,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_372.has_value) {
                                                         return SLOP_STR("slop_result_int64_t_thread_ChanError");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("join")) || strlib_ends_with(op, SLOP_STR(":join"))) {
                                                 return SLOP_STR("int64_t");
@@ -5544,6 +5704,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_373.has_value) {
                                                         return SLOP_STR("slop_chan_int*");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("chan")) || strlib_ends_with(op, SLOP_STR(":chan"))) {
                                                 if (((int64_t)((items).len)) < 3) {
@@ -5560,6 +5721,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                     } else if (!_mv_374.has_value) {
                                                         return SLOP_STR("slop_chan_int*");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("arena-alloc"))) {
                                                 return SLOP_STR("void*");
@@ -5583,6 +5745,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                         context_ctx_add_error_at(ctx, SLOP_STR("Cannot infer list-new element type"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                                                         return SLOP_STR("__type_error__");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("list-get"))) {
                                                 if (((int64_t)((items).len)) < 2) {
@@ -5608,6 +5771,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                         context_ctx_add_error_at(ctx, SLOP_STR("Cannot infer list-get type: missing argument"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                                                         return SLOP_STR("__type_error__");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
                                             } else if (string_eq(op, SLOP_STR("int-to-string"))) {
                                                 return SLOP_STR("slop_string");
@@ -5649,7 +5813,9 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                                         context_ctx_add_error_at(ctx, context_ctx_str3(ctx, SLOP_STR("unknown function or type '"), op, SLOP_STR("'")), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                                                         return SLOP_STR("__type_error__");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         }
                                     }
@@ -5662,6 +5828,7 @@ slop_string expr_infer_expr_c_type(context_TranspileContext* ctx, types_SExpr* e
                                 context_ctx_add_error_at(ctx, SLOP_STR("cannot infer type of empty list"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                                 return SLOP_STR("__type_error__");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -5838,6 +6005,7 @@ slop_string expr_build_enum_case_expr(context_TranspileContext* ctx, slop_arena*
                 context_ctx_add_error_at(ctx, context_ctx_str3(ctx, SLOP_STR("unknown enum variant '"), tag, SLOP_STR("' in match expression")), context_ctx_sexpr_line(pattern), context_ctx_sexpr_col(pattern));
                 return cases;
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -5942,6 +6110,7 @@ slop_string expr_wrap_fn_ref_as_closure(context_TranspileContext* ctx, slop_stri
                     } else if (!_mv_392.has_value) {
                         return arg_c;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             default: {
@@ -6051,10 +6220,12 @@ slop_string expr_build_union_case_expr(context_TranspileContext* ctx, slop_arena
                             return s5;
                         }
                     }
+                    SLOP_UNREACHABLE();
                 }
             } else if (!_mv_394.has_value) {
                 return cases;
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -6146,6 +6317,7 @@ uint8_t expr_discard_needs_void(types_SExpr* e) {
             } else if (!_mv_400.has_value) {
                 return 0;
             }
+            SLOP_UNREACHABLE();
         }
         default: {
             return 0;
@@ -6238,6 +6410,7 @@ slop_string expr_transpile_let_expr(context_TranspileContext* ctx, slop_list_typ
             } else if (!_mv_402.has_value) {
                 return SLOP_STR("({ (void)0; })");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -6344,6 +6517,7 @@ slop_string expr_transpile_binding_expr(context_TranspileContext* ctx, types_SEx
                                                         } else if (!_mv_414.has_value) {
                                                             return context_ctx_str5(ctx, c_type, SLOP_STR(" "), var_name, SLOP_STR(" = {0};"), SLOP_STR(""));
                                                         }
+                                                        SLOP_UNREACHABLE();
                                                     }
                                                 } else if (!_mv_413.has_value) {
                                                     __auto_type _mv_415 = ({ __auto_type _lst = items; size_t _idx = (size_t)init_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
@@ -6356,7 +6530,9 @@ slop_string expr_transpile_binding_expr(context_TranspileContext* ctx, types_SEx
                                                     } else if (!_mv_415.has_value) {
                                                         return context_ctx_str3(ctx, SLOP_STR("__auto_type "), var_name, SLOP_STR(" = 0;"));
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 __auto_type _mv_416 = ({ __auto_type _lst = items; size_t _idx = (size_t)init_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                                 if (_mv_416.has_value) {
@@ -6368,6 +6544,7 @@ slop_string expr_transpile_binding_expr(context_TranspileContext* ctx, types_SEx
                                                 } else if (!_mv_416.has_value) {
                                                     return context_ctx_str3(ctx, SLOP_STR("__auto_type "), var_name, SLOP_STR(" = 0;"));
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         }
                                     }
@@ -6378,6 +6555,7 @@ slop_string expr_transpile_binding_expr(context_TranspileContext* ctx, types_SEx
                             } else if (!_mv_411.has_value) {
                                 return SLOP_STR("");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -6410,6 +6588,7 @@ uint8_t expr_binding_has_mut(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_417.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -6450,6 +6629,7 @@ slop_string expr_transpile_typed_init(context_TranspileContext* ctx, types_SExpr
                                             } else if (!_mv_422.has_value) {
                                                 return expr_transpile_expr(ctx, init_expr);
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     } else if (string_eq(op, SLOP_STR("none"))) {
                                         return context_ctx_str3(ctx, SLOP_STR("("), target_type, SLOP_STR("){.has_value = false}"));
@@ -6465,6 +6645,7 @@ slop_string expr_transpile_typed_init(context_TranspileContext* ctx, types_SExpr
                     } else if (!_mv_420.has_value) {
                         return expr_transpile_expr(ctx, init_expr);
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6511,6 +6692,7 @@ slop_string expr_transpile_while_expr(context_TranspileContext* ctx, slop_list_t
             } else if (!_mv_423.has_value) {
                 return SLOP_STR("({ (void)0; })");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -6575,6 +6757,7 @@ slop_string expr_transpile_when_expr(context_TranspileContext* ctx, slop_list_ty
             } else if (!_mv_426.has_value) {
                 return SLOP_STR("({ (void)0; })");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -6606,6 +6789,7 @@ uint8_t expr_set_is_self_assign(slop_list_types_SExpr_ptr items) {
                     } else if (!_mv_430.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
                 default: {
                     return 0;
@@ -6614,6 +6798,7 @@ uint8_t expr_set_is_self_assign(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_428.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     } else {
         return 0;
     }
@@ -6676,9 +6861,11 @@ slop_string expr_transpile_set_expr(context_TranspileContext* ctx, slop_list_typ
                                                                         } else if (!_mv_438.has_value) {
                                                                             return SLOP_STR("({ (void)0; })");
                                                                         }
+                                                                        SLOP_UNREACHABLE();
                                                                     } else if (!_mv_437.has_value) {
                                                                         return SLOP_STR("({ (void)0; })");
                                                                     }
+                                                                    SLOP_UNREACHABLE();
                                                                 }
                                                             } else if (string_eq(op, SLOP_STR("."))) {
                                                                 {
@@ -6703,6 +6890,7 @@ slop_string expr_transpile_set_expr(context_TranspileContext* ctx, slop_list_typ
                                             } else if (!_mv_435.has_value) {
                                                 return SLOP_STR("({ (void)0; })");
                                             }
+                                            SLOP_UNREACHABLE();
                                         }
                                     }
                                 }
@@ -6726,9 +6914,11 @@ slop_string expr_transpile_set_expr(context_TranspileContext* ctx, slop_list_typ
                     } else if (!_mv_433.has_value) {
                         return SLOP_STR("({ (void)0; })");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_432.has_value) {
                     return SLOP_STR("({ (void)0; })");
                 }
+                SLOP_UNREACHABLE();
             }
         }
     }
@@ -6749,7 +6939,9 @@ slop_string expr_resolve_arena_c_name(context_TranspileContext* ctx, slop_string
             context_ctx_add_error_at(ctx, context_ctx_str(ctx, op, SLOP_STR(": no arena in scope")), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             return SLOP_STR("arena");
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_get_arena_for_list_push_expr(context_TranspileContext* ctx, types_SExpr* list_expr, slop_string list_c) {
@@ -6777,10 +6969,13 @@ slop_string expr_get_arena_for_list_push_expr(context_TranspileContext* ctx, typ
                     } else if (!_mv_443.has_value) {
                         return SLOP_STR("arena");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_get_arena_from_field_access(context_TranspileContext* ctx, types_SExpr* expr) {
@@ -6813,6 +7008,7 @@ slop_string expr_get_arena_from_field_access(context_TranspileContext* ctx, type
                                     } else if (!_mv_447.has_value) {
                                         return SLOP_STR("");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else {
                                     return SLOP_STR("");
                                 }
@@ -6824,6 +7020,7 @@ slop_string expr_get_arena_from_field_access(context_TranspileContext* ctx, type
                     } else if (!_mv_445.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6858,6 +7055,7 @@ slop_string expr_get_arena_from_base(context_TranspileContext* ctx, types_SExpr*
                         return context_ctx_str(ctx, c_name, SLOP_STR("->arena"));
                     }
                 }
+                SLOP_UNREACHABLE();
             }
         }
         case types_SExpr_lst:
@@ -6887,6 +7085,7 @@ slop_string expr_get_arena_from_base(context_TranspileContext* ctx, types_SExpr*
                                     } else if (!_mv_452.has_value) {
                                         return SLOP_STR("arena");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else {
                                     return SLOP_STR("arena");
                                 }
@@ -6898,6 +7097,7 @@ slop_string expr_get_arena_from_base(context_TranspileContext* ctx, types_SExpr*
                     } else if (!_mv_450.has_value) {
                         return SLOP_STR("arena");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6932,6 +7132,7 @@ uint8_t expr_is_ptr_to_ptr_map(context_TranspileContext* ctx, types_SExpr* expr)
                 } else if (!_mv_454.has_value) {
                     return 0;
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -7024,6 +7225,7 @@ slop_string expr_transpile_record_new(context_TranspileContext* ctx, slop_list_t
                                     context_ctx_add_error_at(ctx, SLOP_STR("record-new: empty type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                                     return SLOP_STR("0");
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -7036,6 +7238,7 @@ slop_string expr_transpile_record_new(context_TranspileContext* ctx, slop_list_t
                 context_ctx_add_error_at(ctx, SLOP_STR("record-new: missing type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7316,6 +7519,7 @@ slop_string expr_transpile_list_literal(context_TranspileContext* ctx, slop_list
                                     return context_ctx_str(ctx, result, context_ctx_str(ctx, data_part, SLOP_STR("}})")));
                                 }
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -7323,6 +7527,7 @@ slop_string expr_transpile_list_literal(context_TranspileContext* ctx, slop_list
                 context_ctx_add_error_at(ctx, SLOP_STR("list: missing type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7403,6 +7608,7 @@ slop_string expr_get_map_key_c_info(context_TranspileContext* ctx, types_SExpr* 
                     } else if (!_mv_480.has_value) {
                         return SLOP_STR("sizeof(void*), slop_hash_ptr, slop_eq_ptr");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -7439,11 +7645,14 @@ slop_string expr_get_struct_key_info_by_name(context_TranspileContext* ctx, slop
                 } else if (!_mv_484.has_value) {
                     return SLOP_STR("");
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (!_mv_483.has_value) {
             return SLOP_STR("");
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_transpile_map_new(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items) {
@@ -7466,6 +7675,7 @@ slop_string expr_transpile_map_new(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("map-new: missing arena"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             }
         } else {
             __auto_type _mv_486 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
@@ -7483,10 +7693,12 @@ slop_string expr_transpile_map_new(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("map-new: missing KeyType"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_486.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("map-new: missing arena"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7598,14 +7810,17 @@ slop_string expr_transpile_map_put(context_TranspileContext* ctx, slop_list_type
                         context_ctx_add_error_at(ctx, SLOP_STR("map-put: missing val"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         return SLOP_STR("0");
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_489.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("map-put: missing key"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_488.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("map-put: missing map"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7645,10 +7860,12 @@ slop_string expr_transpile_map_get(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("map-get: missing key"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_491.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("map-get: missing map"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7677,10 +7894,12 @@ slop_string expr_transpile_map_has(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("map-has: missing key"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("false");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_493.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("map-has: missing map"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("false");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7709,10 +7928,12 @@ slop_string expr_transpile_map_remove(context_TranspileContext* ctx, slop_list_t
                     context_ctx_add_error_at(ctx, SLOP_STR("map-remove: missing key"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_495.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("map-remove: missing map"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7752,6 +7973,7 @@ slop_string expr_transpile_map_keys(context_TranspileContext* ctx, slop_list_typ
                 context_ctx_add_error_at(ctx, SLOP_STR("map-keys: missing map"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7779,10 +8001,12 @@ slop_string expr_transpile_set_new(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("set-new: missing ElementType"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("NULL");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_498.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("set-new: missing arena"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7812,10 +8036,12 @@ slop_string expr_transpile_set_put(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("set-put: missing element"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_500.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("set-put: missing set"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7844,10 +8070,12 @@ slop_string expr_transpile_set_has(context_TranspileContext* ctx, slop_list_type
                     context_ctx_add_error_at(ctx, SLOP_STR("set-has: missing element"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("false");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_502.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("set-has: missing set"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("false");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7876,10 +8104,12 @@ slop_string expr_transpile_set_remove(context_TranspileContext* ctx, slop_list_t
                     context_ctx_add_error_at(ctx, SLOP_STR("set-remove: missing element"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("0");
                 }
+                SLOP_UNREACHABLE();
             } else if (!_mv_504.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("set-remove: missing set"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("0");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7919,6 +8149,7 @@ slop_string expr_transpile_set_elements(context_TranspileContext* ctx, slop_list
                 context_ctx_add_error_at(ctx, SLOP_STR("set-elements: missing set"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -7963,6 +8194,7 @@ slop_string expr_transpile_set_literal(context_TranspileContext* ctx, slop_list_
                 context_ctx_add_error_at(ctx, SLOP_STR("set: missing type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -8032,9 +8264,11 @@ slop_string expr_transpile_for_as_expr(context_TranspileContext* ctx, slop_list_
                                                     } else if (!_mv_514.has_value) {
                                                         return SLOP_STR("({ /* for: missing end */ 0; })");
                                                     }
+                                                    SLOP_UNREACHABLE();
                                                 } else if (!_mv_513.has_value) {
                                                     return SLOP_STR("({ /* for: missing start */ 0; })");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         }
                                         default: {
@@ -8044,6 +8278,7 @@ slop_string expr_transpile_for_as_expr(context_TranspileContext* ctx, slop_list_
                                 } else if (!_mv_511.has_value) {
                                     return SLOP_STR("({ /* for: missing var */ 0; })");
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -8054,6 +8289,7 @@ slop_string expr_transpile_for_as_expr(context_TranspileContext* ctx, slop_list_
             } else if (!_mv_509.has_value) {
                 return SLOP_STR("({ /* for: missing binding */ 0; })");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -8112,6 +8348,7 @@ slop_string expr_transpile_for_each_as_expr(context_TranspileContext* ctx, slop_
                                                 } else if (!_mv_520.has_value) {
                                                     return SLOP_STR("({ /* for-each: missing collection */ 0; })");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         }
                                         default: {
@@ -8121,6 +8358,7 @@ slop_string expr_transpile_for_each_as_expr(context_TranspileContext* ctx, slop_
                                 } else if (!_mv_518.has_value) {
                                     return SLOP_STR("({ /* for-each: missing var */ 0; })");
                                 }
+                                SLOP_UNREACHABLE();
                             }
                         }
                     }
@@ -8131,6 +8369,7 @@ slop_string expr_transpile_for_each_as_expr(context_TranspileContext* ctx, slop_
             } else if (!_mv_516.has_value) {
                 return SLOP_STR("({ /* for-each: missing binding */ 0; })");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -8335,12 +8574,15 @@ slop_string expr_transpile_for_each_map_kv_as_expr(context_TranspileContext* ctx
                                     } else if (!_mv_528.has_value) {
                                         return SLOP_STR("({ /* for-each: missing map expression */ 0; })");
                                     }
+                                    SLOP_UNREACHABLE();
                                 } else if (!_mv_527.has_value) {
                                     return SLOP_STR("({ /* for-each: missing value binding */ 0; })");
                                 }
+                                SLOP_UNREACHABLE();
                             } else if (!_mv_526.has_value) {
                                 return SLOP_STR("({ /* for-each: missing key binding */ 0; })");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -8351,6 +8593,7 @@ slop_string expr_transpile_for_each_map_kv_as_expr(context_TranspileContext* ctx
         } else if (!_mv_524.has_value) {
             return SLOP_STR("({ /* for-each: missing binding */ 0; })");
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -8418,6 +8661,7 @@ slop_string expr_transpile_lambda_expr(context_TranspileContext* ctx, slop_list_
                 context_ctx_add_error_at(ctx, SLOP_STR("lambda missing params"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 return SLOP_STR("NULL");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -8685,7 +8929,9 @@ slop_string expr_find_arena_ptr_expr(context_TranspileContext* ctx) {
         } else if (!_mv_542.has_value) {
             return SLOP_STR("");
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string expr_build_closure_instance(context_TranspileContext* ctx, slop_string lambda_name, slop_string env_name, slop_string env_type, slop_list_string free_vars, slop_list_string captured_accesses) {
@@ -8892,6 +9138,7 @@ uint8_t expr_is_pointer_type_sexpr(types_SExpr* type_expr) {
                     } else if (!_mv_555.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -8993,6 +9240,7 @@ uint8_t expr_is_capturing_lambda(types_SExpr* expr) {
                                     } else if (!_mv_561.has_value) {
                                         return 0;
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             }
                             default: {
@@ -9002,6 +9250,7 @@ uint8_t expr_is_capturing_lambda(types_SExpr* expr) {
                     } else if (!_mv_559.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -9035,6 +9284,7 @@ slop_string expr_transpile_spawn_closure(context_TranspileContext* ctx, slop_lis
             context_ctx_add_error_at(ctx, SLOP_STR("spawn: missing arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             return SLOP_STR("NULL");
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -9075,6 +9325,7 @@ uint8_t expr_lambda_has_captures(context_TranspileContext* ctx, types_SExpr* fn_
                     } else if (!_mv_565.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -9140,6 +9391,7 @@ slop_string expr_infer_generic_type_binding(context_TranspileContext* ctx, slop_
             } else if (!_mv_568.has_value) {
                 return SLOP_STR("");
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -9477,6 +9729,7 @@ uint8_t expr_is_mut_binding(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_580.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -9660,6 +9913,7 @@ slop_list_string expr_extract_for_loop_var_pending(slop_arena* arena, slop_list_
         } else if (!_mv_592.has_value) {
             return pending;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -9753,8 +10007,11 @@ uint8_t expr_is_free_var(context_TranspileContext* ctx, slop_list_string param_n
                         } else if (!_mv_600.has_value) {
                             return 0;
                         }
+                        SLOP_UNREACHABLE();
                     }
+                    SLOP_UNREACHABLE();
                 }
+                SLOP_UNREACHABLE();
             }
         }
     }
@@ -9939,6 +10196,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                                 } else if (!_mv_607.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         } else if (string_eq(op, SLOP_STR("set-elements"))) {
                                             if (((int64_t)((items).len)) < 2) {
@@ -9961,6 +10219,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                                 } else if (!_mv_608.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         } else if (string_eq(op, SLOP_STR("map-values"))) {
                                             if (((int64_t)((items).len)) < 2) {
@@ -9983,6 +10242,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                                 } else if (!_mv_609.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             }
                                         } else {
                                             return expr_infer_elem_from_type(ctx, coll_expr);
@@ -9996,6 +10256,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                         } else if (!_mv_605.has_value) {
                             return SLOP_STR("");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }

--- a/bootstrap/transpiler/slop_match.c
+++ b/bootstrap/transpiler/slop_match.c
@@ -24,6 +24,7 @@ void match_emit_literal_case(context_TranspileContext* ctx, slop_string scrutine
 void match_transpile_union_match(context_TranspileContext* ctx, slop_string scrutinee_c, slop_list_types_SExpr_ptr patterns, slop_list_types_SExpr_ptr items, uint8_t is_return);
 void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_c, types_SExpr* pattern, slop_string tag, slop_string union_type_name, slop_list_types_SExpr_ptr branch_items, uint8_t is_return);
 void match_transpile_generic_match(context_TranspileContext* ctx, slop_string scrutinee_c, slop_list_types_SExpr_ptr items, uint8_t is_return);
+void match_emit_match_fallthrough_trap(context_TranspileContext* ctx, uint8_t is_return, uint8_t has_else);
 void match_emit_else_branch(context_TranspileContext* ctx, slop_list_types_SExpr_ptr branch_items, uint8_t is_return, uint8_t first);
 void match_emit_branch_body(context_TranspileContext* ctx, slop_list_types_SExpr_ptr branch_items, uint8_t is_return);
 void match_emit_branch_body_item(context_TranspileContext* ctx, types_SExpr* body_expr, uint8_t is_return, uint8_t is_last);
@@ -242,6 +243,7 @@ slop_string match_get_pattern_tag(types_SExpr* pat_expr) {
                     } else if (!_mv_655.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -285,6 +287,7 @@ slop_option_string match_extract_binding_name(types_SExpr* pat_expr) {
                     } else if (!_mv_658.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -431,6 +434,7 @@ void match_transpile_option_match(context_TranspileContext* ctx, slop_string scr
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 2;
         uint8_t first = 1;
+        uint8_t has_else = 0;
         while (i < len) {
             __auto_type _mv_666 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_666.has_value) {
@@ -456,6 +460,7 @@ void match_transpile_option_match(context_TranspileContext* ctx, slop_string scr
                                             first = 0;
                                         } else if (string_eq(tag, SLOP_STR("else"))) {
                                             match_emit_else_branch(ctx, branch_items, is_return, first);
+                                            has_else = 1;
                                             first = 0;
                                         } else {
                                         }
@@ -477,6 +482,7 @@ void match_transpile_option_match(context_TranspileContext* ctx, slop_string scr
         if (!(first)) {
             context_ctx_emit(ctx, SLOP_STR("}"));
         }
+        match_emit_match_fallthrough_trap(ctx, is_return, has_else);
     }
 }
 
@@ -531,6 +537,7 @@ void match_transpile_result_match(context_TranspileContext* ctx, slop_string scr
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 2;
         uint8_t first = 1;
+        uint8_t has_else = 0;
         while (i < len) {
             __auto_type _mv_670 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_670.has_value) {
@@ -556,6 +563,7 @@ void match_transpile_result_match(context_TranspileContext* ctx, slop_string scr
                                             first = 0;
                                         } else if (string_eq(tag, SLOP_STR("else"))) {
                                             match_emit_else_branch(ctx, branch_items, is_return, first);
+                                            has_else = 1;
                                             first = 0;
                                         } else {
                                         }
@@ -577,6 +585,7 @@ void match_transpile_result_match(context_TranspileContext* ctx, slop_string scr
         if (!(first)) {
             context_ctx_emit(ctx, SLOP_STR("}"));
         }
+        match_emit_match_fallthrough_trap(ctx, is_return, has_else);
     }
 }
 
@@ -650,6 +659,7 @@ void match_transpile_enum_match(context_TranspileContext* ctx, slop_string scrut
         __auto_type arena = (*ctx).arena;
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 2;
+        uint8_t has_else = 0;
         context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("switch ("), scrutinee_c, SLOP_STR(") {")));
         context_ctx_indent(ctx);
         while (i < len) {
@@ -667,6 +677,12 @@ void match_transpile_enum_match(context_TranspileContext* ctx, slop_string scrut
                                 __auto_type _mv_677 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_677.has_value) {
                                     __auto_type pattern = _mv_677.value;
+                                    {
+                                        __auto_type tag = match_get_pattern_tag(pattern);
+                                        if (string_eq(tag, SLOP_STR("else")) || string_eq(tag, SLOP_STR("_"))) {
+                                            has_else = 1;
+                                        }
+                                    }
                                     match_emit_enum_case(ctx, pattern, branch_items, is_return);
                                 } else if (!_mv_677.has_value) {
                                 }
@@ -684,6 +700,7 @@ void match_transpile_enum_match(context_TranspileContext* ctx, slop_string scrut
         }
         context_ctx_dedent(ctx);
         context_ctx_emit(ctx, SLOP_STR("}"));
+        match_emit_match_fallthrough_trap(ctx, is_return, has_else);
     }
 }
 
@@ -728,6 +745,7 @@ void match_transpile_literal_match(context_TranspileContext* ctx, slop_string sc
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 2;
         uint8_t first = 1;
+        uint8_t has_else = 0;
         while (i < len) {
             __auto_type _mv_679 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_679.has_value) {
@@ -743,6 +761,9 @@ void match_transpile_literal_match(context_TranspileContext* ctx, slop_string sc
                                 __auto_type _mv_681 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                 if (_mv_681.has_value) {
                                     __auto_type pattern = _mv_681.value;
+                                    if (string_eq(match_get_pattern_tag(pattern), SLOP_STR("else"))) {
+                                        has_else = 1;
+                                    }
                                     match_emit_literal_case(ctx, scrutinee_c, pattern, branch_items, is_return, first);
                                     first = 0;
                                 } else if (!_mv_681.has_value) {
@@ -762,6 +783,7 @@ void match_transpile_literal_match(context_TranspileContext* ctx, slop_string sc
         if (!(first)) {
             context_ctx_emit(ctx, SLOP_STR("}"));
         }
+        match_emit_match_fallthrough_trap(ctx, is_return, has_else);
     }
 }
 
@@ -806,6 +828,7 @@ void match_transpile_union_match(context_TranspileContext* ctx, slop_string scru
             __auto_type len = ((int64_t)((items).len));
             int64_t i = 2;
             uint8_t first = 1;
+            uint8_t has_else = 0;
             context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("switch ("), scrutinee_c, SLOP_STR(".tag) {")));
             context_ctx_indent(ctx);
             while (i < len) {
@@ -826,6 +849,7 @@ void match_transpile_union_match(context_TranspileContext* ctx, slop_string scru
                                         {
                                             __auto_type tag = match_get_pattern_tag(pattern);
                                             if (string_eq(tag, SLOP_STR("else")) || string_eq(tag, SLOP_STR("_"))) {
+                                                has_else = 1;
                                                 context_ctx_emit(ctx, SLOP_STR("default: {"));
                                                 context_ctx_indent(ctx);
                                                 match_emit_branch_body(ctx, branch_items, is_return);
@@ -860,6 +884,7 @@ void match_transpile_union_match(context_TranspileContext* ctx, slop_string scru
             }
             context_ctx_dedent(ctx);
             context_ctx_emit(ctx, SLOP_STR("}"));
+            match_emit_match_fallthrough_trap(ctx, is_return, has_else);
         }
     }
 }
@@ -945,6 +970,13 @@ void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_
 void match_transpile_generic_match(context_TranspileContext* ctx, slop_string scrutinee_c, slop_list_types_SExpr_ptr items, uint8_t is_return) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     match_transpile_literal_match(ctx, scrutinee_c, items, is_return);
+}
+
+void match_emit_match_fallthrough_trap(context_TranspileContext* ctx, uint8_t is_return, uint8_t has_else) {
+    SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
+    if (is_return && !(has_else)) {
+        context_ctx_emit(ctx, SLOP_STR("SLOP_UNREACHABLE();"));
+    }
 }
 
 void match_emit_else_branch(context_TranspileContext* ctx, slop_list_types_SExpr_ptr branch_items, uint8_t is_return, uint8_t first) {
@@ -1299,6 +1331,7 @@ uint8_t match_binding_starts_with_mut(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_706.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -1364,6 +1397,7 @@ uint8_t match_is_none_form_inline(types_SExpr* expr) {
                     } else if (!_mv_710.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 } else {
                     return 0;
                 }
@@ -1409,6 +1443,7 @@ slop_option_string match_get_arena_alloc_ptr_type_inline(context_TranspileContex
                                         } else if (!_mv_715.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else {
                                         return (slop_option_string){.has_value = false};
                                     }
@@ -1420,6 +1455,7 @@ slop_option_string match_get_arena_alloc_ptr_type_inline(context_TranspileContex
                         } else if (!_mv_713.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     } else {
                         return (slop_option_string){.has_value = false};
                     }
@@ -1451,6 +1487,7 @@ slop_option_string match_extract_sizeof_type_inline(context_TranspileContext* ct
                     } else if (!_mv_717.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             case types_SExpr_lst:
@@ -1478,6 +1515,7 @@ slop_option_string match_extract_sizeof_type_inline(context_TranspileContext* ct
                                         } else if (!_mv_720.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else {
                                         return (slop_option_string){.has_value = false};
                                     }
@@ -1489,6 +1527,7 @@ slop_option_string match_extract_sizeof_type_inline(context_TranspileContext* ct
                         } else if (!_mv_718.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     } else {
                         return (slop_option_string){.has_value = false};
                     }
@@ -1607,6 +1646,7 @@ slop_option_string match_get_var_c_type_inline(context_TranspileContext* ctx, ty
                 } else if (!_mv_727.has_value) {
                     return (slop_option_string){.has_value = false};
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -1881,6 +1921,7 @@ uint8_t match_is_deref_inline(types_SExpr* expr) {
                     } else if (!_mv_747.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1906,6 +1947,7 @@ slop_string match_get_deref_inner_inline(context_TranspileContext* ctx, types_SE
                 } else if (!_mv_750.has_value) {
                     return SLOP_STR("/* missing deref arg */");
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -1966,6 +2008,7 @@ void match_emit_inline_cond(context_TranspileContext* ctx, slop_list_types_SExpr
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 1;
         uint8_t first = 1;
+        uint8_t has_else = 0;
         while (i < len) {
             __auto_type _mv_753 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_753.has_value) {
@@ -1990,6 +2033,7 @@ void match_emit_inline_cond(context_TranspileContext* ctx, slop_list_types_SExpr
                                         {
                                             __auto_type sym = _mv_756.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("else"))) {
+                                                has_else = 1;
                                                 context_ctx_emit(ctx, SLOP_STR("} else {"));
                                                 context_ctx_indent(ctx);
                                                 match_emit_inline_cond_body(ctx, clause_items, 1, is_return, is_last);
@@ -2045,6 +2089,7 @@ void match_emit_inline_cond(context_TranspileContext* ctx, slop_list_types_SExpr
         if (!(first)) {
             context_ctx_emit(ctx, SLOP_STR("}"));
         }
+        match_emit_match_fallthrough_trap(ctx, is_return, has_else);
     }
 }
 
@@ -2848,6 +2893,7 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 2;
         uint8_t first = 1;
+        uint8_t has_else = 0;
         while (i < len) {
             __auto_type _mv_796 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_796.has_value) {
@@ -2866,6 +2912,7 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
                                     {
                                         __auto_type tag = match_get_pattern_tag(pattern);
                                         if (string_eq(tag, SLOP_STR("else")) || string_eq(tag, SLOP_STR("_"))) {
+                                            has_else = 1;
                                             if (first) {
                                                 context_ctx_emit(ctx, SLOP_STR("{"));
                                             } else {
@@ -2921,6 +2968,7 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
         if (!(first)) {
             context_ctx_emit(ctx, SLOP_STR("}"));
         }
+        match_emit_match_fallthrough_trap(ctx, is_return, has_else);
     }
 }
 

--- a/bootstrap/transpiler/slop_match.h
+++ b/bootstrap/transpiler/slop_match.h
@@ -44,6 +44,7 @@ void match_emit_literal_case(context_TranspileContext* ctx, slop_string scrutine
 void match_transpile_union_match(context_TranspileContext* ctx, slop_string scrutinee_c, slop_list_types_SExpr_ptr patterns, slop_list_types_SExpr_ptr items, uint8_t is_return);
 void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_c, types_SExpr* pattern, slop_string tag, slop_string union_type_name, slop_list_types_SExpr_ptr branch_items, uint8_t is_return);
 void match_transpile_generic_match(context_TranspileContext* ctx, slop_string scrutinee_c, slop_list_types_SExpr_ptr items, uint8_t is_return);
+void match_emit_match_fallthrough_trap(context_TranspileContext* ctx, uint8_t is_return, uint8_t has_else);
 void match_emit_else_branch(context_TranspileContext* ctx, slop_list_types_SExpr_ptr branch_items, uint8_t is_return, uint8_t first);
 void match_emit_branch_body(context_TranspileContext* ctx, slop_list_types_SExpr_ptr branch_items, uint8_t is_return);
 void match_emit_branch_body_item(context_TranspileContext* ctx, types_SExpr* body_expr, uint8_t is_return, uint8_t is_last);

--- a/bootstrap/transpiler/slop_parser.c
+++ b/bootstrap/transpiler/slop_parser.c
@@ -383,6 +383,7 @@ parser_Token parser_parser_peek(parser_ParserState* state) {
     } else if (!_mv_611.has_value) {
         return (parser_Token){parser_TokenType_tok_eof, SLOP_STR(""), 1, 1};
     }
+    SLOP_UNREACHABLE();
 }
 
 void parser_parser_advance(parser_ParserState* state) {
@@ -447,6 +448,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_expr(slop_arena* aren
                 __auto_type e = _mv_612.data.err;
                 return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
             }
+            SLOP_UNREACHABLE();
         } else if (tok.kind == parser_TokenType_tok_symbol) {
             parser_parser_advance(state);
             {
@@ -592,7 +594,9 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_paren_group(slo
             __auto_type _ = _mv_615.data.ok;
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = expr });
         }
+        SLOP_UNREACHABLE();
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_arena* arena, parser_ParserState* state) {
@@ -629,6 +633,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                         return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = node });
                     }
                 }
+                SLOP_UNREACHABLE();
             } else {
                 parser_parser_advance(state);
                 {
@@ -659,6 +664,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                     return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = node });
                 }
             }
+            SLOP_UNREACHABLE();
         } else if (tok.kind == parser_TokenType_tok_operator) {
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = (parser_ParseError){SLOP_STR("Unexpected operator in expression"), tok.line, tok.col} });
         } else if (tok.kind == parser_TokenType_tok_lparen) {
@@ -683,6 +689,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                         }
                     }
                 }
+                SLOP_UNREACHABLE();
             }
         } else if (tok.kind == parser_TokenType_tok_quote) {
             parser_parser_advance(state);
@@ -703,6 +710,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
                     return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = node });
                 }
             }
+            SLOP_UNREACHABLE();
         } else {
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = (parser_ParseError){SLOP_STR("Expected expression in infix"), tok.line, tok.col} });
         }
@@ -767,6 +775,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_prec(slop_arena
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix(slop_arena* arena, parser_ParserState* state) {
@@ -794,6 +803,7 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix(slop_arena* are
                     }
                 }
             }
+            SLOP_UNREACHABLE();
         }
     }
 }
@@ -836,6 +846,7 @@ slop_result_list_types_SExpr_ptr_parser_ParseError parser_parse(slop_arena* aren
         __auto_type e = _mv_623.data.err;
         return ((slop_result_list_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
     }
+    SLOP_UNREACHABLE();
 }
 
 int64_t parser_sexpr_line(types_SExpr* expr) {
@@ -862,6 +873,7 @@ int64_t parser_sexpr_line(types_SExpr* expr) {
             return l.line;
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 int64_t parser_sexpr_col(types_SExpr* expr) {
@@ -888,6 +900,7 @@ int64_t parser_sexpr_col(types_SExpr* expr) {
             return l.col;
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t parser_sexpr_is_symbol_with_name(types_SExpr* expr, slop_string name) {
@@ -920,6 +933,7 @@ uint8_t parser_is_form(types_SExpr* expr, slop_string keyword) {
                 } else if (!_mv_629.has_value) {
                     return 0;
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -1197,6 +1211,7 @@ slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string parser_json_escape_string(slop_arena* arena, slop_string s) {
@@ -1324,5 +1339,6 @@ slop_string parser_json_print(slop_arena* arena, types_SExpr* expr) {
             }
         }
     }
+    SLOP_UNREACHABLE();
 }
 

--- a/bootstrap/transpiler/slop_stmt.c
+++ b/bootstrap/transpiler/slop_stmt.c
@@ -109,6 +109,7 @@ slop_option_string stmt_get_arena_alloc_ptr_type(context_TranspileContext* ctx, 
                                             } else if (!_mv_805.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else if (string_eq(op, SLOP_STR("cast")) && (((int64_t)((items).len)) >= 3)) {
                                             __auto_type _mv_806 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                             if (_mv_806.has_value) {
@@ -117,6 +118,7 @@ slop_option_string stmt_get_arena_alloc_ptr_type(context_TranspileContext* ctx, 
                                             } else if (!_mv_806.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else {
                                             return (slop_option_string){.has_value = false};
                                         }
@@ -129,6 +131,7 @@ slop_option_string stmt_get_arena_alloc_ptr_type(context_TranspileContext* ctx, 
                         } else if (!_mv_803.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     } else {
                         return (slop_option_string){.has_value = false};
                     }
@@ -160,6 +163,7 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
                     } else if (!_mv_808.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             case types_SExpr_lst:
@@ -187,6 +191,7 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
                                         } else if (!_mv_811.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
+                                        SLOP_UNREACHABLE();
                                     } else {
                                         return (slop_option_string){.has_value = false};
                                     }
@@ -198,6 +203,7 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
                         } else if (!_mv_809.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
+                        SLOP_UNREACHABLE();
                     } else {
                         return (slop_option_string){.has_value = false};
                     }
@@ -242,6 +248,7 @@ uint8_t stmt_is_stmt_form(types_SExpr* expr) {
                     } else if (!_mv_813.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -470,6 +477,7 @@ uint8_t stmt_binding_has_mut(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_827.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -585,6 +593,7 @@ uint8_t stmt_is_none_form(types_SExpr* expr) {
                     } else if (!_mv_834.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 } else {
                     return 0;
                 }
@@ -888,6 +897,7 @@ slop_option_string stmt_get_var_c_type(context_TranspileContext* ctx, types_SExp
                 } else if (!_mv_854.has_value) {
                     return (slop_option_string){.has_value = false};
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -913,6 +923,7 @@ uint8_t stmt_is_pointer_target(context_TranspileContext* ctx, types_SExpr* expr)
                 } else if (!_mv_856.has_value) {
                     return 0;
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {
@@ -1058,6 +1069,7 @@ uint8_t stmt_is_deref_expr(types_SExpr* expr) {
                     } else if (!_mv_866.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1083,6 +1095,7 @@ types_SExpr* stmt_get_deref_inner(types_SExpr* expr) {
                 } else if (!_mv_869.has_value) {
                     return expr;
                 }
+                SLOP_UNREACHABLE();
             }
         }
         default: {

--- a/bootstrap/transpiler/slop_strlib.c
+++ b/bootstrap/transpiler/slop_strlib.c
@@ -183,6 +183,7 @@ uint8_t strlib_contains(slop_string haystack, slop_string needle) {
     } else if (!_mv_0.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t strlib_starts_with(slop_string s, slop_string prefix) {
@@ -602,6 +603,7 @@ slop_string strlib_join(slop_arena* arena, slop_list_string strings, slop_string
                 } else if (!_mv_1.has_value) {
                     return (slop_string){.len = ((uint64_t)(0)), .data = ((uint8_t*)(({ __auto_type _alloc = (uint8_t*)slop_arena_alloc(arena, 1); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })))};
                 }
+                SLOP_UNREACHABLE();
             } else {
                 {
                     int64_t total_len = 0;
@@ -679,6 +681,7 @@ slop_string strlib_replace(slop_arena* arena, slop_string s, slop_string old, sl
             return (slop_string){.len = ((uint64_t)(result_len)), .data = ((uint8_t*)(buf))};
         }
     }
+    SLOP_UNREACHABLE();
 }
 
 slop_string strlib_replace_all(slop_arena* arena, slop_string s, slop_string old, slop_string new) {

--- a/bootstrap/transpiler/slop_transpiler.c
+++ b/bootstrap/transpiler/slop_transpiler.c
@@ -1025,6 +1025,7 @@ slop_string transpiler_prescan_get_param_c_type(context_TranspileContext* ctx, t
                             } else if (!_mv_1166.has_value) {
                                 return SLOP_STR("void*");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -1070,6 +1071,7 @@ uint8_t transpiler_prescan_is_param_mode(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_1167.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -1122,6 +1124,7 @@ uint8_t transpiler_is_spec_annotation(types_SExpr* expr) {
                     } else if (!_mv_1171.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -1947,6 +1950,7 @@ slop_string transpiler_get_ffi_struct_c_name(slop_arena* arena, slop_list_types_
                             } else if (!_mv_1228.has_value) {
                                 return transpiler_apply_struct_prefix_heuristic(arena, default_name);
                             }
+                            SLOP_UNREACHABLE();
                         } else {
                             return transpiler_apply_struct_prefix_heuristic(arena, default_name);
                         }
@@ -1958,6 +1962,7 @@ slop_string transpiler_get_ffi_struct_c_name(slop_arena* arena, slop_list_types_
             } else if (!_mv_1226.has_value) {
                 return transpiler_apply_struct_prefix_heuristic(arena, default_name);
             }
+            SLOP_UNREACHABLE();
         } else {
             return transpiler_apply_struct_prefix_heuristic(arena, default_name);
         }
@@ -2017,6 +2022,7 @@ uint8_t transpiler_is_ffi_string_item(slop_list_types_SExpr_ptr items, int64_t i
     } else if (!_mv_1230.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t transpiler_is_enum_def(slop_list_types_SExpr_ptr items) {
@@ -2053,6 +2059,7 @@ uint8_t transpiler_is_enum_def(slop_list_types_SExpr_ptr items) {
                             } else if (!_mv_1234.has_value) {
                                 return 0;
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -2063,6 +2070,7 @@ uint8_t transpiler_is_enum_def(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_1232.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2100,6 +2108,7 @@ uint8_t transpiler_is_record_def(slop_list_types_SExpr_ptr items) {
                             } else if (!_mv_1238.has_value) {
                                 return 0;
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -2110,6 +2119,7 @@ uint8_t transpiler_is_record_def(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_1236.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2147,6 +2157,7 @@ uint8_t transpiler_is_union_def(slop_list_types_SExpr_ptr items) {
                             } else if (!_mv_1242.has_value) {
                                 return 0;
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -2157,6 +2168,7 @@ uint8_t transpiler_is_union_def(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_1240.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2197,6 +2209,7 @@ slop_string transpiler_get_array_c_type(context_TranspileContext* ctx, slop_list
                                             } else if (!_mv_1248.has_value) {
                                                 return default_c_type;
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else {
                                             return default_c_type;
                                         }
@@ -2208,6 +2221,7 @@ slop_string transpiler_get_array_c_type(context_TranspileContext* ctx, slop_list
                             } else if (!_mv_1246.has_value) {
                                 return default_c_type;
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -2218,6 +2232,7 @@ slop_string transpiler_get_array_c_type(context_TranspileContext* ctx, slop_list
         } else if (!_mv_1244.has_value) {
             return default_c_type;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -2305,6 +2320,7 @@ uint8_t transpiler_is_union_type_def(types_SExpr* item) {
                                         } else if (!_mv_1254.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -2315,6 +2331,7 @@ uint8_t transpiler_is_union_type_def(types_SExpr* item) {
                     } else if (!_mv_1252.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2353,6 +2370,7 @@ uint8_t transpiler_is_type_def(types_SExpr* item) {
                     } else if (!_mv_1257.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2410,6 +2428,7 @@ uint8_t transpiler_is_fn_def(types_SExpr* item) {
                     } else if (!_mv_1261.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -2539,6 +2558,7 @@ int64_t transpiler_get_body_start(slop_list_types_SExpr_ptr items) {
                             } else if (!_mv_1268.has_value) {
                                 return 2;
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -2549,6 +2569,7 @@ int64_t transpiler_get_body_start(slop_list_types_SExpr_ptr items) {
         } else if (!_mv_1266.has_value) {
             return 2;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -3059,6 +3080,7 @@ uint8_t transpiler_is_struct_type_def(types_SExpr* item) {
                                         } else if (!_mv_1303.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -3069,6 +3091,7 @@ uint8_t transpiler_is_struct_type_def(types_SExpr* item) {
                     } else if (!_mv_1301.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -3157,6 +3180,7 @@ uint8_t transpiler_is_type_alias_def(types_SExpr* item) {
                                         } else if (!_mv_1310.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -3167,6 +3191,7 @@ uint8_t transpiler_is_type_alias_def(types_SExpr* item) {
                     } else if (!_mv_1308.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -3218,6 +3243,7 @@ uint8_t transpiler_is_result_type_alias_def(types_SExpr* item) {
                                         } else if (!_mv_1315.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -3228,6 +3254,7 @@ uint8_t transpiler_is_result_type_alias_def(types_SExpr* item) {
                     } else if (!_mv_1313.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -3328,6 +3355,7 @@ uint8_t transpiler_is_array_type_body(types_SExpr* body_expr) {
                     } else if (!_mv_1322.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -3785,6 +3813,7 @@ slop_option_string transpiler_get_type_name(types_SExpr* item) {
                     } else if (!_mv_1344.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -4444,6 +4473,7 @@ uint8_t transpiler_is_range_type_alias(context_TranspileContext* ctx, slop_strin
     } else if (!_mv_1367.has_value) {
         return 0;
     }
+    SLOP_UNREACHABLE();
 }
 
 uint8_t transpiler_is_unsigned_payload_type(slop_string slop_type) {
@@ -4464,6 +4494,7 @@ slop_string transpiler_resolve_payload_slop_type(context_TranspileContext* ctx, 
         } else if (!_mv_1368.has_value) {
             return slop_type;
         }
+        SLOP_UNREACHABLE();
     } else {
         return slop_type;
     }
@@ -5268,6 +5299,7 @@ uint8_t transpiler_is_simple_enum_def(types_SExpr* item) {
                                         } else if (!_mv_1384.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -5278,6 +5310,7 @@ uint8_t transpiler_is_simple_enum_def(types_SExpr* item) {
                     } else if (!_mv_1382.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -5872,6 +5905,7 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                     } else if (!_mv_1416.has_value) {
                         return ctype_to_c_type(arena, type_expr);
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
             case types_SExpr_lst:
@@ -5910,6 +5944,7 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                                                 } else if (!_mv_1419.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -5929,6 +5964,7 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                                                 } else if (!_mv_1420.has_value) {
                                                     return SLOP_STR("");
                                                 }
+                                                SLOP_UNREACHABLE();
                                             } else {
                                                 return SLOP_STR("");
                                             }
@@ -5944,6 +5980,7 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                         } else if (!_mv_1417.has_value) {
                             return SLOP_STR("");
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -5996,6 +6033,7 @@ slop_string transpiler_get_type_c_name(context_TranspileContext* ctx, types_SExp
                                     } else if (!_mv_1424.has_value) {
                                         return SLOP_STR("");
                                     }
+                                    SLOP_UNREACHABLE();
                                 }
                             }
                             default: {
@@ -6005,6 +6043,7 @@ slop_string transpiler_get_type_c_name(context_TranspileContext* ctx, types_SExp
                     } else if (!_mv_1422.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6225,6 +6264,7 @@ uint8_t transpiler_is_imported_type(context_TranspileContext* ctx, slop_string t
         } else if (!_mv_1433.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -6311,6 +6351,7 @@ uint8_t transpiler_struct_uses_list_type(context_TranspileContext* ctx, types_SE
                         } else if (!_mv_1437.has_value) {
                             return 0;
                         }
+                        SLOP_UNREACHABLE();
                     }
                 }
             }
@@ -6386,6 +6427,7 @@ uint8_t transpiler_field_uses_typename(context_TranspileContext* ctx, types_SExp
                     } else if (!_mv_1441.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6650,6 +6692,7 @@ uint8_t transpiler_is_pointer_type_expr_header(types_SExpr* type_expr) {
                     } else if (!_mv_1457.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6745,6 +6788,7 @@ slop_string transpiler_get_variant_name(types_SExpr* variant_expr) {
                     } else if (!_mv_1462.has_value) {
                         return SLOP_STR("unknown");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6894,6 +6938,7 @@ slop_string transpiler_get_const_name(types_SExpr* item) {
                     } else if (!_mv_1471.has_value) {
                         return SLOP_STR("");
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -6962,6 +7007,7 @@ uint8_t transpiler_emit_const_header_if_exported(context_TranspileContext* ctx, 
                                         } else if (!_mv_1477.has_value) {
                                             return 0;
                                         }
+                                        SLOP_UNREACHABLE();
                                     }
                                 }
                             }
@@ -6972,6 +7018,7 @@ uint8_t transpiler_emit_const_header_if_exported(context_TranspileContext* ctx, 
                     } else if (!_mv_1475.has_value) {
                         return 0;
                     }
+                    SLOP_UNREACHABLE();
                 }
             }
         }
@@ -7134,6 +7181,7 @@ uint8_t transpiler_is_module_expr(slop_list_types_SExpr_ptr exprs) {
                             } else if (!_mv_1484.has_value) {
                                 return 0;
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -7144,6 +7192,7 @@ uint8_t transpiler_is_module_expr(slop_list_types_SExpr_ptr exprs) {
         } else if (!_mv_1482.has_value) {
             return 0;
         }
+        SLOP_UNREACHABLE();
     }
 }
 

--- a/bootstrap/transpiler/slop_transpiler_main.c
+++ b/bootstrap/transpiler/slop_transpiler_main.c
@@ -186,6 +186,7 @@ slop_string transpiler_main_extract_module_name(slop_list_types_SExpr_ptr exprs)
                                             } else if (!_mv_1492.has_value) {
                                                 return SLOP_STR("unknown");
                                             }
+                                            SLOP_UNREACHABLE();
                                         } else {
                                             return SLOP_STR("unknown");
                                         }
@@ -197,6 +198,7 @@ slop_string transpiler_main_extract_module_name(slop_list_types_SExpr_ptr exprs)
                             } else if (!_mv_1490.has_value) {
                                 return SLOP_STR("unknown");
                             }
+                            SLOP_UNREACHABLE();
                         }
                     }
                 }
@@ -207,6 +209,7 @@ slop_string transpiler_main_extract_module_name(slop_list_types_SExpr_ptr exprs)
         } else if (!_mv_1488.has_value) {
             return SLOP_STR("unknown");
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -294,6 +297,7 @@ int64_t transpiler_main_transpile_single_file_with_ctx(context_TranspileContext*
             putchar(10);
             return 1;
         }
+        SLOP_UNREACHABLE();
     }
 }
 
@@ -330,6 +334,7 @@ int64_t transpiler_main_transpile_single_file(slop_arena* arena, slop_string sou
             putchar(10);
             return 1;
         }
+        SLOP_UNREACHABLE();
     }
 }
 

--- a/bootstrap/transpiler/slop_types.c
+++ b/bootstrap/transpiler/slop_types.c
@@ -347,6 +347,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_11.has_value) {
                     return SLOP_STR("Option");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_ptr) {
                 __auto_type _mv_12 = (*t).inner_type;
                 if (_mv_12.has_value) {
@@ -355,6 +356,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_12.has_value) {
                     return SLOP_STR("Ptr");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_list) {
                 __auto_type _mv_13 = (*t).inner_type;
                 if (_mv_13.has_value) {
@@ -363,6 +365,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_13.has_value) {
                     return SLOP_STR("List");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_map) {
                 __auto_type _mv_14 = (*t).inner_type;
                 if (_mv_14.has_value) {
@@ -374,9 +377,11 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                     } else if (!_mv_15.has_value) {
                         return string_concat(arena, SLOP_STR("(Map "), string_concat(arena, types_resolved_type_to_slop_string(arena, key_type), SLOP_STR(")")));
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_14.has_value) {
                     return SLOP_STR("Map");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_result) {
                 __auto_type _mv_16 = (*t).inner_type;
                 if (_mv_16.has_value) {
@@ -388,9 +393,11 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                     } else if (!_mv_17.has_value) {
                         return string_concat(arena, SLOP_STR("(Result "), string_concat(arena, types_resolved_type_to_slop_string(arena, ok_type), SLOP_STR(")")));
                     }
+                    SLOP_UNREACHABLE();
                 } else if (!_mv_16.has_value) {
                     return SLOP_STR("Result");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_array) {
                 __auto_type _mv_18 = (*t).inner_type;
                 if (_mv_18.has_value) {
@@ -399,6 +406,7 @@ slop_string types_resolved_type_to_slop_string(slop_arena* arena, types_Resolved
                 } else if (!_mv_18.has_value) {
                     return SLOP_STR("Array");
                 }
+                SLOP_UNREACHABLE();
             } else if (_mv_10 == types_ResolvedTypeKind_rk_typevar) {
                 return name;
             } else {

--- a/lib/compiler/checker/infer.slop
+++ b/lib/compiler/checker/infer.slop
@@ -29,7 +29,7 @@
                env-make-option-type env-make-ptr-type env-make-result-type env-make-fn-type env-get-generic-type
                env-add-warning env-add-error
                env-set-fn-type-params env-clear-fn-type-params env-is-type-param))
-  (import strlib (starts-with ends-with string-build))
+  (import strlib (starts-with ends-with string-build join))
   (import collect (find-fn-type-params))
 
   ;; ============================================================
@@ -1783,6 +1783,132 @@
                     ((none) (do)))))))
           ((none) (do))))))
 
+  ;; ============================================================
+  ;; Match Exhaustiveness (te-non-exhaustive)
+  ;;
+  ;; spec/LANGUAGE.md says a match must be exhaustive and types.slop
+  ;; reserves te-non-exhaustive for it, but nothing ever emitted the
+  ;; diagnostic. The only thing catching a missing arm was the C
+  ;; compiler's -Wswitch, and only for enum/union matches -- an Option
+  ;; match compiles to an if-chain, so a missing (none) arm was
+  ;; invisible at every single stage.
+  ;;
+  ;; This is deliberately conservative and stays silent whenever it
+  ;; cannot reason about a pattern. A false positive on a brand-new
+  ;; diagnostic is what gets it suppressed and then ignored, which is
+  ;; exactly how the -Wreturn-type noise it replaces got ignored.
+  ;; ============================================================
+
+  (fn match-pattern-head ((pattern (Ptr SExpr)))
+    (@intent "Name the variant a match pattern selects, or the bare symbol for _ / else")
+    (@spec (((Ptr SExpr)) -> String))
+    (@pre (!= pattern nil))
+    (if (sexpr-is-list pattern)
+      (if (> (sexpr-list-len pattern) 0)
+        (match (sexpr-list-get pattern 0)
+          ((some head) (sexpr-get-symbol-name head))
+          ((none) ""))
+        "")
+      (sexpr-get-symbol-name pattern)))
+
+  (fn is-wildcard-head ((head String))
+    (@intent "Check if a pattern head covers every variant not already named")
+    (@spec ((String) -> Bool))
+    (@pure)
+    (or (string-eq head "_")
+        (string-eq head "else")))
+
+  (fn string-list-contains ((names (List String)) (name String))
+    (@intent "Check if a list of names contains the given name")
+    (@spec (((List String) String) -> Bool))
+    (@pure)
+    (let ((n (list-len names))
+          (mut i 0)
+          (mut found false))
+      (while (and (< i n) (not found))
+        (match (list-get names i)
+          ((some existing)
+            (when (string-eq existing name) (set! found true)))
+          ((none) (do)))
+        (set! i (+ i 1)))
+      found))
+
+  (fn match-expected-variants ((arena Arena) (scrutinee-type (Ptr ResolvedType)))
+    (@intent "Every variant an exhaustive match must cover; empty when exhaustiveness is undecidable")
+    (@spec ((Arena (Ptr ResolvedType)) -> (List String)))
+    (@pre (!= scrutinee-type nil))
+    (let ((kind (. (deref scrutinee-type) kind))
+          (result (list-new arena String)))
+      (cond
+        ((or (== kind 'rk-union) (== kind 'rk-enum))
+          (let ((variants (. (deref scrutinee-type) variants))
+                (n (list-len variants))
+                (mut i 0))
+            (while (< i n)
+              (match (list-get variants i)
+                ((some v) (list-push result (. v name)))
+                ((none) (do)))
+              (set! i (+ i 1)))
+            result))
+        ((== kind 'rk-option)
+          (do (list-push result "some")
+              (list-push result "none")
+              result))
+        ((== kind 'rk-result)
+          (do (list-push result "ok")
+              (list-push result "error")
+              result))
+        ;; Primitives, ranges, lists, type variables: no finite variant set, so
+        ;; nothing here can be shown exhaustive. Say nothing.
+        (else result))))
+
+  (fn check-match-exhaustive ((env (Ptr TypeEnv)) (scrutinee-type (Ptr ResolvedType))
+                              (covered (List String)) (has-wildcard Bool) (line Int) (col Int))
+    (@intent "Report a match that cannot be shown to cover every variant of its scrutinee")
+    (@spec (((Ptr TypeEnv) (Ptr ResolvedType) (List String) Bool Int Int) -> Unit))
+    (@pre (!= env nil))
+    (@pre (!= scrutinee-type nil))
+    (when (not has-wildcard)
+      (let ((arena (env-arena env))
+            (type-name (. (deref scrutinee-type) name))
+            (expected (match-expected-variants arena scrutinee-type)))
+        ;; A bare generic scrutinee has no variant list worth reasoning about;
+        ;; bind-match-pattern skips it for the same reason. Option_T is NOT skipped:
+        ;; genericity affects the payload, not the some/none variant set.
+        (when (and (> (list-len expected) 0)
+                   (not (string-eq type-name "T")))
+          (let ((n (list-len covered))
+                (mut i 0)
+                (mut all-known true)
+                (missing (list-new arena String)))
+            ;; Guard, record and array patterns produce heads that are not variant
+            ;; names. One unrecognised head means coverage cannot be reasoned about
+            ;; at all, so the whole match is left alone.
+            (while (< i n)
+              (match (list-get covered i)
+                ((some head)
+                  (when (not (string-list-contains expected head))
+                    (set! all-known false)))
+                ((none) (do)))
+              (set! i (+ i 1)))
+            (when all-known
+              (let ((e-len (list-len expected))
+                    (mut j 0))
+                (while (< j e-len)
+                  (match (list-get expected j)
+                    ((some want)
+                      (when (not (string-list-contains covered want))
+                        (list-push missing want)))
+                    ((none) (do)))
+                  (set! j (+ j 1)))
+                (when (> (list-len missing) 0)
+                  (let ((parts (list-new arena String)))
+                    (list-push parts "non-exhaustive match on ")
+                    (list-push parts type-name)
+                    (list-push parts ": missing ")
+                    (list-push parts (join arena missing ", "))
+                    (env-add-warning env (string-build arena parts) line col)))))))))) 
+
   (fn infer-match-expr ((env (Ptr TypeEnv)) (expr (Ptr SExpr)) (lst SExprList))
     (@intent "Infer type of match expression, checking branch types")
     (@spec (((Ptr TypeEnv) (Ptr SExpr) SExprList) -> (Ptr ResolvedType)))
@@ -1792,6 +1918,9 @@
           (line (sexpr-line expr))
           (col (sexpr-col expr))
           (mut has-result Bool false)
+          (mut has-wildcard false)
+          (match-arena (env-arena env))
+          (covered (list-new match-arena String))
           (mut result-type (Ptr ResolvedType) (env-get-unit-type env))
           ;; Get scrutinee type for pattern binding
           (scrutinee-type (if (>= len 2)
@@ -1808,6 +1937,17 @@
               ((lst clause-lst)
                 (let ((clause-items (. clause-lst items))
                       (clause-len (list-len clause-items)))
+                  ;; Record coverage before the body check, and outside the
+                  ;; clause-len guard: a bodiless clause such as ((none)) still
+                  ;; covers its variant.
+                  (when (> clause-len 0)
+                    (match (list-get clause-items 0)
+                      ((some pattern)
+                        (let ((head (match-pattern-head pattern)))
+                          (if (is-wildcard-head head)
+                            (set! has-wildcard true)
+                            (list-push covered head))))
+                      ((none) (do))))
                   (when (> clause-len 1)
                     ;; Push scope for this clause's pattern bindings
                     (env-push-scope env)
@@ -1836,6 +1976,7 @@
               (_ (do))))
           ((none) (do)))
         (set! i (+ i 1)))
+      (check-match-exhaustive env scrutinee-type covered has-wildcard line col)
       result-type))
 
   (fn check-return-type ((env (Ptr TypeEnv)) (fn-form (Ptr SExpr))

--- a/lib/compiler/transpiler/match.slop
+++ b/lib/compiler/transpiler/match.slop
@@ -273,7 +273,8 @@
     (let ((arena (. (deref ctx) arena))
           (len (list-len items))
           (mut i 2)
-          (mut first true))
+          (mut first true)
+          (mut has-else false))
       (while (< i len)
         (match (list-get items i)
           ((some branch)
@@ -293,6 +294,7 @@
                               (set! first false))
                             ((string-eq tag "else")
                               (emit-else-branch ctx branch-items is-return first)
+                              (set! has-else true)
                               (set! first false))
                             (else (do)))))
                       ((none) (do))))))
@@ -301,7 +303,8 @@
         (set! i (+ i 1)))
       ;; Close the if chain
       (when (not first)
-        (ctx-emit ctx "}"))))
+        (ctx-emit ctx "}"))
+      (emit-match-fallthrough-trap ctx is-return has-else)))
 
   (fn emit-option-some-branch ((ctx (Ptr TranspileContext)) (scrutinee-c String)
                                (scrutinee-expr (Ptr SExpr))
@@ -359,7 +362,8 @@
     (let ((arena (. (deref ctx) arena))
           (len (list-len items))
           (mut i 2)
-          (mut first true))
+          (mut first true)
+          (mut has-else false))
       (while (< i len)
         (match (list-get items i)
           ((some branch)
@@ -379,6 +383,7 @@
                               (set! first false))
                             ((string-eq tag "else")
                               (emit-else-branch ctx branch-items is-return first)
+                              (set! has-else true)
                               (set! first false))
                             (else (do)))))
                       ((none) (do))))))
@@ -386,7 +391,8 @@
           ((none) (do)))
         (set! i (+ i 1)))
       (when (not first)
-        (ctx-emit ctx "}"))))
+        (ctx-emit ctx "}"))
+      (emit-match-fallthrough-trap ctx is-return has-else)))
 
   (fn emit-result-ok-branch ((ctx (Ptr TranspileContext)) (scrutinee-c String)
                              (scrutinee-expr (Ptr SExpr))
@@ -453,7 +459,8 @@
     (@pre {ctx != nil})
     (let ((arena (. (deref ctx) arena))
           (len (list-len items))
-          (mut i 2))
+          (mut i 2)
+          (mut has-else false))
       ;; Emit switch
       (ctx-emit ctx (ctx-str3 ctx "switch (" scrutinee-c ") {"))
       (ctx-indent ctx)
@@ -466,13 +473,17 @@
                   (when (>= (list-len branch-items) 2)
                     (match (list-get branch-items 0)
                       ((some pattern)
+                        (let ((tag (get-pattern-tag pattern)))
+                          (when (or (string-eq tag "else") (string-eq tag "_"))
+                            (set! has-else true)))
                         (emit-enum-case ctx pattern branch-items is-return))
                       ((none) (do))))))
               (else (do))))
           ((none) (do)))
         (set! i (+ i 1)))
       (ctx-dedent ctx)
-      (ctx-emit ctx "}")))
+      (ctx-emit ctx "}")
+      (emit-match-fallthrough-trap ctx is-return has-else)))
 
   (fn emit-enum-case ((ctx (Ptr TranspileContext)) (pattern (Ptr SExpr))
                       (branch-items (List (Ptr SExpr))) (is-return Bool))
@@ -516,7 +527,8 @@
     (let ((arena (. (deref ctx) arena))
           (len (list-len items))
           (mut i 2)
-          (mut first true))
+          (mut first true)
+          (mut has-else false))
       (while (< i len)
         (match (list-get items i)
           ((some branch)
@@ -526,6 +538,8 @@
                   (when (>= (list-len branch-items) 2)
                     (match (list-get branch-items 0)
                       ((some pattern)
+                        (when (string-eq (get-pattern-tag pattern) "else")
+                          (set! has-else true))
                         (emit-literal-case ctx scrutinee-c pattern branch-items is-return first)
                         (set! first false))
                       ((none) (do))))))
@@ -533,7 +547,8 @@
           ((none) (do)))
         (set! i (+ i 1)))
       (when (not first)
-        (ctx-emit ctx "}"))))
+        (ctx-emit ctx "}"))
+      (emit-match-fallthrough-trap ctx is-return has-else)))
 
   (fn emit-literal-case ((ctx (Ptr TranspileContext)) (scrutinee-c String) (pattern (Ptr SExpr))
                          (branch-items (List (Ptr SExpr))) (is-return Bool) (first Bool))
@@ -575,7 +590,8 @@
       (let ((arena (. (deref ctx) arena))
             (len (list-len items))
             (mut i 2)
-            (mut first true))
+            (mut first true)
+            (mut has-else false))
         ;; Emit switch on the tag
         (ctx-emit ctx (ctx-str3 ctx "switch (" scrutinee-c ".tag) {"))
         (ctx-indent ctx)
@@ -592,6 +608,7 @@
                             (cond
                               ((or (string-eq tag "else") (string-eq tag "_"))
                                 ;; Default case
+                                (set! has-else true)
                                 (ctx-emit ctx "default: {")
                                 (ctx-indent ctx)
                                 (emit-branch-body ctx branch-items is-return)
@@ -611,7 +628,8 @@
             ((none) (do)))
           (set! i (+ i 1)))
         (ctx-dedent ctx)
-        (ctx-emit ctx "}"))))
+        (ctx-emit ctx "}")
+        (emit-match-fallthrough-trap ctx is-return has-else))))
 
   (fn emit-union-case ((ctx (Ptr TranspileContext)) (scrutinee-c String)
                        (pattern (Ptr SExpr)) (tag String) (union-type-name String)
@@ -697,6 +715,23 @@
   ;; ============================================================
   ;; Else Branch
   ;; ============================================================
+
+  (fn emit-match-fallthrough-trap ((ctx (Ptr TranspileContext)) (is-return Bool) (has-else Bool))
+    (@intent "Trap the path where a return-position match matched none of its arms (#86)")
+    (@spec (((Ptr TranspileContext) Bool Bool) -> Unit))
+    (@pre {ctx != nil})
+    ;; Only in return position. There every arm returns, so falling past the
+    ;; construct runs off the end of a non-void function -- undefined behaviour,
+    ;; and the -Wreturn-type noise issue #86 is about. In statement position the
+    ;; fallthrough is ordinary control flow and must be left alone; trapping it
+    ;; would turn working code into an abort.
+    ;;
+    ;; Emitted AFTER the closed chain or switch, never as a final else or
+    ;; `default:`. A `default:` silences -Wswitch, and a plain `else` would run the
+    ;; last arm's body for an unmatched value. -Wswitch is currently the only
+    ;; exhaustiveness signal C gives us, so it stays live.
+    (when (and is-return (not has-else))
+      (ctx-emit ctx "SLOP_UNREACHABLE();")))
 
   (fn emit-else-branch ((ctx (Ptr TranspileContext)) (branch-items (List (Ptr SExpr))) (is-return Bool) (first Bool))
     (@intent "Emit an else branch")
@@ -1385,7 +1420,8 @@
     (let ((arena (. (deref ctx) arena))
           (len (list-len items))
           (mut i 1)
-          (mut first true))
+          (mut first true)
+          (mut has-else false))
       (while (< i len)
         (match (list-get items i)
           ((some clause-expr)
@@ -1403,6 +1439,7 @@
                             (if (string-eq (. sym name) "else")
                               (do
                                 ;; else clause
+                                (set! has-else true)
                                 (ctx-emit ctx "} else {")
                                 (ctx-indent ctx)
                                 (emit-inline-cond-body ctx clause-items 1 is-return is-last)
@@ -1435,7 +1472,8 @@
         (set! i (+ i 1)))
       ;; Close final brace
       (when (not first)
-        (ctx-emit ctx "}"))))
+        (ctx-emit ctx "}"))
+      (emit-match-fallthrough-trap ctx is-return has-else)))
 
   (fn emit-inline-cond-body ((ctx (Ptr TranspileContext)) (items (List (Ptr SExpr))) (start Int) (is-return Bool) (is-last Bool))
     (@intent "Emit body statements of a cond clause inline")
@@ -2047,7 +2085,8 @@
     (let ((arena (. (deref ctx) arena))
           (len (list-len items))
           (mut i 2)
-          (mut first true))
+          (mut first true)
+          (mut has-else false))
       (while (< i len)
         (match (list-get items i)
           ((some branch)
@@ -2061,6 +2100,7 @@
                           (if (or (string-eq tag "else") (string-eq tag "_"))
                             ;; Else/wildcard arm
                             (do
+                              (set! has-else true)
                               (if first
                                 (ctx-emit ctx "{")
                                 (ctx-emit ctx "} else {"))
@@ -2096,6 +2136,7 @@
           ((none) (do)))
         (set! i (+ i 1)))
       (when (not first)
-        (ctx-emit ctx "}"))))
+        (ctx-emit ctx "}"))
+      (emit-match-fallthrough-trap ctx is-return has-else)))
 
 ) ;; end module

--- a/src/slop/runtime/slop_runtime.h
+++ b/src/slop/runtime/slop_runtime.h
@@ -75,6 +75,23 @@ _Atomic size_t slop_global_allocated __attribute__((weak)) = 0;
     #define SLOP_ASSERT(cond, msg) ((void)0)
 #endif
 
+/* Reached when a match in return position matched none of its arms.
+ *
+ * Deliberately NOT gated on SLOP_DEBUG, unlike the contracts above. The checker
+ * warns about a non-exhaustive match but does not yet reject one, so this path is
+ * genuinely reachable -- and __builtin_unreachable() on a path that actually runs
+ * licenses the optimiser to do considerably worse than the fall-off-the-end this
+ * replaces. One cold branch at the tail of a match is the cheaper mistake.
+ *
+ * Emitted AFTER the closed if-chain or switch rather than as a final else/default,
+ * so -Wswitch still fires on a missing enum case. */
+#define SLOP_UNREACHABLE() \
+    do { \
+        fprintf(stderr, "SLOP: non-exhaustive match reached\n  at %s:%d\n", \
+                __FILE__, __LINE__); \
+        abort(); \
+    } while(0)
+
 /* Expression-form range check - returns value after checking bounds.
  * Unlike SLOP_PRE, this can be used in expression contexts like return statements. */
 #ifdef SLOP_DEBUG

--- a/tests/fixtures/test_match_exhaustive_ok.slop
+++ b/tests/fixtures/test_match_exhaustive_ok.slop
@@ -1,0 +1,46 @@
+;; Companion to test_match_nonexhaustive.slop: every shape here is
+;; exhaustive, or is one the check deliberately refuses to reason about.
+;;
+;; This is the half that matters most. The diagnostic is conservative by
+;; design -- a false positive on a new warning is what gets it suppressed
+;; and then ignored, which is exactly how the -Wreturn-type noise it
+;; replaces came to be ignored. Without this fixture that conservatism is
+;; untested and will erode.
+(module match-exhaustive-ok
+
+  (type Colour (union red green blue))
+
+  (fn all-arms ((c Colour))
+    (@intent "every variant named")
+    (@spec ((Colour) -> Int))
+    (match c ((red) 1) ((green) 2) ((blue) 3)))
+
+  (fn wildcard ((c Colour))
+    (@intent "_ covers the rest")
+    (@spec ((Colour) -> Int))
+    (match c ((red) 1) (_ 0)))
+
+  (fn else-arm ((c Colour))
+    (@intent "else covers the rest")
+    (@spec ((Colour) -> Int))
+    (match c ((red) 1) ((else) 0)))
+
+  (fn option-complete ((xs (List Int)))
+    (@intent "both Option arms")
+    (@spec (((List Int)) -> Int))
+    (match (list-get xs 0) ((some v) v) ((none) -1)))
+
+  (fn result-complete ((r (Result Int String)))
+    (@intent "both Result arms")
+    (@spec (((Result Int String)) -> Int))
+    (match r ((ok v) v) ((error e) -1)))
+
+  (fn int-scrutinee ((n Int))
+    (@intent "a literal match has no finite variant set, so it is never reported")
+    (@spec ((Int) -> Int))
+    (match n (1 10) (2 20) (else 0)))
+
+  (fn main ()
+    (@intent "Unused entry point; the fixture is never run")
+    (@spec (() -> Int))
+    0))

--- a/tests/fixtures/test_match_nonexhaustive.slop
+++ b/tests/fixtures/test_match_nonexhaustive.slop
@@ -1,0 +1,41 @@
+;; Fixture for the match-exhaustiveness diagnostic (root cause of #86).
+;;
+;; spec/LANGUAGE.md says a match must be exhaustive and types.slop has
+;; reserved te-non-exhaustive for it since the beginning, but nothing
+;; ever emitted the diagnostic. The only thing catching a missing arm
+;; was the C compiler's -Wswitch, and only for enum/union matches --
+;; an Option match compiles to an if-chain, so a missing (none) arm was
+;; invisible at every single stage.
+;;
+;; Lives under fixtures/ because it must produce diagnostics, and
+;; run_native_tests.sh builds every top-level tests/*.slop.
+(module match-nonexhaustive
+
+  (type Colour (union red green blue))
+  (type Fault (union (io-fault String) (parse-fault String Int)))
+
+  (fn union-partial ((c Colour))
+    (@intent "two of three arms - the third must be named in the message")
+    (@spec ((Colour) -> Int))
+    (match c ((red) 1) ((green) 2)))
+
+  (fn multi-payload-partial ((f Fault))
+    (@intent "multi-payload variant missing - must be named")
+    (@spec ((Fault) -> Int))
+    (match f ((io-fault m) 1)))
+
+  (fn option-partial ((xs (List Int)))
+    (@intent "some with no none - the case C cannot see at all")
+    (@spec (((List Int)) -> Unit))
+    (match (list-get xs 0)
+      ((some v) (println "got"))))
+
+  (fn result-partial ((r (Result Int String)))
+    (@intent "ok with no error arm")
+    (@spec (((Result Int String)) -> Int))
+    (match r ((ok v) v)))
+
+  (fn main ()
+    (@intent "Unused entry point; the fixture is never run")
+    (@spec (() -> Int))
+    0))

--- a/tests/test_transpiler_warnings.py
+++ b/tests/test_transpiler_warnings.py
@@ -207,3 +207,86 @@ class TestAggregateEquality:
         # second time under "Transpilation failed:", so count only the first copy.
         first_copy = combined.split("Transpilation failed:")[0]
         assert first_copy.count("has no structural equality") == 1, first_copy
+
+
+def slop_check(test_file: str):
+    """Type check a .slop file and return (returncode, stdout, stderr)."""
+    result = subprocess.run(
+        ["uv", "run", "slop", "check", str(TESTS_DIR / test_file)],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+class TestMatchExhaustiveness:
+    """The checker reports a match that cannot be shown to cover every variant.
+
+    Root cause of #86: the C compiler's -Wswitch was the only thing catching a
+    missing arm, and only for enum/union matches. An Option match compiles to an
+    if-chain, so a missing (none) arm was invisible at every stage.
+    """
+
+    def test_missing_variants_are_named(self):
+        """The message must name what is missing, not just say 'non-exhaustive'."""
+        rc, stdout, stderr = slop_check("fixtures/test_match_nonexhaustive.slop")
+        combined = stdout + stderr
+
+        assert "non-exhaustive match on Colour: missing blue" in combined, combined
+        # Multi-payload variant, named by its SLOP name not its C name.
+        assert "non-exhaustive match on Fault: missing parse-fault" in combined, combined
+        # The case C cannot see: an Option match is an if-chain, never a switch.
+        assert "non-exhaustive match on Option_Int: missing none" in combined, combined
+        assert "non-exhaustive match on Result: missing error" in combined, combined
+
+        # Positioned at the match, not at the module.
+        assert re.search(r"test_match_nonexhaustive\.slop:\d+:\d+: warning:", combined), combined
+
+    def test_exhaustive_forms_are_silent(self):
+        """The check is conservative by design; this pins that it stays that way.
+
+        A false positive on a new diagnostic is what gets it suppressed and then
+        ignored -- exactly how the -Wreturn-type noise it replaces was ignored.
+        Covers: all arms named, `_`, `else`, complete Option, complete Result,
+        and a literal match (no finite variant set, so never reportable).
+        """
+        rc, stdout, stderr = slop_check("fixtures/test_match_exhaustive_ok.slop")
+        combined = stdout + stderr
+        assert "non-exhaustive" not in combined, combined
+
+
+class TestMatchFallthroughTrap:
+    """A return-position match emits SLOP_UNREACHABLE() after the construct (#86)."""
+
+    def test_trap_after_chain_and_switch_preserves_wswitch(self, tmp_path):
+        """The trap goes AFTER the closed construct, never as `else` / `default:`.
+
+        A `default:` would silence -Wswitch, and a plain `else` would run the last
+        arm's body for an unmatched value -- which the checker cannot yet rule out.
+        -Wswitch is the only exhaustiveness signal C gives us, so it stays live.
+        """
+        output = str(tmp_path / "test_match_exhaustive_ok.c")
+        rc, stdout, stderr = slop_transpile("fixtures/test_match_exhaustive_ok.slop", output)
+        assert rc == 0, f"Transpile failed: {stderr}"
+        c_src = Path(output).read_text()
+
+        # all-arms is a return-position union match with no else: gets the trap.
+        assert "SLOP_UNREACHABLE();" in c_src, c_src
+        # The switch must NOT have grown a default: arm.
+        switch_body = c_src[c_src.index("switch ("):]
+        assert "default:" not in switch_body.split("SLOP_UNREACHABLE")[0], switch_body[:400]
+
+    def test_no_trap_when_an_else_arm_exists(self, tmp_path):
+        """`else` / `_` already makes the chain total; a trap there would be dead code."""
+        output = str(tmp_path / "test_match_exhaustive_ok2.c")
+        rc, stdout, stderr = slop_transpile("fixtures/test_match_exhaustive_ok.slop", output)
+        assert rc == 0, f"Transpile failed: {stderr}"
+        c_src = Path(output).read_text()
+
+        # wildcard/else arms compile to `default:`; those functions end with a
+        # closing brace and no trap.
+        for fn in ("match_exhaustive_ok_wildcard", "match_exhaustive_ok_else_arm"):
+            body = c_src.split(f"{fn}(")[-1]
+            body = body[:body.index("\n}\n")]
+            assert "SLOP_UNREACHABLE" not in body, f"{fn} should not be trapped:\n{body}"


### PR DESCRIPTION
plain `else`. That treats the symptom. The C compiler's exhaustiveness warnings fire because the checker never checked exhaustiveness, so the fix belongs there and the codegen change becomes a backstop rather than a workaround.

Everything needed was already in place and simply unused. spec/LANGUAGE.md says a match must be exhaustive, reference.py claims the checker enforces it, and common/types.slop has reserved te-non-exhaustive since the beginning -- emitted nowhere. Meanwhile infer-match-expr already computed the scrutinee's ResolvedType before walking the clauses, and ResolvedType already carried the full variants list. The check reads what was already there:

  non-exhaustive match on Colour: missing blue
  non-exhaustive match on Fault: missing parse-fault
  non-exhaustive match on Option_Int: missing none
  non-exhaustive match on Result: missing error

The Option case is the one that mattered. Enum and union matches compile to a switch, so -Wswitch caught a missing arm; an Option match compiles to an if-chain, so a missing (none) arm was invisible at every single stage, in C as well as in SLOP.

It is deliberately conservative and stays silent whenever it cannot reason about a pattern: a wildcard arm, a bare generic scrutinee, or any clause head that is not a variant name -- guard, record and array patterns all land there. A false positive on a new diagnostic is what gets it suppressed and then ignored, which is precisely how the -Wreturn-type noise it replaces came to be ignored.

For the codegen half, SLOP_UNREACHABLE() is emitted AFTER the closed if-chain or switch, never as a final `else` or `default:`. Both of the obvious placements destroy information: a `default:` silences -Wswitch, and a plain `else` would run the last arm's body for an unmatched value, which the checker still cannot rule out. Emitting after the construct leaves every condition tested and keeps -Wswitch live. Seven sites in match.slop, one shared helper, and only in return position -- a statement-position match that falls through is ordinary control flow and must not be trapped.

The macro is NOT gated on SLOP_DEBUG, unlike the contracts beside it. The checker warns about a non-exhaustive match but does not yet reject one, so this path is genuinely reachable, and __builtin_unreachable() on a path that runs licenses the optimiser to do considerably worse than the fall-off-the-end it replaces. One cold branch is the cheaper mistake.

Measured on the compiler's own generated C: 142 -Wreturn-type warnings to 0, with "not handled in switch" staying at 0 and still firing on a deliberately partial enum match. HOWL's src/types.slop goes 3 to 0, so -Wno-return-type can come out of its Makefile once its csrc is regenerated.

Coverage lives in tests/fixtures/ plus pytest, since a diagnostic cannot be asserted from tests/*.slop -- that harness only builds and checks exit codes. Two fixtures: one non-exhaustive across union, multi-payload variant, Option and Result, asserting the message NAMES what is missing; one exhaustive across all arms, `_`, `else`, complete Option and Result, and a literal match, asserting silence. The second is the one that keeps the conservatism honest.

Not done here, and filed instead. Wiring the diagnostic through revealed that checker diagnostics are discarded entirely in multi-module builds (#93): transpile-single-file computes them and never reads them, and cli.py drops the compiler's stderr on success. Fixing both locally immediately surfaced pre-existing checker false positives on valid, working code -- every float literal types as Int (#94), string-copy is registered with the wrong arity, and expr.slop calls context.slop functions that are defined but never exported. That took the suite from 42 passed to 39 passed and 3 failed, none of it related to this change. Reverted and filed rather than dragged in.

The practical consequence: this warning is visible today via `slop check` and single-file builds, but not yet in the multi-module path real projects use. #94 then #93 is the unblock, after which promoting it from warning to error is a one-token change.

Also filed while here: #91 (string literal match patterns are spec'd but unimplemented) and #92 (the checker does not type-check == operands, which is why #89 could only be caught at transpile time).

make test-native stays at 42. pytest goes 475 -> 479.