### PR TITLE
type the nil literal as a null pointer, not Unit

### DIFF
--- a/bootstrap/checker/slop_env.c
+++ b/bootstrap/checker/slop_env.c
@@ -40,6 +40,7 @@ slop_option_string env_env_get_module(env_TypeEnv* env);
 types_ResolvedType* env_env_get_int_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_bool_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_string_type(env_TypeEnv* env);
+types_ResolvedType* env_env_get_null_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_float_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_unit_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_arena_type(env_TypeEnv* env);
@@ -71,12 +72,13 @@ env_TypeEnv* env_env_new(slop_arena* arena) {
         __auto_type bool_t = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, SLOP_STR("Bool"), ((slop_option_string){.has_value = false}), SLOP_STR("bool"));
         __auto_type string_t = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, SLOP_STR("String"), ((slop_option_string){.has_value = false}), SLOP_STR("slop_string_t"));
         __auto_type float_t = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, SLOP_STR("Float"), ((slop_option_string){.has_value = false}), SLOP_STR("double"));
+        __auto_type null_t = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_ptr, SLOP_STR("<nil>"), ((slop_option_string){.has_value = false}), SLOP_STR("void*"));
         __auto_type unit_t = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, SLOP_STR("Unit"), ((slop_option_string){.has_value = false}), SLOP_STR("void"));
         __auto_type arena_t = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, SLOP_STR("Arena"), ((slop_option_string){.has_value = false}), SLOP_STR("slop_arena_t*"));
         __auto_type unknown_t = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, SLOP_STR("Unknown"), ((slop_option_string){.has_value = false}), SLOP_STR("void"));
         __auto_type never_t = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_never, SLOP_STR("Never"), ((slop_option_string){.has_value = false}), SLOP_STR("void"));
         __auto_type env = ((env_TypeEnv*)(({ __auto_type _alloc = (env_TypeEnv*)slop_arena_alloc(arena, sizeof(env_TypeEnv)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
-        (*env) = (env_TypeEnv){arena, ((slop_list_types_ResolvedType_ptr){ .data = (types_ResolvedType**)slop_arena_alloc(arena, 16 * sizeof(types_ResolvedType*)), .len = 0, .cap = 16 }), ((slop_list_types_FnSignature_ptr){ .data = (types_FnSignature**)slop_arena_alloc(arena, 16 * sizeof(types_FnSignature*)), .len = 0, .cap = 16 }), ((slop_list_env_ConstBinding){ .data = (env_ConstBinding*)slop_arena_alloc(arena, 16 * sizeof(env_ConstBinding)), .len = 0, .cap = 16 }), ((slop_list_env_ImportEntry){ .data = (env_ImportEntry*)slop_arena_alloc(arena, 16 * sizeof(env_ImportEntry)), .len = 0, .cap = 16 }), ((slop_list_env_VariantMapping){ .data = (env_VariantMapping*)slop_arena_alloc(arena, 16 * sizeof(env_VariantMapping)), .len = 0, .cap = 16 }), ((slop_list_env_CheckerScope_ptr){ .data = (env_CheckerScope**)slop_arena_alloc(arena, 16 * sizeof(env_CheckerScope*)), .len = 0, .cap = 16 }), ((slop_option_string){.has_value = false}), int_t, bool_t, string_t, float_t, unit_t, arena_t, unknown_t, ((slop_list_types_Diagnostic){ .data = (types_Diagnostic*)slop_arena_alloc(arena, 16 * sizeof(types_Diagnostic)), .len = 0, .cap = 16 }), ((slop_list_env_BindingAnnotation){ .data = (env_BindingAnnotation*)slop_arena_alloc(arena, 16 * sizeof(env_BindingAnnotation)), .len = 0, .cap = 16 }), ((slop_option_string){.has_value = false}), ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 }), never_t, ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 })};
+        (*env) = (env_TypeEnv){arena, ((slop_list_types_ResolvedType_ptr){ .data = (types_ResolvedType**)slop_arena_alloc(arena, 16 * sizeof(types_ResolvedType*)), .len = 0, .cap = 16 }), ((slop_list_types_FnSignature_ptr){ .data = (types_FnSignature**)slop_arena_alloc(arena, 16 * sizeof(types_FnSignature*)), .len = 0, .cap = 16 }), ((slop_list_env_ConstBinding){ .data = (env_ConstBinding*)slop_arena_alloc(arena, 16 * sizeof(env_ConstBinding)), .len = 0, .cap = 16 }), ((slop_list_env_ImportEntry){ .data = (env_ImportEntry*)slop_arena_alloc(arena, 16 * sizeof(env_ImportEntry)), .len = 0, .cap = 16 }), ((slop_list_env_VariantMapping){ .data = (env_VariantMapping*)slop_arena_alloc(arena, 16 * sizeof(env_VariantMapping)), .len = 0, .cap = 16 }), ((slop_list_env_CheckerScope_ptr){ .data = (env_CheckerScope**)slop_arena_alloc(arena, 16 * sizeof(env_CheckerScope*)), .len = 0, .cap = 16 }), ((slop_option_string){.has_value = false}), int_t, bool_t, string_t, float_t, null_t, unit_t, arena_t, unknown_t, ((slop_list_types_Diagnostic){ .data = (types_Diagnostic*)slop_arena_alloc(arena, 16 * sizeof(types_Diagnostic)), .len = 0, .cap = 16 }), ((slop_list_env_BindingAnnotation){ .data = (env_BindingAnnotation*)slop_arena_alloc(arena, 16 * sizeof(env_BindingAnnotation)), .len = 0, .cap = 16 }), ((slop_option_string){.has_value = false}), ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 }), never_t, ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 })};
         ({ __auto_type _lst_p = &((*env).types); __auto_type _item = (int_t); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
         ({ __auto_type _lst_p = &((*env).types); __auto_type _item = (bool_t); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
         ({ __auto_type _lst_p = &((*env).types); __auto_type _item = (string_t); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
@@ -879,6 +881,14 @@ types_ResolvedType* env_env_get_string_type(env_TypeEnv* env) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     types_ResolvedType* _retval = {0};
     _retval = (*env).string_type;
+    SLOP_POST(((_retval != NULL)), "(!= $result nil)");
+    return _retval;
+}
+
+types_ResolvedType* env_env_get_null_type(env_TypeEnv* env) {
+    SLOP_PRE(((env != NULL)), "(!= env nil)");
+    types_ResolvedType* _retval = {0};
+    _retval = (*env).null_type;
     SLOP_POST(((_retval != NULL)), "(!= $result nil)");
     return _retval;
 }

--- a/bootstrap/checker/slop_env.h
+++ b/bootstrap/checker/slop_env.h
@@ -171,6 +171,7 @@ struct env_TypeEnv {
     types_ResolvedType* bool_type;
     types_ResolvedType* string_type;
     types_ResolvedType* float_type;
+    types_ResolvedType* null_type;
     types_ResolvedType* unit_type;
     types_ResolvedType* arena_type;
     types_ResolvedType* unknown_type;
@@ -227,6 +228,7 @@ slop_option_string env_env_get_module(env_TypeEnv* env);
 types_ResolvedType* env_env_get_int_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_bool_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_string_type(env_TypeEnv* env);
+types_ResolvedType* env_env_get_null_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_float_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_unit_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_arena_type(env_TypeEnv* env);

--- a/bootstrap/checker/slop_infer.c
+++ b/bootstrap/checker/slop_infer.c
@@ -21,6 +21,7 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
 types_ResolvedType* infer_infer_generic_call(env_TypeEnv* env, types_FnSignature* sig, types_SExpr* expr, int64_t line, int64_t col);
 uint8_t infer_types_equal(types_ResolvedType* a, types_ResolvedType* b);
 uint8_t infer_types_compatible_with_range(types_ResolvedType* a, types_ResolvedType* b);
+uint8_t infer_type_is_null_pointer(types_ResolvedType* t);
 types_ResolvedType* infer_unify_branch_types(env_TypeEnv* env, types_ResolvedType* a, types_ResolvedType* b, int64_t line, int64_t col);
 void infer_sexpr_set_resolved_type(types_SExpr* expr, types_ResolvedType* t);
 types_ResolvedType* infer_infer_expr(env_TypeEnv* env, types_SExpr* expr);
@@ -547,6 +548,10 @@ uint8_t infer_types_equal(types_ResolvedType* a, types_ResolvedType* b) {
             return 1;
         } else if ((a_kind == types_ResolvedTypeKind_rk_typevar) || (b_kind == types_ResolvedTypeKind_rk_typevar)) {
             return 1;
+        } else if (string_eq(a_name, SLOP_STR("<nil>")) && (b_kind == types_ResolvedTypeKind_rk_ptr)) {
+            return 1;
+        } else if (string_eq(b_name, SLOP_STR("<nil>")) && (a_kind == types_ResolvedTypeKind_rk_ptr)) {
+            return 1;
         } else if (string_eq(a_name, SLOP_STR("T")) || string_eq(b_name, SLOP_STR("T"))) {
             return 1;
         } else if ((a_kind == types_ResolvedTypeKind_rk_option) && (b_kind == types_ResolvedTypeKind_rk_option)) {
@@ -595,6 +600,11 @@ uint8_t infer_types_compatible_with_range(types_ResolvedType* a, types_ResolvedT
     }
 }
 
+uint8_t infer_type_is_null_pointer(types_ResolvedType* t) {
+    SLOP_PRE(((t != NULL)), "(!= t nil)");
+    return string_eq((*t).name, SLOP_STR("<nil>"));
+}
+
 types_ResolvedType* infer_unify_branch_types(env_TypeEnv* env, types_ResolvedType* a, types_ResolvedType* b, int64_t line, int64_t col) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((a != NULL)), "(!= a nil)");
@@ -605,14 +615,22 @@ types_ResolvedType* infer_unify_branch_types(env_TypeEnv* env, types_ResolvedTyp
         if ((*b).kind == types_ResolvedTypeKind_rk_never) {
             return a;
         } else {
-            if (infer_types_equal(a, b)) {
-                return a;
+            if (infer_type_is_null_pointer(a) && ((*b).kind == types_ResolvedTypeKind_rk_ptr)) {
+                return b;
             } else {
-                {
-                    __auto_type arena = env_env_arena(env);
-                    __auto_type msg = string_concat(arena, SLOP_STR("Branch types differ: "), string_concat(arena, (*a).name, string_concat(arena, SLOP_STR(" vs "), (*b).name)));
-                    env_env_add_warning(env, msg, line, col);
+                if (infer_type_is_null_pointer(b) && ((*a).kind == types_ResolvedTypeKind_rk_ptr)) {
                     return a;
+                } else {
+                    if (infer_types_equal(a, b)) {
+                        return a;
+                    } else {
+                        {
+                            __auto_type arena = env_env_arena(env);
+                            __auto_type msg = string_concat(arena, SLOP_STR("Branch types differ: "), string_concat(arena, (*a).name, string_concat(arena, SLOP_STR(" vs "), (*b).name)));
+                            env_env_add_warning(env, msg, line, col);
+                            return a;
+                        }
+                    }
                 }
             }
         }
@@ -677,7 +695,9 @@ types_ResolvedType* infer_infer_expr_inner(env_TypeEnv* env, types_SExpr* expr) 
                     __auto_type name = sym.name;
                     if (string_eq(name, SLOP_STR("true")) || string_eq(name, SLOP_STR("false"))) {
                         return env_env_get_bool_type(env);
-                    } else if (string_eq(name, SLOP_STR("nil")) || string_eq(name, SLOP_STR("unit"))) {
+                    } else if (string_eq(name, SLOP_STR("nil"))) {
+                        return env_env_get_null_type(env);
+                    } else if (string_eq(name, SLOP_STR("unit"))) {
                         return env_env_get_unit_type(env);
                     } else if (string_eq(name, SLOP_STR("none"))) {
                         return env_env_make_option_type(env, NULL);
@@ -2020,52 +2040,60 @@ types_ResolvedType* infer_check_field_exists(env_TypeEnv* env, types_ResolvedTyp
     {
         __auto_type type_name = (*obj_type).name;
         __auto_type arena = env_env_arena(env);
-        if (types_resolved_type_is_record(obj_type)) {
-            __auto_type _mv_312 = types_resolved_type_get_field_type(obj_type, field_name);
-            if (_mv_312.has_value) {
-                __auto_type field_type = _mv_312.value;
-                return field_type;
-            } else if (!_mv_312.has_value) {
-                {
-                    __auto_type msg = string_concat(arena, SLOP_STR("Record '"), string_concat(arena, type_name, string_concat(arena, SLOP_STR("' has no field '"), string_concat(arena, field_name, SLOP_STR("'")))));
-                    env_env_add_error(env, msg, line, col);
-                    return env_env_get_unit_type(env);
-                }
+        if (infer_type_is_null_pointer(obj_type)) {
+            {
+                __auto_type msg = string_concat(arena, SLOP_STR("cannot access field '"), string_concat(arena, field_name, SLOP_STR("' on nil")));
+                env_env_add_error(env, msg, line, col);
+                return env_env_get_unknown_type(env);
             }
-            SLOP_UNREACHABLE();
         } else {
-            if (string_eq(type_name, SLOP_STR("T"))) {
-                return env_env_get_generic_type(env);
-            } else {
-                if (string_eq(type_name, SLOP_STR("String"))) {
-                    if (string_eq(field_name, SLOP_STR("data"))) {
-                        return env_env_get_int_type(env);
-                    } else if (string_eq(field_name, SLOP_STR("len"))) {
-                        return env_env_get_int_type(env);
-                    } else {
-                        return env_env_get_unknown_type(env);
+            if (types_resolved_type_is_record(obj_type)) {
+                __auto_type _mv_312 = types_resolved_type_get_field_type(obj_type, field_name);
+                if (_mv_312.has_value) {
+                    __auto_type field_type = _mv_312.value;
+                    return field_type;
+                } else if (!_mv_312.has_value) {
+                    {
+                        __auto_type msg = string_concat(arena, SLOP_STR("Record '"), string_concat(arena, type_name, string_concat(arena, SLOP_STR("' has no field '"), string_concat(arena, field_name, SLOP_STR("'")))));
+                        env_env_add_error(env, msg, line, col);
+                        return env_env_get_unit_type(env);
                     }
+                }
+                SLOP_UNREACHABLE();
+            } else {
+                if (string_eq(type_name, SLOP_STR("T"))) {
+                    return env_env_get_generic_type(env);
                 } else {
-                    if (string_eq(type_name, SLOP_STR("Unknown"))) {
-                        return env_env_get_unknown_type(env);
-                    } else {
-                        if (types_resolved_type_is_pointer(obj_type)) {
-                            __auto_type _mv_313 = (*obj_type).inner_type;
-                            if (_mv_313.has_value) {
-                                __auto_type inner_type = _mv_313.value;
-                                return infer_check_field_exists(env, inner_type, field_name, line, col);
-                            } else if (!_mv_313.has_value) {
-                                return env_env_get_unknown_type(env);
-                            }
-                            SLOP_UNREACHABLE();
+                    if (string_eq(type_name, SLOP_STR("String"))) {
+                        if (string_eq(field_name, SLOP_STR("data"))) {
+                            return env_env_get_int_type(env);
+                        } else if (string_eq(field_name, SLOP_STR("len"))) {
+                            return env_env_get_int_type(env);
                         } else {
-                            if (string_eq(type_name, SLOP_STR("Chan")) || string_eq(type_name, SLOP_STR("Thread"))) {
-                                return env_env_get_unknown_type(env);
-                            } else {
-                                {
-                                    __auto_type msg = string_concat(arena, SLOP_STR("Cannot access field '"), string_concat(arena, field_name, string_concat(arena, SLOP_STR("' on non-record type '"), string_concat(arena, type_name, SLOP_STR("'")))));
-                                    env_env_add_error(env, msg, line, col);
+                            return env_env_get_unknown_type(env);
+                        }
+                    } else {
+                        if (string_eq(type_name, SLOP_STR("Unknown"))) {
+                            return env_env_get_unknown_type(env);
+                        } else {
+                            if (types_resolved_type_is_pointer(obj_type)) {
+                                __auto_type _mv_313 = (*obj_type).inner_type;
+                                if (_mv_313.has_value) {
+                                    __auto_type inner_type = _mv_313.value;
+                                    return infer_check_field_exists(env, inner_type, field_name, line, col);
+                                } else if (!_mv_313.has_value) {
                                     return env_env_get_unknown_type(env);
+                                }
+                                SLOP_UNREACHABLE();
+                            } else {
+                                if (string_eq(type_name, SLOP_STR("Chan")) || string_eq(type_name, SLOP_STR("Thread"))) {
+                                    return env_env_get_unknown_type(env);
+                                } else {
+                                    {
+                                        __auto_type msg = string_concat(arena, SLOP_STR("Cannot access field '"), string_concat(arena, field_name, string_concat(arena, SLOP_STR("' on non-record type '"), string_concat(arena, type_name, SLOP_STR("'")))));
+                                        env_env_add_error(env, msg, line, col);
+                                        return env_env_get_unknown_type(env);
+                                    }
                                 }
                             }
                         }
@@ -2590,7 +2618,7 @@ void infer_check_return_expr(env_TypeEnv* env, types_SExpr* ret_expr, slop_strin
             {
                 __auto_type declared_name = ret_sym.name;
                 __auto_type inferred_name = (*inferred_type).name;
-                if (!(string_eq(declared_name, inferred_name)) && (infer_checker_is_primitive_type(declared_name) && infer_checker_is_primitive_type(inferred_name))) {
+                if (!(string_eq(declared_name, inferred_name)) && ((infer_checker_is_primitive_type(declared_name) && infer_checker_is_primitive_type(inferred_name)) || (string_eq(inferred_name, SLOP_STR("<nil>")) && infer_checker_is_primitive_type(declared_name)))) {
                     {
                         __auto_type arena = env_env_arena(env);
                         __auto_type msg = string_concat(arena, SLOP_STR("return value of '"), string_concat(arena, fn_name, string_concat(arena, SLOP_STR("': expected "), string_concat(arena, declared_name, string_concat(arena, SLOP_STR(", got "), inferred_name)))));

--- a/bootstrap/checker/slop_infer.h
+++ b/bootstrap/checker/slop_infer.h
@@ -50,6 +50,7 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
 types_ResolvedType* infer_infer_generic_call(env_TypeEnv* env, types_FnSignature* sig, types_SExpr* expr, int64_t line, int64_t col);
 uint8_t infer_types_equal(types_ResolvedType* a, types_ResolvedType* b);
 uint8_t infer_types_compatible_with_range(types_ResolvedType* a, types_ResolvedType* b);
+uint8_t infer_type_is_null_pointer(types_ResolvedType* t);
 types_ResolvedType* infer_unify_branch_types(env_TypeEnv* env, types_ResolvedType* a, types_ResolvedType* b, int64_t line, int64_t col);
 void infer_sexpr_set_resolved_type(types_SExpr* expr, types_ResolvedType* t);
 types_ResolvedType* infer_infer_expr(env_TypeEnv* env, types_SExpr* expr);

--- a/bootstrap/compiler/slop_env.c
+++ b/bootstrap/compiler/slop_env.c
@@ -40,6 +40,7 @@ slop_option_string env_env_get_module(env_TypeEnv* env);
 types_ResolvedType* env_env_get_int_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_bool_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_string_type(env_TypeEnv* env);
+types_ResolvedType* env_env_get_null_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_float_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_unit_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_arena_type(env_TypeEnv* env);
@@ -71,12 +72,13 @@ env_TypeEnv* env_env_new(slop_arena* arena) {
         __auto_type bool_t = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, SLOP_STR("Bool"), ((slop_option_string){.has_value = false}), SLOP_STR("bool"));
         __auto_type string_t = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, SLOP_STR("String"), ((slop_option_string){.has_value = false}), SLOP_STR("slop_string_t"));
         __auto_type float_t = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, SLOP_STR("Float"), ((slop_option_string){.has_value = false}), SLOP_STR("double"));
+        __auto_type null_t = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_ptr, SLOP_STR("<nil>"), ((slop_option_string){.has_value = false}), SLOP_STR("void*"));
         __auto_type unit_t = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, SLOP_STR("Unit"), ((slop_option_string){.has_value = false}), SLOP_STR("void"));
         __auto_type arena_t = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, SLOP_STR("Arena"), ((slop_option_string){.has_value = false}), SLOP_STR("slop_arena_t*"));
         __auto_type unknown_t = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, SLOP_STR("Unknown"), ((slop_option_string){.has_value = false}), SLOP_STR("void"));
         __auto_type never_t = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_never, SLOP_STR("Never"), ((slop_option_string){.has_value = false}), SLOP_STR("void"));
         __auto_type env = ((env_TypeEnv*)(({ __auto_type _alloc = (env_TypeEnv*)slop_arena_alloc(arena, sizeof(env_TypeEnv)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
-        (*env) = (env_TypeEnv){arena, ((slop_list_types_ResolvedType_ptr){ .data = (types_ResolvedType**)slop_arena_alloc(arena, 16 * sizeof(types_ResolvedType*)), .len = 0, .cap = 16 }), ((slop_list_types_FnSignature_ptr){ .data = (types_FnSignature**)slop_arena_alloc(arena, 16 * sizeof(types_FnSignature*)), .len = 0, .cap = 16 }), ((slop_list_env_ConstBinding){ .data = (env_ConstBinding*)slop_arena_alloc(arena, 16 * sizeof(env_ConstBinding)), .len = 0, .cap = 16 }), ((slop_list_env_ImportEntry){ .data = (env_ImportEntry*)slop_arena_alloc(arena, 16 * sizeof(env_ImportEntry)), .len = 0, .cap = 16 }), ((slop_list_env_VariantMapping){ .data = (env_VariantMapping*)slop_arena_alloc(arena, 16 * sizeof(env_VariantMapping)), .len = 0, .cap = 16 }), ((slop_list_env_CheckerScope_ptr){ .data = (env_CheckerScope**)slop_arena_alloc(arena, 16 * sizeof(env_CheckerScope*)), .len = 0, .cap = 16 }), ((slop_option_string){.has_value = false}), int_t, bool_t, string_t, float_t, unit_t, arena_t, unknown_t, ((slop_list_types_Diagnostic){ .data = (types_Diagnostic*)slop_arena_alloc(arena, 16 * sizeof(types_Diagnostic)), .len = 0, .cap = 16 }), ((slop_list_env_BindingAnnotation){ .data = (env_BindingAnnotation*)slop_arena_alloc(arena, 16 * sizeof(env_BindingAnnotation)), .len = 0, .cap = 16 }), ((slop_option_string){.has_value = false}), ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 }), never_t, ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 })};
+        (*env) = (env_TypeEnv){arena, ((slop_list_types_ResolvedType_ptr){ .data = (types_ResolvedType**)slop_arena_alloc(arena, 16 * sizeof(types_ResolvedType*)), .len = 0, .cap = 16 }), ((slop_list_types_FnSignature_ptr){ .data = (types_FnSignature**)slop_arena_alloc(arena, 16 * sizeof(types_FnSignature*)), .len = 0, .cap = 16 }), ((slop_list_env_ConstBinding){ .data = (env_ConstBinding*)slop_arena_alloc(arena, 16 * sizeof(env_ConstBinding)), .len = 0, .cap = 16 }), ((slop_list_env_ImportEntry){ .data = (env_ImportEntry*)slop_arena_alloc(arena, 16 * sizeof(env_ImportEntry)), .len = 0, .cap = 16 }), ((slop_list_env_VariantMapping){ .data = (env_VariantMapping*)slop_arena_alloc(arena, 16 * sizeof(env_VariantMapping)), .len = 0, .cap = 16 }), ((slop_list_env_CheckerScope_ptr){ .data = (env_CheckerScope**)slop_arena_alloc(arena, 16 * sizeof(env_CheckerScope*)), .len = 0, .cap = 16 }), ((slop_option_string){.has_value = false}), int_t, bool_t, string_t, float_t, null_t, unit_t, arena_t, unknown_t, ((slop_list_types_Diagnostic){ .data = (types_Diagnostic*)slop_arena_alloc(arena, 16 * sizeof(types_Diagnostic)), .len = 0, .cap = 16 }), ((slop_list_env_BindingAnnotation){ .data = (env_BindingAnnotation*)slop_arena_alloc(arena, 16 * sizeof(env_BindingAnnotation)), .len = 0, .cap = 16 }), ((slop_option_string){.has_value = false}), ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 }), never_t, ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 })};
         ({ __auto_type _lst_p = &((*env).types); __auto_type _item = (int_t); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
         ({ __auto_type _lst_p = &((*env).types); __auto_type _item = (bool_t); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
         ({ __auto_type _lst_p = &((*env).types); __auto_type _item = (string_t); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
@@ -879,6 +881,14 @@ types_ResolvedType* env_env_get_string_type(env_TypeEnv* env) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     types_ResolvedType* _retval = {0};
     _retval = (*env).string_type;
+    SLOP_POST(((_retval != NULL)), "(!= $result nil)");
+    return _retval;
+}
+
+types_ResolvedType* env_env_get_null_type(env_TypeEnv* env) {
+    SLOP_PRE(((env != NULL)), "(!= env nil)");
+    types_ResolvedType* _retval = {0};
+    _retval = (*env).null_type;
     SLOP_POST(((_retval != NULL)), "(!= $result nil)");
     return _retval;
 }

--- a/bootstrap/compiler/slop_env.h
+++ b/bootstrap/compiler/slop_env.h
@@ -171,6 +171,7 @@ struct env_TypeEnv {
     types_ResolvedType* bool_type;
     types_ResolvedType* string_type;
     types_ResolvedType* float_type;
+    types_ResolvedType* null_type;
     types_ResolvedType* unit_type;
     types_ResolvedType* arena_type;
     types_ResolvedType* unknown_type;
@@ -227,6 +228,7 @@ slop_option_string env_env_get_module(env_TypeEnv* env);
 types_ResolvedType* env_env_get_int_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_bool_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_string_type(env_TypeEnv* env);
+types_ResolvedType* env_env_get_null_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_float_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_unit_type(env_TypeEnv* env);
 types_ResolvedType* env_env_get_arena_type(env_TypeEnv* env);

--- a/bootstrap/compiler/slop_infer.c
+++ b/bootstrap/compiler/slop_infer.c
@@ -21,6 +21,7 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
 types_ResolvedType* infer_infer_generic_call(env_TypeEnv* env, types_FnSignature* sig, types_SExpr* expr, int64_t line, int64_t col);
 uint8_t infer_types_equal(types_ResolvedType* a, types_ResolvedType* b);
 uint8_t infer_types_compatible_with_range(types_ResolvedType* a, types_ResolvedType* b);
+uint8_t infer_type_is_null_pointer(types_ResolvedType* t);
 types_ResolvedType* infer_unify_branch_types(env_TypeEnv* env, types_ResolvedType* a, types_ResolvedType* b, int64_t line, int64_t col);
 void infer_sexpr_set_resolved_type(types_SExpr* expr, types_ResolvedType* t);
 types_ResolvedType* infer_infer_expr(env_TypeEnv* env, types_SExpr* expr);
@@ -547,6 +548,10 @@ uint8_t infer_types_equal(types_ResolvedType* a, types_ResolvedType* b) {
             return 1;
         } else if ((a_kind == types_ResolvedTypeKind_rk_typevar) || (b_kind == types_ResolvedTypeKind_rk_typevar)) {
             return 1;
+        } else if (string_eq(a_name, SLOP_STR("<nil>")) && (b_kind == types_ResolvedTypeKind_rk_ptr)) {
+            return 1;
+        } else if (string_eq(b_name, SLOP_STR("<nil>")) && (a_kind == types_ResolvedTypeKind_rk_ptr)) {
+            return 1;
         } else if (string_eq(a_name, SLOP_STR("T")) || string_eq(b_name, SLOP_STR("T"))) {
             return 1;
         } else if ((a_kind == types_ResolvedTypeKind_rk_option) && (b_kind == types_ResolvedTypeKind_rk_option)) {
@@ -595,6 +600,11 @@ uint8_t infer_types_compatible_with_range(types_ResolvedType* a, types_ResolvedT
     }
 }
 
+uint8_t infer_type_is_null_pointer(types_ResolvedType* t) {
+    SLOP_PRE(((t != NULL)), "(!= t nil)");
+    return string_eq((*t).name, SLOP_STR("<nil>"));
+}
+
 types_ResolvedType* infer_unify_branch_types(env_TypeEnv* env, types_ResolvedType* a, types_ResolvedType* b, int64_t line, int64_t col) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((a != NULL)), "(!= a nil)");
@@ -605,14 +615,22 @@ types_ResolvedType* infer_unify_branch_types(env_TypeEnv* env, types_ResolvedTyp
         if ((*b).kind == types_ResolvedTypeKind_rk_never) {
             return a;
         } else {
-            if (infer_types_equal(a, b)) {
-                return a;
+            if (infer_type_is_null_pointer(a) && ((*b).kind == types_ResolvedTypeKind_rk_ptr)) {
+                return b;
             } else {
-                {
-                    __auto_type arena = env_env_arena(env);
-                    __auto_type msg = string_concat(arena, SLOP_STR("Branch types differ: "), string_concat(arena, (*a).name, string_concat(arena, SLOP_STR(" vs "), (*b).name)));
-                    env_env_add_warning(env, msg, line, col);
+                if (infer_type_is_null_pointer(b) && ((*a).kind == types_ResolvedTypeKind_rk_ptr)) {
                     return a;
+                } else {
+                    if (infer_types_equal(a, b)) {
+                        return a;
+                    } else {
+                        {
+                            __auto_type arena = env_env_arena(env);
+                            __auto_type msg = string_concat(arena, SLOP_STR("Branch types differ: "), string_concat(arena, (*a).name, string_concat(arena, SLOP_STR(" vs "), (*b).name)));
+                            env_env_add_warning(env, msg, line, col);
+                            return a;
+                        }
+                    }
                 }
             }
         }
@@ -677,7 +695,9 @@ types_ResolvedType* infer_infer_expr_inner(env_TypeEnv* env, types_SExpr* expr) 
                     __auto_type name = sym.name;
                     if (string_eq(name, SLOP_STR("true")) || string_eq(name, SLOP_STR("false"))) {
                         return env_env_get_bool_type(env);
-                    } else if (string_eq(name, SLOP_STR("nil")) || string_eq(name, SLOP_STR("unit"))) {
+                    } else if (string_eq(name, SLOP_STR("nil"))) {
+                        return env_env_get_null_type(env);
+                    } else if (string_eq(name, SLOP_STR("unit"))) {
                         return env_env_get_unit_type(env);
                     } else if (string_eq(name, SLOP_STR("none"))) {
                         return env_env_make_option_type(env, NULL);
@@ -2020,52 +2040,60 @@ types_ResolvedType* infer_check_field_exists(env_TypeEnv* env, types_ResolvedTyp
     {
         __auto_type type_name = (*obj_type).name;
         __auto_type arena = env_env_arena(env);
-        if (types_resolved_type_is_record(obj_type)) {
-            __auto_type _mv_1743 = types_resolved_type_get_field_type(obj_type, field_name);
-            if (_mv_1743.has_value) {
-                __auto_type field_type = _mv_1743.value;
-                return field_type;
-            } else if (!_mv_1743.has_value) {
-                {
-                    __auto_type msg = string_concat(arena, SLOP_STR("Record '"), string_concat(arena, type_name, string_concat(arena, SLOP_STR("' has no field '"), string_concat(arena, field_name, SLOP_STR("'")))));
-                    env_env_add_error(env, msg, line, col);
-                    return env_env_get_unit_type(env);
-                }
+        if (infer_type_is_null_pointer(obj_type)) {
+            {
+                __auto_type msg = string_concat(arena, SLOP_STR("cannot access field '"), string_concat(arena, field_name, SLOP_STR("' on nil")));
+                env_env_add_error(env, msg, line, col);
+                return env_env_get_unknown_type(env);
             }
-            SLOP_UNREACHABLE();
         } else {
-            if (string_eq(type_name, SLOP_STR("T"))) {
-                return env_env_get_generic_type(env);
-            } else {
-                if (string_eq(type_name, SLOP_STR("String"))) {
-                    if (string_eq(field_name, SLOP_STR("data"))) {
-                        return env_env_get_int_type(env);
-                    } else if (string_eq(field_name, SLOP_STR("len"))) {
-                        return env_env_get_int_type(env);
-                    } else {
-                        return env_env_get_unknown_type(env);
+            if (types_resolved_type_is_record(obj_type)) {
+                __auto_type _mv_1743 = types_resolved_type_get_field_type(obj_type, field_name);
+                if (_mv_1743.has_value) {
+                    __auto_type field_type = _mv_1743.value;
+                    return field_type;
+                } else if (!_mv_1743.has_value) {
+                    {
+                        __auto_type msg = string_concat(arena, SLOP_STR("Record '"), string_concat(arena, type_name, string_concat(arena, SLOP_STR("' has no field '"), string_concat(arena, field_name, SLOP_STR("'")))));
+                        env_env_add_error(env, msg, line, col);
+                        return env_env_get_unit_type(env);
                     }
+                }
+                SLOP_UNREACHABLE();
+            } else {
+                if (string_eq(type_name, SLOP_STR("T"))) {
+                    return env_env_get_generic_type(env);
                 } else {
-                    if (string_eq(type_name, SLOP_STR("Unknown"))) {
-                        return env_env_get_unknown_type(env);
-                    } else {
-                        if (types_resolved_type_is_pointer(obj_type)) {
-                            __auto_type _mv_1744 = (*obj_type).inner_type;
-                            if (_mv_1744.has_value) {
-                                __auto_type inner_type = _mv_1744.value;
-                                return infer_check_field_exists(env, inner_type, field_name, line, col);
-                            } else if (!_mv_1744.has_value) {
-                                return env_env_get_unknown_type(env);
-                            }
-                            SLOP_UNREACHABLE();
+                    if (string_eq(type_name, SLOP_STR("String"))) {
+                        if (string_eq(field_name, SLOP_STR("data"))) {
+                            return env_env_get_int_type(env);
+                        } else if (string_eq(field_name, SLOP_STR("len"))) {
+                            return env_env_get_int_type(env);
                         } else {
-                            if (string_eq(type_name, SLOP_STR("Chan")) || string_eq(type_name, SLOP_STR("Thread"))) {
-                                return env_env_get_unknown_type(env);
-                            } else {
-                                {
-                                    __auto_type msg = string_concat(arena, SLOP_STR("Cannot access field '"), string_concat(arena, field_name, string_concat(arena, SLOP_STR("' on non-record type '"), string_concat(arena, type_name, SLOP_STR("'")))));
-                                    env_env_add_error(env, msg, line, col);
+                            return env_env_get_unknown_type(env);
+                        }
+                    } else {
+                        if (string_eq(type_name, SLOP_STR("Unknown"))) {
+                            return env_env_get_unknown_type(env);
+                        } else {
+                            if (types_resolved_type_is_pointer(obj_type)) {
+                                __auto_type _mv_1744 = (*obj_type).inner_type;
+                                if (_mv_1744.has_value) {
+                                    __auto_type inner_type = _mv_1744.value;
+                                    return infer_check_field_exists(env, inner_type, field_name, line, col);
+                                } else if (!_mv_1744.has_value) {
                                     return env_env_get_unknown_type(env);
+                                }
+                                SLOP_UNREACHABLE();
+                            } else {
+                                if (string_eq(type_name, SLOP_STR("Chan")) || string_eq(type_name, SLOP_STR("Thread"))) {
+                                    return env_env_get_unknown_type(env);
+                                } else {
+                                    {
+                                        __auto_type msg = string_concat(arena, SLOP_STR("Cannot access field '"), string_concat(arena, field_name, string_concat(arena, SLOP_STR("' on non-record type '"), string_concat(arena, type_name, SLOP_STR("'")))));
+                                        env_env_add_error(env, msg, line, col);
+                                        return env_env_get_unknown_type(env);
+                                    }
                                 }
                             }
                         }
@@ -2590,7 +2618,7 @@ void infer_check_return_expr(env_TypeEnv* env, types_SExpr* ret_expr, slop_strin
             {
                 __auto_type declared_name = ret_sym.name;
                 __auto_type inferred_name = (*inferred_type).name;
-                if (!(string_eq(declared_name, inferred_name)) && (infer_checker_is_primitive_type(declared_name) && infer_checker_is_primitive_type(inferred_name))) {
+                if (!(string_eq(declared_name, inferred_name)) && ((infer_checker_is_primitive_type(declared_name) && infer_checker_is_primitive_type(inferred_name)) || (string_eq(inferred_name, SLOP_STR("<nil>")) && infer_checker_is_primitive_type(declared_name)))) {
                     {
                         __auto_type arena = env_env_arena(env);
                         __auto_type msg = string_concat(arena, SLOP_STR("return value of '"), string_concat(arena, fn_name, string_concat(arena, SLOP_STR("': expected "), string_concat(arena, declared_name, string_concat(arena, SLOP_STR(", got "), inferred_name)))));

--- a/bootstrap/compiler/slop_infer.h
+++ b/bootstrap/compiler/slop_infer.h
@@ -50,6 +50,7 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
 types_ResolvedType* infer_infer_generic_call(env_TypeEnv* env, types_FnSignature* sig, types_SExpr* expr, int64_t line, int64_t col);
 uint8_t infer_types_equal(types_ResolvedType* a, types_ResolvedType* b);
 uint8_t infer_types_compatible_with_range(types_ResolvedType* a, types_ResolvedType* b);
+uint8_t infer_type_is_null_pointer(types_ResolvedType* t);
 types_ResolvedType* infer_unify_branch_types(env_TypeEnv* env, types_ResolvedType* a, types_ResolvedType* b, int64_t line, int64_t col);
 void infer_sexpr_set_resolved_type(types_SExpr* expr, types_ResolvedType* t);
 types_ResolvedType* infer_infer_expr(env_TypeEnv* env, types_SExpr* expr);

--- a/lib/compiler/checker/env.slop
+++ b/lib/compiler/checker/env.slop
@@ -34,7 +34,7 @@
     env-set-current-file env-get-current-file
     env-add-loaded-module env-is-module-loaded
     ;; Builtin types
-    env-get-int-type env-get-bool-type env-get-string-type env-get-float-type
+    env-get-int-type env-get-bool-type env-get-string-type env-get-float-type env-get-null-type
     env-get-unit-type env-get-arena-type env-get-unknown-type env-get-never-type
     ;; Type constructors
     env-make-option-type env-make-ptr-type env-make-result-type env-make-fn-type env-get-generic-type
@@ -111,6 +111,7 @@
     (bool-type (Ptr ResolvedType))
     (string-type (Ptr ResolvedType))
     (float-type (Ptr ResolvedType))
+    (null-type (Ptr ResolvedType))
     (unit-type (Ptr ResolvedType))
     (arena-type (Ptr ResolvedType))
     (unknown-type (Ptr ResolvedType))
@@ -143,6 +144,11 @@
           ;; built it on demand, and nothing cached it, so a float literal had no
           ;; type to be given and fell back to Int.
           (float-t (resolved-type-new arena 'rk-primitive "Float" (none) "double"))
+          ;; The type of the `nil` literal: a pointer with no pointee. Shares the
+          ;; rk-ptr kind so it compares as a pointer, and carries a name that no
+          ;; source type can spell -- angle brackets are not symbol characters --
+          ;; so a user type cannot collide with the sentinel.
+          (null-t (resolved-type-new arena 'rk-ptr "<nil>" (none) "void*"))
           (unit-t (resolved-type-new arena 'rk-primitive "Unit" (none) "void"))
           (arena-t (resolved-type-new arena 'rk-primitive "Arena" (none) "slop_arena_t*"))
           (unknown-t (resolved-type-new arena 'rk-primitive "Unknown" (none) "void"))
@@ -157,7 +163,7 @@
         (list-new arena VariantMapping)          ;; enum-variants
         (list-new arena (Ptr CheckerScope))             ;; scopes - store pointers
         (none)                                   ;; current-module
-        int-t bool-t string-t float-t unit-t arena-t unknown-t
+        int-t bool-t string-t float-t null-t unit-t arena-t unknown-t
         (list-new arena Diagnostic)              ;; diagnostics
         (list-new arena BindingAnnotation)       ;; binding-annotations
         (none)                                   ;; current-file
@@ -878,6 +884,14 @@
     (@pre (!= env nil))
     (@post (!= $result nil))
     (. (deref env) string-type))
+
+  (fn env-get-null-type ((env (Ptr TypeEnv)))
+    (@intent "Get the type of the nil literal - a pointer with no pointee")
+    (@spec (((Ptr TypeEnv)) -> (Ptr ResolvedType)))
+    (@pure)
+    (@pre (!= env nil))
+    (@post (!= $result nil))
+    (. (deref env) null-type))
 
   (fn env-get-float-type ((env (Ptr TypeEnv)))
     (@intent "Get the builtin Float type")

--- a/lib/compiler/checker/infer.slop
+++ b/lib/compiler/checker/infer.slop
@@ -23,7 +23,7 @@
   (import env (TypeEnv env-arena env-push-scope env-pop-scope
                env-bind-var env-lookup-var env-lookup-type
                env-lookup-function env-lookup-variant env-lookup-constant
-               env-get-int-type env-get-bool-type env-get-float-type
+               env-get-int-type env-get-bool-type env-get-float-type env-get-null-type
                env-get-string-type env-get-unit-type env-get-arena-type
                env-get-unknown-type env-get-never-type
                env-make-option-type env-make-ptr-type env-make-result-type env-make-fn-type env-get-generic-type
@@ -460,6 +460,10 @@
         ;; Type variables match anything
         ((or (== a-kind 'rk-typevar) (== b-kind 'rk-typevar)) true)
 
+        ;; The nil literal stands in for any pointer.
+        ((and (string-eq a-name "<nil>") (== b-kind 'rk-ptr)) true)
+        ((and (string-eq b-name "<nil>") (== a-kind 'rk-ptr)) true)
+
         ;; Generic type variable "T" matches anything (legacy)
         ((or (string-eq a-name "T") (string-eq b-name "T")) true)
 
@@ -508,6 +512,13 @@
             ((none) false)))
         (else false))))
 
+  (fn type-is-null-pointer ((t (Ptr ResolvedType)))
+    (@intent "Check if a type is the nil literal's type rather than a concrete pointer")
+    (@spec (((Ptr ResolvedType)) -> Bool))
+    (@pure)
+    (@pre (!= t nil))
+    (string-eq (. (deref t) name) "<nil>"))
+
   (fn unify-branch-types ((env (Ptr TypeEnv)) (a (Ptr ResolvedType)) (b (Ptr ResolvedType))
                           (line Int) (col Int))
     (@intent "Unify two branch types, emitting warning if they differ")
@@ -520,6 +531,14 @@
       b  ;; First branch diverges, use second type
       (if (== (. (deref b) kind) 'rk-never)
         a  ;; Second branch diverges, use first type
+        ;; nil unified with a concrete pointer: keep the concrete one. Returning
+        ;; the NullPtr side would erase the pointee, and a later (. p field)
+        ;; would then infer Unknown and pass unchecked -- which happens only
+        ;; when the nil arm comes first, so the bug would be order-dependent.
+        (if (and (type-is-null-pointer a) (== (. (deref b) kind) 'rk-ptr))
+          b
+        (if (and (type-is-null-pointer b) (== (. (deref a) kind) 'rk-ptr))
+          a
         ;; If types are equal, return either
         (if (types-equal a b)
           a
@@ -529,7 +548,7 @@
                        (string-concat arena (. (deref a) name)
                          (string-concat arena " vs " (. (deref b) name))))))
             (env-add-warning env msg line col)
-            a)))))
+            a)))))))
 
   ;; ============================================================
   ;; AST Type Annotation
@@ -583,7 +602,12 @@
               ((or (string-eq name "true") (string-eq name "false"))
                 (env-get-bool-type env))
               ;; nil and unit
-              ((or (string-eq name "nil") (string-eq name "unit"))
+              ;; `nil` is the null pointer, not Unit. Conflating them made every
+              ;; `((none) nil)` arm read as Unit and collide with the pointer the
+              ;; other arm produced -- the bulk of the "Branch types differ" noise.
+              ((string-eq name "nil")
+                (env-get-null-type env))
+              ((string-eq name "unit")
                 (env-get-unit-type env))
               ;; none - Option type with unknown inner type
               ((string-eq name "none")
@@ -779,7 +803,10 @@
                                     (let ((elem-type (match (. (deref coll-type) inner-type)
                                                        ((some inner) inner)
                                                        ((none)
-                                                         ;; Error: collection has no known element type
+                                                         ;; No element type to bind. Only worth reporting for a
+                                                         ;; concrete collection: over a generic T the checker
+                                                         ;; genuinely cannot know, so the warning describes a
+                                                         ;; limitation rather than anything the author can fix.
                                                          (let ((arena (env-arena env))
                                                                (coll-name (. (deref coll-type) name))
                                                                (msg (string-concat arena "for-each: cannot determine element type of '"
@@ -1618,6 +1645,14 @@
     (@pre (!= obj-type nil))
     (let ((type-name (. (deref obj-type) name))
           (arena (env-arena env)))
+      ;; nil has no pointee, so it has no fields either. Without this it would
+      ;; fall through to the not-a-record path, yield Unknown, and let
+      ;; (. nil field) reach the C compiler as NULL.field.
+      (if (type-is-null-pointer obj-type)
+        (let ((msg (string-concat arena "cannot access field '"
+                     (string-concat arena field-name "' on nil"))))
+          (env-add-error env msg line col)
+          (env-get-unknown-type env))
       ;; Check if it's a record type
       (if (resolved-type-is-record obj-type)
         ;; Look up the field type
@@ -1661,7 +1696,7 @@
                                  (string-concat arena "' on non-record type '"
                                    (string-concat arena type-name "'"))))))
                     (env-add-error env msg line col)
-                    (env-get-unknown-type env))))))))))
+                    (env-get-unknown-type env)))))))))))
 
   (fn infer-cond-expr ((env (Ptr TypeEnv)) (expr (Ptr SExpr)) (lst SExprList))
     (@intent "Infer type of cond expression, checking branch types")
@@ -2088,9 +2123,19 @@
               (inferred-name (. (deref inferred-type) name)))
           ;; Only check if types differ AND both are primitives
           ;; Custom types (enums, records) need proper variant tracking
+          ;;
+          ;; A `nil` body is the exception: the null type is not a primitive, so
+          ;; without the second clause `(fn f () (@spec (() -> Int)) nil)` slipped
+          ;; through to Clang's pointer-to-integer error. The declared name here is
+          ;; a bare symbol, and a primitive one can never be a pointer, so that
+          ;; combination is always a mismatch. Aliases are deliberately left alone
+          ;; -- one cannot be resolved from its name here, and a false positive
+          ;; would be worse than the gap.
           (when (and (not (string-eq declared-name inferred-name))
-                     (and (checker-is-primitive-type declared-name)
-                          (checker-is-primitive-type inferred-name)))
+                     (or (and (checker-is-primitive-type declared-name)
+                              (checker-is-primitive-type inferred-name))
+                         (and (string-eq inferred-name "<nil>")
+                              (checker-is-primitive-type declared-name))))
             (let ((arena (env-arena env))
                   (msg (string-concat arena "return value of '"
                          (string-concat arena fn-name

--- a/tests/fixtures/test_nil_pointer_type.slop
+++ b/tests/fixtures/test_nil_pointer_type.slop
@@ -1,0 +1,48 @@
+;; Fixture for the `nil` literal's type.
+;;
+;; infer-expr typed `nil` and `unit` identically, both as Unit. `nil` is
+;; the null pointer, so every `((none) nil)` arm read as Unit and
+;; collided with the pointer the other arm produced:
+;;
+;;   Branch types differ: Ptr_ResolvedType vs Unit
+;;
+;; That was the bulk of the checker's warning noise, and it was noise
+;; rather than signal -- which matters, because a diagnostic channel
+;; that cries wolf is one everybody learns to scroll past.
+;;
+;; `nil` now has its own type (NullPtr, kind rk-ptr, no pointee) and
+;; types-equal lets it stand in for any (Ptr T), the same way it already
+;; lets a type variable stand in for anything.
+;;
+;; Every form here is valid and must check CLEAN.
+(module nil-pointer-type
+
+  (type Node (record (value Int)))
+
+  (fn maybe-node ((flag Bool) (n (Ptr Node)))
+    (@intent "a pointer-returning if with a nil arm - the shape that was noisy")
+    (@spec ((Bool (Ptr Node)) -> (Ptr Node)))
+    (if flag n nil))
+
+  (fn from-match ((flag Bool) (n (Ptr Node)))
+    (@intent "a nil arm in a match, the shape lib/ writes everywhere")
+    (@spec ((Bool (Ptr Node)) -> (Ptr Node)))
+    (match flag
+      (true n)
+      (false nil)))
+
+  ;; NOT covered here: `(match o ((some p) p) ((none) nil))` where o is a
+  ;; parameter of type (Option (Ptr Node)). That shape still warns, but for an
+  ;; unrelated reason -- binding `some`'s payload from a parameter-typed Option
+  ;; yields Unknown, which warns identically with no nil involved at all. Filed
+  ;; separately; asserting silence on it here would be testing someone else's bug.
+
+  (fn compares ((n (Ptr Node)))
+    (@intent "nil in a comparison, the other place it appears constantly")
+    (@spec (((Ptr Node)) -> Bool))
+    (!= n nil))
+
+  (fn main ()
+    (@intent "Unused entry point; the fixture is never run")
+    (@spec (() -> Int))
+    0))

--- a/tests/test_transpiler_warnings.py
+++ b/tests/test_transpiler_warnings.py
@@ -310,3 +310,135 @@ class TestFloatLiteralTyping:
         # Nothing else should fire either -- every form in the fixture is valid.
         assert ": error:" not in combined, combined
         assert ": warning:" not in combined, combined
+
+
+class TestNilPointerType:
+    """`nil` is the null pointer, not Unit.
+
+    infer-expr typed `nil` and `unit` identically, so every `((none) nil)` arm
+    read as Unit and collided with the pointer the sibling arm produced. That
+    was the bulk of the checker's warning volume, and it was noise rather than
+    signal -- which matters, because a channel that cries wolf gets ignored.
+    """
+
+    def test_nil_in_pointer_position_checks_clean(self):
+        rc, stdout, stderr = slop_check("fixtures/test_nil_pointer_type.slop")
+        combined = stdout + stderr
+        assert "Branch types differ" not in combined, combined
+        assert ": error:" not in combined, combined
+        assert ": warning:" not in combined, combined
+
+    def test_a_real_branch_mismatch_still_warns(self, tmp_path):
+        """A Unit arm in value position is a real bug and must keep warning.
+
+        `(if flag 1 (println "x"))` in an Int-returning function emits
+        `return printf(...)` as the result. Most `Branch types differ: * vs Unit`
+        warnings are benign statement-position noise, so quieting the class by
+        ignoring any Unit arm is tempting -- and would hide exactly this. Left
+        as a guard against that shortcut.
+        """
+        src = tmp_path / "unitbranch.slop"
+        src.write_text(
+            "(module unitbranch\n"
+            "  (fn bad ((flag Bool))\n"
+            '    (@intent "value position with a Unit arm")\n'
+            "    (@spec ((Bool) -> Int))\n"
+            '    (if flag 1 (println "x")))\n'
+            "  (fn main () (@spec (() -> Int)) :c-name \"main\" (bad true)))\n"
+        )
+        result = subprocess.run(
+            ["uv", "run", "slop", "check", str(src)],
+            capture_output=True, text=True, cwd=str(REPO_ROOT),
+        )
+        combined = result.stdout + result.stderr
+        assert "Branch types differ" in combined, combined
+
+    def test_nil_arm_first_keeps_the_pointee(self, tmp_path):
+        """Unifying nil with a pointer must keep the pointer, whichever arm is first.
+
+        Returning the NullPtr side erases the pointee, so a later `(. p field)`
+        infers Unknown and passes unchecked -- an order-dependent blind spot.
+        """
+        src = tmp_path / "nilfirst.slop"
+        src.write_text(
+            "(module nilfirst\n"
+            "  (type Node (record (value Int)))\n"
+            "  (fn nil-first ((flag Bool) (n (Ptr Node)))\n"
+            '    (@intent "nil arm first")\n'
+            "    (@spec ((Bool (Ptr Node)) -> Int))\n"
+            "    (let ((p (if flag nil n)))\n"
+            "      (. p missing)))\n"
+            "  (fn nil-second ((flag Bool) (n (Ptr Node)))\n"
+            '    (@intent "nil arm second")\n'
+            "    (@spec ((Bool (Ptr Node)) -> Int))\n"
+            "    (let ((p (if flag n nil)))\n"
+            "      (. p missing)))\n"
+            "  (fn main () (@spec (() -> Int)) :c-name \"main\" 0))\n"
+        )
+        result = subprocess.run(
+            ["uv", "run", "slop", "check", str(src)],
+            capture_output=True, text=True, cwd=str(REPO_ROOT),
+        )
+        combined = result.stdout + result.stderr
+        # Both orderings must report the bad field, not just one.
+        assert combined.count("has no field 'missing'") == 2, combined
+
+    def test_field_access_on_nil_is_rejected(self, tmp_path):
+        """nil has no pointee, so it has no fields -- catch it before C does."""
+        src = tmp_path / "nilfield.slop"
+        src.write_text(
+            "(module nilfield\n"
+            "  (fn bad () (@intent \"field on nil\") (@spec (() -> Int)) (. nil value))\n"
+            "  (fn main () (@spec (() -> Int)) :c-name \"main\" 0))\n"
+        )
+        result = subprocess.run(
+            ["uv", "run", "slop", "check", str(src)],
+            capture_output=True, text=True, cwd=str(REPO_ROOT),
+        )
+        combined = result.stdout + result.stderr
+        assert "cannot access field 'value' on nil" in combined, combined
+
+    def test_nil_against_a_non_pointer_still_warns(self, tmp_path):
+        """nil only stands in for a pointer, never for an arbitrary type.
+
+        `(if flag nil 1)` must not be silently inferred as Int -- the generated
+        C would then fail on a pointer-to-integer conversion.
+        """
+        src = tmp_path / "nilint.slop"
+        src.write_text(
+            "(module nilint\n"
+            "  (fn f ((flag Bool))\n"
+            '    (@intent "nil against a non-pointer")\n'
+            "    (@spec ((Bool) -> Int))\n"
+            "    (if flag nil 1))\n"
+            "  (fn main () (@spec (() -> Int)) :c-name \"main\" 0))\n"
+        )
+        result = subprocess.run(
+            ["uv", "run", "slop", "check", str(src)],
+            capture_output=True, text=True, cwd=str(REPO_ROOT),
+        )
+        combined = result.stdout + result.stderr
+        assert "Branch types differ" in combined, combined
+
+    def test_nil_body_against_a_non_pointer_return_is_rejected(self, tmp_path):
+        """A `nil` body must not satisfy a non-pointer @spec.
+
+        The null type is not a primitive, so the return check -- which fires only
+        when both sides are -- skipped it entirely and let `return NULL;` reach
+        Clang's pointer-to-integer error.
+        """
+        src = tmp_path / "nilret.slop"
+        src.write_text(
+            "(module nilret\n"
+            "  (fn bad ()\n"
+            '    (@intent "returns nil but declares Int")\n'
+            "    (@spec (() -> Int))\n"
+            "    nil)\n"
+            "  (fn main () (@spec (() -> Int)) :c-name \"main\" 0))\n"
+        )
+        result = subprocess.run(
+            ["uv", "run", "slop", "check", str(src)],
+            capture_output=True, text=True, cwd=str(REPO_ROOT),
+        )
+        combined = result.stdout + result.stderr
+        assert "expected Int, got <nil>" in combined, combined


### PR DESCRIPTION
Prerequisite work for #93, split out because it stands on its own.

## The bug

`infer-expr` typed `nil` and `unit` identically, both as `Unit`. `nil` is the null pointer, so every pointer-returning branch that yields it collided with the pointer its sibling arm produced:

```lisp
(match flag (true n) (false nil))
```
```
warning: Branch types differ: Ptr_Node vs Unit
```

That shape is everywhere in `lib/`, and it accounted for the bulk of the checker's warning volume — noise rather than signal, which matters because a channel that cries wolf gets ignored.

## The fix

`nil` gets its own type: kind `rk-ptr`, no pointee, registered alongside the other builtins in `env-new`. `types-equal` lets it stand in for any `(Ptr T)` — the shape that function already uses for type variables, bare `T`, and generic `Option`/`Result`.

Its name is `<nil>`. Angle brackets aren't symbol characters, so no source type can spell it and collide with the sentinel.

## Three consequences, each handled rather than left to be found later

Two of these came out of codex review, and both were real:

**Order-dependent pointee loss.** `unify-branch-types` returns its first argument when the two agree, so `(if flag nil n)` would have returned the null type and erased `n`'s pointee — a later `(. p field)` then infers `Unknown` and passes unchecked. `(if flag n nil)` was fine, so the blind spot depended on arm order. The concrete side now wins regardless of order — but **only when it is actually a pointer**, so `(if flag nil 1)` still warns instead of being silently inferred as `Int` and failing in C on a pointer-to-integer conversion.

**Field access on nil.** `nil` has no pointee, so it has no fields. Sharing the `rk-ptr` kind would otherwise send `(. nil value)` down the valid-pointer path, where the absent inner type becomes `Unknown`, the checker exits clean, and the generated C fails on `NULL.value`. Now an error — which is where CLAUDE.md says it belongs.

**Non-pointer returns.** The null type isn't a primitive, and the return check fires only when both sides are, so `(fn f () (@spec (() -> Int)) nil)` slipped straight through to Clang. Now caught: `expected Int, got <nil>`. Type aliases are deliberately left alone — one can't be resolved from its name at that point, and a false positive there would be worse than the gap.

## What is deliberately *not* quieted

`(if flag 1 (println "x"))` in an `Int`-returning function still warns. It emits `return printf(...)` as the result, so it is a genuine value-position mismatch. Most `Branch types differ: * vs Unit` warnings are benign statement-position noise and quieting the whole class by ignoring any `Unit` arm is tempting — it would hide exactly this. There's a test guarding against that shortcut.

## Effect

`Branch types differ` across a `lib/` sample: **58 → 27**. The remainder are statement-position constructs where the checker can't tell a discarded value from a used one without context it doesn't track — a separate problem, left alone.

Also not covered by the fixture, and worth knowing: `(match o ((some p) p) ((none) nil))` where `o` is a parameter of type `(Option (Ptr Node))` still warns — but for an unrelated reason. Binding `some`'s payload from a parameter-typed Option yields `Unknown`, and it warns identically with no `nil` involved at all. Asserting silence on that here would be testing someone else's bug; I'll file it separately.

| | |
|---|---|
| `make selfhost` | clean |
| `make test-native` | 42/42 |
| `uv run pytest` | 486 passed, 1 xfailed (was 481) |
| Bootstrap | fixed point; cold start clean |
| HOWL | builds unchanged |
| `codex exec review --base origin/main` | clean (after three rounds — every finding was real) |
