### PR TITLE
fix with-arena :as, both the C name and the closure arena (#74, #75)

### DIFF
--- a/bootstrap/compiler/slop_collect.c
+++ b/bootstrap/compiler/slop_collect.c
@@ -63,29 +63,29 @@ void collect_collect_types(env_TypeEnv* env, slop_list_types_SExpr_ptr ast) {
         __auto_type arena = env_env_arena(env);
         __auto_type len = ((int64_t)((ast).len));
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_1151 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1151.has_value) {
-                __auto_type expr = _mv_1151.value;
+            __auto_type _mv_1152 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1152.has_value) {
+                __auto_type expr = _mv_1152.value;
                 if (parser_is_form(expr, SLOP_STR("type"))) {
                     collect_register_type_name(env, arena, expr);
                 } else if (parser_is_form(expr, SLOP_STR("module"))) {
                     collect_register_module_type_names(env, expr);
                 } else {
                 }
-            } else if (!_mv_1151.has_value) {
+            } else if (!_mv_1152.has_value) {
             }
         }
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_1152 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1152.has_value) {
-                __auto_type expr = _mv_1152.value;
+            __auto_type _mv_1153 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1153.has_value) {
+                __auto_type expr = _mv_1153.value;
                 if (parser_is_form(expr, SLOP_STR("type"))) {
                     collect_resolve_type_body(env, arena, expr);
                 } else if (parser_is_form(expr, SLOP_STR("module"))) {
                     collect_resolve_module_type_bodies(env, expr);
                 } else {
                 }
-            } else if (!_mv_1152.has_value) {
+            } else if (!_mv_1153.has_value) {
             }
         }
     }
@@ -95,26 +95,26 @@ void collect_register_type_name(env_TypeEnv* env, slop_arena* arena, types_SExpr
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     {
         __auto_type mod_name = env_env_get_module(env);
-        __auto_type _mv_1153 = (*expr);
-        switch (_mv_1153.tag) {
+        __auto_type _mv_1154 = (*expr);
+        switch (_mv_1154.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1153.data.lst;
+                __auto_type lst = _mv_1154.data.lst;
                 {
                     __auto_type items = lst.items;
-                    __auto_type _mv_1154 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1154.has_value) {
-                        __auto_type name_expr = _mv_1154.value;
-                        __auto_type _mv_1155 = (*name_expr);
-                        switch (_mv_1155.tag) {
+                    __auto_type _mv_1155 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1155.has_value) {
+                        __auto_type name_expr = _mv_1155.value;
+                        __auto_type _mv_1156 = (*name_expr);
+                        switch (_mv_1156.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1155.data.sym;
+                                __auto_type sym = _mv_1156.data.sym;
                                 {
                                     __auto_type type_name = sym.name;
-                                    __auto_type _mv_1156 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_1156.has_value) {
-                                        __auto_type type_expr = _mv_1156.value;
+                                    __auto_type _mv_1157 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_1157.has_value) {
+                                        __auto_type type_expr = _mv_1157.value;
                                         if (parser_is_form(type_expr, SLOP_STR("enum"))) {
                                             {
                                                 __auto_type resolved = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_enum, type_name, mod_name, type_name);
@@ -156,7 +156,7 @@ void collect_register_type_name(env_TypeEnv* env, slop_arena* arena, types_SExpr
                                                 env_env_register_type(env, resolved);
                                             }
                                         }
-                                    } else if (!_mv_1156.has_value) {
+                                    } else if (!_mv_1157.has_value) {
                                         {
                                             __auto_type resolved = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, type_name, mod_name, type_name);
                                             env_env_register_type(env, resolved);
@@ -169,7 +169,7 @@ void collect_register_type_name(env_TypeEnv* env, slop_arena* arena, types_SExpr
                                 break;
                             }
                         }
-                    } else if (!_mv_1154.has_value) {
+                    } else if (!_mv_1155.has_value) {
                     }
                 }
                 break;
@@ -183,75 +183,65 @@ void collect_register_type_name(env_TypeEnv* env, slop_arena* arena, types_SExpr
 
 void collect_resolve_type_body(env_TypeEnv* env, slop_arena* arena, types_SExpr* expr) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_1157 = (*expr);
-    switch (_mv_1157.tag) {
+    __auto_type _mv_1158 = (*expr);
+    switch (_mv_1158.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1157.data.lst;
+            __auto_type lst = _mv_1158.data.lst;
             {
                 __auto_type items = lst.items;
-                __auto_type _mv_1158 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1158.has_value) {
-                    __auto_type name_expr = _mv_1158.value;
-                    __auto_type _mv_1159 = (*name_expr);
-                    switch (_mv_1159.tag) {
+                __auto_type _mv_1159 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1159.has_value) {
+                    __auto_type name_expr = _mv_1159.value;
+                    __auto_type _mv_1160 = (*name_expr);
+                    switch (_mv_1160.tag) {
                         case types_SExpr_sym:
                         {
-                            __auto_type sym = _mv_1159.data.sym;
+                            __auto_type sym = _mv_1160.data.sym;
                             {
                                 __auto_type type_name = sym.name;
-                                __auto_type _mv_1160 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1160.has_value) {
-                                    __auto_type type_expr = _mv_1160.value;
+                                __auto_type _mv_1161 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1161.has_value) {
+                                    __auto_type type_expr = _mv_1161.value;
                                     if (parser_is_form(type_expr, SLOP_STR("enum"))) {
                                         collect_collect_enum_variants(env, type_name, type_expr);
                                     } else if (parser_is_form(type_expr, SLOP_STR("record"))) {
-                                        __auto_type _mv_1161 = env_env_lookup_type_direct(env, type_name);
-                                        if (_mv_1161.has_value) {
-                                            __auto_type resolved = _mv_1161.value;
-                                            collect_collect_record_fields(env, arena, resolved, type_expr);
-                                        } else if (!_mv_1161.has_value) {
-                                        }
-                                    } else if (parser_is_form(type_expr, SLOP_STR("union"))) {
                                         __auto_type _mv_1162 = env_env_lookup_type_direct(env, type_name);
                                         if (_mv_1162.has_value) {
                                             __auto_type resolved = _mv_1162.value;
-                                            collect_collect_union_variants(env, arena, resolved, type_expr);
+                                            collect_collect_record_fields(env, arena, resolved, type_expr);
                                         } else if (!_mv_1162.has_value) {
                                         }
-                                    } else if (collect_is_range_type_expr(type_expr)) {
+                                    } else if (parser_is_form(type_expr, SLOP_STR("union"))) {
                                         __auto_type _mv_1163 = env_env_lookup_type_direct(env, type_name);
                                         if (_mv_1163.has_value) {
                                             __auto_type resolved = _mv_1163.value;
+                                            collect_collect_union_variants(env, arena, resolved, type_expr);
+                                        } else if (!_mv_1163.has_value) {
+                                        }
+                                    } else if (collect_is_range_type_expr(type_expr)) {
+                                        __auto_type _mv_1164 = env_env_lookup_type_direct(env, type_name);
+                                        if (_mv_1164.has_value) {
+                                            __auto_type resolved = _mv_1164.value;
                                             {
                                                 __auto_type base_type = collect_get_range_base_type(env, arena, type_expr);
                                                 types_resolved_type_set_inner(resolved, base_type);
                                             }
-                                        } else if (!_mv_1163.has_value) {
+                                        } else if (!_mv_1164.has_value) {
                                         }
                                     } else if (parser_is_form(type_expr, SLOP_STR("Map"))) {
-                                        __auto_type _mv_1164 = env_env_lookup_type_direct(env, type_name);
-                                        if (_mv_1164.has_value) {
-                                            __auto_type resolved = _mv_1164.value;
+                                        __auto_type _mv_1165 = env_env_lookup_type_direct(env, type_name);
+                                        if (_mv_1165.has_value) {
+                                            __auto_type resolved = _mv_1165.value;
                                             {
                                                 __auto_type key_type = collect_get_field_type(env, arena, collect_get_type_arg(type_expr, 1));
                                                 __auto_type val_type = collect_get_field_type(env, arena, collect_get_type_arg(type_expr, 2));
                                                 types_resolved_type_set_inner(resolved, key_type);
                                                 types_resolved_type_set_inner2(resolved, val_type);
                                             }
-                                        } else if (!_mv_1164.has_value) {
-                                        }
-                                    } else if (parser_is_form(type_expr, SLOP_STR("Set"))) {
-                                        __auto_type _mv_1165 = env_env_lookup_type_direct(env, type_name);
-                                        if (_mv_1165.has_value) {
-                                            __auto_type resolved = _mv_1165.value;
-                                            {
-                                                __auto_type elem_type = collect_get_field_type(env, arena, collect_get_type_arg(type_expr, 1));
-                                                types_resolved_type_set_inner(resolved, elem_type);
-                                            }
                                         } else if (!_mv_1165.has_value) {
                                         }
-                                    } else if (parser_is_form(type_expr, SLOP_STR("List"))) {
+                                    } else if (parser_is_form(type_expr, SLOP_STR("Set"))) {
                                         __auto_type _mv_1166 = env_env_lookup_type_direct(env, type_name);
                                         if (_mv_1166.has_value) {
                                             __auto_type resolved = _mv_1166.value;
@@ -261,23 +251,33 @@ void collect_resolve_type_body(env_TypeEnv* env, slop_arena* arena, types_SExpr*
                                             }
                                         } else if (!_mv_1166.has_value) {
                                         }
+                                    } else if (parser_is_form(type_expr, SLOP_STR("List"))) {
+                                        __auto_type _mv_1167 = env_env_lookup_type_direct(env, type_name);
+                                        if (_mv_1167.has_value) {
+                                            __auto_type resolved = _mv_1167.value;
+                                            {
+                                                __auto_type elem_type = collect_get_field_type(env, arena, collect_get_type_arg(type_expr, 1));
+                                                types_resolved_type_set_inner(resolved, elem_type);
+                                            }
+                                        } else if (!_mv_1167.has_value) {
+                                        }
                                     } else {
                                         {
                                             __auto_type alias_name = parser_sexpr_get_symbol_name(type_expr);
                                             if (!(string_eq(alias_name, SLOP_STR("")))) {
-                                                __auto_type _mv_1167 = env_env_lookup_type_direct(env, type_name);
-                                                if (_mv_1167.has_value) {
-                                                    __auto_type resolved = _mv_1167.value;
+                                                __auto_type _mv_1168 = env_env_lookup_type_direct(env, type_name);
+                                                if (_mv_1168.has_value) {
+                                                    __auto_type resolved = _mv_1168.value;
                                                     {
                                                         __auto_type base_type = collect_get_field_type(env, arena, type_expr);
                                                         types_resolved_type_set_inner(resolved, base_type);
                                                     }
-                                                } else if (!_mv_1167.has_value) {
+                                                } else if (!_mv_1168.has_value) {
                                                 }
                                             }
                                         }
                                     }
-                                } else if (!_mv_1160.has_value) {
+                                } else if (!_mv_1161.has_value) {
                                 }
                             }
                             break;
@@ -286,7 +286,7 @@ void collect_resolve_type_body(env_TypeEnv* env, slop_arena* arena, types_SExpr*
                             break;
                         }
                     }
-                } else if (!_mv_1158.has_value) {
+                } else if (!_mv_1159.has_value) {
                 }
             }
             break;
@@ -301,43 +301,43 @@ void collect_collect_record_fields(env_TypeEnv* env, slop_arena* arena, types_Re
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((resolved != NULL)), "(!= resolved nil)");
     SLOP_PRE(((record_expr != NULL)), "(!= record-expr nil)");
-    __auto_type _mv_1168 = (*record_expr);
-    switch (_mv_1168.tag) {
+    __auto_type _mv_1169 = (*record_expr);
+    switch (_mv_1169.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1168.data.lst;
+            __auto_type lst = _mv_1169.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 for (int64_t i = 1; i < len; i++) {
-                    __auto_type _mv_1169 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1169.has_value) {
-                        __auto_type field_form = _mv_1169.value;
-                        __auto_type _mv_1170 = (*field_form);
-                        switch (_mv_1170.tag) {
+                    __auto_type _mv_1170 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1170.has_value) {
+                        __auto_type field_form = _mv_1170.value;
+                        __auto_type _mv_1171 = (*field_form);
+                        switch (_mv_1171.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type field_lst = _mv_1170.data.lst;
+                                __auto_type field_lst = _mv_1171.data.lst;
                                 {
                                     __auto_type field_items = field_lst.items;
-                                    __auto_type _mv_1171 = ({ __auto_type _lst = field_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_1171.has_value) {
-                                        __auto_type name_expr = _mv_1171.value;
-                                        __auto_type _mv_1172 = (*name_expr);
-                                        switch (_mv_1172.tag) {
+                                    __auto_type _mv_1172 = ({ __auto_type _lst = field_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_1172.has_value) {
+                                        __auto_type name_expr = _mv_1172.value;
+                                        __auto_type _mv_1173 = (*name_expr);
+                                        switch (_mv_1173.tag) {
                                             case types_SExpr_sym:
                                             {
-                                                __auto_type name_sym = _mv_1172.data.sym;
-                                                __auto_type _mv_1173 = ({ __auto_type _lst = field_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1173.has_value) {
-                                                    __auto_type type_expr = _mv_1173.value;
+                                                __auto_type name_sym = _mv_1173.data.sym;
+                                                __auto_type _mv_1174 = ({ __auto_type _lst = field_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1174.has_value) {
+                                                    __auto_type type_expr = _mv_1174.value;
                                                     {
                                                         __auto_type field_name = name_sym.name;
                                                         __auto_type field_type = collect_get_field_type(env, arena, type_expr);
                                                         __auto_type field = types_resolved_field_new(arena, field_name, field_type, (i - 1));
                                                         ({ __auto_type _lst_p = &((*resolved).fields); __auto_type _item = ((*field)); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                     }
-                                                } else if (!_mv_1173.has_value) {
+                                                } else if (!_mv_1174.has_value) {
                                                 }
                                                 break;
                                             }
@@ -345,7 +345,7 @@ void collect_collect_record_fields(env_TypeEnv* env, slop_arena* arena, types_Re
                                                 break;
                                             }
                                         }
-                                    } else if (!_mv_1171.has_value) {
+                                    } else if (!_mv_1172.has_value) {
                                     }
                                 }
                                 break;
@@ -354,7 +354,7 @@ void collect_collect_record_fields(env_TypeEnv* env, slop_arena* arena, types_Re
                                 break;
                             }
                         }
-                    } else if (!_mv_1169.has_value) {
+                    } else if (!_mv_1170.has_value) {
                     }
                 }
             }
@@ -368,16 +368,16 @@ void collect_collect_record_fields(env_TypeEnv* env, slop_arena* arena, types_Re
 
 types_SExpr* collect_get_type_arg(types_SExpr* type_expr, int64_t idx) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_1174 = (*type_expr);
-    switch (_mv_1174.tag) {
+    __auto_type _mv_1175 = (*type_expr);
+    switch (_mv_1175.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1174.data.lst;
-            __auto_type _mv_1175 = ({ __auto_type _lst = lst.items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1175.has_value) {
-                __auto_type arg = _mv_1175.value;
+            __auto_type lst = _mv_1175.data.lst;
+            __auto_type _mv_1176 = ({ __auto_type _lst = lst.items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1176.has_value) {
+                __auto_type arg = _mv_1176.value;
                 return arg;
-            } else if (!_mv_1175.has_value) {
+            } else if (!_mv_1176.has_value) {
                 return type_expr;
             }
             SLOP_UNREACHABLE();
@@ -390,18 +390,18 @@ types_SExpr* collect_get_type_arg(types_SExpr* type_expr, int64_t idx) {
 
 types_ResolvedType* collect_get_field_type(env_TypeEnv* env, slop_arena* arena, types_SExpr* type_expr) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_1176 = (*type_expr);
-    switch (_mv_1176.tag) {
+    __auto_type _mv_1177 = (*type_expr);
+    switch (_mv_1177.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1176.data.sym;
+            __auto_type sym = _mv_1177.data.sym;
             {
                 __auto_type type_name = sym.name;
-                __auto_type _mv_1177 = env_env_lookup_type_direct(env, type_name);
-                if (_mv_1177.has_value) {
-                    __auto_type t = _mv_1177.value;
+                __auto_type _mv_1178 = env_env_lookup_type_direct(env, type_name);
+                if (_mv_1178.has_value) {
+                    __auto_type t = _mv_1178.value;
                     return t;
-                } else if (!_mv_1177.has_value) {
+                } else if (!_mv_1178.has_value) {
                     if (string_eq(type_name, SLOP_STR("Int"))) {
                         return env_env_get_int_type(env);
                     } else if (string_eq(type_name, SLOP_STR("Bool"))) {
@@ -419,12 +419,12 @@ types_ResolvedType* collect_get_field_type(env_TypeEnv* env, slop_arena* arena, 
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1176.data.lst;
+            __auto_type lst = _mv_1177.data.lst;
             {
                 __auto_type items = lst.items;
-                __auto_type _mv_1178 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1178.has_value) {
-                    __auto_type head_expr = _mv_1178.value;
+                __auto_type _mv_1179 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1179.has_value) {
+                    __auto_type head_expr = _mv_1179.value;
                     {
                         __auto_type head_name = parser_sexpr_get_symbol_name(head_expr);
                         if (string_eq(head_name, SLOP_STR("Option"))) {
@@ -488,7 +488,7 @@ types_ResolvedType* collect_get_field_type(env_TypeEnv* env, slop_arena* arena, 
                             return types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, head_name, ((slop_option_string){.has_value = false}), head_name);
                         }
                     }
-                } else if (!_mv_1178.has_value) {
+                } else if (!_mv_1179.has_value) {
                     return env_env_get_unit_type(env);
                 }
                 SLOP_UNREACHABLE();
@@ -505,13 +505,13 @@ uint8_t collect_is_type_param(slop_string name, slop_list_string type_params) {
         __auto_type len = ((int64_t)((type_params).len));
         uint8_t found = 0;
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_1179 = ({ __auto_type _lst = type_params; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1179.has_value) {
-                __auto_type tp = _mv_1179.value;
+            __auto_type _mv_1180 = ({ __auto_type _lst = type_params; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1180.has_value) {
+                __auto_type tp = _mv_1180.value;
                 if (string_eq(name, tp)) {
                     found = 1;
                 }
-            } else if (!_mv_1179.has_value) {
+            } else if (!_mv_1180.has_value) {
             }
         }
         return found;
@@ -520,21 +520,21 @@ uint8_t collect_is_type_param(slop_string name, slop_list_string type_params) {
 
 types_ResolvedType* collect_get_field_type_generic(env_TypeEnv* env, slop_arena* arena, types_SExpr* type_expr, slop_list_string type_params) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_1180 = (*type_expr);
-    switch (_mv_1180.tag) {
+    __auto_type _mv_1181 = (*type_expr);
+    switch (_mv_1181.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1180.data.sym;
+            __auto_type sym = _mv_1181.data.sym;
             {
                 __auto_type type_name = sym.name;
                 if (collect_is_type_param(type_name, type_params)) {
                     return types_resolved_type_new(arena, types_ResolvedTypeKind_rk_typevar, type_name, ((slop_option_string){.has_value = false}), type_name);
                 } else {
-                    __auto_type _mv_1181 = env_env_lookup_type_direct(env, type_name);
-                    if (_mv_1181.has_value) {
-                        __auto_type t = _mv_1181.value;
+                    __auto_type _mv_1182 = env_env_lookup_type_direct(env, type_name);
+                    if (_mv_1182.has_value) {
+                        __auto_type t = _mv_1182.value;
                         return t;
-                    } else if (!_mv_1181.has_value) {
+                    } else if (!_mv_1182.has_value) {
                         if (string_eq(type_name, SLOP_STR("Int"))) {
                             return env_env_get_int_type(env);
                         } else if (string_eq(type_name, SLOP_STR("Bool"))) {
@@ -553,12 +553,12 @@ types_ResolvedType* collect_get_field_type_generic(env_TypeEnv* env, slop_arena*
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1180.data.lst;
+            __auto_type lst = _mv_1181.data.lst;
             {
                 __auto_type items = lst.items;
-                __auto_type _mv_1182 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1182.has_value) {
-                    __auto_type head_expr = _mv_1182.value;
+                __auto_type _mv_1183 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1183.has_value) {
+                    __auto_type head_expr = _mv_1183.value;
                     {
                         __auto_type head_name = parser_sexpr_get_symbol_name(head_expr);
                         if (string_eq(head_name, SLOP_STR("Option"))) {
@@ -622,7 +622,7 @@ types_ResolvedType* collect_get_field_type_generic(env_TypeEnv* env, slop_arena*
                             return types_resolved_type_new(arena, types_ResolvedTypeKind_rk_primitive, head_name, ((slop_option_string){.has_value = false}), head_name);
                         }
                     }
-                } else if (!_mv_1182.has_value) {
+                } else if (!_mv_1183.has_value) {
                     return env_env_get_unit_type(env);
                 }
                 SLOP_UNREACHABLE();
@@ -640,35 +640,35 @@ slop_list_string collect_find_fn_type_params(slop_arena* arena, types_SExpr* fn_
         __auto_type type_params = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
         __auto_type len = parser_sexpr_list_len(fn_form);
         for (int64_t i = 3; i < len; i++) {
-            __auto_type _mv_1183 = parser_sexpr_list_get(fn_form, i);
-            if (_mv_1183.has_value) {
-                __auto_type item = _mv_1183.value;
+            __auto_type _mv_1184 = parser_sexpr_list_get(fn_form, i);
+            if (_mv_1184.has_value) {
+                __auto_type item = _mv_1184.value;
                 if (parser_is_form(item, SLOP_STR("@generic"))) {
-                    __auto_type _mv_1184 = parser_sexpr_list_get(item, 1);
-                    if (_mv_1184.has_value) {
-                        __auto_type params_expr = _mv_1184.value;
+                    __auto_type _mv_1185 = parser_sexpr_list_get(item, 1);
+                    if (_mv_1185.has_value) {
+                        __auto_type params_expr = _mv_1185.value;
                         if (parser_sexpr_is_list(params_expr)) {
                             {
                                 __auto_type num_params = parser_sexpr_list_len(params_expr);
                                 for (int64_t j = 0; j < num_params; j++) {
-                                    __auto_type _mv_1185 = parser_sexpr_list_get(params_expr, j);
-                                    if (_mv_1185.has_value) {
-                                        __auto_type param_expr = _mv_1185.value;
+                                    __auto_type _mv_1186 = parser_sexpr_list_get(params_expr, j);
+                                    if (_mv_1186.has_value) {
+                                        __auto_type param_expr = _mv_1186.value;
                                         {
                                             __auto_type param_name = parser_sexpr_get_symbol_name(param_expr);
                                             if (!(string_eq(param_name, SLOP_STR("")))) {
                                                 ({ __auto_type _lst_p = &(type_params); __auto_type _item = (param_name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                             }
                                         }
-                                    } else if (!_mv_1185.has_value) {
+                                    } else if (!_mv_1186.has_value) {
                                     }
                                 }
                             }
                         }
-                    } else if (!_mv_1184.has_value) {
+                    } else if (!_mv_1185.has_value) {
                     }
                 }
-            } else if (!_mv_1183.has_value) {
+            } else if (!_mv_1184.has_value) {
             }
         }
         return type_params;
@@ -683,16 +683,16 @@ types_ResolvedType* collect_find_fn_return_type_generic(env_TypeEnv* env, types_
         uint8_t found = 0;
         types_ResolvedType* found_type = env_env_get_unit_type(env);
         for (int64_t i = 3; i < len; i++) {
-            __auto_type _mv_1186 = parser_sexpr_list_get(fn_form, i);
-            if (_mv_1186.has_value) {
-                __auto_type item = _mv_1186.value;
+            __auto_type _mv_1187 = parser_sexpr_list_get(fn_form, i);
+            if (_mv_1187.has_value) {
+                __auto_type item = _mv_1187.value;
                 if (parser_is_form(item, SLOP_STR("@spec"))) {
                     if (!(found)) {
                         found_type = collect_extract_spec_return_type_generic(env, item, type_params);
                         found = 1;
                     }
                 }
-            } else if (!_mv_1186.has_value) {
+            } else if (!_mv_1187.has_value) {
             }
         }
         return found_type;
@@ -703,17 +703,17 @@ types_ResolvedType* collect_extract_spec_return_type_generic(env_TypeEnv* env, t
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     {
         __auto_type arena = env_env_arena(env);
-        __auto_type _mv_1187 = parser_sexpr_list_get(spec_form, 1);
-        if (_mv_1187.has_value) {
-            __auto_type spec_body = _mv_1187.value;
+        __auto_type _mv_1188 = parser_sexpr_list_get(spec_form, 1);
+        if (_mv_1188.has_value) {
+            __auto_type spec_body = _mv_1188.value;
             if (parser_sexpr_is_list(spec_body)) {
                 {
                     __auto_type len = parser_sexpr_list_len(spec_body);
-                    __auto_type _mv_1188 = parser_sexpr_list_get(spec_body, (len - 1));
-                    if (_mv_1188.has_value) {
-                        __auto_type ret_expr = _mv_1188.value;
+                    __auto_type _mv_1189 = parser_sexpr_list_get(spec_body, (len - 1));
+                    if (_mv_1189.has_value) {
+                        __auto_type ret_expr = _mv_1189.value;
                         return collect_get_field_type_generic(env, arena, ret_expr, type_params);
-                    } else if (!_mv_1188.has_value) {
+                    } else if (!_mv_1189.has_value) {
                         return env_env_get_unit_type(env);
                     }
                     SLOP_UNREACHABLE();
@@ -721,7 +721,7 @@ types_ResolvedType* collect_extract_spec_return_type_generic(env_TypeEnv* env, t
             } else {
                 return env_env_get_unit_type(env);
             }
-        } else if (!_mv_1187.has_value) {
+        } else if (!_mv_1188.has_value) {
             return env_env_get_unit_type(env);
         }
         SLOP_UNREACHABLE();
@@ -735,40 +735,40 @@ slop_list_types_ResolvedType_ptr collect_collect_fn_spec_params(env_TypeEnv* env
         __auto_type spec_params = ((slop_list_types_ResolvedType_ptr){ .data = (types_ResolvedType**)slop_arena_alloc(arena, 16 * sizeof(types_ResolvedType*)), .len = 0, .cap = 16 });
         __auto_type len = parser_sexpr_list_len(fn_form);
         for (int64_t i = 3; i < len; i++) {
-            __auto_type _mv_1189 = parser_sexpr_list_get(fn_form, i);
-            if (_mv_1189.has_value) {
-                __auto_type item = _mv_1189.value;
+            __auto_type _mv_1190 = parser_sexpr_list_get(fn_form, i);
+            if (_mv_1190.has_value) {
+                __auto_type item = _mv_1190.value;
                 if (parser_is_form(item, SLOP_STR("@spec"))) {
-                    __auto_type _mv_1190 = parser_sexpr_list_get(item, 1);
-                    if (_mv_1190.has_value) {
-                        __auto_type spec_body = _mv_1190.value;
+                    __auto_type _mv_1191 = parser_sexpr_list_get(item, 1);
+                    if (_mv_1191.has_value) {
+                        __auto_type spec_body = _mv_1191.value;
                         if (parser_sexpr_is_list(spec_body)) {
-                            __auto_type _mv_1191 = parser_sexpr_list_get(spec_body, 0);
-                            if (_mv_1191.has_value) {
-                                __auto_type param_types_expr = _mv_1191.value;
+                            __auto_type _mv_1192 = parser_sexpr_list_get(spec_body, 0);
+                            if (_mv_1192.has_value) {
+                                __auto_type param_types_expr = _mv_1192.value;
                                 if (parser_sexpr_is_list(param_types_expr)) {
                                     {
                                         __auto_type num_ptypes = parser_sexpr_list_len(param_types_expr);
                                         for (int64_t j = 0; j < num_ptypes; j++) {
-                                            __auto_type _mv_1192 = parser_sexpr_list_get(param_types_expr, j);
-                                            if (_mv_1192.has_value) {
-                                                __auto_type ptype_expr = _mv_1192.value;
+                                            __auto_type _mv_1193 = parser_sexpr_list_get(param_types_expr, j);
+                                            if (_mv_1193.has_value) {
+                                                __auto_type ptype_expr = _mv_1193.value;
                                                 {
                                                     __auto_type pt = collect_get_field_type_generic(env, arena, ptype_expr, type_params);
                                                     ({ __auto_type _lst_p = &(spec_params); __auto_type _item = (pt); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                 }
-                                            } else if (!_mv_1192.has_value) {
+                                            } else if (!_mv_1193.has_value) {
                                             }
                                         }
                                     }
                                 }
-                            } else if (!_mv_1191.has_value) {
+                            } else if (!_mv_1192.has_value) {
                             }
                         }
-                    } else if (!_mv_1190.has_value) {
+                    } else if (!_mv_1191.has_value) {
                     }
                 }
-            } else if (!_mv_1189.has_value) {
+            } else if (!_mv_1190.has_value) {
             }
         }
         return spec_params;
@@ -777,16 +777,16 @@ slop_list_types_ResolvedType_ptr collect_collect_fn_spec_params(env_TypeEnv* env
 
 void collect_set_module_name_from_form(env_TypeEnv* env, types_SExpr* module_form) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_1193 = parser_sexpr_list_get(module_form, 1);
-    if (_mv_1193.has_value) {
-        __auto_type name_expr = _mv_1193.value;
+    __auto_type _mv_1194 = parser_sexpr_list_get(module_form, 1);
+    if (_mv_1194.has_value) {
+        __auto_type name_expr = _mv_1194.value;
         {
             __auto_type mod_name = parser_sexpr_get_symbol_name(name_expr);
             if (!(string_eq(mod_name, SLOP_STR("")))) {
                 env_env_set_module(env, (slop_option_string){.has_value = 1, .value = mod_name});
             }
         }
-    } else if (!_mv_1193.has_value) {
+    } else if (!_mv_1194.has_value) {
     }
 }
 
@@ -800,13 +800,13 @@ void collect_register_module_type_names(env_TypeEnv* env, types_SExpr* module_fo
             {
                 __auto_type len = parser_sexpr_list_len(module_form);
                 for (int64_t i = 2; i < len; i++) {
-                    __auto_type _mv_1194 = parser_sexpr_list_get(module_form, i);
-                    if (_mv_1194.has_value) {
-                        __auto_type item = _mv_1194.value;
+                    __auto_type _mv_1195 = parser_sexpr_list_get(module_form, i);
+                    if (_mv_1195.has_value) {
+                        __auto_type item = _mv_1195.value;
                         if (parser_is_form(item, SLOP_STR("type"))) {
                             collect_register_type_name(env, arena, item);
                         }
-                    } else if (!_mv_1194.has_value) {
+                    } else if (!_mv_1195.has_value) {
                     }
                 }
             }
@@ -824,13 +824,13 @@ void collect_resolve_module_type_bodies(env_TypeEnv* env, types_SExpr* module_fo
             {
                 __auto_type len = parser_sexpr_list_len(module_form);
                 for (int64_t i = 2; i < len; i++) {
-                    __auto_type _mv_1195 = parser_sexpr_list_get(module_form, i);
-                    if (_mv_1195.has_value) {
-                        __auto_type item = _mv_1195.value;
+                    __auto_type _mv_1196 = parser_sexpr_list_get(module_form, i);
+                    if (_mv_1196.has_value) {
+                        __auto_type item = _mv_1196.value;
                         if (parser_is_form(item, SLOP_STR("type"))) {
                             collect_resolve_type_body(env, arena, item);
                         }
-                    } else if (!_mv_1195.has_value) {
+                    } else if (!_mv_1196.has_value) {
                     }
                 }
             }
@@ -842,11 +842,11 @@ slop_option_types_ResolvedType_ptr collect_lookup_payload_type(env_TypeEnv* env,
     if (string_eq(type_name, SLOP_STR(""))) {
         return (slop_option_types_ResolvedType_ptr){.has_value = false};
     } else {
-        __auto_type _mv_1196 = env_env_lookup_type_direct(env, type_name);
-        if (_mv_1196.has_value) {
-            __auto_type t = _mv_1196.value;
+        __auto_type _mv_1197 = env_env_lookup_type_direct(env, type_name);
+        if (_mv_1197.has_value) {
+            __auto_type t = _mv_1197.value;
             return (slop_option_types_ResolvedType_ptr){.has_value = 1, .value = t};
-        } else if (!_mv_1196.has_value) {
+        } else if (!_mv_1197.has_value) {
             if (string_eq(type_name, SLOP_STR("Int"))) {
                 return (slop_option_types_ResolvedType_ptr){.has_value = 1, .value = env_env_get_int_type(env)};
             } else if (string_eq(type_name, SLOP_STR("Bool"))) {
@@ -868,14 +868,14 @@ uint8_t collect_is_range_type_expr(types_SExpr* type_expr) {
         if (parser_sexpr_list_len(type_expr) < 2) {
             return 0;
         } else {
-            __auto_type _mv_1197 = parser_sexpr_list_get(type_expr, 0);
-            if (_mv_1197.has_value) {
-                __auto_type first_elem = _mv_1197.value;
+            __auto_type _mv_1198 = parser_sexpr_list_get(type_expr, 0);
+            if (_mv_1198.has_value) {
+                __auto_type first_elem = _mv_1198.value;
                 {
                     __auto_type base_name = parser_sexpr_get_symbol_name(first_elem);
                     return (string_eq(base_name, SLOP_STR("Int")) || string_eq(base_name, SLOP_STR("Float")));
                 }
-            } else if (!_mv_1197.has_value) {
+            } else if (!_mv_1198.has_value) {
                 return 0;
             }
             SLOP_UNREACHABLE();
@@ -885,19 +885,19 @@ uint8_t collect_is_range_type_expr(types_SExpr* type_expr) {
 
 types_ResolvedType* collect_get_range_base_type(env_TypeEnv* env, slop_arena* arena, types_SExpr* type_expr) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_1198 = parser_sexpr_list_get(type_expr, 0);
-    if (_mv_1198.has_value) {
-        __auto_type first_elem = _mv_1198.value;
+    __auto_type _mv_1199 = parser_sexpr_list_get(type_expr, 0);
+    if (_mv_1199.has_value) {
+        __auto_type first_elem = _mv_1199.value;
         {
             __auto_type base_name = parser_sexpr_get_symbol_name(first_elem);
             if (string_eq(base_name, SLOP_STR("Int"))) {
                 return env_env_get_int_type(env);
             } else if (string_eq(base_name, SLOP_STR("Float"))) {
-                __auto_type _mv_1199 = env_env_lookup_type_direct(env, SLOP_STR("Float"));
-                if (_mv_1199.has_value) {
-                    __auto_type t = _mv_1199.value;
+                __auto_type _mv_1200 = env_env_lookup_type_direct(env, SLOP_STR("Float"));
+                if (_mv_1200.has_value) {
+                    __auto_type t = _mv_1200.value;
                     return t;
-                } else if (!_mv_1199.has_value) {
+                } else if (!_mv_1200.has_value) {
                     return env_env_get_int_type(env);
                 }
                 SLOP_UNREACHABLE();
@@ -905,18 +905,18 @@ types_ResolvedType* collect_get_range_base_type(env_TypeEnv* env, slop_arena* ar
                 return env_env_get_int_type(env);
             }
         }
-    } else if (!_mv_1198.has_value) {
+    } else if (!_mv_1199.has_value) {
         return env_env_get_int_type(env);
     }
     SLOP_UNREACHABLE();
 }
 
 slop_string collect_get_type_name_from_expr(types_SExpr* expr) {
-    __auto_type _mv_1200 = (*expr);
-    switch (_mv_1200.tag) {
+    __auto_type _mv_1201 = (*expr);
+    switch (_mv_1201.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1200.data.sym;
+            __auto_type sym = _mv_1201.data.sym;
             return sym.name;
         }
         default: {
@@ -938,12 +938,12 @@ void collect_collect_union_variants(env_TypeEnv* env, slop_arena* arena, types_R
             __auto_type len = parser_sexpr_list_len(union_expr);
             int64_t variant_idx = 0;
             for (int64_t i = 1; i < len; i++) {
-                __auto_type _mv_1201 = parser_sexpr_list_get(union_expr, i);
-                if (_mv_1201.has_value) {
-                    __auto_type variant_form = _mv_1201.value;
+                __auto_type _mv_1202 = parser_sexpr_list_get(union_expr, i);
+                if (_mv_1202.has_value) {
+                    __auto_type variant_form = _mv_1202.value;
                     collect_collect_single_union_variant(env, arena, resolved, variant_form, variant_idx);
                     variant_idx = (variant_idx + 1);
-                } else if (!_mv_1201.has_value) {
+                } else if (!_mv_1202.has_value) {
                 }
             }
         }
@@ -958,11 +958,11 @@ slop_list_types_ResolvedType_ptr collect_get_variant_payload_types(env_TypeEnv* 
         __auto_type result = ((slop_list_types_ResolvedType_ptr){ .data = (types_ResolvedType**)slop_arena_alloc(arena, 16 * sizeof(types_ResolvedType*)), .len = 0, .cap = 16 });
         __auto_type vlen = parser_sexpr_list_len(variant_form);
         for (int64_t idx = 1; idx < vlen; idx++) {
-            __auto_type _mv_1202 = parser_sexpr_list_get(variant_form, idx);
-            if (_mv_1202.has_value) {
-                __auto_type type_expr = _mv_1202.value;
+            __auto_type _mv_1203 = parser_sexpr_list_get(variant_form, idx);
+            if (_mv_1203.has_value) {
+                __auto_type type_expr = _mv_1203.value;
                 ({ __auto_type _lst_p = &(result); __auto_type _item = (collect_get_field_type(env, arena, type_expr)); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-            } else if (!_mv_1202.has_value) {
+            } else if (!_mv_1203.has_value) {
             }
         }
         return result;
@@ -973,11 +973,11 @@ slop_option_types_ResolvedType_ptr collect_get_variant_payload_type(env_TypeEnv*
     if (parser_sexpr_list_len(variant_form) <= 1) {
         return (slop_option_types_ResolvedType_ptr){.has_value = false};
     } else {
-        __auto_type _mv_1203 = parser_sexpr_list_get(variant_form, 1);
-        if (_mv_1203.has_value) {
-            __auto_type type_expr = _mv_1203.value;
+        __auto_type _mv_1204 = parser_sexpr_list_get(variant_form, 1);
+        if (_mv_1204.has_value) {
+            __auto_type type_expr = _mv_1204.value;
             return (slop_option_types_ResolvedType_ptr){.has_value = 1, .value = collect_get_field_type(env, env_env_arena(env), type_expr)};
-        } else if (!_mv_1203.has_value) {
+        } else if (!_mv_1204.has_value) {
             return (slop_option_types_ResolvedType_ptr){.has_value = false};
         }
         SLOP_UNREACHABLE();
@@ -989,21 +989,21 @@ slop_string collect_checker_get_variant_name(types_SExpr* variant_form) {
         if (parser_sexpr_list_len(variant_form) == 0) {
             return SLOP_STR("");
         } else {
-            __auto_type _mv_1204 = parser_sexpr_list_get(variant_form, 0);
-            if (_mv_1204.has_value) {
-                __auto_type name_expr = _mv_1204.value;
+            __auto_type _mv_1205 = parser_sexpr_list_get(variant_form, 0);
+            if (_mv_1205.has_value) {
+                __auto_type name_expr = _mv_1205.value;
                 return parser_sexpr_get_symbol_name(name_expr);
-            } else if (!_mv_1204.has_value) {
+            } else if (!_mv_1205.has_value) {
                 return SLOP_STR("");
             }
             SLOP_UNREACHABLE();
         }
     } else {
-        __auto_type _mv_1205 = (*variant_form);
-        switch (_mv_1205.tag) {
+        __auto_type _mv_1206 = (*variant_form);
+        switch (_mv_1206.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1205.data.sym;
+                __auto_type sym = _mv_1206.data.sym;
                 return sym.name;
             }
             default: {
@@ -1015,35 +1015,35 @@ slop_string collect_checker_get_variant_name(types_SExpr* variant_form) {
 
 uint8_t collect_check_type_expr_recursive(types_SExpr* type_expr, slop_string union_name) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_1206 = (*type_expr);
-    switch (_mv_1206.tag) {
+    __auto_type _mv_1207 = (*type_expr);
+    switch (_mv_1207.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1206.data.sym;
+            __auto_type sym = _mv_1207.data.sym;
             return string_eq(sym.name, union_name);
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1206.data.lst;
+            __auto_type lst = _mv_1207.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return 0;
                 } else {
-                    __auto_type _mv_1207 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1207.has_value) {
-                        __auto_type head = _mv_1207.value;
-                        __auto_type _mv_1208 = (*head);
-                        switch (_mv_1208.tag) {
+                    __auto_type _mv_1208 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1208.has_value) {
+                        __auto_type head = _mv_1208.value;
+                        __auto_type _mv_1209 = (*head);
+                        switch (_mv_1209.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1208.data.sym;
+                                __auto_type sym = _mv_1209.data.sym;
                                 if (string_eq(sym.name, SLOP_STR("Option"))) {
-                                    __auto_type _mv_1209 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_1209.has_value) {
-                                        __auto_type inner = _mv_1209.value;
+                                    __auto_type _mv_1210 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_1210.has_value) {
+                                        __auto_type inner = _mv_1210.value;
                                         return string_eq(parser_sexpr_get_symbol_name(inner), union_name);
-                                    } else if (!_mv_1209.has_value) {
+                                    } else if (!_mv_1210.has_value) {
                                         return 0;
                                     }
                                     SLOP_UNREACHABLE();
@@ -1055,7 +1055,7 @@ uint8_t collect_check_type_expr_recursive(types_SExpr* type_expr, slop_string un
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1207.has_value) {
+                    } else if (!_mv_1208.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1075,13 +1075,13 @@ uint8_t collect_has_recursive_value_payload(types_SExpr* variant_form, slop_stri
         uint8_t found = 0;
         for (int64_t idx = 1; idx < vlen; idx++) {
             if (!(found)) {
-                __auto_type _mv_1210 = parser_sexpr_list_get(variant_form, idx);
-                if (_mv_1210.has_value) {
-                    __auto_type type_expr = _mv_1210.value;
+                __auto_type _mv_1211 = parser_sexpr_list_get(variant_form, idx);
+                if (_mv_1211.has_value) {
+                    __auto_type type_expr = _mv_1211.value;
                     if (collect_check_type_expr_recursive(type_expr, union_name)) {
                         found = 1;
                     }
-                } else if (!_mv_1210.has_value) {
+                } else if (!_mv_1211.has_value) {
                 }
             }
         }
@@ -1130,23 +1130,23 @@ void collect_collect_single_union_variant(env_TypeEnv* env, slop_arena* arena, t
 void collect_collect_enum_variants(env_TypeEnv* env, slop_string enum_name, types_SExpr* enum_expr) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((enum_expr != NULL)), "(!= enum-expr nil)");
-    __auto_type _mv_1211 = (*enum_expr);
-    switch (_mv_1211.tag) {
+    __auto_type _mv_1212 = (*enum_expr);
+    switch (_mv_1212.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1211.data.lst;
+            __auto_type lst = _mv_1212.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 for (int64_t i = 1; i < len; i++) {
-                    __auto_type _mv_1212 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1212.has_value) {
-                        __auto_type variant_expr = _mv_1212.value;
-                        __auto_type _mv_1213 = (*variant_expr);
-                        switch (_mv_1213.tag) {
+                    __auto_type _mv_1213 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1213.has_value) {
+                        __auto_type variant_expr = _mv_1213.value;
+                        __auto_type _mv_1214 = (*variant_expr);
+                        switch (_mv_1214.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1213.data.sym;
+                                __auto_type sym = _mv_1214.data.sym;
                                 env_env_register_variant(env, sym.name, enum_name);
                                 break;
                             }
@@ -1154,7 +1154,7 @@ void collect_collect_enum_variants(env_TypeEnv* env, slop_string enum_name, type
                                 break;
                             }
                         }
-                    } else if (!_mv_1212.has_value) {
+                    } else if (!_mv_1213.has_value) {
                     }
                 }
             }
@@ -1172,16 +1172,16 @@ void collect_collect_constants(env_TypeEnv* env, slop_list_types_SExpr_ptr ast) 
         __auto_type arena = env_env_arena(env);
         __auto_type len = ((int64_t)((ast).len));
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_1214 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1214.has_value) {
-                __auto_type expr = _mv_1214.value;
+            __auto_type _mv_1215 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1215.has_value) {
+                __auto_type expr = _mv_1215.value;
                 if (parser_is_form(expr, SLOP_STR("const"))) {
                     collect_collect_single_constant(env, arena, expr);
                 } else if (parser_is_form(expr, SLOP_STR("module"))) {
                     collect_collect_module_constants(env, expr);
                 } else {
                 }
-            } else if (!_mv_1214.has_value) {
+            } else if (!_mv_1215.has_value) {
             }
         }
     }
@@ -1196,13 +1196,13 @@ void collect_collect_module_constants(env_TypeEnv* env, types_SExpr* module_form
             {
                 __auto_type len = parser_sexpr_list_len(module_form);
                 for (int64_t i = 2; i < len; i++) {
-                    __auto_type _mv_1215 = parser_sexpr_list_get(module_form, i);
-                    if (_mv_1215.has_value) {
-                        __auto_type item = _mv_1215.value;
+                    __auto_type _mv_1216 = parser_sexpr_list_get(module_form, i);
+                    if (_mv_1216.has_value) {
+                        __auto_type item = _mv_1216.value;
                         if (parser_is_form(item, SLOP_STR("const"))) {
                             collect_collect_single_constant(env, arena, item);
                         }
-                    } else if (!_mv_1215.has_value) {
+                    } else if (!_mv_1216.has_value) {
                     }
                 }
             }
@@ -1215,24 +1215,24 @@ void collect_collect_single_constant(env_TypeEnv* env, slop_arena* arena, types_
     SLOP_PRE(((const_form != NULL)), "(!= const-form nil)");
     if (parser_sexpr_is_list(const_form)) {
         if (parser_sexpr_list_len(const_form) >= 3) {
-            __auto_type _mv_1216 = parser_sexpr_list_get(const_form, 1);
-            if (_mv_1216.has_value) {
-                __auto_type name_expr = _mv_1216.value;
+            __auto_type _mv_1217 = parser_sexpr_list_get(const_form, 1);
+            if (_mv_1217.has_value) {
+                __auto_type name_expr = _mv_1217.value;
                 {
                     __auto_type const_name = parser_sexpr_get_symbol_name(name_expr);
                     if (!(string_eq(const_name, SLOP_STR("")))) {
-                        __auto_type _mv_1217 = parser_sexpr_list_get(const_form, 2);
-                        if (_mv_1217.has_value) {
-                            __auto_type type_expr = _mv_1217.value;
+                        __auto_type _mv_1218 = parser_sexpr_list_get(const_form, 2);
+                        if (_mv_1218.has_value) {
+                            __auto_type type_expr = _mv_1218.value;
                             {
                                 __auto_type const_type = collect_get_const_type(env, arena, type_expr);
                                 env_env_register_constant(env, const_name, const_type);
                             }
-                        } else if (!_mv_1217.has_value) {
+                        } else if (!_mv_1218.has_value) {
                         }
                     }
                 }
-            } else if (!_mv_1216.has_value) {
+            } else if (!_mv_1217.has_value) {
             }
         }
     }
@@ -1240,18 +1240,18 @@ void collect_collect_single_constant(env_TypeEnv* env, slop_arena* arena, types_
 
 types_ResolvedType* collect_get_const_type(env_TypeEnv* env, slop_arena* arena, types_SExpr* type_expr) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_1218 = (*type_expr);
-    switch (_mv_1218.tag) {
+    __auto_type _mv_1219 = (*type_expr);
+    switch (_mv_1219.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1218.data.sym;
+            __auto_type sym = _mv_1219.data.sym;
             {
                 __auto_type type_name = sym.name;
-                __auto_type _mv_1219 = env_env_lookup_type_direct(env, type_name);
-                if (_mv_1219.has_value) {
-                    __auto_type t = _mv_1219.value;
+                __auto_type _mv_1220 = env_env_lookup_type_direct(env, type_name);
+                if (_mv_1220.has_value) {
+                    __auto_type t = _mv_1220.value;
                     return t;
-                } else if (!_mv_1219.has_value) {
+                } else if (!_mv_1220.has_value) {
                     if (string_eq(type_name, SLOP_STR("Int"))) {
                         return env_env_get_int_type(env);
                     } else if (string_eq(type_name, SLOP_STR("Bool"))) {
@@ -1279,16 +1279,16 @@ void collect_collect_functions(env_TypeEnv* env, slop_list_types_SExpr_ptr ast) 
         __auto_type arena = env_env_arena(env);
         __auto_type len = ((int64_t)((ast).len));
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_1220 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1220.has_value) {
-                __auto_type expr = _mv_1220.value;
+            __auto_type _mv_1221 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1221.has_value) {
+                __auto_type expr = _mv_1221.value;
                 if (parser_is_form(expr, SLOP_STR("fn"))) {
                     collect_collect_single_function(env, arena, expr);
                 } else if (parser_is_form(expr, SLOP_STR("module"))) {
                     collect_collect_module_functions(env, expr);
                 } else {
                 }
-            } else if (!_mv_1220.has_value) {
+            } else if (!_mv_1221.has_value) {
             }
         }
     }
@@ -1300,30 +1300,30 @@ void collect_collect_module_functions(env_TypeEnv* env, types_SExpr* module_form
     {
         __auto_type arena = env_env_arena(env);
         if (parser_sexpr_is_list(module_form)) {
-            __auto_type _mv_1221 = parser_sexpr_list_get(module_form, 1);
-            if (_mv_1221.has_value) {
-                __auto_type name_expr = _mv_1221.value;
+            __auto_type _mv_1222 = parser_sexpr_list_get(module_form, 1);
+            if (_mv_1222.has_value) {
+                __auto_type name_expr = _mv_1222.value;
                 {
                     __auto_type mod_name = parser_sexpr_get_symbol_name(name_expr);
                     if (!(string_eq(mod_name, SLOP_STR("")))) {
                         env_env_set_module(env, (slop_option_string){.has_value = 1, .value = mod_name});
                     }
                 }
-            } else if (!_mv_1221.has_value) {
+            } else if (!_mv_1222.has_value) {
             }
             {
                 __auto_type len = parser_sexpr_list_len(module_form);
                 for (int64_t i = 2; i < len; i++) {
-                    __auto_type _mv_1222 = parser_sexpr_list_get(module_form, i);
-                    if (_mv_1222.has_value) {
-                        __auto_type item = _mv_1222.value;
+                    __auto_type _mv_1223 = parser_sexpr_list_get(module_form, i);
+                    if (_mv_1223.has_value) {
+                        __auto_type item = _mv_1223.value;
                         if (parser_is_form(item, SLOP_STR("fn"))) {
                             collect_collect_single_function(env, arena, item);
                         } else if (parser_is_form(item, SLOP_STR("ffi"))) {
                             collect_collect_ffi_functions(env, arena, item);
                         } else {
                         }
-                    } else if (!_mv_1222.has_value) {
+                    } else if (!_mv_1223.has_value) {
                     }
                 }
             }
@@ -1338,11 +1338,11 @@ void collect_collect_ffi_functions(env_TypeEnv* env, slop_arena* arena, types_SE
         {
             __auto_type len = parser_sexpr_list_len(ffi_form);
             for (int64_t i = 2; i < len; i++) {
-                __auto_type _mv_1223 = parser_sexpr_list_get(ffi_form, i);
-                if (_mv_1223.has_value) {
-                    __auto_type func_decl = _mv_1223.value;
+                __auto_type _mv_1224 = parser_sexpr_list_get(ffi_form, i);
+                if (_mv_1224.has_value) {
+                    __auto_type func_decl = _mv_1224.value;
                     collect_collect_ffi_function(env, arena, func_decl);
-                } else if (!_mv_1223.has_value) {
+                } else if (!_mv_1224.has_value) {
                 }
             }
         }
@@ -1356,9 +1356,9 @@ void collect_collect_ffi_function(env_TypeEnv* env, slop_arena* arena, types_SEx
         {
             __auto_type decl_len = parser_sexpr_list_len(func_decl);
             if (decl_len >= 3) {
-                __auto_type _mv_1224 = parser_sexpr_list_get(func_decl, 0);
-                if (_mv_1224.has_value) {
-                    __auto_type name_expr = _mv_1224.value;
+                __auto_type _mv_1225 = parser_sexpr_list_get(func_decl, 0);
+                if (_mv_1225.has_value) {
+                    __auto_type name_expr = _mv_1225.value;
                     {
                         __auto_type fn_name = parser_sexpr_get_symbol_name(name_expr);
                         if (!(string_eq(fn_name, SLOP_STR("")))) {
@@ -1374,27 +1374,27 @@ void collect_collect_ffi_function(env_TypeEnv* env, slop_arena* arena, types_SEx
                             }
                         }
                     }
-                } else if (!_mv_1224.has_value) {
+                } else if (!_mv_1225.has_value) {
                 }
             } else if (decl_len == 2) {
-                __auto_type _mv_1225 = parser_sexpr_list_get(func_decl, 0);
-                if (_mv_1225.has_value) {
-                    __auto_type name_expr = _mv_1225.value;
+                __auto_type _mv_1226 = parser_sexpr_list_get(func_decl, 0);
+                if (_mv_1226.has_value) {
+                    __auto_type name_expr = _mv_1226.value;
                     {
                         __auto_type const_name = parser_sexpr_get_symbol_name(name_expr);
                         if (!(string_eq(const_name, SLOP_STR("")))) {
-                            __auto_type _mv_1226 = parser_sexpr_list_get(func_decl, 1);
-                            if (_mv_1226.has_value) {
-                                __auto_type type_expr = _mv_1226.value;
+                            __auto_type _mv_1227 = parser_sexpr_list_get(func_decl, 1);
+                            if (_mv_1227.has_value) {
+                                __auto_type type_expr = _mv_1227.value;
                                 {
                                     __auto_type const_type = collect_get_field_type(env, arena, type_expr);
                                     env_env_register_constant(env, const_name, const_type);
                                 }
-                            } else if (!_mv_1226.has_value) {
+                            } else if (!_mv_1227.has_value) {
                             }
                         }
                     }
-                } else if (!_mv_1225.has_value) {
+                } else if (!_mv_1226.has_value) {
                 }
             } else {
             }
@@ -1407,11 +1407,11 @@ uint8_t collect_ffi_has_variadic(types_SExpr* func_decl) {
     {
         __auto_type len = parser_sexpr_list_len(func_decl);
         if (len >= 4) {
-            __auto_type _mv_1227 = parser_sexpr_list_get(func_decl, (len - 1));
-            if (_mv_1227.has_value) {
-                __auto_type last_expr = _mv_1227.value;
+            __auto_type _mv_1228 = parser_sexpr_list_get(func_decl, (len - 1));
+            if (_mv_1228.has_value) {
+                __auto_type last_expr = _mv_1228.value;
                 return string_eq(parser_sexpr_get_symbol_name(last_expr), SLOP_STR(":variadic"));
-            } else if (!_mv_1227.has_value) {
+            } else if (!_mv_1228.has_value) {
                 return 0;
             }
             SLOP_UNREACHABLE();
@@ -1425,46 +1425,46 @@ slop_list_types_ParamInfo collect_collect_ffi_params(env_TypeEnv* env, slop_aren
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     {
         __auto_type params = ((slop_list_types_ParamInfo){ .data = (types_ParamInfo*)slop_arena_alloc(arena, 16 * sizeof(types_ParamInfo)), .len = 0, .cap = 16 });
-        __auto_type _mv_1228 = parser_sexpr_list_get(func_decl, 1);
-        if (_mv_1228.has_value) {
-            __auto_type params_expr = _mv_1228.value;
+        __auto_type _mv_1229 = parser_sexpr_list_get(func_decl, 1);
+        if (_mv_1229.has_value) {
+            __auto_type params_expr = _mv_1229.value;
             if (parser_sexpr_is_list(params_expr)) {
                 {
                     __auto_type num_params = parser_sexpr_list_len(params_expr);
                     for (int64_t j = 0; j < num_params; j++) {
-                        __auto_type _mv_1229 = parser_sexpr_list_get(params_expr, j);
-                        if (_mv_1229.has_value) {
-                            __auto_type param_form = _mv_1229.value;
+                        __auto_type _mv_1230 = parser_sexpr_list_get(params_expr, j);
+                        if (_mv_1230.has_value) {
+                            __auto_type param_form = _mv_1230.value;
                             if (parser_sexpr_is_list(param_form)) {
                                 if (parser_sexpr_list_len(param_form) >= 2) {
-                                    __auto_type _mv_1230 = parser_sexpr_list_get(param_form, 0);
-                                    if (_mv_1230.has_value) {
-                                        __auto_type pname_expr = _mv_1230.value;
+                                    __auto_type _mv_1231 = parser_sexpr_list_get(param_form, 0);
+                                    if (_mv_1231.has_value) {
+                                        __auto_type pname_expr = _mv_1231.value;
                                         {
                                             __auto_type param_name = parser_sexpr_get_symbol_name(pname_expr);
                                             if (!(string_eq(param_name, SLOP_STR("")))) {
-                                                __auto_type _mv_1231 = parser_sexpr_list_get(param_form, 1);
-                                                if (_mv_1231.has_value) {
-                                                    __auto_type ptype_expr = _mv_1231.value;
+                                                __auto_type _mv_1232 = parser_sexpr_list_get(param_form, 1);
+                                                if (_mv_1232.has_value) {
+                                                    __auto_type ptype_expr = _mv_1232.value;
                                                     {
                                                         __auto_type param_type = collect_get_field_type(env, arena, ptype_expr);
                                                         __auto_type info = types_param_info_new(arena, param_name, param_type);
                                                         ({ __auto_type _lst_p = &(params); __auto_type _item = ((*info)); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                     }
-                                                } else if (!_mv_1231.has_value) {
+                                                } else if (!_mv_1232.has_value) {
                                                 }
                                             }
                                         }
-                                    } else if (!_mv_1230.has_value) {
+                                    } else if (!_mv_1231.has_value) {
                                     }
                                 }
                             }
-                        } else if (!_mv_1229.has_value) {
+                        } else if (!_mv_1230.has_value) {
                         }
                     }
                 }
             }
-        } else if (!_mv_1228.has_value) {
+        } else if (!_mv_1229.has_value) {
         }
         return params;
     }
@@ -1472,11 +1472,11 @@ slop_list_types_ParamInfo collect_collect_ffi_params(env_TypeEnv* env, slop_aren
 
 types_ResolvedType* collect_get_ffi_return_type(env_TypeEnv* env, slop_arena* arena, types_SExpr* func_decl) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_1232 = parser_sexpr_list_get(func_decl, 2);
-    if (_mv_1232.has_value) {
-        __auto_type ret_expr = _mv_1232.value;
+    __auto_type _mv_1233 = parser_sexpr_list_get(func_decl, 2);
+    if (_mv_1233.has_value) {
+        __auto_type ret_expr = _mv_1233.value;
         return collect_get_field_type(env, arena, ret_expr);
-    } else if (!_mv_1232.has_value) {
+    } else if (!_mv_1233.has_value) {
         return env_env_get_unit_type(env);
     }
     SLOP_UNREACHABLE();
@@ -1487,9 +1487,9 @@ void collect_collect_single_function(env_TypeEnv* env, slop_arena* arena, types_
     SLOP_PRE(((fn_form != NULL)), "(!= fn-form nil)");
     if (parser_sexpr_is_list(fn_form)) {
         if (parser_sexpr_list_len(fn_form) >= 3) {
-            __auto_type _mv_1233 = parser_sexpr_list_get(fn_form, 1);
-            if (_mv_1233.has_value) {
-                __auto_type name_expr = _mv_1233.value;
+            __auto_type _mv_1234 = parser_sexpr_list_get(fn_form, 1);
+            if (_mv_1234.has_value) {
+                __auto_type name_expr = _mv_1234.value;
                 {
                     __auto_type fn_name = parser_sexpr_get_symbol_name(name_expr);
                     if (!(string_eq(fn_name, SLOP_STR("")))) {
@@ -1513,7 +1513,7 @@ void collect_collect_single_function(env_TypeEnv* env, slop_arena* arena, types_
                         }
                     }
                 }
-            } else if (!_mv_1233.has_value) {
+            } else if (!_mv_1234.has_value) {
             }
         }
     }
@@ -1532,9 +1532,9 @@ void collect_validate_main_params(env_TypeEnv* env, types_SExpr* fn_form, slop_l
         __auto_type col = parser_sexpr_col(fn_form);
         if (num_params == 0) {
         } else if (num_params == 2) {
-            __auto_type _mv_1234 = ({ __auto_type _lst = params; size_t _idx = (size_t)0; slop_option_types_ParamInfo _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1234.has_value) {
-                __auto_type p0 = _mv_1234.value;
+            __auto_type _mv_1235 = ({ __auto_type _lst = params; size_t _idx = (size_t)0; slop_option_types_ParamInfo _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1235.has_value) {
+                __auto_type p0 = _mv_1235.value;
                 {
                     __auto_type t0 = p0.param_type;
                     if (t0 != NULL) {
@@ -1546,11 +1546,11 @@ void collect_validate_main_params(env_TypeEnv* env, types_SExpr* fn_form, slop_l
                         }
                     }
                 }
-            } else if (!_mv_1234.has_value) {
+            } else if (!_mv_1235.has_value) {
             }
-            __auto_type _mv_1235 = ({ __auto_type _lst = params; size_t _idx = (size_t)1; slop_option_types_ParamInfo _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1235.has_value) {
-                __auto_type p1 = _mv_1235.value;
+            __auto_type _mv_1236 = ({ __auto_type _lst = params; size_t _idx = (size_t)1; slop_option_types_ParamInfo _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1236.has_value) {
+                __auto_type p1 = _mv_1236.value;
                 {
                     __auto_type t1 = p1.param_type;
                     if (t1 != NULL) {
@@ -1559,7 +1559,7 @@ void collect_validate_main_params(env_TypeEnv* env, types_SExpr* fn_form, slop_l
                         }
                     }
                 }
-            } else if (!_mv_1235.has_value) {
+            } else if (!_mv_1236.has_value) {
             }
         } else {
             env_env_add_error(env, SLOP_STR("main function must have either no parameters or exactly two parameters (argc: Int, argv: (Ptr (Ptr U8)))"), line, col);
@@ -1572,69 +1572,69 @@ slop_list_types_ParamInfo collect_collect_fn_params(env_TypeEnv* env, slop_arena
     SLOP_PRE(((fn_form != NULL)), "(!= fn-form nil)");
     {
         __auto_type params = ((slop_list_types_ParamInfo){ .data = (types_ParamInfo*)slop_arena_alloc(arena, 16 * sizeof(types_ParamInfo)), .len = 0, .cap = 16 });
-        __auto_type _mv_1236 = parser_sexpr_list_get(fn_form, 2);
-        if (_mv_1236.has_value) {
-            __auto_type params_expr = _mv_1236.value;
+        __auto_type _mv_1237 = parser_sexpr_list_get(fn_form, 2);
+        if (_mv_1237.has_value) {
+            __auto_type params_expr = _mv_1237.value;
             if (parser_sexpr_is_list(params_expr)) {
                 {
                     __auto_type num_params = parser_sexpr_list_len(params_expr);
                     for (int64_t i = 0; i < num_params; i++) {
-                        __auto_type _mv_1237 = parser_sexpr_list_get(params_expr, i);
-                        if (_mv_1237.has_value) {
-                            __auto_type param_form = _mv_1237.value;
+                        __auto_type _mv_1238 = parser_sexpr_list_get(params_expr, i);
+                        if (_mv_1238.has_value) {
+                            __auto_type param_form = _mv_1238.value;
                             if (parser_sexpr_is_list(param_form) && (parser_sexpr_list_len(param_form) >= 2)) {
-                                __auto_type _mv_1238 = parser_sexpr_list_get(param_form, 0);
-                                if (_mv_1238.has_value) {
-                                    __auto_type first_expr = _mv_1238.value;
+                                __auto_type _mv_1239 = parser_sexpr_list_get(param_form, 0);
+                                if (_mv_1239.has_value) {
+                                    __auto_type first_expr = _mv_1239.value;
                                     {
                                         __auto_type first_name = parser_sexpr_get_symbol_name(first_expr);
                                         if ((string_eq(first_name, SLOP_STR("in"))) || (string_eq(first_name, SLOP_STR("out"))) || (string_eq(first_name, SLOP_STR("mut")))) {
                                             if (parser_sexpr_list_len(param_form) >= 3) {
-                                                __auto_type _mv_1239 = parser_sexpr_list_get(param_form, 1);
-                                                if (_mv_1239.has_value) {
-                                                    __auto_type name_expr = _mv_1239.value;
+                                                __auto_type _mv_1240 = parser_sexpr_list_get(param_form, 1);
+                                                if (_mv_1240.has_value) {
+                                                    __auto_type name_expr = _mv_1240.value;
                                                     {
                                                         __auto_type param_name = parser_sexpr_get_symbol_name(name_expr);
                                                         if (!(string_eq(param_name, SLOP_STR("")))) {
-                                                            __auto_type _mv_1240 = parser_sexpr_list_get(param_form, 2);
-                                                            if (_mv_1240.has_value) {
-                                                                __auto_type type_expr = _mv_1240.value;
+                                                            __auto_type _mv_1241 = parser_sexpr_list_get(param_form, 2);
+                                                            if (_mv_1241.has_value) {
+                                                                __auto_type type_expr = _mv_1241.value;
                                                                 {
                                                                     __auto_type param_type = collect_get_field_type(env, arena, type_expr);
                                                                     __auto_type info = types_param_info_new(arena, param_name, param_type);
                                                                     ({ __auto_type _lst_p = &(params); __auto_type _item = ((*info)); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                                 }
-                                                            } else if (!_mv_1240.has_value) {
+                                                            } else if (!_mv_1241.has_value) {
                                                             }
                                                         }
                                                     }
-                                                } else if (!_mv_1239.has_value) {
+                                                } else if (!_mv_1240.has_value) {
                                                 }
                                             }
                                         } else {
                                             if (!(string_eq(first_name, SLOP_STR("")))) {
-                                                __auto_type _mv_1241 = parser_sexpr_list_get(param_form, 1);
-                                                if (_mv_1241.has_value) {
-                                                    __auto_type type_expr = _mv_1241.value;
+                                                __auto_type _mv_1242 = parser_sexpr_list_get(param_form, 1);
+                                                if (_mv_1242.has_value) {
+                                                    __auto_type type_expr = _mv_1242.value;
                                                     {
                                                         __auto_type param_type = collect_get_field_type(env, arena, type_expr);
                                                         __auto_type info = types_param_info_new(arena, first_name, param_type);
                                                         ({ __auto_type _lst_p = &(params); __auto_type _item = ((*info)); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                     }
-                                                } else if (!_mv_1241.has_value) {
+                                                } else if (!_mv_1242.has_value) {
                                                 }
                                             }
                                         }
                                     }
-                                } else if (!_mv_1238.has_value) {
+                                } else if (!_mv_1239.has_value) {
                                 }
                             }
-                        } else if (!_mv_1237.has_value) {
+                        } else if (!_mv_1238.has_value) {
                         }
                     }
                 }
             }
-        } else if (!_mv_1236.has_value) {
+        } else if (!_mv_1237.has_value) {
         }
         return params;
     }
@@ -1645,69 +1645,69 @@ slop_list_types_ParamInfo collect_collect_fn_params_generic(env_TypeEnv* env, sl
     SLOP_PRE(((fn_form != NULL)), "(!= fn-form nil)");
     {
         __auto_type params = ((slop_list_types_ParamInfo){ .data = (types_ParamInfo*)slop_arena_alloc(arena, 16 * sizeof(types_ParamInfo)), .len = 0, .cap = 16 });
-        __auto_type _mv_1242 = parser_sexpr_list_get(fn_form, 2);
-        if (_mv_1242.has_value) {
-            __auto_type params_expr = _mv_1242.value;
+        __auto_type _mv_1243 = parser_sexpr_list_get(fn_form, 2);
+        if (_mv_1243.has_value) {
+            __auto_type params_expr = _mv_1243.value;
             if (parser_sexpr_is_list(params_expr)) {
                 {
                     __auto_type num_params = parser_sexpr_list_len(params_expr);
                     for (int64_t i = 0; i < num_params; i++) {
-                        __auto_type _mv_1243 = parser_sexpr_list_get(params_expr, i);
-                        if (_mv_1243.has_value) {
-                            __auto_type param_form = _mv_1243.value;
+                        __auto_type _mv_1244 = parser_sexpr_list_get(params_expr, i);
+                        if (_mv_1244.has_value) {
+                            __auto_type param_form = _mv_1244.value;
                             if (parser_sexpr_is_list(param_form) && (parser_sexpr_list_len(param_form) >= 2)) {
-                                __auto_type _mv_1244 = parser_sexpr_list_get(param_form, 0);
-                                if (_mv_1244.has_value) {
-                                    __auto_type first_expr = _mv_1244.value;
+                                __auto_type _mv_1245 = parser_sexpr_list_get(param_form, 0);
+                                if (_mv_1245.has_value) {
+                                    __auto_type first_expr = _mv_1245.value;
                                     {
                                         __auto_type first_name = parser_sexpr_get_symbol_name(first_expr);
                                         if ((string_eq(first_name, SLOP_STR("in"))) || (string_eq(first_name, SLOP_STR("out"))) || (string_eq(first_name, SLOP_STR("mut")))) {
                                             if (parser_sexpr_list_len(param_form) >= 3) {
-                                                __auto_type _mv_1245 = parser_sexpr_list_get(param_form, 1);
-                                                if (_mv_1245.has_value) {
-                                                    __auto_type name_expr = _mv_1245.value;
+                                                __auto_type _mv_1246 = parser_sexpr_list_get(param_form, 1);
+                                                if (_mv_1246.has_value) {
+                                                    __auto_type name_expr = _mv_1246.value;
                                                     {
                                                         __auto_type param_name = parser_sexpr_get_symbol_name(name_expr);
                                                         if (!(string_eq(param_name, SLOP_STR("")))) {
-                                                            __auto_type _mv_1246 = parser_sexpr_list_get(param_form, 2);
-                                                            if (_mv_1246.has_value) {
-                                                                __auto_type type_expr = _mv_1246.value;
+                                                            __auto_type _mv_1247 = parser_sexpr_list_get(param_form, 2);
+                                                            if (_mv_1247.has_value) {
+                                                                __auto_type type_expr = _mv_1247.value;
                                                                 {
                                                                     __auto_type param_type = collect_get_field_type_generic(env, arena, type_expr, type_params);
                                                                     __auto_type info = types_param_info_new(arena, param_name, param_type);
                                                                     ({ __auto_type _lst_p = &(params); __auto_type _item = ((*info)); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                                 }
-                                                            } else if (!_mv_1246.has_value) {
+                                                            } else if (!_mv_1247.has_value) {
                                                             }
                                                         }
                                                     }
-                                                } else if (!_mv_1245.has_value) {
+                                                } else if (!_mv_1246.has_value) {
                                                 }
                                             }
                                         } else {
                                             if (!(string_eq(first_name, SLOP_STR("")))) {
-                                                __auto_type _mv_1247 = parser_sexpr_list_get(param_form, 1);
-                                                if (_mv_1247.has_value) {
-                                                    __auto_type type_expr = _mv_1247.value;
+                                                __auto_type _mv_1248 = parser_sexpr_list_get(param_form, 1);
+                                                if (_mv_1248.has_value) {
+                                                    __auto_type type_expr = _mv_1248.value;
                                                     {
                                                         __auto_type param_type = collect_get_field_type_generic(env, arena, type_expr, type_params);
                                                         __auto_type info = types_param_info_new(arena, first_name, param_type);
                                                         ({ __auto_type _lst_p = &(params); __auto_type _item = ((*info)); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                     }
-                                                } else if (!_mv_1247.has_value) {
+                                                } else if (!_mv_1248.has_value) {
                                                 }
                                             }
                                         }
                                     }
-                                } else if (!_mv_1244.has_value) {
+                                } else if (!_mv_1245.has_value) {
                                 }
                             }
-                        } else if (!_mv_1243.has_value) {
+                        } else if (!_mv_1244.has_value) {
                         }
                     }
                 }
             }
-        } else if (!_mv_1242.has_value) {
+        } else if (!_mv_1243.has_value) {
         }
         return params;
     }
@@ -1721,16 +1721,16 @@ types_ResolvedType* collect_find_fn_return_type(env_TypeEnv* env, types_SExpr* f
         uint8_t found = 0;
         types_ResolvedType* found_type = env_env_get_unit_type(env);
         for (int64_t i = 3; i < len; i++) {
-            __auto_type _mv_1248 = parser_sexpr_list_get(fn_form, i);
-            if (_mv_1248.has_value) {
-                __auto_type item = _mv_1248.value;
+            __auto_type _mv_1249 = parser_sexpr_list_get(fn_form, i);
+            if (_mv_1249.has_value) {
+                __auto_type item = _mv_1249.value;
                 if (parser_is_form(item, SLOP_STR("@spec"))) {
                     if (!(found)) {
                         found_type = collect_checker_extract_spec_return_type(env, item);
                         found = 1;
                     }
                 }
-            } else if (!_mv_1248.has_value) {
+            } else if (!_mv_1249.has_value) {
             }
         }
         return found_type;
@@ -1741,17 +1741,17 @@ types_ResolvedType* collect_checker_extract_spec_return_type(env_TypeEnv* env, t
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     {
         __auto_type arena = env_env_arena(env);
-        __auto_type _mv_1249 = parser_sexpr_list_get(spec_form, 1);
-        if (_mv_1249.has_value) {
-            __auto_type spec_body = _mv_1249.value;
+        __auto_type _mv_1250 = parser_sexpr_list_get(spec_form, 1);
+        if (_mv_1250.has_value) {
+            __auto_type spec_body = _mv_1250.value;
             if (parser_sexpr_is_list(spec_body)) {
                 {
                     __auto_type len = parser_sexpr_list_len(spec_body);
-                    __auto_type _mv_1250 = parser_sexpr_list_get(spec_body, (len - 1));
-                    if (_mv_1250.has_value) {
-                        __auto_type ret_expr = _mv_1250.value;
+                    __auto_type _mv_1251 = parser_sexpr_list_get(spec_body, (len - 1));
+                    if (_mv_1251.has_value) {
+                        __auto_type ret_expr = _mv_1251.value;
                         return collect_get_field_type(env, arena, ret_expr);
-                    } else if (!_mv_1250.has_value) {
+                    } else if (!_mv_1251.has_value) {
                         return env_env_get_unit_type(env);
                     }
                     SLOP_UNREACHABLE();
@@ -1759,7 +1759,7 @@ types_ResolvedType* collect_checker_extract_spec_return_type(env_TypeEnv* env, t
             } else {
                 return env_env_get_unit_type(env);
             }
-        } else if (!_mv_1249.has_value) {
+        } else if (!_mv_1250.has_value) {
             return env_env_get_unit_type(env);
         }
         SLOP_UNREACHABLE();

--- a/bootstrap/compiler/slop_compiler.c
+++ b/bootstrap/compiler/slop_compiler.c
@@ -103,11 +103,11 @@ slop_string compiler_lines_to_string(slop_arena* arena, slop_list_string lines) 
                 int64_t total = 0;
                 int64_t i = 0;
                 while (i < len) {
-                    __auto_type _mv_1832 = ({ __auto_type _lst = lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1832.has_value) {
-                        __auto_type line = _mv_1832.value;
+                    __auto_type _mv_1833 = ({ __auto_type _lst = lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1833.has_value) {
+                        __auto_type line = _mv_1833.value;
                         total = (total + (((int64_t)(line.len)) + 1));
-                    } else if (!_mv_1832.has_value) {
+                    } else if (!_mv_1833.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -116,9 +116,9 @@ slop_string compiler_lines_to_string(slop_arena* arena, slop_list_string lines) 
                     int64_t pos = 0;
                     int64_t j = 0;
                     while (j < len) {
-                        __auto_type _mv_1833 = ({ __auto_type _lst = lines; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1833.has_value) {
-                            __auto_type line = _mv_1833.value;
+                        __auto_type _mv_1834 = ({ __auto_type _lst = lines; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1834.has_value) {
+                            __auto_type line = _mv_1834.value;
                             {
                                 __auto_type line_len = ((int64_t)(line.len));
                                 __auto_type line_data = line.data;
@@ -131,7 +131,7 @@ slop_string compiler_lines_to_string(slop_arena* arena, slop_list_string lines) 
                                 buf[pos] = 10;
                                 pos = (pos + 1);
                             }
-                        } else if (!_mv_1833.has_value) {
+                        } else if (!_mv_1834.has_value) {
                         }
                         j = (j + 1);
                     }
@@ -147,43 +147,43 @@ slop_string compiler_extract_module_name(slop_list_types_SExpr_ptr exprs) {
     if (((int64_t)((exprs).len)) < 1) {
         return SLOP_STR("unknown");
     } else {
-        __auto_type _mv_1834 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1834.has_value) {
-            __auto_type first_expr = _mv_1834.value;
-            __auto_type _mv_1835 = (*first_expr);
-            switch (_mv_1835.tag) {
+        __auto_type _mv_1835 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1835.has_value) {
+            __auto_type first_expr = _mv_1835.value;
+            __auto_type _mv_1836 = (*first_expr);
+            switch (_mv_1836.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type lst = _mv_1835.data.lst;
+                    __auto_type lst = _mv_1836.data.lst;
                     {
                         __auto_type items = lst.items;
                         if (((int64_t)((items).len)) < 2) {
                             return SLOP_STR("unknown");
                         } else {
-                            __auto_type _mv_1836 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1836.has_value) {
-                                __auto_type head = _mv_1836.value;
-                                __auto_type _mv_1837 = (*head);
-                                switch (_mv_1837.tag) {
+                            __auto_type _mv_1837 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1837.has_value) {
+                                __auto_type head = _mv_1837.value;
+                                __auto_type _mv_1838 = (*head);
+                                switch (_mv_1838.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1837.data.sym;
+                                        __auto_type sym = _mv_1838.data.sym;
                                         if (string_eq(sym.name, SLOP_STR("module"))) {
-                                            __auto_type _mv_1838 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1838.has_value) {
-                                                __auto_type name_expr = _mv_1838.value;
-                                                __auto_type _mv_1839 = (*name_expr);
-                                                switch (_mv_1839.tag) {
+                                            __auto_type _mv_1839 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1839.has_value) {
+                                                __auto_type name_expr = _mv_1839.value;
+                                                __auto_type _mv_1840 = (*name_expr);
+                                                switch (_mv_1840.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type name_sym = _mv_1839.data.sym;
+                                                        __auto_type name_sym = _mv_1840.data.sym;
                                                         return name_sym.name;
                                                     }
                                                     default: {
                                                         return SLOP_STR("unknown");
                                                     }
                                                 }
-                                            } else if (!_mv_1838.has_value) {
+                                            } else if (!_mv_1839.has_value) {
                                                 return SLOP_STR("unknown");
                                             }
                                             SLOP_UNREACHABLE();
@@ -195,7 +195,7 @@ slop_string compiler_extract_module_name(slop_list_types_SExpr_ptr exprs) {
                                         return SLOP_STR("unknown");
                                     }
                                 }
-                            } else if (!_mv_1836.has_value) {
+                            } else if (!_mv_1837.has_value) {
                                 return SLOP_STR("unknown");
                             }
                             SLOP_UNREACHABLE();
@@ -206,7 +206,7 @@ slop_string compiler_extract_module_name(slop_list_types_SExpr_ptr exprs) {
                     return SLOP_STR("unknown");
                 }
             }
-        } else if (!_mv_1834.has_value) {
+        } else if (!_mv_1835.has_value) {
             return SLOP_STR("unknown");
         }
         SLOP_UNREACHABLE();
@@ -233,9 +233,9 @@ void compiler_check_all_functions(env_TypeEnv* env, slop_list_types_SExpr_ptr as
     {
         __auto_type len = ((int64_t)((ast).len));
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_1840 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1840.has_value) {
-                __auto_type expr = _mv_1840.value;
+            __auto_type _mv_1841 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1841.has_value) {
+                __auto_type expr = _mv_1841.value;
                 if (parser_is_form(expr, SLOP_STR("fn"))) {
                     {
                         __auto_type _ = infer_infer_fn_body(env, expr);
@@ -244,7 +244,7 @@ void compiler_check_all_functions(env_TypeEnv* env, slop_list_types_SExpr_ptr as
                     compiler_check_module_functions(env, expr);
                 } else {
                 }
-            } else if (!_mv_1840.has_value) {
+            } else if (!_mv_1841.has_value) {
             }
         }
     }
@@ -252,11 +252,11 @@ void compiler_check_all_functions(env_TypeEnv* env, slop_list_types_SExpr_ptr as
 
 uint8_t compiler_is_annotation_form(types_SExpr* item) {
     if (parser_sexpr_is_list(item)) {
-        __auto_type _mv_1841 = parser_sexpr_list_get(item, 0);
-        if (_mv_1841.has_value) {
-            __auto_type head = _mv_1841.value;
+        __auto_type _mv_1842 = parser_sexpr_list_get(item, 0);
+        if (_mv_1842.has_value) {
+            __auto_type head = _mv_1842.value;
             return ((uint8_t)(({ __auto_type name = parser_sexpr_get_symbol_name(head); (((name.len > 0)) ? (name.data[0] == 64) : 0); })));
-        } else if (!_mv_1841.has_value) {
+        } else if (!_mv_1842.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -289,11 +289,11 @@ uint8_t compiler_is_valid_toplevel_form(types_SExpr* item) {
 
 slop_string compiler_get_form_name(types_SExpr* item) {
     if (parser_sexpr_is_list(item)) {
-        __auto_type _mv_1842 = parser_sexpr_list_get(item, 0);
-        if (_mv_1842.has_value) {
-            __auto_type head = _mv_1842.value;
+        __auto_type _mv_1843 = parser_sexpr_list_get(item, 0);
+        if (_mv_1843.has_value) {
+            __auto_type head = _mv_1843.value;
             return parser_sexpr_get_symbol_name(head);
-        } else if (!_mv_1842.has_value) {
+        } else if (!_mv_1843.has_value) {
             return SLOP_STR("<empty>");
         }
         SLOP_UNREACHABLE();
@@ -306,23 +306,23 @@ void compiler_check_module_functions(env_TypeEnv* env, types_SExpr* module_form)
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((module_form != NULL)), "(!= module-form nil)");
     if (parser_sexpr_is_list(module_form)) {
-        __auto_type _mv_1843 = parser_sexpr_list_get(module_form, 1);
-        if (_mv_1843.has_value) {
-            __auto_type name_expr = _mv_1843.value;
+        __auto_type _mv_1844 = parser_sexpr_list_get(module_form, 1);
+        if (_mv_1844.has_value) {
+            __auto_type name_expr = _mv_1844.value;
             {
                 __auto_type mod_name = parser_sexpr_get_symbol_name(name_expr);
                 if (!(string_eq(mod_name, SLOP_STR("")))) {
                     env_env_set_module(env, (slop_option_string){.has_value = 1, .value = mod_name});
                 }
             }
-        } else if (!_mv_1843.has_value) {
+        } else if (!_mv_1844.has_value) {
         }
         {
             __auto_type len = parser_sexpr_list_len(module_form);
             for (int64_t i = 2; i < len; i++) {
-                __auto_type _mv_1844 = parser_sexpr_list_get(module_form, i);
-                if (_mv_1844.has_value) {
-                    __auto_type item = _mv_1844.value;
+                __auto_type _mv_1845 = parser_sexpr_list_get(module_form, i);
+                if (_mv_1845.has_value) {
+                    __auto_type item = _mv_1845.value;
                     if (parser_is_form(item, SLOP_STR("fn"))) {
                         {
                             __auto_type _ = infer_infer_fn_body(env, item);
@@ -335,7 +335,7 @@ void compiler_check_module_functions(env_TypeEnv* env, types_SExpr* module_form)
                             env_env_add_error(env, msg, parser_sexpr_line(item), parser_sexpr_col(item));
                         }
                     }
-                } else if (!_mv_1844.has_value) {
+                } else if (!_mv_1845.has_value) {
                 }
             }
         }
@@ -348,15 +348,15 @@ int64_t compiler_count_errors(slop_list_types_Diagnostic diagnostics) {
         int64_t errors = 0;
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1845 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1845.has_value) {
-                __auto_type diag = _mv_1845.value;
-                __auto_type _mv_1846 = diag.level;
-                if (_mv_1846 == types_DiagnosticLevel_diag_error) {
+            __auto_type _mv_1846 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1846.has_value) {
+                __auto_type diag = _mv_1846.value;
+                __auto_type _mv_1847 = diag.level;
+                if (_mv_1847 == types_DiagnosticLevel_diag_error) {
                     errors = (errors + 1);
-                } else if (_mv_1846 == types_DiagnosticLevel_diag_warning) {
+                } else if (_mv_1847 == types_DiagnosticLevel_diag_warning) {
                 }
-            } else if (!_mv_1845.has_value) {
+            } else if (!_mv_1846.has_value) {
             }
             i = (i + 1);
         }
@@ -371,10 +371,10 @@ void compiler_print_diagnostic(slop_arena* arena, slop_string filename, types_Di
     printf("%s", ":");
     printf("%lld", (long long)(diag.col));
     printf("%s", ": ");
-    __auto_type _mv_1847 = diag.level;
-    if (_mv_1847 == types_DiagnosticLevel_diag_warning) {
+    __auto_type _mv_1848 = diag.level;
+    if (_mv_1848 == types_DiagnosticLevel_diag_warning) {
         printf("%s", "warning: ");
-    } else if (_mv_1847 == types_DiagnosticLevel_diag_error) {
+    } else if (_mv_1848 == types_DiagnosticLevel_diag_error) {
         printf("%s", "error: ");
     }
     printf("%.*s\n", (int)(diag.message).len, (diag.message).data);
@@ -385,11 +385,11 @@ void compiler_output_diagnostics_text(slop_arena* arena, slop_string filename, s
         __auto_type len = ((int64_t)((diagnostics).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1848 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1848.has_value) {
-                __auto_type diag = _mv_1848.value;
+            __auto_type _mv_1849 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1849.has_value) {
+                __auto_type diag = _mv_1849.value;
                 compiler_print_diagnostic(arena, filename, diag);
-            } else if (!_mv_1848.has_value) {
+            } else if (!_mv_1849.has_value) {
             }
             i = (i + 1);
         }
@@ -405,11 +405,11 @@ void compiler_output_diagnostics_json(slop_arena* arena, slop_list_types_Diagnos
             if (i > 0) {
                 putchar(44);
             }
-            __auto_type _mv_1849 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1849.has_value) {
-                __auto_type diag = _mv_1849.value;
+            __auto_type _mv_1850 = ({ __auto_type _lst = diagnostics; size_t _idx = (size_t)i; slop_option_types_Diagnostic _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1850.has_value) {
+                __auto_type diag = _mv_1850.value;
                 compiler_output_single_diagnostic_json(arena, diag);
-            } else if (!_mv_1849.has_value) {
+            } else if (!_mv_1850.has_value) {
             }
             i = (i + 1);
         }
@@ -420,10 +420,10 @@ void compiler_output_diagnostics_json(slop_arena* arena, slop_list_types_Diagnos
 void compiler_output_single_diagnostic_json(slop_arena* arena, types_Diagnostic diag) {
     putchar(123);
     compiler_print_str(((uint8_t*)(SLOP_STR("\"level\":").data)));
-    __auto_type _mv_1850 = diag.level;
-    if (_mv_1850 == types_DiagnosticLevel_diag_warning) {
+    __auto_type _mv_1851 = diag.level;
+    if (_mv_1851 == types_DiagnosticLevel_diag_warning) {
         compiler_print_str(((uint8_t*)(SLOP_STR("\"warning\"").data)));
-    } else if (_mv_1850 == types_DiagnosticLevel_diag_error) {
+    } else if (_mv_1851 == types_DiagnosticLevel_diag_error) {
         compiler_print_str(((uint8_t*)(SLOP_STR("\"error\"").data)));
     }
     putchar(44);
@@ -455,27 +455,27 @@ int64_t compiler_check_single_file(env_TypeEnv* env, slop_arena* arena, uint8_t*
     SLOP_PRE(((filename != NULL)), "(!= filename nil)");
     {
         __auto_type filename_str = strlib_cstring_to_string(filename);
-        __auto_type _mv_1851 = file_file_open(filename_str, file_FileMode_read);
-        if (!_mv_1851.is_ok) {
-            __auto_type e = _mv_1851.data.err;
+        __auto_type _mv_1852 = file_file_open(filename_str, file_FileMode_read);
+        if (!_mv_1852.is_ok) {
+            __auto_type e = _mv_1852.data.err;
             printf("%s", "Error: Could not open file: ");
             printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
             return 1;
-        } else if (_mv_1851.is_ok) {
-            __auto_type f = _mv_1851.data.ok;
-            __auto_type _mv_1852 = file_file_read_all(arena, (&f));
-            if (!_mv_1852.is_ok) {
-                __auto_type e = _mv_1852.data.err;
+        } else if (_mv_1852.is_ok) {
+            __auto_type f = _mv_1852.data.ok;
+            __auto_type _mv_1853 = file_file_read_all(arena, (&f));
+            if (!_mv_1853.is_ok) {
+                __auto_type e = _mv_1853.data.err;
                 file_file_close((&f));
                 printf("%s", "Error: Could not read file: ");
                 printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
                 return 1;
-            } else if (_mv_1852.is_ok) {
-                __auto_type source = _mv_1852.data.ok;
+            } else if (_mv_1853.is_ok) {
+                __auto_type source = _mv_1853.data.ok;
                 file_file_close((&f));
-                __auto_type _mv_1853 = parser_parse(arena, source);
-                if (_mv_1853.is_ok) {
-                    __auto_type ast = _mv_1853.data.ok;
+                __auto_type _mv_1854 = parser_parse(arena, source);
+                if (_mv_1854.is_ok) {
+                    __auto_type ast = _mv_1854.data.ok;
                     {
                         __auto_type mod_name = compiler_extract_module_name(ast);
                         env_env_clear_imports(env);
@@ -492,8 +492,8 @@ int64_t compiler_check_single_file(env_TypeEnv* env, slop_arena* arena, uint8_t*
                             return compiler_count_errors(diagnostics);
                         }
                     }
-                } else if (!_mv_1853.is_ok) {
-                    __auto_type parse_err = _mv_1853.data.err;
+                } else if (!_mv_1854.is_ok) {
+                    __auto_type parse_err = _mv_1854.data.err;
                     printf("%.*s", (int)(filename_str).len, (filename_str).data);
                     printf("%s", ":");
                     printf("%lld", (long long)(parse_err.line));
@@ -513,15 +513,15 @@ int64_t compiler_check_single_file(env_TypeEnv* env, slop_arena* arena, uint8_t*
 
 types_ResolvedType* compiler_resolve_type_string(env_TypeEnv* env, slop_arena* arena, slop_string type_str) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_1854 = parser_parse(arena, type_str);
-    if (_mv_1854.is_ok) {
-        __auto_type type_ast = _mv_1854.data.ok;
+    __auto_type _mv_1855 = parser_parse(arena, type_str);
+    if (_mv_1855.is_ok) {
+        __auto_type type_ast = _mv_1855.data.ok;
         if (((int64_t)((type_ast).len)) == 0) {
             return env_env_get_int_type(env);
         } else {
-            __auto_type _mv_1855 = ({ __auto_type _lst = type_ast; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1855.has_value) {
-                __auto_type type_expr = _mv_1855.value;
+            __auto_type _mv_1856 = ({ __auto_type _lst = type_ast; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1856.has_value) {
+                __auto_type type_expr = _mv_1856.value;
                 if (parser_sexpr_is_list(type_expr)) {
                     return infer_resolve_complex_type_expr(env, type_expr);
                 } else {
@@ -534,13 +534,13 @@ types_ResolvedType* compiler_resolve_type_string(env_TypeEnv* env, slop_arena* a
                         }
                     }
                 }
-            } else if (!_mv_1855.has_value) {
+            } else if (!_mv_1856.has_value) {
                 return env_env_get_int_type(env);
             }
             SLOP_UNREACHABLE();
         }
-    } else if (!_mv_1854.is_ok) {
-        __auto_type _ = _mv_1854.data.err;
+    } else if (!_mv_1855.is_ok) {
+        __auto_type _ = _mv_1855.data.err;
         return env_env_get_int_type(env);
     }
     SLOP_UNREACHABLE();
@@ -548,51 +548,51 @@ types_ResolvedType* compiler_resolve_type_string(env_TypeEnv* env, slop_arena* a
 
 void compiler_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_string params_str) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_1856 = parser_parse(arena, params_str);
-    if (_mv_1856.is_ok) {
-        __auto_type params_ast = _mv_1856.data.ok;
+    __auto_type _mv_1857 = parser_parse(arena, params_str);
+    if (_mv_1857.is_ok) {
+        __auto_type params_ast = _mv_1857.data.ok;
         if (((int64_t)((params_ast).len)) > 0) {
-            __auto_type _mv_1857 = ({ __auto_type _lst = params_ast; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1857.has_value) {
-                __auto_type params_list = _mv_1857.value;
-                __auto_type _mv_1858 = (*params_list);
-                switch (_mv_1858.tag) {
+            __auto_type _mv_1858 = ({ __auto_type _lst = params_ast; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1858.has_value) {
+                __auto_type params_list = _mv_1858.value;
+                __auto_type _mv_1859 = (*params_list);
+                switch (_mv_1859.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type lst = _mv_1858.data.lst;
+                        __auto_type lst = _mv_1859.data.lst;
                         {
                             __auto_type items = lst.items;
                             __auto_type len = ((int64_t)((items).len));
                             for (int64_t i = 0; i < len; i++) {
-                                __auto_type _mv_1859 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1859.has_value) {
-                                    __auto_type param = _mv_1859.value;
-                                    __auto_type _mv_1860 = (*param);
-                                    switch (_mv_1860.tag) {
+                                __auto_type _mv_1860 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1860.has_value) {
+                                    __auto_type param = _mv_1860.value;
+                                    __auto_type _mv_1861 = (*param);
+                                    switch (_mv_1861.tag) {
                                         case types_SExpr_lst:
                                         {
-                                            __auto_type param_lst = _mv_1860.data.lst;
+                                            __auto_type param_lst = _mv_1861.data.lst;
                                             {
                                                 __auto_type param_items = param_lst.items;
                                                 if (((int64_t)((param_items).len)) >= 2) {
-                                                    __auto_type _mv_1861 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1861.has_value) {
-                                                        __auto_type name_expr = _mv_1861.value;
-                                                        __auto_type _mv_1862 = (*name_expr);
-                                                        switch (_mv_1862.tag) {
+                                                    __auto_type _mv_1862 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1862.has_value) {
+                                                        __auto_type name_expr = _mv_1862.value;
+                                                        __auto_type _mv_1863 = (*name_expr);
+                                                        switch (_mv_1863.tag) {
                                                             case types_SExpr_sym:
                                                             {
-                                                                __auto_type name_sym = _mv_1862.data.sym;
+                                                                __auto_type name_sym = _mv_1863.data.sym;
                                                                 {
                                                                     __auto_type param_name = name_sym.name;
-                                                                    __auto_type _mv_1863 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                    if (_mv_1863.has_value) {
-                                                                        __auto_type type_expr = _mv_1863.value;
-                                                                        __auto_type _mv_1864 = (*type_expr);
-                                                                        switch (_mv_1864.tag) {
+                                                                    __auto_type _mv_1864 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; struct { bool has_value; __typeof__(_lst.data[0]) value; } _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                    if (_mv_1864.has_value) {
+                                                                        __auto_type type_expr = _mv_1864.value;
+                                                                        __auto_type _mv_1865 = (*type_expr);
+                                                                        switch (_mv_1865.tag) {
                                                                             case types_SExpr_sym:
                                                                             {
-                                                                                __auto_type type_sym = _mv_1864.data.sym;
+                                                                                __auto_type type_sym = _mv_1865.data.sym;
                                                                                 {
                                                                                     __auto_type param_type = compiler_resolve_type_string(env, arena, type_sym.name);
                                                                                     env_env_bind_var(env, param_name, param_type);
@@ -601,7 +601,7 @@ void compiler_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_st
                                                                             }
                                                                             case types_SExpr_lst:
                                                                             {
-                                                                                __auto_type _ = _mv_1864.data.lst;
+                                                                                __auto_type _ = _mv_1865.data.lst;
                                                                                 {
                                                                                     __auto_type param_type = infer_resolve_complex_type_expr(env, type_expr);
                                                                                     env_env_bind_var(env, param_name, param_type);
@@ -613,7 +613,7 @@ void compiler_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_st
                                                                                 break;
                                                                             }
                                                                         }
-                                                                    } else if (!_mv_1863.has_value) {
+                                                                    } else if (!_mv_1864.has_value) {
                                                                     }
                                                                 }
                                                                 break;
@@ -622,7 +622,7 @@ void compiler_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_st
                                                                 break;
                                                             }
                                                         }
-                                                    } else if (!_mv_1861.has_value) {
+                                                    } else if (!_mv_1862.has_value) {
                                                     }
                                                 }
                                             }
@@ -632,7 +632,7 @@ void compiler_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_st
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1859.has_value) {
+                                } else if (!_mv_1860.has_value) {
                                 }
                             }
                         }
@@ -642,11 +642,11 @@ void compiler_parse_and_bind_params(env_TypeEnv* env, slop_arena* arena, slop_st
                         break;
                     }
                 }
-            } else if (!_mv_1857.has_value) {
+            } else if (!_mv_1858.has_value) {
             }
         }
-    } else if (!_mv_1856.is_ok) {
-        __auto_type _ = _mv_1856.data.err;
+    } else if (!_mv_1857.is_ok) {
+        __auto_type _ = _mv_1857.data.err;
     }
 }
 
@@ -665,18 +665,18 @@ uint8_t compiler_types_names_equal(types_ResolvedType* a, types_ResolvedType* b)
         } else if (string_eq(a_name, SLOP_STR("Unknown")) || string_eq(b_name, SLOP_STR("Unknown"))) {
             return 1;
         } else if ((a_kind == types_ResolvedTypeKind_rk_option) && (b_kind == types_ResolvedTypeKind_rk_option)) {
-            __auto_type _mv_1865 = (*a).inner_type;
-            if (_mv_1865.has_value) {
-                __auto_type a_inner = _mv_1865.value;
-                __auto_type _mv_1866 = (*b).inner_type;
-                if (_mv_1866.has_value) {
-                    __auto_type b_inner = _mv_1866.value;
+            __auto_type _mv_1866 = (*a).inner_type;
+            if (_mv_1866.has_value) {
+                __auto_type a_inner = _mv_1866.value;
+                __auto_type _mv_1867 = (*b).inner_type;
+                if (_mv_1867.has_value) {
+                    __auto_type b_inner = _mv_1867.value;
                     return compiler_types_names_equal(a_inner, b_inner);
-                } else if (!_mv_1866.has_value) {
+                } else if (!_mv_1867.has_value) {
                     return 1;
                 }
                 SLOP_UNREACHABLE();
-            } else if (!_mv_1865.has_value) {
+            } else if (!_mv_1866.has_value) {
                 return 1;
             }
             SLOP_UNREACHABLE();
@@ -687,36 +687,36 @@ uint8_t compiler_types_names_equal(types_ResolvedType* a, types_ResolvedType* b)
                 return (ok_match && err_match);
             }
         } else if ((a_kind == types_ResolvedTypeKind_rk_ptr) && (b_kind == types_ResolvedTypeKind_rk_ptr)) {
-            __auto_type _mv_1867 = (*a).inner_type;
-            if (_mv_1867.has_value) {
-                __auto_type a_inner = _mv_1867.value;
-                __auto_type _mv_1868 = (*b).inner_type;
-                if (_mv_1868.has_value) {
-                    __auto_type b_inner = _mv_1868.value;
+            __auto_type _mv_1868 = (*a).inner_type;
+            if (_mv_1868.has_value) {
+                __auto_type a_inner = _mv_1868.value;
+                __auto_type _mv_1869 = (*b).inner_type;
+                if (_mv_1869.has_value) {
+                    __auto_type b_inner = _mv_1869.value;
                     return compiler_types_names_equal(a_inner, b_inner);
-                } else if (!_mv_1868.has_value) {
+                } else if (!_mv_1869.has_value) {
                     return 1;
                 }
                 SLOP_UNREACHABLE();
-            } else if (!_mv_1867.has_value) {
+            } else if (!_mv_1868.has_value) {
                 return 1;
             }
             SLOP_UNREACHABLE();
         } else if (a_kind == types_ResolvedTypeKind_rk_range) {
-            __auto_type _mv_1869 = (*a).inner_type;
-            if (_mv_1869.has_value) {
-                __auto_type base = _mv_1869.value;
+            __auto_type _mv_1870 = (*a).inner_type;
+            if (_mv_1870.has_value) {
+                __auto_type base = _mv_1870.value;
                 return compiler_types_names_equal(base, b);
-            } else if (!_mv_1869.has_value) {
+            } else if (!_mv_1870.has_value) {
                 return 0;
             }
             SLOP_UNREACHABLE();
         } else if (b_kind == types_ResolvedTypeKind_rk_range) {
-            __auto_type _mv_1870 = (*b).inner_type;
-            if (_mv_1870.has_value) {
-                __auto_type base = _mv_1870.value;
+            __auto_type _mv_1871 = (*b).inner_type;
+            if (_mv_1871.has_value) {
+                __auto_type base = _mv_1871.value;
                 return compiler_types_names_equal(a, base);
-            } else if (!_mv_1870.has_value) {
+            } else if (!_mv_1871.has_value) {
                 return 0;
             }
             SLOP_UNREACHABLE();
@@ -727,20 +727,20 @@ uint8_t compiler_types_names_equal(types_ResolvedType* a, types_ResolvedType* b)
                 return (a_match || b_match);
             }
         } else if (a_kind == types_ResolvedTypeKind_rk_primitive) {
-            __auto_type _mv_1871 = (*a).inner_type;
-            if (_mv_1871.has_value) {
-                __auto_type a_base = _mv_1871.value;
+            __auto_type _mv_1872 = (*a).inner_type;
+            if (_mv_1872.has_value) {
+                __auto_type a_base = _mv_1872.value;
                 return compiler_types_names_equal(a_base, b);
-            } else if (!_mv_1871.has_value) {
+            } else if (!_mv_1872.has_value) {
                 return 0;
             }
             SLOP_UNREACHABLE();
         } else if (b_kind == types_ResolvedTypeKind_rk_primitive) {
-            __auto_type _mv_1872 = (*b).inner_type;
-            if (_mv_1872.has_value) {
-                __auto_type b_base = _mv_1872.value;
+            __auto_type _mv_1873 = (*b).inner_type;
+            if (_mv_1873.has_value) {
+                __auto_type b_base = _mv_1873.value;
                 return compiler_types_names_equal(a, b_base);
-            } else if (!_mv_1872.has_value) {
+            } else if (!_mv_1873.has_value) {
                 return 0;
             }
             SLOP_UNREACHABLE();
@@ -753,26 +753,26 @@ uint8_t compiler_types_names_equal(types_ResolvedType* a, types_ResolvedType* b)
 int64_t compiler_check_expr_mode(slop_arena* arena, env_TypeEnv* env, slop_string expr_str, slop_string type_str, slop_string context_file, slop_string params_str) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     if (string_len(context_file) > 0) {
-        __auto_type _mv_1873 = file_file_open(context_file, file_FileMode_read);
-        if (!_mv_1873.is_ok) {
-            __auto_type _ = _mv_1873.data.err;
-        } else if (_mv_1873.is_ok) {
-            __auto_type f = _mv_1873.data.ok;
-            __auto_type _mv_1874 = file_file_read_all(arena, (&f));
-            if (!_mv_1874.is_ok) {
-                __auto_type _ = _mv_1874.data.err;
+        __auto_type _mv_1874 = file_file_open(context_file, file_FileMode_read);
+        if (!_mv_1874.is_ok) {
+            __auto_type _ = _mv_1874.data.err;
+        } else if (_mv_1874.is_ok) {
+            __auto_type f = _mv_1874.data.ok;
+            __auto_type _mv_1875 = file_file_read_all(arena, (&f));
+            if (!_mv_1875.is_ok) {
+                __auto_type _ = _mv_1875.data.err;
                 file_file_close((&f));
-            } else if (_mv_1874.is_ok) {
-                __auto_type source = _mv_1874.data.ok;
+            } else if (_mv_1875.is_ok) {
+                __auto_type source = _mv_1875.data.ok;
                 file_file_close((&f));
-                __auto_type _mv_1875 = parser_parse(arena, source);
-                if (_mv_1875.is_ok) {
-                    __auto_type context_ast = _mv_1875.data.ok;
+                __auto_type _mv_1876 = parser_parse(arena, source);
+                if (_mv_1876.is_ok) {
+                    __auto_type context_ast = _mv_1876.data.ok;
                     collect_collect_module(env, context_ast);
                     resolve_resolve_imports(env, context_ast);
                     env_env_clear_diagnostics(env);
-                } else if (!_mv_1875.is_ok) {
-                    __auto_type _ = _mv_1875.data.err;
+                } else if (!_mv_1876.is_ok) {
+                    __auto_type _ = _mv_1876.data.err;
                 }
             }
         }
@@ -811,27 +811,27 @@ int64_t compiler_transpile_single_file(env_TypeEnv* env, context_TranspileContex
     {
         __auto_type filename_str = strlib_cstring_to_string(filename);
         context_ctx_set_file(ctx, filename_str);
-        __auto_type _mv_1876 = file_file_open(filename_str, file_FileMode_read);
-        if (!_mv_1876.is_ok) {
-            __auto_type e = _mv_1876.data.err;
+        __auto_type _mv_1877 = file_file_open(filename_str, file_FileMode_read);
+        if (!_mv_1877.is_ok) {
+            __auto_type e = _mv_1877.data.err;
             printf("%s", "Error: Could not open file: ");
             printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
             return 1;
-        } else if (_mv_1876.is_ok) {
-            __auto_type f = _mv_1876.data.ok;
-            __auto_type _mv_1877 = file_file_read_all(arena, (&f));
-            if (!_mv_1877.is_ok) {
-                __auto_type e = _mv_1877.data.err;
+        } else if (_mv_1877.is_ok) {
+            __auto_type f = _mv_1877.data.ok;
+            __auto_type _mv_1878 = file_file_read_all(arena, (&f));
+            if (!_mv_1878.is_ok) {
+                __auto_type e = _mv_1878.data.err;
                 file_file_close((&f));
                 printf("%s", "Error: Could not read file: ");
                 printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
                 return 1;
-            } else if (_mv_1877.is_ok) {
-                __auto_type source = _mv_1877.data.ok;
+            } else if (_mv_1878.is_ok) {
+                __auto_type source = _mv_1878.data.ok;
                 file_file_close((&f));
-                __auto_type _mv_1878 = parser_parse(arena, source);
-                if (_mv_1878.is_ok) {
-                    __auto_type ast = _mv_1878.data.ok;
+                __auto_type _mv_1879 = parser_parse(arena, source);
+                if (_mv_1879.is_ok) {
+                    __auto_type ast = _mv_1879.data.ok;
                     {
                         __auto_type mod_name = compiler_extract_module_name(ast);
                         env_env_clear_imports(env);
@@ -849,8 +849,8 @@ int64_t compiler_transpile_single_file(env_TypeEnv* env, context_TranspileContex
                         compiler_output_transpile_module_json(arena, ctx, mod_name, first);
                         return 0;
                     }
-                } else if (!_mv_1878.is_ok) {
-                    __auto_type parse_err = _mv_1878.data.err;
+                } else if (!_mv_1879.is_ok) {
+                    __auto_type parse_err = _mv_1879.data.err;
                     printf("%.*s", (int)(filename_str).len, (filename_str).data);
                     printf("%s", ":");
                     printf("%lld", (long long)(parse_err.line));
@@ -894,26 +894,26 @@ void compiler_output_transpile_module_json(slop_arena* arena, context_TranspileC
 
 slop_string compiler_emit_sexpr_inner(slop_arena* arena, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1879 = (*expr);
-    switch (_mv_1879.tag) {
+    __auto_type _mv_1880 = (*expr);
+    switch (_mv_1880.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1879.data.sym;
+            __auto_type sym = _mv_1880.data.sym;
             return sym.name;
         }
         case types_SExpr_str:
         {
-            __auto_type str = _mv_1879.data.str;
+            __auto_type str = _mv_1880.data.str;
             return string_concat(arena, SLOP_STR("\""), string_concat(arena, str.value, SLOP_STR("\"")));
         }
         case types_SExpr_num:
         {
-            __auto_type num = _mv_1879.data.num;
+            __auto_type num = _mv_1880.data.num;
             return num.raw;
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1879.data.lst;
+            __auto_type lst = _mv_1880.data.lst;
             return compiler_emit_typed_list(arena, lst.items);
         }
     }
@@ -925,14 +925,14 @@ slop_string compiler_emit_typed_sexpr(slop_arena* arena, types_SExpr* expr) {
     {
         __auto_type type_opt = ctype_get_node_resolved_type(expr);
         __auto_type inner = compiler_emit_sexpr_inner(arena, expr);
-        __auto_type _mv_1880 = type_opt;
-        if (_mv_1880.has_value) {
-            __auto_type rt = _mv_1880.value;
+        __auto_type _mv_1881 = type_opt;
+        if (_mv_1881.has_value) {
+            __auto_type rt = _mv_1881.value;
             {
                 __auto_type type_str = types_resolved_type_to_slop_string(arena, rt);
                 return string_concat(arena, SLOP_STR("(typed "), string_concat(arena, type_str, string_concat(arena, SLOP_STR(" "), string_concat(arena, inner, SLOP_STR(")")))));
             }
-        } else if (!_mv_1880.has_value) {
+        } else if (!_mv_1881.has_value) {
             return inner;
         }
         SLOP_UNREACHABLE();
@@ -945,9 +945,9 @@ slop_string compiler_emit_typed_list(slop_arena* arena, slop_list_types_SExpr_pt
         __auto_type result = SLOP_STR("(");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1881 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1881.has_value) {
-                __auto_type item = _mv_1881.value;
+            __auto_type _mv_1882 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1882.has_value) {
+                __auto_type item = _mv_1882.value;
                 {
                     __auto_type child_str = compiler_emit_typed_sexpr(arena, item);
                     if (i > 0) {
@@ -956,7 +956,7 @@ slop_string compiler_emit_typed_list(slop_arena* arena, slop_list_types_SExpr_pt
                         result = string_concat(arena, result, child_str);
                     }
                 }
-            } else if (!_mv_1881.has_value) {
+            } else if (!_mv_1882.has_value) {
             }
             i = (i + 1);
         }
@@ -983,9 +983,9 @@ slop_string compiler_emit_typed_module(slop_arena* arena, types_SExpr* module_fo
             __auto_type result = SLOP_STR("(");
             int64_t i = 0;
             while (i < len) {
-                __auto_type _mv_1882 = parser_sexpr_list_get(module_form, i);
-                if (_mv_1882.has_value) {
-                    __auto_type item = _mv_1882.value;
+                __auto_type _mv_1883 = parser_sexpr_list_get(module_form, i);
+                if (_mv_1883.has_value) {
+                    __auto_type item = _mv_1883.value;
                     {
                         __auto_type child_str = ((parser_is_form(item, SLOP_STR("fn"))) ? compiler_emit_typed_sexpr(arena, item) : compiler_emit_typed_sexpr(arena, item));
                         if (i > 0) {
@@ -994,7 +994,7 @@ slop_string compiler_emit_typed_module(slop_arena* arena, types_SExpr* module_fo
                             result = string_concat(arena, result, child_str);
                         }
                     }
-                } else if (!_mv_1882.has_value) {
+                } else if (!_mv_1883.has_value) {
                 }
                 i = (i + 1);
             }
@@ -1011,9 +1011,9 @@ slop_string compiler_emit_typed_ast(slop_arena* arena, slop_list_types_SExpr_ptr
         __auto_type result = SLOP_STR("");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1883 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1883.has_value) {
-                __auto_type expr = _mv_1883.value;
+            __auto_type _mv_1884 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1884.has_value) {
+                __auto_type expr = _mv_1884.value;
                 {
                     __auto_type form_str = compiler_emit_typed_toplevel(arena, expr);
                     if (i > 0) {
@@ -1022,7 +1022,7 @@ slop_string compiler_emit_typed_ast(slop_arena* arena, slop_list_types_SExpr_ptr
                         result = form_str;
                     }
                 }
-            } else if (!_mv_1883.has_value) {
+            } else if (!_mv_1884.has_value) {
             }
             i = (i + 1);
         }
@@ -1035,27 +1035,27 @@ int64_t compiler_typed_ast_single_file(env_TypeEnv* env, slop_arena* arena, uint
     SLOP_PRE(((filename != NULL)), "(!= filename nil)");
     {
         __auto_type filename_str = strlib_cstring_to_string(filename);
-        __auto_type _mv_1884 = file_file_open(filename_str, file_FileMode_read);
-        if (!_mv_1884.is_ok) {
-            __auto_type e = _mv_1884.data.err;
+        __auto_type _mv_1885 = file_file_open(filename_str, file_FileMode_read);
+        if (!_mv_1885.is_ok) {
+            __auto_type e = _mv_1885.data.err;
             printf("%s", "Error: Could not open file: ");
             printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
             return 1;
-        } else if (_mv_1884.is_ok) {
-            __auto_type f = _mv_1884.data.ok;
-            __auto_type _mv_1885 = file_file_read_all(arena, (&f));
-            if (!_mv_1885.is_ok) {
-                __auto_type e = _mv_1885.data.err;
+        } else if (_mv_1885.is_ok) {
+            __auto_type f = _mv_1885.data.ok;
+            __auto_type _mv_1886 = file_file_read_all(arena, (&f));
+            if (!_mv_1886.is_ok) {
+                __auto_type e = _mv_1886.data.err;
                 file_file_close((&f));
                 printf("%s", "Error: Could not read file: ");
                 printf("%.*s\n", (int)(filename_str).len, (filename_str).data);
                 return 1;
-            } else if (_mv_1885.is_ok) {
-                __auto_type source = _mv_1885.data.ok;
+            } else if (_mv_1886.is_ok) {
+                __auto_type source = _mv_1886.data.ok;
                 file_file_close((&f));
-                __auto_type _mv_1886 = parser_parse(arena, source);
-                if (_mv_1886.is_ok) {
-                    __auto_type ast = _mv_1886.data.ok;
+                __auto_type _mv_1887 = parser_parse(arena, source);
+                if (_mv_1887.is_ok) {
+                    __auto_type ast = _mv_1887.data.ok;
                     {
                         __auto_type mod_name = compiler_extract_module_name(ast);
                         env_env_clear_imports(env);
@@ -1083,8 +1083,8 @@ int64_t compiler_typed_ast_single_file(env_TypeEnv* env, slop_arena* arena, uint
                             }
                         }
                     }
-                } else if (!_mv_1886.is_ok) {
-                    __auto_type parse_err = _mv_1886.data.err;
+                } else if (!_mv_1887.is_ok) {
+                    __auto_type parse_err = _mv_1887.data.err;
                     printf("%.*s", (int)(filename_str).len, (filename_str).data);
                     printf("%s", ":");
                     printf("%lld", (long long)(parse_err.line));

--- a/bootstrap/compiler/slop_defn.c
+++ b/bootstrap/compiler/slop_defn.c
@@ -86,31 +86,31 @@ slop_string defn_escape_for_c_string(slop_arena* arena, slop_string s);
 
 uint8_t defn_is_type_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_964 = (*expr);
-    switch (_mv_964.tag) {
+    __auto_type _mv_965 = (*expr);
+    switch (_mv_965.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_964.data.lst;
+            __auto_type lst = _mv_965.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_965 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_965.has_value) {
-                        __auto_type head = _mv_965.value;
-                        __auto_type _mv_966 = (*head);
-                        switch (_mv_966.tag) {
+                    __auto_type _mv_966 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_966.has_value) {
+                        __auto_type head = _mv_966.value;
+                        __auto_type _mv_967 = (*head);
+                        switch (_mv_967.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_966.data.sym;
+                                __auto_type sym = _mv_967.data.sym;
                                 return string_eq(sym.name, SLOP_STR("type"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_965.has_value) {
+                    } else if (!_mv_966.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -125,31 +125,31 @@ uint8_t defn_is_type_form(types_SExpr* expr) {
 
 uint8_t defn_is_function_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_967 = (*expr);
-    switch (_mv_967.tag) {
+    __auto_type _mv_968 = (*expr);
+    switch (_mv_968.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_967.data.lst;
+            __auto_type lst = _mv_968.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_968 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_968.has_value) {
-                        __auto_type head = _mv_968.value;
-                        __auto_type _mv_969 = (*head);
-                        switch (_mv_969.tag) {
+                    __auto_type _mv_969 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_969.has_value) {
+                        __auto_type head = _mv_969.value;
+                        __auto_type _mv_970 = (*head);
+                        switch (_mv_970.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_969.data.sym;
+                                __auto_type sym = _mv_970.data.sym;
                                 return string_eq(sym.name, SLOP_STR("fn"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_968.has_value) {
+                    } else if (!_mv_969.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -164,31 +164,31 @@ uint8_t defn_is_function_form(types_SExpr* expr) {
 
 uint8_t defn_is_const_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_970 = (*expr);
-    switch (_mv_970.tag) {
+    __auto_type _mv_971 = (*expr);
+    switch (_mv_971.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_970.data.lst;
+            __auto_type lst = _mv_971.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_971 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_971.has_value) {
-                        __auto_type head = _mv_971.value;
-                        __auto_type _mv_972 = (*head);
-                        switch (_mv_972.tag) {
+                    __auto_type _mv_972 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_972.has_value) {
+                        __auto_type head = _mv_972.value;
+                        __auto_type _mv_973 = (*head);
+                        switch (_mv_973.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_972.data.sym;
+                                __auto_type sym = _mv_973.data.sym;
                                 return string_eq(sym.name, SLOP_STR("const"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_971.has_value) {
+                    } else if (!_mv_972.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -203,31 +203,31 @@ uint8_t defn_is_const_form(types_SExpr* expr) {
 
 uint8_t defn_is_ffi_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_973 = (*expr);
-    switch (_mv_973.tag) {
+    __auto_type _mv_974 = (*expr);
+    switch (_mv_974.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_973.data.lst;
+            __auto_type lst = _mv_974.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_974 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_974.has_value) {
-                        __auto_type head = _mv_974.value;
-                        __auto_type _mv_975 = (*head);
-                        switch (_mv_975.tag) {
+                    __auto_type _mv_975 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_975.has_value) {
+                        __auto_type head = _mv_975.value;
+                        __auto_type _mv_976 = (*head);
+                        switch (_mv_976.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_975.data.sym;
+                                __auto_type sym = _mv_976.data.sym;
                                 return string_eq(sym.name, SLOP_STR("ffi"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_974.has_value) {
+                    } else if (!_mv_975.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -242,31 +242,31 @@ uint8_t defn_is_ffi_form(types_SExpr* expr) {
 
 uint8_t defn_is_ffi_struct_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_976 = (*expr);
-    switch (_mv_976.tag) {
+    __auto_type _mv_977 = (*expr);
+    switch (_mv_977.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_976.data.lst;
+            __auto_type lst = _mv_977.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_977 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_977.has_value) {
-                        __auto_type head = _mv_977.value;
-                        __auto_type _mv_978 = (*head);
-                        switch (_mv_978.tag) {
+                    __auto_type _mv_978 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_978.has_value) {
+                        __auto_type head = _mv_978.value;
+                        __auto_type _mv_979 = (*head);
+                        switch (_mv_979.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_978.data.sym;
+                                __auto_type sym = _mv_979.data.sym;
                                 return string_eq(sym.name, SLOP_STR("ffi-struct"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_977.has_value) {
+                    } else if (!_mv_978.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -285,25 +285,25 @@ uint8_t defn_has_generic_annotation(slop_list_types_SExpr_ptr items) {
         __auto_type i = 0;
         __auto_type found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_979 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_979.has_value) {
-                __auto_type item = _mv_979.value;
-                __auto_type _mv_980 = (*item);
-                switch (_mv_980.tag) {
+            __auto_type _mv_980 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_980.has_value) {
+                __auto_type item = _mv_980.value;
+                __auto_type _mv_981 = (*item);
+                switch (_mv_981.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type lst = _mv_980.data.lst;
+                        __auto_type lst = _mv_981.data.lst;
                         {
                             __auto_type sub_items = lst.items;
                             if (((int64_t)((sub_items).len)) > 0) {
-                                __auto_type _mv_981 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_981.has_value) {
-                                    __auto_type head = _mv_981.value;
-                                    __auto_type _mv_982 = (*head);
-                                    switch (_mv_982.tag) {
+                                __auto_type _mv_982 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_982.has_value) {
+                                    __auto_type head = _mv_982.value;
+                                    __auto_type _mv_983 = (*head);
+                                    switch (_mv_983.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_982.data.sym;
+                                            __auto_type sym = _mv_983.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("@generic"))) {
                                                 found = 1;
                                             } else {
@@ -314,7 +314,7 @@ uint8_t defn_has_generic_annotation(slop_list_types_SExpr_ptr items) {
                                             break;
                                         }
                                     }
-                                } else if (!_mv_981.has_value) {
+                                } else if (!_mv_982.has_value) {
                                 }
                             } else {
                             }
@@ -325,7 +325,7 @@ uint8_t defn_has_generic_annotation(slop_list_types_SExpr_ptr items) {
                         break;
                     }
                 }
-            } else if (!_mv_979.has_value) {
+            } else if (!_mv_980.has_value) {
             }
             i = (i + 1);
         }
@@ -334,31 +334,31 @@ uint8_t defn_has_generic_annotation(slop_list_types_SExpr_ptr items) {
 }
 
 uint8_t defn_is_pointer_type_expr(types_SExpr* type_expr) {
-    __auto_type _mv_983 = (*type_expr);
-    switch (_mv_983.tag) {
+    __auto_type _mv_984 = (*type_expr);
+    switch (_mv_984.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_983.data.lst;
+            __auto_type lst = _mv_984.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_984 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_984.has_value) {
-                        __auto_type head = _mv_984.value;
-                        __auto_type _mv_985 = (*head);
-                        switch (_mv_985.tag) {
+                    __auto_type _mv_985 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_985.has_value) {
+                        __auto_type head = _mv_985.value;
+                        __auto_type _mv_986 = (*head);
+                        switch (_mv_986.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_985.data.sym;
+                                __auto_type sym = _mv_986.data.sym;
                                 return (string_eq(sym.name, SLOP_STR("Ptr")) || string_eq(sym.name, SLOP_STR("ScopedPtr")));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_984.has_value) {
+                    } else if (!_mv_985.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -376,44 +376,44 @@ void defn_transpile_const(context_TranspileContext* ctx, types_SExpr* expr, uint
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_986 = (*expr);
-        switch (_mv_986.tag) {
+        __auto_type _mv_987 = (*expr);
+        switch (_mv_987.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_986.data.lst;
+                __auto_type lst = _mv_987.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 4) {
                         context_ctx_fail(ctx, SLOP_STR("invalid const: need name, type, value"));
                     } else {
-                        __auto_type _mv_987 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_987.has_value) {
-                            __auto_type name_expr = _mv_987.value;
-                            __auto_type _mv_988 = (*name_expr);
-                            switch (_mv_988.tag) {
+                        __auto_type _mv_988 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_988.has_value) {
+                            __auto_type name_expr = _mv_988.value;
+                            __auto_type _mv_989 = (*name_expr);
+                            switch (_mv_989.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_988.data.sym;
+                                    __auto_type name_sym = _mv_989.data.sym;
                                     {
                                         __auto_type raw_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, raw_name);
                                         __auto_type c_name = context_ctx_prefix_type(ctx, base_name);
-                                        __auto_type _mv_989 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_989.has_value) {
-                                            __auto_type type_expr = _mv_989.value;
+                                        __auto_type _mv_990 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_990.has_value) {
+                                            __auto_type type_expr = _mv_990.value;
                                             {
                                                 __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
                                                 context_ctx_bind_var(ctx, (context_VarEntry){raw_name, c_name, SLOP_STR("auto"), slop_type_str, 0, 0, 0, SLOP_STR(""), SLOP_STR("")});
-                                                __auto_type _mv_990 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_990.has_value) {
-                                                    __auto_type value_expr = _mv_990.value;
+                                                __auto_type _mv_991 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_991.has_value) {
+                                                    __auto_type value_expr = _mv_991.value;
                                                     defn_emit_const_def(ctx, c_name, type_expr, value_expr, is_exported);
-                                                } else if (!_mv_990.has_value) {
+                                                } else if (!_mv_991.has_value) {
                                                     context_ctx_fail(ctx, SLOP_STR("missing const value"));
                                                 }
                                             }
-                                        } else if (!_mv_989.has_value) {
+                                        } else if (!_mv_990.has_value) {
                                             context_ctx_fail(ctx, SLOP_STR("missing const type"));
                                         }
                                     }
@@ -424,7 +424,7 @@ void defn_transpile_const(context_TranspileContext* ctx, types_SExpr* expr, uint
                                     break;
                                 }
                             }
-                        } else if (!_mv_987.has_value) {
+                        } else if (!_mv_988.has_value) {
                             context_ctx_fail(ctx, SLOP_STR("missing const name"));
                         }
                     }
@@ -458,11 +458,11 @@ void defn_emit_const_def(context_TranspileContext* ctx, slop_string c_name, type
             {
                 __auto_type storage = ((is_exported) ? SLOP_STR("const ") : SLOP_STR("static const "));
                 if (string_eq(type_name, SLOP_STR("String"))) {
-                    __auto_type _mv_991 = (*value_expr);
-                    switch (_mv_991.tag) {
+                    __auto_type _mv_992 = (*value_expr);
+                    switch (_mv_992.tag) {
                         case types_SExpr_str:
                         {
-                            __auto_type str = _mv_991.data.str;
+                            __auto_type str = _mv_992.data.str;
                             context_ctx_emit(ctx, context_ctx_str5(ctx, storage, c_type, SLOP_STR(" "), c_name, context_ctx_str3(ctx, SLOP_STR(" = SLOP_STR(\""), str.value, SLOP_STR("\");"))));
                             break;
                         }
@@ -487,11 +487,11 @@ void defn_emit_const_def(context_TranspileContext* ctx, slop_string c_name, type
 
 slop_string defn_get_type_name_str(types_SExpr* type_expr) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_992 = (*type_expr);
-    switch (_mv_992.tag) {
+    __auto_type _mv_993 = (*type_expr);
+    switch (_mv_993.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_992.data.sym;
+            __auto_type sym = _mv_993.data.sym;
             return sym.name;
         }
         default: {
@@ -505,26 +505,26 @@ slop_string defn_eval_const_value(context_TranspileContext* ctx, types_SExpr* ex
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_993 = (*expr);
-        switch (_mv_993.tag) {
+        __auto_type _mv_994 = (*expr);
+        switch (_mv_994.tag) {
             case types_SExpr_num:
             {
-                __auto_type num = _mv_993.data.num;
+                __auto_type num = _mv_994.data.num;
                 return num.raw;
             }
             case types_SExpr_str:
             {
-                __auto_type str = _mv_993.data.str;
+                __auto_type str = _mv_994.data.str;
                 return context_ctx_str3(ctx, SLOP_STR("\""), str.value, SLOP_STR("\""));
             }
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_993.data.sym;
+                __auto_type sym = _mv_994.data.sym;
                 return ctype_to_c_name(arena, sym.name);
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_993.data.lst;
+                __auto_type lst = _mv_994.data.lst;
                 return expr_transpile_expr(ctx, expr);
             }
         }
@@ -542,25 +542,25 @@ void defn_transpile_ffi_struct(context_TranspileContext* ctx, types_SExpr* expr)
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_994 = (*expr);
-        switch (_mv_994.tag) {
+        __auto_type _mv_995 = (*expr);
+        switch (_mv_995.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_994.data.lst;
+                __auto_type lst = _mv_995.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     {
                         __auto_type name_idx = ((((len >= 2) && defn_is_string_expr(items, 1))) ? 2 : 1);
                         if (len >= (name_idx + 1)) {
-                            __auto_type _mv_995 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_995.has_value) {
-                                __auto_type name_expr = _mv_995.value;
-                                __auto_type _mv_996 = (*name_expr);
-                                switch (_mv_996.tag) {
+                            __auto_type _mv_996 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_996.has_value) {
+                                __auto_type name_expr = _mv_996.value;
+                                __auto_type _mv_997 = (*name_expr);
+                                switch (_mv_997.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_996.data.sym;
+                                        __auto_type sym = _mv_997.data.sym;
                                         {
                                             __auto_type type_name = sym.name;
                                             __auto_type c_name = ctype_to_c_name(arena, type_name);
@@ -575,7 +575,7 @@ void defn_transpile_ffi_struct(context_TranspileContext* ctx, types_SExpr* expr)
                                         break;
                                     }
                                 }
-                            } else if (!_mv_995.has_value) {
+                            } else if (!_mv_996.has_value) {
                             }
                         }
                     }
@@ -590,21 +590,21 @@ void defn_transpile_ffi_struct(context_TranspileContext* ctx, types_SExpr* expr)
 }
 
 uint8_t defn_is_string_expr(slop_list_types_SExpr_ptr items, int64_t idx) {
-    __auto_type _mv_997 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-    if (_mv_997.has_value) {
-        __auto_type item = _mv_997.value;
-        __auto_type _mv_998 = (*item);
-        switch (_mv_998.tag) {
+    __auto_type _mv_998 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+    if (_mv_998.has_value) {
+        __auto_type item = _mv_998.value;
+        __auto_type _mv_999 = (*item);
+        switch (_mv_999.tag) {
             case types_SExpr_str:
             {
-                __auto_type _ = _mv_998.data.str;
+                __auto_type _ = _mv_999.data.str;
                 return 1;
             }
             default: {
                 return 0;
             }
         }
-    } else if (!_mv_997.has_value) {
+    } else if (!_mv_998.has_value) {
         return 0;
     }
     SLOP_UNREACHABLE();
@@ -619,34 +619,34 @@ void defn_transpile_type(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_999 = (*expr);
-        switch (_mv_999.tag) {
+        __auto_type _mv_1000 = (*expr);
+        switch (_mv_1000.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_999.data.lst;
+                __auto_type lst = _mv_1000.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 3) {
                         context_ctx_add_error_at(ctx, SLOP_STR("invalid type: need name and definition"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     } else {
-                        __auto_type _mv_1000 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1000.has_value) {
-                            __auto_type name_expr = _mv_1000.value;
-                            __auto_type _mv_1001 = (*name_expr);
-                            switch (_mv_1001.tag) {
+                        __auto_type _mv_1001 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1001.has_value) {
+                            __auto_type name_expr = _mv_1001.value;
+                            __auto_type _mv_1002 = (*name_expr);
+                            switch (_mv_1002.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1001.data.sym;
+                                    __auto_type name_sym = _mv_1002.data.sym;
                                     {
                                         __auto_type raw_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, raw_name);
                                         __auto_type qualified_name = ((context_ctx_prefixing_enabled(ctx)) ? ({ __auto_type _mv = context_ctx_get_module(ctx); _mv.has_value ? ({ __auto_type mod_name = _mv.value; context_ctx_str(ctx, ctype_to_c_name(arena, mod_name), context_ctx_str(ctx, SLOP_STR("_"), base_name)); }) : (base_name); }) : base_name);
-                                        __auto_type _mv_1002 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1002.has_value) {
-                                            __auto_type type_def = _mv_1002.value;
+                                        __auto_type _mv_1003 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1003.has_value) {
+                                            __auto_type type_def = _mv_1003.value;
                                             defn_dispatch_type_def(ctx, raw_name, qualified_name, type_def);
-                                        } else if (!_mv_1002.has_value) {
+                                        } else if (!_mv_1003.has_value) {
                                             context_ctx_add_error_at(ctx, SLOP_STR("missing type definition"), context_ctx_sexpr_line(name_expr), context_ctx_sexpr_col(name_expr));
                                         }
                                     }
@@ -657,7 +657,7 @@ void defn_transpile_type(context_TranspileContext* ctx, types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_1000.has_value) {
+                        } else if (!_mv_1001.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing type name"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                     }
@@ -675,24 +675,24 @@ void defn_transpile_type(context_TranspileContext* ctx, types_SExpr* expr) {
 void defn_dispatch_type_def(context_TranspileContext* ctx, slop_string raw_name, slop_string qualified_name, types_SExpr* type_def) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
-    __auto_type _mv_1003 = (*type_def);
-    switch (_mv_1003.tag) {
+    __auto_type _mv_1004 = (*type_def);
+    switch (_mv_1004.tag) {
         case types_SExpr_lst:
         {
-            __auto_type def_lst = _mv_1003.data.lst;
+            __auto_type def_lst = _mv_1004.data.lst;
             {
                 __auto_type items = def_lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     context_ctx_add_error_at(ctx, SLOP_STR("empty type definition"), context_ctx_sexpr_line(type_def), context_ctx_sexpr_col(type_def));
                 } else {
-                    __auto_type _mv_1004 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1004.has_value) {
-                        __auto_type head = _mv_1004.value;
-                        __auto_type _mv_1005 = (*head);
-                        switch (_mv_1005.tag) {
+                    __auto_type _mv_1005 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1005.has_value) {
+                        __auto_type head = _mv_1005.value;
+                        __auto_type _mv_1006 = (*head);
+                        switch (_mv_1006.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1005.data.sym;
+                                __auto_type sym = _mv_1006.data.sym;
                                 {
                                     __auto_type kind = sym.name;
                                     if (string_eq(kind, SLOP_STR("record"))) {
@@ -716,7 +716,7 @@ void defn_dispatch_type_def(context_TranspileContext* ctx, slop_string raw_name,
                                 break;
                             }
                         }
-                    } else if (!_mv_1004.has_value) {
+                    } else if (!_mv_1005.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("empty type definition"), context_ctx_sexpr_line(type_def), context_ctx_sexpr_col(type_def));
                     }
                 }
@@ -725,7 +725,7 @@ void defn_dispatch_type_def(context_TranspileContext* ctx, slop_string raw_name,
         }
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1003.data.sym;
+            __auto_type sym = _mv_1004.data.sym;
             defn_transpile_type_alias(ctx, raw_name, qualified_name, type_def);
             break;
         }
@@ -742,14 +742,14 @@ uint8_t defn_has_payload_variants(slop_list_types_SExpr_ptr items) {
         int64_t i = 1;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1006 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1006.has_value) {
-                __auto_type item = _mv_1006.value;
-                __auto_type _mv_1007 = (*item);
-                switch (_mv_1007.tag) {
+            __auto_type _mv_1007 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1007.has_value) {
+                __auto_type item = _mv_1007.value;
+                __auto_type _mv_1008 = (*item);
+                switch (_mv_1008.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type _ = _mv_1007.data.lst;
+                        __auto_type _ = _mv_1008.data.lst;
                         found = 1;
                         break;
                     }
@@ -757,7 +757,7 @@ uint8_t defn_has_payload_variants(slop_list_types_SExpr_ptr items) {
                         break;
                     }
                 }
-            } else if (!_mv_1006.has_value) {
+            } else if (!_mv_1007.has_value) {
             }
             i = (i + 1);
         }
@@ -770,11 +770,11 @@ void defn_transpile_record(context_TranspileContext* ctx, slop_string raw_name, 
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1008 = (*expr);
-        switch (_mv_1008.tag) {
+        __auto_type _mv_1009 = (*expr);
+        switch (_mv_1009.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1008.data.lst;
+                __auto_type lst = _mv_1009.data.lst;
                 {
                     __auto_type items = lst.items;
                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("struct "), qualified_name, SLOP_STR(" {")));
@@ -801,11 +801,11 @@ void defn_emit_record_fields(context_TranspileContext* ctx, slop_string raw_type
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start_idx;
         while (i < len) {
-            __auto_type _mv_1009 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1009.has_value) {
-                __auto_type field_expr = _mv_1009.value;
+            __auto_type _mv_1010 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1010.has_value) {
+                __auto_type field_expr = _mv_1010.value;
                 defn_emit_record_field(ctx, raw_type_name, qualified_type_name, field_expr);
-            } else if (!_mv_1009.has_value) {
+            } else if (!_mv_1010.has_value) {
             }
             i = (i + 1);
         }
@@ -817,28 +817,28 @@ void defn_emit_record_field(context_TranspileContext* ctx, slop_string raw_type_
     SLOP_PRE(((field != NULL)), "(!= field nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1010 = (*field);
-        switch (_mv_1010.tag) {
+        __auto_type _mv_1011 = (*field);
+        switch (_mv_1011.tag) {
             case types_SExpr_lst:
             {
-                __auto_type field_lst = _mv_1010.data.lst;
+                __auto_type field_lst = _mv_1011.data.lst;
                 {
                     __auto_type items = field_lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 2) {
                         context_ctx_emit(ctx, SLOP_STR("    /* invalid field */"));
                     } else {
-                        __auto_type _mv_1011 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1011.has_value) {
-                            __auto_type name_expr = _mv_1011.value;
-                            __auto_type _mv_1012 = (*name_expr);
-                            switch (_mv_1012.tag) {
+                        __auto_type _mv_1012 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1012.has_value) {
+                            __auto_type name_expr = _mv_1012.value;
+                            __auto_type _mv_1013 = (*name_expr);
+                            switch (_mv_1013.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1012.data.sym;
-                                    __auto_type _mv_1013 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_1013.has_value) {
-                                        __auto_type type_expr = _mv_1013.value;
+                                    __auto_type name_sym = _mv_1013.data.sym;
+                                    __auto_type _mv_1014 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_1014.has_value) {
+                                        __auto_type type_expr = _mv_1014.value;
                                         {
                                             __auto_type raw_field_name = name_sym.name;
                                             __auto_type field_name = ctype_to_c_name(arena, raw_field_name);
@@ -849,7 +849,7 @@ void defn_emit_record_field(context_TranspileContext* ctx, slop_string raw_type_
                                             context_ctx_register_field_type(ctx, raw_type_name, raw_field_name, field_type, slop_type_str, is_ptr);
                                             context_ctx_register_field_type(ctx, qualified_type_name, raw_field_name, field_type, slop_type_str, is_ptr);
                                         }
-                                    } else if (!_mv_1013.has_value) {
+                                    } else if (!_mv_1014.has_value) {
                                         context_ctx_emit(ctx, SLOP_STR("    /* missing field type */"));
                                     }
                                     break;
@@ -859,7 +859,7 @@ void defn_emit_record_field(context_TranspileContext* ctx, slop_string raw_type_
                                     break;
                                 }
                             }
-                        } else if (!_mv_1011.has_value) {
+                        } else if (!_mv_1012.has_value) {
                             context_ctx_emit(ctx, SLOP_STR("    /* missing field name */"));
                         }
                     }
@@ -879,11 +879,11 @@ void defn_transpile_enum(context_TranspileContext* ctx, slop_string raw_name, sl
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1014 = (*expr);
-        switch (_mv_1014.tag) {
+        __auto_type _mv_1015 = (*expr);
+        switch (_mv_1015.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1014.data.lst;
+                __auto_type lst = _mv_1015.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -909,14 +909,14 @@ void defn_emit_enum_values(context_TranspileContext* ctx, slop_string type_name,
         __auto_type arena = (*ctx).arena;
         int64_t i = start_idx;
         while (i < len) {
-            __auto_type _mv_1015 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1015.has_value) {
-                __auto_type val_expr = _mv_1015.value;
-                __auto_type _mv_1016 = (*val_expr);
-                switch (_mv_1016.tag) {
+            __auto_type _mv_1016 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1016.has_value) {
+                __auto_type val_expr = _mv_1016.value;
+                __auto_type _mv_1017 = (*val_expr);
+                switch (_mv_1017.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_1016.data.sym;
+                        __auto_type sym = _mv_1017.data.sym;
                         {
                             __auto_type val_name = ctype_to_c_name(arena, sym.name);
                             __auto_type full_name = context_ctx_str3(ctx, type_name, SLOP_STR("_"), val_name);
@@ -933,7 +933,7 @@ void defn_emit_enum_values(context_TranspileContext* ctx, slop_string type_name,
                         break;
                     }
                 }
-            } else if (!_mv_1015.has_value) {
+            } else if (!_mv_1016.has_value) {
             }
             i = (i + 1);
         }
@@ -945,11 +945,11 @@ void defn_transpile_union(context_TranspileContext* ctx, slop_string raw_name, s
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1017 = (*expr);
-        switch (_mv_1017.tag) {
+        __auto_type _mv_1018 = (*expr);
+        switch (_mv_1018.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1017.data.lst;
+                __auto_type lst = _mv_1018.data.lst;
                 {
                     __auto_type items = lst.items;
                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("struct "), qualified_name, SLOP_STR(" {")));
@@ -982,33 +982,33 @@ void defn_emit_union_variants(context_TranspileContext* ctx, slop_list_types_SEx
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start_idx;
         while (i < len) {
-            __auto_type _mv_1018 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1018.has_value) {
-                __auto_type variant_expr = _mv_1018.value;
-                __auto_type _mv_1019 = (*variant_expr);
-                switch (_mv_1019.tag) {
+            __auto_type _mv_1019 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1019.has_value) {
+                __auto_type variant_expr = _mv_1019.value;
+                __auto_type _mv_1020 = (*variant_expr);
+                switch (_mv_1020.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type var_lst = _mv_1019.data.lst;
+                        __auto_type var_lst = _mv_1020.data.lst;
                         {
                             __auto_type var_items = var_lst.items;
                             __auto_type var_len = ((int64_t)((var_items).len));
                             if (var_len >= 1) {
-                                __auto_type _mv_1020 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1020.has_value) {
-                                    __auto_type tag_expr = _mv_1020.value;
-                                    __auto_type _mv_1021 = (*tag_expr);
-                                    switch (_mv_1021.tag) {
+                                __auto_type _mv_1021 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1021.has_value) {
+                                    __auto_type tag_expr = _mv_1021.value;
+                                    __auto_type _mv_1022 = (*tag_expr);
+                                    switch (_mv_1022.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type tag_sym = _mv_1021.data.sym;
+                                            __auto_type tag_sym = _mv_1022.data.sym;
                                             {
                                                 __auto_type tag_name = tag_sym.name;
                                                 __auto_type c_tag = ctype_to_c_name(arena, tag_name);
                                                 if (var_len == 2) {
-                                                    __auto_type _mv_1022 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1022.has_value) {
-                                                        __auto_type type_expr = _mv_1022.value;
+                                                    __auto_type _mv_1023 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1023.has_value) {
+                                                        __auto_type type_expr = _mv_1023.value;
                                                         {
                                                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                             {
@@ -1016,14 +1016,14 @@ void defn_emit_union_variants(context_TranspileContext* ctx, slop_list_types_SEx
                                                                 context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("        "), actual_type, SLOP_STR(" "), c_tag, SLOP_STR(";")));
                                                             }
                                                         }
-                                                    } else if (!_mv_1022.has_value) {
+                                                    } else if (!_mv_1023.has_value) {
                                                     }
                                                 } else if (var_len >= 3) {
                                                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("        struct { "), SLOP_STR(""), SLOP_STR("")));
                                                     for (int64_t fi = 1; fi < var_len; fi++) {
-                                                        __auto_type _mv_1023 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                        if (_mv_1023.has_value) {
-                                                            __auto_type type_expr = _mv_1023.value;
+                                                        __auto_type _mv_1024 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                        if (_mv_1024.has_value) {
+                                                            __auto_type type_expr = _mv_1024.value;
                                                             {
                                                                 __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                                 {
@@ -1032,7 +1032,7 @@ void defn_emit_union_variants(context_TranspileContext* ctx, slop_list_types_SEx
                                                                     context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("            "), actual_type, SLOP_STR(" "), field_name, SLOP_STR(";")));
                                                                 }
                                                             }
-                                                        } else if (!_mv_1023.has_value) {
+                                                        } else if (!_mv_1024.has_value) {
                                                         }
                                                     }
                                                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("        } "), c_tag, SLOP_STR(";")));
@@ -1045,7 +1045,7 @@ void defn_emit_union_variants(context_TranspileContext* ctx, slop_list_types_SEx
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1020.has_value) {
+                                } else if (!_mv_1021.has_value) {
                                 }
                             }
                         }
@@ -1055,7 +1055,7 @@ void defn_emit_union_variants(context_TranspileContext* ctx, slop_list_types_SEx
                         break;
                     }
                 }
-            } else if (!_mv_1018.has_value) {
+            } else if (!_mv_1019.has_value) {
             }
             i = (i + 1);
         }
@@ -1070,25 +1070,25 @@ void defn_emit_tag_constants(context_TranspileContext* ctx, slop_string type_nam
         int64_t i = start_idx;
         int64_t tag_idx = 0;
         while (i < len) {
-            __auto_type _mv_1024 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1024.has_value) {
-                __auto_type variant_expr = _mv_1024.value;
-                __auto_type _mv_1025 = (*variant_expr);
-                switch (_mv_1025.tag) {
+            __auto_type _mv_1025 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1025.has_value) {
+                __auto_type variant_expr = _mv_1025.value;
+                __auto_type _mv_1026 = (*variant_expr);
+                switch (_mv_1026.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type var_lst = _mv_1025.data.lst;
+                        __auto_type var_lst = _mv_1026.data.lst;
                         {
                             __auto_type var_items = var_lst.items;
                             if (((int64_t)((var_items).len)) >= 1) {
-                                __auto_type _mv_1026 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1026.has_value) {
-                                    __auto_type tag_expr = _mv_1026.value;
-                                    __auto_type _mv_1027 = (*tag_expr);
-                                    switch (_mv_1027.tag) {
+                                __auto_type _mv_1027 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1027.has_value) {
+                                    __auto_type tag_expr = _mv_1027.value;
+                                    __auto_type _mv_1028 = (*tag_expr);
+                                    switch (_mv_1028.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type tag_sym = _mv_1027.data.sym;
+                                            __auto_type tag_sym = _mv_1028.data.sym;
                                             {
                                                 __auto_type tag_name = tag_sym.name;
                                                 __auto_type define_name = context_ctx_str4(ctx, type_name, SLOP_STR("_"), ctype_to_c_name(arena, tag_name), SLOP_STR("_TAG"));
@@ -1100,7 +1100,7 @@ void defn_emit_tag_constants(context_TranspileContext* ctx, slop_string type_nam
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1026.has_value) {
+                                } else if (!_mv_1027.has_value) {
                                 }
                             }
                             tag_idx = (tag_idx + 1);
@@ -1111,7 +1111,7 @@ void defn_emit_tag_constants(context_TranspileContext* ctx, slop_string type_nam
                         break;
                     }
                 }
-            } else if (!_mv_1024.has_value) {
+            } else if (!_mv_1025.has_value) {
             }
             i = (i + 1);
         }
@@ -1125,32 +1125,32 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start_idx;
         while (i < len) {
-            __auto_type _mv_1028 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1028.has_value) {
-                __auto_type variant_expr = _mv_1028.value;
-                __auto_type _mv_1029 = (*variant_expr);
-                switch (_mv_1029.tag) {
+            __auto_type _mv_1029 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1029.has_value) {
+                __auto_type variant_expr = _mv_1029.value;
+                __auto_type _mv_1030 = (*variant_expr);
+                switch (_mv_1030.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type var_lst = _mv_1029.data.lst;
+                        __auto_type var_lst = _mv_1030.data.lst;
                         {
                             __auto_type var_items = var_lst.items;
                             __auto_type var_len = ((int64_t)((var_items).len));
                             if (var_len >= 2) {
-                                __auto_type _mv_1030 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1030.has_value) {
-                                    __auto_type tag_expr = _mv_1030.value;
-                                    __auto_type _mv_1031 = (*tag_expr);
-                                    switch (_mv_1031.tag) {
+                                __auto_type _mv_1031 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1031.has_value) {
+                                    __auto_type tag_expr = _mv_1031.value;
+                                    __auto_type _mv_1032 = (*tag_expr);
+                                    switch (_mv_1032.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type tag_sym = _mv_1031.data.sym;
+                                            __auto_type tag_sym = _mv_1032.data.sym;
                                             {
                                                 __auto_type tag_name = tag_sym.name;
                                                 if (var_len == 2) {
-                                                    __auto_type _mv_1032 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1032.has_value) {
-                                                        __auto_type type_expr = _mv_1032.value;
+                                                    __auto_type _mv_1033 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1033.has_value) {
+                                                        __auto_type type_expr = _mv_1033.value;
                                                         {
                                                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                             __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
@@ -1158,7 +1158,7 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
                                                             context_ctx_register_field_type(ctx, raw_name, tag_name, c_type, slop_type_str, is_ptr);
                                                             context_ctx_register_field_type(ctx, qualified_name, tag_name, c_type, slop_type_str, is_ptr);
                                                         }
-                                                    } else if (!_mv_1032.has_value) {
+                                                    } else if (!_mv_1033.has_value) {
                                                     }
                                                 } else if (var_len >= 3) {
                                                     {
@@ -1168,9 +1168,9 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
                                                         context_ctx_register_field_type(ctx, qualified_name, count_key, count_str, SLOP_STR(""), 0);
                                                     }
                                                     for (int64_t fi = 1; fi < var_len; fi++) {
-                                                        __auto_type _mv_1033 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                        if (_mv_1033.has_value) {
-                                                            __auto_type type_expr = _mv_1033.value;
+                                                        __auto_type _mv_1034 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                        if (_mv_1034.has_value) {
+                                                            __auto_type type_expr = _mv_1034.value;
                                                             {
                                                                 __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                                 __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
@@ -1179,12 +1179,12 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
                                                                 context_ctx_register_field_type(ctx, raw_name, field_key, c_type, slop_type_str, is_ptr);
                                                                 context_ctx_register_field_type(ctx, qualified_name, field_key, c_type, slop_type_str, is_ptr);
                                                             }
-                                                        } else if (!_mv_1033.has_value) {
+                                                        } else if (!_mv_1034.has_value) {
                                                         }
                                                     }
-                                                    __auto_type _mv_1034 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1034.has_value) {
-                                                        __auto_type type_expr = _mv_1034.value;
+                                                    __auto_type _mv_1035 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1035.has_value) {
+                                                        __auto_type type_expr = _mv_1035.value;
                                                         {
                                                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                             __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
@@ -1192,7 +1192,7 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
                                                             context_ctx_register_field_type(ctx, raw_name, tag_name, c_type, slop_type_str, is_ptr);
                                                             context_ctx_register_field_type(ctx, qualified_name, tag_name, c_type, slop_type_str, is_ptr);
                                                         }
-                                                    } else if (!_mv_1034.has_value) {
+                                                    } else if (!_mv_1035.has_value) {
                                                     }
                                                 } else {
                                                 }
@@ -1203,7 +1203,7 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1030.has_value) {
+                                } else if (!_mv_1031.has_value) {
                                 }
                             }
                         }
@@ -1213,7 +1213,7 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
                         break;
                     }
                 }
-            } else if (!_mv_1028.has_value) {
+            } else if (!_mv_1029.has_value) {
             }
             i = (i + 1);
         }
@@ -1250,31 +1250,31 @@ uint8_t defn_is_generic_type_alias(slop_string s) {
 
 uint8_t defn_is_array_type(types_SExpr* type_expr) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_1035 = (*type_expr);
-    switch (_mv_1035.tag) {
+    __auto_type _mv_1036 = (*type_expr);
+    switch (_mv_1036.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1035.data.lst;
+            __auto_type lst = _mv_1036.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1036 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1036.has_value) {
-                        __auto_type head = _mv_1036.value;
-                        __auto_type _mv_1037 = (*head);
-                        switch (_mv_1037.tag) {
+                    __auto_type _mv_1037 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1037.has_value) {
+                        __auto_type head = _mv_1037.value;
+                        __auto_type _mv_1038 = (*head);
+                        switch (_mv_1038.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1037.data.sym;
+                                __auto_type sym = _mv_1038.data.sym;
                                 return string_eq(sym.name, SLOP_STR("Array"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1036.has_value) {
+                    } else if (!_mv_1037.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1292,23 +1292,23 @@ void defn_emit_array_typedef(context_TranspileContext* ctx, slop_string qualifie
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1038 = (*type_expr);
-        switch (_mv_1038.tag) {
+        __auto_type _mv_1039 = (*type_expr);
+        switch (_mv_1039.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1038.data.lst;
+                __auto_type lst = _mv_1039.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 3) {
                         context_ctx_emit(ctx, context_ctx_str(ctx, SLOP_STR("typedef void* "), context_ctx_str(ctx, qualified_name, SLOP_STR(";"))));
                     } else {
-                        __auto_type _mv_1039 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1039.has_value) {
-                            __auto_type elem_type_expr = _mv_1039.value;
-                            __auto_type _mv_1040 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1040.has_value) {
-                                __auto_type size_expr = _mv_1040.value;
+                        __auto_type _mv_1040 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1040.has_value) {
+                            __auto_type elem_type_expr = _mv_1040.value;
+                            __auto_type _mv_1041 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1041.has_value) {
+                                __auto_type size_expr = _mv_1041.value;
                                 {
                                     __auto_type elem_c_type = context_to_c_type_prefixed(ctx, elem_type_expr);
                                     __auto_type size_str = defn_get_number_as_string(size_expr);
@@ -1319,10 +1319,10 @@ void defn_emit_array_typedef(context_TranspileContext* ctx, slop_string qualifie
                                         context_ctx_register_type(ctx, (context_TypeEntry){qualified_name, qualified_name, ptr_type, 0, 0, 0});
                                     }
                                 }
-                            } else if (!_mv_1040.has_value) {
+                            } else if (!_mv_1041.has_value) {
                                 context_ctx_emit(ctx, context_ctx_str(ctx, SLOP_STR("typedef void* "), context_ctx_str(ctx, qualified_name, SLOP_STR(";"))));
                             }
-                        } else if (!_mv_1039.has_value) {
+                        } else if (!_mv_1040.has_value) {
                             context_ctx_emit(ctx, context_ctx_str(ctx, SLOP_STR("typedef void* "), context_ctx_str(ctx, qualified_name, SLOP_STR(";"))));
                         }
                     }
@@ -1339,11 +1339,11 @@ void defn_emit_array_typedef(context_TranspileContext* ctx, slop_string qualifie
 
 slop_string defn_get_number_as_string(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1041 = (*expr);
-    switch (_mv_1041.tag) {
+    __auto_type _mv_1042 = (*expr);
+    switch (_mv_1042.tag) {
         case types_SExpr_num:
         {
-            __auto_type num = _mv_1041.data.num;
+            __auto_type num = _mv_1042.data.num;
             return num.raw;
         }
         default: {
@@ -1354,25 +1354,25 @@ slop_string defn_get_number_as_string(types_SExpr* expr) {
 
 uint8_t defn_is_range_type(types_SExpr* type_expr) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_1042 = (*type_expr);
-    switch (_mv_1042.tag) {
+    __auto_type _mv_1043 = (*type_expr);
+    switch (_mv_1043.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1042.data.lst;
+            __auto_type lst = _mv_1043.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type found_dots = 0;
                 __auto_type i = 0;
                 while ((i < len) && !(found_dots)) {
-                    __auto_type _mv_1043 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1043.has_value) {
-                        __auto_type item = _mv_1043.value;
-                        __auto_type _mv_1044 = (*item);
-                        switch (_mv_1044.tag) {
+                    __auto_type _mv_1044 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1044.has_value) {
+                        __auto_type item = _mv_1044.value;
+                        __auto_type _mv_1045 = (*item);
+                        switch (_mv_1045.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1044.data.sym;
+                                __auto_type sym = _mv_1045.data.sym;
                                 if (string_eq(sym.name, SLOP_STR(".."))) {
                                     found_dots = 1;
                                 }
@@ -1382,7 +1382,7 @@ uint8_t defn_is_range_type(types_SExpr* type_expr) {
                                 break;
                             }
                         }
-                    } else if (!_mv_1043.has_value) {
+                    } else if (!_mv_1044.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -1403,24 +1403,24 @@ types_RangeBounds defn_parse_range_bounds(types_SExpr* type_expr) {
         uint8_t has_min = 0;
         uint8_t has_max = 0;
         uint8_t found_dots = 0;
-        __auto_type _mv_1045 = (*type_expr);
-        switch (_mv_1045.tag) {
+        __auto_type _mv_1046 = (*type_expr);
+        switch (_mv_1046.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1045.data.lst;
+                __auto_type lst = _mv_1046.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type i = 1;
                     while (i < len) {
-                        __auto_type _mv_1046 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1046.has_value) {
-                            __auto_type item = _mv_1046.value;
-                            __auto_type _mv_1047 = (*item);
-                            switch (_mv_1047.tag) {
+                        __auto_type _mv_1047 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1047.has_value) {
+                            __auto_type item = _mv_1047.value;
+                            __auto_type _mv_1048 = (*item);
+                            switch (_mv_1048.tag) {
                                 case types_SExpr_num:
                                 {
-                                    __auto_type num = _mv_1047.data.num;
+                                    __auto_type num = _mv_1048.data.num;
                                     if (!(found_dots)) {
                                         min_val = defn_string_to_int(num.raw);
                                         has_min = 1;
@@ -1432,7 +1432,7 @@ types_RangeBounds defn_parse_range_bounds(types_SExpr* type_expr) {
                                 }
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1047.data.sym;
+                                    __auto_type sym = _mv_1048.data.sym;
                                     if (string_eq(sym.name, SLOP_STR(".."))) {
                                         found_dots = 1;
                                     }
@@ -1442,7 +1442,7 @@ types_RangeBounds defn_parse_range_bounds(types_SExpr* type_expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_1046.has_value) {
+                        } else if (!_mv_1047.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -1549,25 +1549,25 @@ void defn_transpile_function(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1048 = (*expr);
-        switch (_mv_1048.tag) {
+        __auto_type _mv_1049 = (*expr);
+        switch (_mv_1049.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1048.data.lst;
+                __auto_type lst = _mv_1049.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 3) {
                         context_ctx_add_error_at(ctx, SLOP_STR("invalid fn: need name and params"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     } else {
-                        __auto_type _mv_1049 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1049.has_value) {
-                            __auto_type name_expr = _mv_1049.value;
-                            __auto_type _mv_1050 = (*name_expr);
-                            switch (_mv_1050.tag) {
+                        __auto_type _mv_1050 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1050.has_value) {
+                            __auto_type name_expr = _mv_1050.value;
+                            __auto_type _mv_1051 = (*name_expr);
+                            switch (_mv_1051.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1050.data.sym;
+                                    __auto_type name_sym = _mv_1051.data.sym;
                                     {
                                         __auto_type raw_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, raw_name);
@@ -1575,11 +1575,11 @@ void defn_transpile_function(context_TranspileContext* ctx, types_SExpr* expr) {
                                         __auto_type base_fn_name = context_extract_fn_c_name(arena, items, mangled_name);
                                         __auto_type fn_name = base_fn_name;
                                         __auto_type is_public_api = !(string_eq(base_fn_name, mangled_name));
-                                        __auto_type _mv_1051 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1051.has_value) {
-                                            __auto_type params_expr = _mv_1051.value;
+                                        __auto_type _mv_1052 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1052.has_value) {
+                                            __auto_type params_expr = _mv_1052.value;
                                             defn_emit_function_def(ctx, raw_name, fn_name, params_expr, items, is_public_api);
-                                        } else if (!_mv_1051.has_value) {
+                                        } else if (!_mv_1052.has_value) {
                                             context_ctx_add_error_at(ctx, SLOP_STR("missing params"), context_ctx_sexpr_line(name_expr), context_ctx_sexpr_col(name_expr));
                                         }
                                     }
@@ -1590,7 +1590,7 @@ void defn_transpile_function(context_TranspileContext* ctx, types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_1049.has_value) {
+                        } else if (!_mv_1050.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing function name"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                     }
@@ -1624,18 +1624,18 @@ void defn_emit_function_def(context_TranspileContext* ctx, slop_string raw_name,
             __auto_type has_post = ((((int64_t)((postconditions).len)) > 0) || (((int64_t)((assumptions).len)) > 0));
             __auto_type needs_retval = (has_post && !(string_eq(actual_return, SLOP_STR("void"))));
             context_ctx_set_current_return_type(ctx, actual_return);
-            __auto_type _mv_1052 = result_type_opt;
-            if (_mv_1052.has_value) {
-                __auto_type result_name = _mv_1052.value;
+            __auto_type _mv_1053 = result_type_opt;
+            if (_mv_1053.has_value) {
+                __auto_type result_name = _mv_1053.value;
                 context_ctx_set_current_result_type(ctx, result_name);
-            } else if (!_mv_1052.has_value) {
+            } else if (!_mv_1053.has_value) {
                 context_ctx_clear_current_result_type(ctx);
             }
-            __auto_type _mv_1053 = doc_string;
-            if (_mv_1053.has_value) {
-                __auto_type doc = _mv_1053.value;
+            __auto_type _mv_1054 = doc_string;
+            if (_mv_1054.has_value) {
+                __auto_type doc = _mv_1054.value;
                 context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("/* "), doc, SLOP_STR(" */")));
-            } else if (!_mv_1053.has_value) {
+            } else if (!_mv_1054.has_value) {
             }
             context_ctx_emit(ctx, context_ctx_str5(ctx, actual_return, SLOP_STR(" "), fn_name, SLOP_STR("("), context_ctx_str(ctx, ((string_eq(param_str, SLOP_STR(""))) ? SLOP_STR("void") : param_str), SLOP_STR(") {"))));
             context_ctx_indent(ctx);
@@ -1685,21 +1685,21 @@ void defn_bind_params_to_scope(context_TranspileContext* ctx, types_SExpr* param
     SLOP_PRE(((params_expr != NULL)), "(!= params-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1054 = (*params_expr);
-        switch (_mv_1054.tag) {
+        __auto_type _mv_1055 = (*params_expr);
+        switch (_mv_1055.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1054.data.lst;
+                __auto_type lst = _mv_1055.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type i = 0;
                     while (i < len) {
-                        __auto_type _mv_1055 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1055.has_value) {
-                            __auto_type param = _mv_1055.value;
+                        __auto_type _mv_1056 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1056.has_value) {
+                            __auto_type param = _mv_1056.value;
                             defn_bind_single_param(ctx, param);
-                        } else if (!_mv_1055.has_value) {
+                        } else if (!_mv_1056.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -1718,11 +1718,11 @@ void defn_bind_single_param(context_TranspileContext* ctx, types_SExpr* param) {
     SLOP_PRE(((param != NULL)), "(!= param nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1056 = (*param);
-        switch (_mv_1056.tag) {
+        __auto_type _mv_1057 = (*param);
+        switch (_mv_1057.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1056.data.lst;
+                __auto_type lst = _mv_1057.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -1731,17 +1731,17 @@ void defn_bind_single_param(context_TranspileContext* ctx, types_SExpr* param) {
                             __auto_type has_mode = ((len >= 3) && defn_is_param_mode(items));
                             __auto_type name_idx = ((has_mode) ? 1 : 0);
                             __auto_type type_idx = ((has_mode) ? 2 : 1);
-                            __auto_type _mv_1057 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1057.has_value) {
-                                __auto_type name_expr = _mv_1057.value;
-                                __auto_type _mv_1058 = (*name_expr);
-                                switch (_mv_1058.tag) {
+                            __auto_type _mv_1058 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1058.has_value) {
+                                __auto_type name_expr = _mv_1058.value;
+                                __auto_type _mv_1059 = (*name_expr);
+                                switch (_mv_1059.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type name_sym = _mv_1058.data.sym;
-                                        __auto_type _mv_1059 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1059.has_value) {
-                                            __auto_type type_expr = _mv_1059.value;
+                                        __auto_type name_sym = _mv_1059.data.sym;
+                                        __auto_type _mv_1060 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1060.has_value) {
+                                            __auto_type type_expr = _mv_1060.value;
                                             {
                                                 __auto_type param_name = name_sym.name;
                                                 __auto_type c_name = ctype_to_c_name(arena, param_name);
@@ -1751,7 +1751,7 @@ void defn_bind_single_param(context_TranspileContext* ctx, types_SExpr* param) {
                                                 __auto_type is_closure = defn_is_fn_type(type_expr);
                                                 context_ctx_bind_var(ctx, (context_VarEntry){param_name, c_name, c_type, slop_type_str, is_ptr, 0, is_closure, SLOP_STR(""), SLOP_STR("")});
                                             }
-                                        } else if (!_mv_1059.has_value) {
+                                        } else if (!_mv_1060.has_value) {
                                         }
                                         break;
                                     }
@@ -1759,7 +1759,7 @@ void defn_bind_single_param(context_TranspileContext* ctx, types_SExpr* param) {
                                         break;
                                     }
                                 }
-                            } else if (!_mv_1057.has_value) {
+                            } else if (!_mv_1058.has_value) {
                             }
                         }
                     }
@@ -1775,31 +1775,31 @@ void defn_bind_single_param(context_TranspileContext* ctx, types_SExpr* param) {
 
 uint8_t defn_is_pointer_type(types_SExpr* type_expr) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_1060 = (*type_expr);
-    switch (_mv_1060.tag) {
+    __auto_type _mv_1061 = (*type_expr);
+    switch (_mv_1061.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1060.data.lst;
+            __auto_type lst = _mv_1061.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1061 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1061.has_value) {
-                        __auto_type head = _mv_1061.value;
-                        __auto_type _mv_1062 = (*head);
-                        switch (_mv_1062.tag) {
+                    __auto_type _mv_1062 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1062.has_value) {
+                        __auto_type head = _mv_1062.value;
+                        __auto_type _mv_1063 = (*head);
+                        switch (_mv_1063.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1062.data.sym;
+                                __auto_type sym = _mv_1063.data.sym;
                                 return string_eq(sym.name, SLOP_STR("Ptr"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1061.has_value) {
+                    } else if (!_mv_1062.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1818,26 +1818,26 @@ slop_list_context_FuncParamType_ptr defn_collect_param_types(context_TranspileCo
     {
         __auto_type arena = (*ctx).arena;
         __auto_type result = ((slop_list_context_FuncParamType_ptr){ .data = (context_FuncParamType**)slop_arena_alloc(arena, 16 * sizeof(context_FuncParamType*)), .len = 0, .cap = 16 });
-        __auto_type _mv_1063 = (*params_expr);
-        switch (_mv_1063.tag) {
+        __auto_type _mv_1064 = (*params_expr);
+        switch (_mv_1064.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1063.data.lst;
+                __auto_type lst = _mv_1064.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type i = 0;
                     while (i < len) {
-                        __auto_type _mv_1064 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1064.has_value) {
-                            __auto_type param = _mv_1064.value;
+                        __auto_type _mv_1065 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1065.has_value) {
+                            __auto_type param = _mv_1065.value;
                             {
                                 __auto_type c_type = defn_get_param_c_type(ctx, param);
                                 __auto_type param_info = ((context_FuncParamType*)(({ __auto_type _alloc = (context_FuncParamType*)slop_arena_alloc(arena, sizeof(context_FuncParamType)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                                 (*param_info).c_type = c_type;
                                 ({ __auto_type _lst_p = &(result); __auto_type _item = (param_info); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                             }
-                        } else if (!_mv_1064.has_value) {
+                        } else if (!_mv_1065.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -1857,11 +1857,11 @@ slop_string defn_get_param_c_type(context_TranspileContext* ctx, types_SExpr* pa
     SLOP_PRE(((param != NULL)), "(!= param nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1065 = (*param);
-        switch (_mv_1065.tag) {
+        __auto_type _mv_1066 = (*param);
+        switch (_mv_1066.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1065.data.lst;
+                __auto_type lst = _mv_1066.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -1871,11 +1871,11 @@ slop_string defn_get_param_c_type(context_TranspileContext* ctx, types_SExpr* pa
                         {
                             __auto_type has_mode = ((len >= 3) && defn_is_param_mode(items));
                             __auto_type type_idx = ((has_mode) ? 2 : 1);
-                            __auto_type _mv_1066 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1066.has_value) {
-                                __auto_type type_expr = _mv_1066.value;
+                            __auto_type _mv_1067 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1067.has_value) {
+                                __auto_type type_expr = _mv_1067.value;
                                 return context_to_c_type_prefixed(ctx, type_expr);
-                            } else if (!_mv_1066.has_value) {
+                            } else if (!_mv_1067.has_value) {
                                 return SLOP_STR("void*");
                             }
                             SLOP_UNREACHABLE();
@@ -1895,31 +1895,31 @@ void defn_emit_forward_declaration(context_TranspileContext* ctx, types_SExpr* e
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1067 = (*expr);
-        switch (_mv_1067.tag) {
+        __auto_type _mv_1068 = (*expr);
+        switch (_mv_1068.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1067.data.lst;
+                __auto_type lst = _mv_1068.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 3) {
-                        __auto_type _mv_1068 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1068.has_value) {
-                            __auto_type name_expr = _mv_1068.value;
-                            __auto_type _mv_1069 = (*name_expr);
-                            switch (_mv_1069.tag) {
+                        __auto_type _mv_1069 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1069.has_value) {
+                            __auto_type name_expr = _mv_1069.value;
+                            __auto_type _mv_1070 = (*name_expr);
+                            switch (_mv_1070.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1069.data.sym;
+                                    __auto_type name_sym = _mv_1070.data.sym;
                                     {
                                         __auto_type raw_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, raw_name);
                                         __auto_type mangled_name = context_ctx_prefix_type(ctx, base_name);
                                         __auto_type fn_name = context_extract_fn_c_name(arena, items, mangled_name);
-                                        __auto_type _mv_1070 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1070.has_value) {
-                                            __auto_type params_expr = _mv_1070.value;
+                                        __auto_type _mv_1071 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1071.has_value) {
+                                            __auto_type params_expr = _mv_1071.value;
                                             {
                                                 __auto_type result_type_opt = defn_get_result_type_name(ctx, items);
                                                 __auto_type raw_return = defn_get_return_type(ctx, items);
@@ -1930,7 +1930,7 @@ void defn_emit_forward_declaration(context_TranspileContext* ctx, types_SExpr* e
                                                     context_ctx_emit(ctx, context_ctx_str5(ctx, actual_return, SLOP_STR(" "), fn_name, SLOP_STR("("), context_ctx_str(ctx, ((string_eq(param_str, SLOP_STR(""))) ? SLOP_STR("void") : param_str), SLOP_STR(");"))));
                                                 }
                                             }
-                                        } else if (!_mv_1070.has_value) {
+                                        } else if (!_mv_1071.has_value) {
                                         }
                                     }
                                     break;
@@ -1939,7 +1939,7 @@ void defn_emit_forward_declaration(context_TranspileContext* ctx, types_SExpr* e
                                     break;
                                 }
                             }
-                        } else if (!_mv_1068.has_value) {
+                        } else if (!_mv_1069.has_value) {
                         }
                     }
                 }
@@ -1960,13 +1960,13 @@ slop_string defn_get_return_type(context_TranspileContext* ctx, slop_list_types_
         int64_t i = 3;
         __auto_type result = SLOP_STR("void");
         while (i < len) {
-            __auto_type _mv_1071 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1071.has_value) {
-                __auto_type item = _mv_1071.value;
+            __auto_type _mv_1072 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1072.has_value) {
+                __auto_type item = _mv_1072.value;
                 if (defn_is_spec_form(item)) {
                     result = defn_extract_spec_return_type(ctx, item);
                 }
-            } else if (!_mv_1071.has_value) {
+            } else if (!_mv_1072.has_value) {
             }
             i = (i + 1);
         }
@@ -1976,31 +1976,31 @@ slop_string defn_get_return_type(context_TranspileContext* ctx, slop_list_types_
 
 uint8_t defn_is_spec_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1072 = (*expr);
-    switch (_mv_1072.tag) {
+    __auto_type _mv_1073 = (*expr);
+    switch (_mv_1073.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1072.data.lst;
+            __auto_type lst = _mv_1073.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1073 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1073.has_value) {
-                        __auto_type head = _mv_1073.value;
-                        __auto_type _mv_1074 = (*head);
-                        switch (_mv_1074.tag) {
+                    __auto_type _mv_1074 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1074.has_value) {
+                        __auto_type head = _mv_1074.value;
+                        __auto_type _mv_1075 = (*head);
+                        switch (_mv_1075.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1074.data.sym;
+                                __auto_type sym = _mv_1075.data.sym;
                                 return string_eq(sym.name, SLOP_STR("@spec"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1073.has_value) {
+                    } else if (!_mv_1074.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2018,35 +2018,35 @@ slop_string defn_extract_spec_return_type(context_TranspileContext* ctx, types_S
     SLOP_PRE(((spec_expr != NULL)), "(!= spec-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1075 = (*spec_expr);
-        switch (_mv_1075.tag) {
+        __auto_type _mv_1076 = (*spec_expr);
+        switch (_mv_1076.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1075.data.lst;
+                __auto_type lst = _mv_1076.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 2) {
                         return SLOP_STR("void");
                     } else {
-                        __auto_type _mv_1076 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1076.has_value) {
-                            __auto_type spec_body = _mv_1076.value;
-                            __auto_type _mv_1077 = (*spec_body);
-                            switch (_mv_1077.tag) {
+                        __auto_type _mv_1077 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1077.has_value) {
+                            __auto_type spec_body = _mv_1077.value;
+                            __auto_type _mv_1078 = (*spec_body);
+                            switch (_mv_1078.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type body_lst = _mv_1077.data.lst;
+                                    __auto_type body_lst = _mv_1078.data.lst;
                                     {
                                         __auto_type body_items = body_lst.items;
                                         __auto_type body_len = ((int64_t)((body_items).len));
                                         if (body_len < 1) {
                                             return SLOP_STR("void");
                                         } else {
-                                            __auto_type _mv_1078 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1078.has_value) {
-                                                __auto_type ret_type = _mv_1078.value;
+                                            __auto_type _mv_1079 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1079.has_value) {
+                                                __auto_type ret_type = _mv_1079.value;
                                                 return context_to_c_type_prefixed(ctx, ret_type);
-                                            } else if (!_mv_1078.has_value) {
+                                            } else if (!_mv_1079.has_value) {
                                                 return SLOP_STR("void");
                                             }
                                             SLOP_UNREACHABLE();
@@ -2057,7 +2057,7 @@ slop_string defn_extract_spec_return_type(context_TranspileContext* ctx, types_S
                                     return SLOP_STR("void");
                                 }
                             }
-                        } else if (!_mv_1076.has_value) {
+                        } else if (!_mv_1077.has_value) {
                             return SLOP_STR("void");
                         }
                         SLOP_UNREACHABLE();
@@ -2076,35 +2076,35 @@ slop_string defn_extract_spec_slop_return_type(context_TranspileContext* ctx, ty
     SLOP_PRE(((spec_expr != NULL)), "(!= spec-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1079 = (*spec_expr);
-        switch (_mv_1079.tag) {
+        __auto_type _mv_1080 = (*spec_expr);
+        switch (_mv_1080.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1079.data.lst;
+                __auto_type lst = _mv_1080.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 2) {
                         return SLOP_STR("");
                     } else {
-                        __auto_type _mv_1080 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1080.has_value) {
-                            __auto_type spec_body = _mv_1080.value;
-                            __auto_type _mv_1081 = (*spec_body);
-                            switch (_mv_1081.tag) {
+                        __auto_type _mv_1081 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1081.has_value) {
+                            __auto_type spec_body = _mv_1081.value;
+                            __auto_type _mv_1082 = (*spec_body);
+                            switch (_mv_1082.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type body_lst = _mv_1081.data.lst;
+                                    __auto_type body_lst = _mv_1082.data.lst;
                                     {
                                         __auto_type body_items = body_lst.items;
                                         __auto_type body_len = ((int64_t)((body_items).len));
                                         if (body_len < 1) {
                                             return SLOP_STR("");
                                         } else {
-                                            __auto_type _mv_1082 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1082.has_value) {
-                                                __auto_type ret_type = _mv_1082.value;
+                                            __auto_type _mv_1083 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1083.has_value) {
+                                                __auto_type ret_type = _mv_1083.value;
                                                 return parser_pretty_print(arena, ret_type);
-                                            } else if (!_mv_1082.has_value) {
+                                            } else if (!_mv_1083.has_value) {
                                                 return SLOP_STR("");
                                             }
                                             SLOP_UNREACHABLE();
@@ -2115,7 +2115,7 @@ slop_string defn_extract_spec_slop_return_type(context_TranspileContext* ctx, ty
                                     return SLOP_STR("");
                                 }
                             }
-                        } else if (!_mv_1080.has_value) {
+                        } else if (!_mv_1081.has_value) {
                             return SLOP_STR("");
                         }
                         SLOP_UNREACHABLE();
@@ -2136,13 +2136,13 @@ slop_string defn_get_slop_return_type(context_TranspileContext* ctx, slop_list_t
         int64_t i = 3;
         __auto_type result = SLOP_STR("");
         while (i < len) {
-            __auto_type _mv_1083 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1083.has_value) {
-                __auto_type item = _mv_1083.value;
+            __auto_type _mv_1084 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1084.has_value) {
+                __auto_type item = _mv_1084.value;
                 if (defn_is_spec_form(item)) {
                     result = defn_extract_spec_slop_return_type(ctx, item);
                 }
-            } else if (!_mv_1083.has_value) {
+            } else if (!_mv_1084.has_value) {
             }
             i = (i + 1);
         }
@@ -2158,13 +2158,13 @@ slop_option_string defn_get_result_type_name(context_TranspileContext* ctx, slop
         int64_t i = 3;
         slop_option_string result = (slop_option_string){.has_value = false};
         while ((i < len) && ({ __auto_type _mv = result; _mv.has_value ? ({ __auto_type _ = _mv.value; 0; }) : (1); })) {
-            __auto_type _mv_1084 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1084.has_value) {
-                __auto_type item = _mv_1084.value;
+            __auto_type _mv_1085 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1085.has_value) {
+                __auto_type item = _mv_1085.value;
                 if (defn_is_spec_form(item)) {
                     result = defn_extract_result_type_name(ctx, item);
                 }
-            } else if (!_mv_1084.has_value) {
+            } else if (!_mv_1085.has_value) {
             }
             i = (i + 1);
         }
@@ -2177,35 +2177,35 @@ slop_option_string defn_extract_result_type_name(context_TranspileContext* ctx, 
     SLOP_PRE(((spec_expr != NULL)), "(!= spec-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1085 = (*spec_expr);
-        switch (_mv_1085.tag) {
+        __auto_type _mv_1086 = (*spec_expr);
+        switch (_mv_1086.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1085.data.lst;
+                __auto_type lst = _mv_1086.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 2) {
                         return (slop_option_string){.has_value = false};
                     } else {
-                        __auto_type _mv_1086 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1086.has_value) {
-                            __auto_type spec_body = _mv_1086.value;
-                            __auto_type _mv_1087 = (*spec_body);
-                            switch (_mv_1087.tag) {
+                        __auto_type _mv_1087 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1087.has_value) {
+                            __auto_type spec_body = _mv_1087.value;
+                            __auto_type _mv_1088 = (*spec_body);
+                            switch (_mv_1088.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type body_lst = _mv_1087.data.lst;
+                                    __auto_type body_lst = _mv_1088.data.lst;
                                     {
                                         __auto_type body_items = body_lst.items;
                                         __auto_type body_len = ((int64_t)((body_items).len));
                                         if (body_len < 1) {
                                             return (slop_option_string){.has_value = false};
                                         } else {
-                                            __auto_type _mv_1088 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1088.has_value) {
-                                                __auto_type ret_type = _mv_1088.value;
+                                            __auto_type _mv_1089 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1089.has_value) {
+                                                __auto_type ret_type = _mv_1089.value;
                                                 return defn_check_result_type(ctx, ret_type);
-                                            } else if (!_mv_1088.has_value) {
+                                            } else if (!_mv_1089.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
                                             SLOP_UNREACHABLE();
@@ -2216,7 +2216,7 @@ slop_option_string defn_extract_result_type_name(context_TranspileContext* ctx, 
                                     return (slop_option_string){.has_value = false};
                                 }
                             }
-                        } else if (!_mv_1086.has_value) {
+                        } else if (!_mv_1087.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -2235,23 +2235,23 @@ slop_option_string defn_check_result_type(context_TranspileContext* ctx, types_S
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1089 = (*type_expr);
-        switch (_mv_1089.tag) {
+        __auto_type _mv_1090 = (*type_expr);
+        switch (_mv_1090.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1089.data.sym;
+                __auto_type sym = _mv_1090.data.sym;
                 {
                     __auto_type type_name = sym.name;
-                    __auto_type _mv_1090 = context_ctx_lookup_result_type_alias(ctx, type_name);
-                    if (_mv_1090.has_value) {
-                        __auto_type alias_result = _mv_1090.value;
+                    __auto_type _mv_1091 = context_ctx_lookup_result_type_alias(ctx, type_name);
+                    if (_mv_1091.has_value) {
+                        __auto_type alias_result = _mv_1091.value;
                         return (slop_option_string){.has_value = 1, .value = alias_result};
-                    } else if (!_mv_1090.has_value) {
-                        __auto_type _mv_1091 = context_ctx_lookup_type(ctx, type_name);
-                        if (_mv_1091.has_value) {
-                            __auto_type entry = _mv_1091.value;
+                    } else if (!_mv_1091.has_value) {
+                        __auto_type _mv_1092 = context_ctx_lookup_type(ctx, type_name);
+                        if (_mv_1092.has_value) {
+                            __auto_type entry = _mv_1092.value;
                             return (slop_option_string){.has_value = 1, .value = entry.c_name};
-                        } else if (!_mv_1091.has_value) {
+                        } else if (!_mv_1092.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -2261,38 +2261,38 @@ slop_option_string defn_check_result_type(context_TranspileContext* ctx, types_S
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1089.data.lst;
+                __auto_type lst = _mv_1090.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 3) {
                         return (slop_option_string){.has_value = false};
                     } else {
-                        __auto_type _mv_1092 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1092.has_value) {
-                            __auto_type head = _mv_1092.value;
-                            __auto_type _mv_1093 = (*head);
-                            switch (_mv_1093.tag) {
+                        __auto_type _mv_1093 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1093.has_value) {
+                            __auto_type head = _mv_1093.value;
+                            __auto_type _mv_1094 = (*head);
+                            switch (_mv_1094.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1093.data.sym;
+                                    __auto_type sym = _mv_1094.data.sym;
                                     if (string_eq(sym.name, SLOP_STR("Result"))) {
-                                        __auto_type _mv_1094 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1094.has_value) {
-                                            __auto_type ok_type_expr = _mv_1094.value;
-                                            __auto_type _mv_1095 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1095.has_value) {
-                                                __auto_type err_type_expr = _mv_1095.value;
+                                        __auto_type _mv_1095 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1095.has_value) {
+                                            __auto_type ok_type_expr = _mv_1095.value;
+                                            __auto_type _mv_1096 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1096.has_value) {
+                                                __auto_type err_type_expr = _mv_1096.value;
                                                 {
                                                     __auto_type ok_c_type = context_to_c_type_prefixed(ctx, ok_type_expr);
                                                     __auto_type err_c_type = context_to_c_type_prefixed(ctx, err_type_expr);
                                                     __auto_type result_name = defn_build_result_name(arena, ok_c_type, err_c_type);
                                                     return (slop_option_string){.has_value = 1, .value = result_name};
                                                 }
-                                            } else if (!_mv_1095.has_value) {
+                                            } else if (!_mv_1096.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
                                             SLOP_UNREACHABLE();
-                                        } else if (!_mv_1094.has_value) {
+                                        } else if (!_mv_1095.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
                                         SLOP_UNREACHABLE();
@@ -2304,7 +2304,7 @@ slop_option_string defn_check_result_type(context_TranspileContext* ctx, types_S
                                     return (slop_option_string){.has_value = false};
                                 }
                             }
-                        } else if (!_mv_1092.has_value) {
+                        } else if (!_mv_1093.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -2331,20 +2331,20 @@ slop_string defn_build_param_str(context_TranspileContext* ctx, types_SExpr* par
     SLOP_PRE(((params_expr != NULL)), "(!= params-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1096 = (*params_expr);
-        switch (_mv_1096.tag) {
+        __auto_type _mv_1097 = (*params_expr);
+        switch (_mv_1097.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1096.data.lst;
+                __auto_type lst = _mv_1097.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type result = SLOP_STR("");
                     __auto_type i = 0;
                     while (i < len) {
-                        __auto_type _mv_1097 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1097.has_value) {
-                            __auto_type param = _mv_1097.value;
+                        __auto_type _mv_1098 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1098.has_value) {
+                            __auto_type param = _mv_1098.value;
                             {
                                 __auto_type param_str = defn_build_single_param(ctx, param);
                                 if (string_eq(result, SLOP_STR(""))) {
@@ -2353,7 +2353,7 @@ slop_string defn_build_param_str(context_TranspileContext* ctx, types_SExpr* par
                                     result = context_ctx_str3(ctx, result, SLOP_STR(", "), param_str);
                                 }
                             }
-                        } else if (!_mv_1097.has_value) {
+                        } else if (!_mv_1098.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -2372,11 +2372,11 @@ slop_string defn_build_single_param(context_TranspileContext* ctx, types_SExpr* 
     SLOP_PRE(((param != NULL)), "(!= param nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1098 = (*param);
-        switch (_mv_1098.tag) {
+        __auto_type _mv_1099 = (*param);
+        switch (_mv_1099.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1098.data.lst;
+                __auto_type lst = _mv_1099.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -2387,17 +2387,17 @@ slop_string defn_build_single_param(context_TranspileContext* ctx, types_SExpr* 
                             __auto_type has_mode = ((len >= 3) && defn_is_param_mode(items));
                             __auto_type name_idx = ((((len >= 3) && defn_is_param_mode(items))) ? 1 : 0);
                             __auto_type type_idx = ((((len >= 3) && defn_is_param_mode(items))) ? 2 : 1);
-                            __auto_type _mv_1099 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1099.has_value) {
-                                __auto_type name_expr = _mv_1099.value;
-                                __auto_type _mv_1100 = (*name_expr);
-                                switch (_mv_1100.tag) {
+                            __auto_type _mv_1100 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1100.has_value) {
+                                __auto_type name_expr = _mv_1100.value;
+                                __auto_type _mv_1101 = (*name_expr);
+                                switch (_mv_1101.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type name_sym = _mv_1100.data.sym;
-                                        __auto_type _mv_1101 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1101.has_value) {
-                                            __auto_type type_expr = _mv_1101.value;
+                                        __auto_type name_sym = _mv_1101.data.sym;
+                                        __auto_type _mv_1102 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1102.has_value) {
+                                            __auto_type type_expr = _mv_1102.value;
                                             {
                                                 __auto_type param_name = ctype_to_c_name(arena, name_sym.name);
                                                 {
@@ -2405,7 +2405,7 @@ slop_string defn_build_single_param(context_TranspileContext* ctx, types_SExpr* 
                                                     return context_ctx_str3(ctx, param_type, SLOP_STR(" "), param_name);
                                                 }
                                             }
-                                        } else if (!_mv_1101.has_value) {
+                                        } else if (!_mv_1102.has_value) {
                                             return SLOP_STR("/* missing param type */");
                                         }
                                         SLOP_UNREACHABLE();
@@ -2414,7 +2414,7 @@ slop_string defn_build_single_param(context_TranspileContext* ctx, types_SExpr* 
                                         return SLOP_STR("/* param name must be symbol */");
                                     }
                                 }
-                            } else if (!_mv_1099.has_value) {
+                            } else if (!_mv_1100.has_value) {
                                 return SLOP_STR("/* missing param name */");
                             }
                             SLOP_UNREACHABLE();
@@ -2433,14 +2433,14 @@ uint8_t defn_is_param_mode(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_1102 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1102.has_value) {
-            __auto_type first = _mv_1102.value;
-            __auto_type _mv_1103 = (*first);
-            switch (_mv_1103.tag) {
+        __auto_type _mv_1103 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1103.has_value) {
+            __auto_type first = _mv_1103.value;
+            __auto_type _mv_1104 = (*first);
+            switch (_mv_1104.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_1103.data.sym;
+                    __auto_type sym = _mv_1104.data.sym;
                     {
                         __auto_type name = sym.name;
                         return ((string_eq(name, SLOP_STR("in"))) || (string_eq(name, SLOP_STR("out"))) || (string_eq(name, SLOP_STR("mut"))));
@@ -2450,7 +2450,7 @@ uint8_t defn_is_param_mode(slop_list_types_SExpr_ptr items) {
                     return 0;
                 }
             }
-        } else if (!_mv_1102.has_value) {
+        } else if (!_mv_1103.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -2458,31 +2458,31 @@ uint8_t defn_is_param_mode(slop_list_types_SExpr_ptr items) {
 }
 
 uint8_t defn_is_fn_type(types_SExpr* type_expr) {
-    __auto_type _mv_1104 = (*type_expr);
-    switch (_mv_1104.tag) {
+    __auto_type _mv_1105 = (*type_expr);
+    switch (_mv_1105.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1104.data.lst;
+            __auto_type lst = _mv_1105.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1105 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1105.has_value) {
-                        __auto_type first = _mv_1105.value;
-                        __auto_type _mv_1106 = (*first);
-                        switch (_mv_1106.tag) {
+                    __auto_type _mv_1106 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1106.has_value) {
+                        __auto_type first = _mv_1106.value;
+                        __auto_type _mv_1107 = (*first);
+                        switch (_mv_1107.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1106.data.sym;
+                                __auto_type sym = _mv_1107.data.sym;
                                 return string_eq(sym.name, SLOP_STR("Fn"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1105.has_value) {
+                    } else if (!_mv_1106.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2499,11 +2499,11 @@ slop_string defn_emit_fn_param_type(context_TranspileContext* ctx, types_SExpr* 
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1107 = (*type_expr);
-        switch (_mv_1107.tag) {
+        __auto_type _mv_1108 = (*type_expr);
+        switch (_mv_1108.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1107.data.lst;
+                __auto_type lst = _mv_1108.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -2515,14 +2515,14 @@ slop_string defn_emit_fn_param_type(context_TranspileContext* ctx, types_SExpr* 
                             if (len == 2) {
                                 return context_ctx_str(ctx, context_ctx_str(ctx, ret_type, SLOP_STR("(*")), context_ctx_str(ctx, param_name, SLOP_STR(")(void)")));
                             } else {
-                                __auto_type _mv_1108 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1108.has_value) {
-                                    __auto_type args_expr = _mv_1108.value;
+                                __auto_type _mv_1109 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1109.has_value) {
+                                    __auto_type args_expr = _mv_1109.value;
                                     {
                                         __auto_type args_str = defn_build_fn_args_str_for_param(ctx, args_expr);
                                         return context_ctx_str(ctx, context_ctx_str(ctx, ret_type, SLOP_STR("(*")), context_ctx_str(ctx, param_name, context_ctx_str(ctx, SLOP_STR(")"), args_str)));
                                     }
-                                } else if (!_mv_1108.has_value) {
+                                } else if (!_mv_1109.has_value) {
                                     return context_ctx_str(ctx, context_ctx_str(ctx, ret_type, SLOP_STR("(*")), context_ctx_str(ctx, param_name, SLOP_STR(")(void)")));
                                 }
                                 SLOP_UNREACHABLE();
@@ -2542,11 +2542,11 @@ slop_string defn_build_fn_args_str_for_param(context_TranspileContext* ctx, type
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1109 = (*args_expr);
-        switch (_mv_1109.tag) {
+        __auto_type _mv_1110 = (*args_expr);
+        switch (_mv_1110.tag) {
             case types_SExpr_lst:
             {
-                __auto_type args_list = _mv_1109.data.lst;
+                __auto_type args_list = _mv_1110.data.lst;
                 {
                     __auto_type arg_items = args_list.items;
                     __auto_type arg_count = ((int64_t)((arg_items).len));
@@ -2557,9 +2557,9 @@ slop_string defn_build_fn_args_str_for_param(context_TranspileContext* ctx, type
                             __auto_type result = SLOP_STR("(");
                             __auto_type i = 0;
                             while (i < arg_count) {
-                                __auto_type _mv_1110 = ({ __auto_type _lst = arg_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1110.has_value) {
-                                    __auto_type arg_expr = _mv_1110.value;
+                                __auto_type _mv_1111 = ({ __auto_type _lst = arg_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1111.has_value) {
+                                    __auto_type arg_expr = _mv_1111.value;
                                     {
                                         __auto_type arg_type = context_to_c_type_prefixed(ctx, arg_expr);
                                         if (i > 0) {
@@ -2568,7 +2568,7 @@ slop_string defn_build_fn_args_str_for_param(context_TranspileContext* ctx, type
                                             result = context_ctx_str(ctx, result, arg_type);
                                         }
                                     }
-                                } else if (!_mv_1110.has_value) {
+                                } else if (!_mv_1111.has_value) {
                                     /* empty list */;
                                 }
                                 i = (i + 1);
@@ -2594,9 +2594,9 @@ void defn_emit_function_body(context_TranspileContext* ctx, slop_list_types_SExp
         __auto_type body_start = defn_find_body_start(items);
         i = body_start;
         while (i < len) {
-            __auto_type _mv_1111 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1111.has_value) {
-                __auto_type item = _mv_1111.value;
+            __auto_type _mv_1112 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1112.has_value) {
+                __auto_type item = _mv_1112.value;
                 if (defn_is_c_name_attr(item)) {
                     i = (i + 1);
                 } else {
@@ -2608,7 +2608,7 @@ void defn_emit_function_body(context_TranspileContext* ctx, slop_list_types_SExp
                         }
                     }
                 }
-            } else if (!_mv_1111.has_value) {
+            } else if (!_mv_1112.has_value) {
             }
             i = (i + 1);
         }
@@ -2617,11 +2617,11 @@ void defn_emit_function_body(context_TranspileContext* ctx, slop_list_types_SExp
 
 uint8_t defn_is_c_name_attr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1112 = (*expr);
-    switch (_mv_1112.tag) {
+    __auto_type _mv_1113 = (*expr);
+    switch (_mv_1113.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1112.data.sym;
+            __auto_type sym = _mv_1113.data.sym;
             return string_eq(sym.name, SLOP_STR(":c-name"));
         }
         default: {
@@ -2636,9 +2636,9 @@ uint8_t defn_is_last_body_item(slop_list_types_SExpr_ptr items, int64_t current_
         int64_t i = (current_i + 1);
         uint8_t found_body = 0;
         while ((i < len) && !(found_body)) {
-            __auto_type _mv_1113 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1113.has_value) {
-                __auto_type item = _mv_1113.value;
+            __auto_type _mv_1114 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1114.has_value) {
+                __auto_type item = _mv_1114.value;
                 if (defn_is_annotation(item) || defn_is_c_name_attr(item)) {
                     i = (i + 1);
                 } else {
@@ -2648,7 +2648,7 @@ uint8_t defn_is_last_body_item(slop_list_types_SExpr_ptr items, int64_t current_
                         found_body = 1;
                     }
                 }
-            } else if (!_mv_1113.has_value) {
+            } else if (!_mv_1114.has_value) {
                 i = (i + 1);
             }
         }
@@ -2657,11 +2657,11 @@ uint8_t defn_is_last_body_item(slop_list_types_SExpr_ptr items, int64_t current_
 }
 
 uint8_t defn_is_c_name_attr_at(slop_list_types_SExpr_ptr items, int64_t idx) {
-    __auto_type _mv_1114 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-    if (_mv_1114.has_value) {
-        __auto_type item = _mv_1114.value;
+    __auto_type _mv_1115 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+    if (_mv_1115.has_value) {
+        __auto_type item = _mv_1115.value;
         return defn_is_c_name_attr(item);
-    } else if (!_mv_1114.has_value) {
+    } else if (!_mv_1115.has_value) {
         return 0;
     }
     SLOP_UNREACHABLE();
@@ -2673,15 +2673,15 @@ int64_t defn_find_body_start(slop_list_types_SExpr_ptr items) {
         int64_t i = 3;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1115 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1115.has_value) {
-                __auto_type item = _mv_1115.value;
+            __auto_type _mv_1116 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1116.has_value) {
+                __auto_type item = _mv_1116.value;
                 if (defn_is_annotation(item)) {
                     i = (i + 1);
                 } else {
                     found = 1;
                 }
-            } else if (!_mv_1115.has_value) {
+            } else if (!_mv_1116.has_value) {
                 found = 1;
             }
         }
@@ -2691,24 +2691,24 @@ int64_t defn_find_body_start(slop_list_types_SExpr_ptr items) {
 
 uint8_t defn_is_annotation(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1116 = (*expr);
-    switch (_mv_1116.tag) {
+    __auto_type _mv_1117 = (*expr);
+    switch (_mv_1117.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1116.data.lst;
+            __auto_type lst = _mv_1117.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1117 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1117.has_value) {
-                        __auto_type head = _mv_1117.value;
-                        __auto_type _mv_1118 = (*head);
-                        switch (_mv_1118.tag) {
+                    __auto_type _mv_1118 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1118.has_value) {
+                        __auto_type head = _mv_1118.value;
+                        __auto_type _mv_1119 = (*head);
+                        switch (_mv_1119.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1118.data.sym;
+                                __auto_type sym = _mv_1119.data.sym;
                                 {
                                     __auto_type name = sym.name;
                                     return ((string_eq(name, SLOP_STR("@intent"))) || (string_eq(name, SLOP_STR("@spec"))) || (string_eq(name, SLOP_STR("@pre"))) || (string_eq(name, SLOP_STR("@post"))) || (string_eq(name, SLOP_STR("@assume"))) || (string_eq(name, SLOP_STR("@alloc"))) || (string_eq(name, SLOP_STR("@example"))) || (string_eq(name, SLOP_STR("@pure"))) || (string_eq(name, SLOP_STR("@doc"))) || (string_eq(name, SLOP_STR("@loop-invariant"))) || (string_eq(name, SLOP_STR("@property"))) || (string_eq(name, SLOP_STR("@callback-assume"))) || (string_eq(name, SLOP_STR("@generic"))));
@@ -2718,7 +2718,7 @@ uint8_t defn_is_annotation(types_SExpr* expr) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1117.has_value) {
+                    } else if (!_mv_1118.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2733,31 +2733,31 @@ uint8_t defn_is_annotation(types_SExpr* expr) {
 
 uint8_t defn_is_pre_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1119 = (*expr);
-    switch (_mv_1119.tag) {
+    __auto_type _mv_1120 = (*expr);
+    switch (_mv_1120.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1119.data.lst;
+            __auto_type lst = _mv_1120.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1120 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1120.has_value) {
-                        __auto_type head = _mv_1120.value;
-                        __auto_type _mv_1121 = (*head);
-                        switch (_mv_1121.tag) {
+                    __auto_type _mv_1121 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1121.has_value) {
+                        __auto_type head = _mv_1121.value;
+                        __auto_type _mv_1122 = (*head);
+                        switch (_mv_1122.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1121.data.sym;
+                                __auto_type sym = _mv_1122.data.sym;
                                 return string_eq(sym.name, SLOP_STR("@pre"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1120.has_value) {
+                    } else if (!_mv_1121.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2772,31 +2772,31 @@ uint8_t defn_is_pre_form(types_SExpr* expr) {
 
 uint8_t defn_is_post_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1122 = (*expr);
-    switch (_mv_1122.tag) {
+    __auto_type _mv_1123 = (*expr);
+    switch (_mv_1123.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1122.data.lst;
+            __auto_type lst = _mv_1123.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1123 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1123.has_value) {
-                        __auto_type head = _mv_1123.value;
-                        __auto_type _mv_1124 = (*head);
-                        switch (_mv_1124.tag) {
+                    __auto_type _mv_1124 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1124.has_value) {
+                        __auto_type head = _mv_1124.value;
+                        __auto_type _mv_1125 = (*head);
+                        switch (_mv_1125.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1124.data.sym;
+                                __auto_type sym = _mv_1125.data.sym;
                                 return string_eq(sym.name, SLOP_STR("@post"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1123.has_value) {
+                    } else if (!_mv_1124.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2811,31 +2811,31 @@ uint8_t defn_is_post_form(types_SExpr* expr) {
 
 uint8_t defn_is_assume_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1125 = (*expr);
-    switch (_mv_1125.tag) {
+    __auto_type _mv_1126 = (*expr);
+    switch (_mv_1126.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1125.data.lst;
+            __auto_type lst = _mv_1126.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1126 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1126.has_value) {
-                        __auto_type head = _mv_1126.value;
-                        __auto_type _mv_1127 = (*head);
-                        switch (_mv_1127.tag) {
+                    __auto_type _mv_1127 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1127.has_value) {
+                        __auto_type head = _mv_1127.value;
+                        __auto_type _mv_1128 = (*head);
+                        switch (_mv_1128.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1127.data.sym;
+                                __auto_type sym = _mv_1128.data.sym;
                                 return string_eq(sym.name, SLOP_STR("@assume"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1126.has_value) {
+                    } else if (!_mv_1127.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2850,11 +2850,11 @@ uint8_t defn_is_assume_form(types_SExpr* expr) {
 
 uint8_t defn_is_verification_only_expr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1128 = (*expr);
-    switch (_mv_1128.tag) {
+    __auto_type _mv_1129 = (*expr);
+    switch (_mv_1129.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1128.data.lst;
+            __auto_type lst = _mv_1129.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
@@ -2864,14 +2864,14 @@ uint8_t defn_is_verification_only_expr(types_SExpr* expr) {
                     {
                         __auto_type found = 0;
                         __auto_type i = 0;
-                        __auto_type _mv_1129 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1129.has_value) {
-                            __auto_type head = _mv_1129.value;
-                            __auto_type _mv_1130 = (*head);
-                            switch (_mv_1130.tag) {
+                        __auto_type _mv_1130 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1130.has_value) {
+                            __auto_type head = _mv_1130.value;
+                            __auto_type _mv_1131 = (*head);
+                            switch (_mv_1131.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1130.data.sym;
+                                    __auto_type sym = _mv_1131.data.sym;
                                     {
                                         __auto_type name = sym.name;
                                         if ((string_eq(name, SLOP_STR("forall"))) || (string_eq(name, SLOP_STR("exists"))) || (string_eq(name, SLOP_STR("implies")))) {
@@ -2884,16 +2884,16 @@ uint8_t defn_is_verification_only_expr(types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_1129.has_value) {
+                        } else if (!_mv_1130.has_value) {
                         }
                         while ((i < len) && !(found)) {
-                            __auto_type _mv_1131 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1131.has_value) {
-                                __auto_type item = _mv_1131.value;
+                            __auto_type _mv_1132 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1132.has_value) {
+                                __auto_type item = _mv_1132.value;
                                 if (defn_is_verification_only_expr(item)) {
                                     found = 1;
                                 }
-                            } else if (!_mv_1131.has_value) {
+                            } else if (!_mv_1132.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -2910,31 +2910,31 @@ uint8_t defn_is_verification_only_expr(types_SExpr* expr) {
 
 uint8_t defn_is_doc_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1132 = (*expr);
-    switch (_mv_1132.tag) {
+    __auto_type _mv_1133 = (*expr);
+    switch (_mv_1133.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1132.data.lst;
+            __auto_type lst = _mv_1133.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1133 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1133.has_value) {
-                        __auto_type head = _mv_1133.value;
-                        __auto_type _mv_1134 = (*head);
-                        switch (_mv_1134.tag) {
+                    __auto_type _mv_1134 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1134.has_value) {
+                        __auto_type head = _mv_1134.value;
+                        __auto_type _mv_1135 = (*head);
+                        switch (_mv_1135.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1134.data.sym;
+                                __auto_type sym = _mv_1135.data.sym;
                                 return string_eq(sym.name, SLOP_STR("@doc"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1133.has_value) {
+                    } else if (!_mv_1134.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2951,22 +2951,22 @@ slop_option_string defn_get_doc_string(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         slop_option_string result = (slop_option_string){.has_value = false};
-        __auto_type _mv_1135 = (*expr);
-        switch (_mv_1135.tag) {
+        __auto_type _mv_1136 = (*expr);
+        switch (_mv_1136.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1135.data.lst;
+                __auto_type lst = _mv_1136.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_1136 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1136.has_value) {
-                            __auto_type val = _mv_1136.value;
-                            __auto_type _mv_1137 = (*val);
-                            switch (_mv_1137.tag) {
+                        __auto_type _mv_1137 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1137.has_value) {
+                            __auto_type val = _mv_1137.value;
+                            __auto_type _mv_1138 = (*val);
+                            switch (_mv_1138.tag) {
                                 case types_SExpr_str:
                                 {
-                                    __auto_type str = _mv_1137.data.str;
+                                    __auto_type str = _mv_1138.data.str;
                                     result = (slop_option_string){.has_value = 1, .value = str.value};
                                     break;
                                 }
@@ -2974,7 +2974,7 @@ slop_option_string defn_get_doc_string(types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_1136.has_value) {
+                        } else if (!_mv_1137.has_value) {
                         }
                     }
                 }
@@ -2994,13 +2994,13 @@ slop_option_string defn_collect_doc_string(slop_arena* arena, slop_list_types_SE
         int64_t i = 3;
         slop_option_string result = (slop_option_string){.has_value = false};
         while ((i < len) && ({ __auto_type _mv = result; _mv.has_value ? (0) : (1); })) {
-            __auto_type _mv_1138 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1138.has_value) {
-                __auto_type item = _mv_1138.value;
+            __auto_type _mv_1139 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1139.has_value) {
+                __auto_type item = _mv_1139.value;
                 if (defn_is_doc_form(item)) {
                     result = defn_get_doc_string(item);
                 }
-            } else if (!_mv_1138.has_value) {
+            } else if (!_mv_1139.has_value) {
             }
             i = (i + 1);
         }
@@ -3012,19 +3012,19 @@ slop_option_types_SExpr_ptr defn_get_annotation_condition(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         slop_option_types_SExpr_ptr result = (slop_option_types_SExpr_ptr){.has_value = false};
-        __auto_type _mv_1139 = (*expr);
-        switch (_mv_1139.tag) {
+        __auto_type _mv_1140 = (*expr);
+        switch (_mv_1140.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1139.data.lst;
+                __auto_type lst = _mv_1140.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_1140 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1140.has_value) {
-                            __auto_type val = _mv_1140.value;
+                        __auto_type _mv_1141 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1141.has_value) {
+                            __auto_type val = _mv_1141.value;
                             result = (slop_option_types_SExpr_ptr){.has_value = 1, .value = val};
-                        } else if (!_mv_1140.has_value) {
+                        } else if (!_mv_1141.has_value) {
                         }
                     }
                 }
@@ -3044,18 +3044,18 @@ slop_list_types_SExpr_ptr defn_collect_preconditions(slop_arena* arena, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 3;
         while (i < len) {
-            __auto_type _mv_1141 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1141.has_value) {
-                __auto_type item = _mv_1141.value;
+            __auto_type _mv_1142 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1142.has_value) {
+                __auto_type item = _mv_1142.value;
                 if (defn_is_pre_form(item)) {
-                    __auto_type _mv_1142 = defn_get_annotation_condition(item);
-                    if (_mv_1142.has_value) {
-                        __auto_type cond = _mv_1142.value;
+                    __auto_type _mv_1143 = defn_get_annotation_condition(item);
+                    if (_mv_1143.has_value) {
+                        __auto_type cond = _mv_1143.value;
                         ({ __auto_type _lst_p = &(result); __auto_type _item = (cond); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                    } else if (!_mv_1142.has_value) {
+                    } else if (!_mv_1143.has_value) {
                     }
                 }
-            } else if (!_mv_1141.has_value) {
+            } else if (!_mv_1142.has_value) {
             }
             i = (i + 1);
         }
@@ -3069,18 +3069,18 @@ slop_list_types_SExpr_ptr defn_collect_postconditions(slop_arena* arena, slop_li
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 3;
         while (i < len) {
-            __auto_type _mv_1143 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1143.has_value) {
-                __auto_type item = _mv_1143.value;
+            __auto_type _mv_1144 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1144.has_value) {
+                __auto_type item = _mv_1144.value;
                 if (defn_is_post_form(item)) {
-                    __auto_type _mv_1144 = defn_get_annotation_condition(item);
-                    if (_mv_1144.has_value) {
-                        __auto_type cond = _mv_1144.value;
+                    __auto_type _mv_1145 = defn_get_annotation_condition(item);
+                    if (_mv_1145.has_value) {
+                        __auto_type cond = _mv_1145.value;
                         ({ __auto_type _lst_p = &(result); __auto_type _item = (cond); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                    } else if (!_mv_1144.has_value) {
+                    } else if (!_mv_1145.has_value) {
                     }
                 }
-            } else if (!_mv_1143.has_value) {
+            } else if (!_mv_1144.has_value) {
             }
             i = (i + 1);
         }
@@ -3094,18 +3094,18 @@ slop_list_types_SExpr_ptr defn_collect_assumptions(slop_arena* arena, slop_list_
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 3;
         while (i < len) {
-            __auto_type _mv_1145 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1145.has_value) {
-                __auto_type item = _mv_1145.value;
+            __auto_type _mv_1146 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1146.has_value) {
+                __auto_type item = _mv_1146.value;
                 if (defn_is_assume_form(item)) {
-                    __auto_type _mv_1146 = defn_get_annotation_condition(item);
-                    if (_mv_1146.has_value) {
-                        __auto_type cond = _mv_1146.value;
+                    __auto_type _mv_1147 = defn_get_annotation_condition(item);
+                    if (_mv_1147.has_value) {
+                        __auto_type cond = _mv_1147.value;
                         ({ __auto_type _lst_p = &(result); __auto_type _item = (cond); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                    } else if (!_mv_1146.has_value) {
+                    } else if (!_mv_1147.has_value) {
                     }
                 }
-            } else if (!_mv_1145.has_value) {
+            } else if (!_mv_1146.has_value) {
             }
             i = (i + 1);
         }
@@ -3119,13 +3119,13 @@ uint8_t defn_has_postconditions(slop_list_types_SExpr_ptr items) {
         int64_t i = 3;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1147 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1147.has_value) {
-                __auto_type item = _mv_1147.value;
+            __auto_type _mv_1148 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1148.has_value) {
+                __auto_type item = _mv_1148.value;
                 if (defn_is_post_form(item) || defn_is_assume_form(item)) {
                     found = 1;
                 }
-            } else if (!_mv_1147.has_value) {
+            } else if (!_mv_1148.has_value) {
             }
             i = (i + 1);
         }
@@ -3140,16 +3140,16 @@ void defn_emit_preconditions(context_TranspileContext* ctx, slop_list_types_SExp
         __auto_type len = ((int64_t)((preconditions).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1148 = ({ __auto_type _lst = preconditions; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1148.has_value) {
-                __auto_type cond_expr = _mv_1148.value;
+            __auto_type _mv_1149 = ({ __auto_type _lst = preconditions; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1149.has_value) {
+                __auto_type cond_expr = _mv_1149.value;
                 {
                     __auto_type cond_c = expr_transpile_expr(ctx, cond_expr);
                     __auto_type expr_str = parser_pretty_print(arena, cond_expr);
                     __auto_type escaped_str = defn_escape_for_c_string(arena, expr_str);
                     context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("SLOP_PRE(("), cond_c, SLOP_STR("), \""), escaped_str, SLOP_STR("\");")));
                 }
-            } else if (!_mv_1148.has_value) {
+            } else if (!_mv_1149.has_value) {
             }
             i = (i + 1);
         }
@@ -3163,9 +3163,9 @@ void defn_emit_postconditions(context_TranspileContext* ctx, slop_list_types_SEx
         __auto_type len = ((int64_t)((postconditions).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1149 = ({ __auto_type _lst = postconditions; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1149.has_value) {
-                __auto_type cond_expr = _mv_1149.value;
+            __auto_type _mv_1150 = ({ __auto_type _lst = postconditions; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1150.has_value) {
+                __auto_type cond_expr = _mv_1150.value;
                 if (!(defn_is_verification_only_expr(cond_expr))) {
                     {
                         __auto_type cond_c = expr_transpile_expr(ctx, cond_expr);
@@ -3174,7 +3174,7 @@ void defn_emit_postconditions(context_TranspileContext* ctx, slop_list_types_SEx
                         context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("SLOP_POST(("), cond_c, SLOP_STR("), \""), escaped_str, SLOP_STR("\");")));
                     }
                 }
-            } else if (!_mv_1149.has_value) {
+            } else if (!_mv_1150.has_value) {
             }
             i = (i + 1);
         }
@@ -3188,9 +3188,9 @@ void defn_emit_assumptions(context_TranspileContext* ctx, slop_list_types_SExpr_
         __auto_type len = ((int64_t)((assumptions).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1150 = ({ __auto_type _lst = assumptions; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1150.has_value) {
-                __auto_type cond_expr = _mv_1150.value;
+            __auto_type _mv_1151 = ({ __auto_type _lst = assumptions; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1151.has_value) {
+                __auto_type cond_expr = _mv_1151.value;
                 if (!(defn_is_verification_only_expr(cond_expr))) {
                     {
                         __auto_type cond_c = expr_transpile_expr(ctx, cond_expr);
@@ -3199,7 +3199,7 @@ void defn_emit_assumptions(context_TranspileContext* ctx, slop_list_types_SExpr_
                         context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("SLOP_POST(("), cond_c, SLOP_STR("), \""), escaped_str, SLOP_STR("\");")));
                     }
                 }
-            } else if (!_mv_1150.has_value) {
+            } else if (!_mv_1151.has_value) {
             }
             i = (i + 1);
         }

--- a/bootstrap/compiler/slop_env.c
+++ b/bootstrap/compiler/slop_env.c
@@ -223,11 +223,11 @@ void env_env_bind_var(env_TypeEnv* env, slop_string name, types_ResolvedType* va
         __auto_type arena = (*env).arena;
         __auto_type scopes = (*env).scopes;
         __auto_type top_idx = (((int64_t)((scopes).len)) - 1);
-        __auto_type _mv_920 = ({ __auto_type _lst = scopes; size_t _idx = (size_t)top_idx; slop_option_env_CheckerScope_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_920.has_value) {
-            __auto_type scope_ptr = _mv_920.value;
+        __auto_type _mv_921 = ({ __auto_type _lst = scopes; size_t _idx = (size_t)top_idx; slop_option_env_CheckerScope_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_921.has_value) {
+            __auto_type scope_ptr = _mv_921.value;
             ({ __auto_type _lst_p = &((*scope_ptr).bindings); __auto_type _item = ((env_VarBinding){name, var_type}); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-        } else if (!_mv_920.has_value) {
+        } else if (!_mv_921.has_value) {
         }
     }
 }
@@ -240,14 +240,14 @@ slop_option_types_ResolvedType_ptr env_scope_lookup_var(env_CheckerScope* scope_
         uint8_t found = 0;
         slop_option_types_ResolvedType_ptr result = (slop_option_types_ResolvedType_ptr){.has_value = false};
         for (int64_t j = 0; j < num_bindings; j++) {
-            __auto_type _mv_921 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)j; slop_option_env_VarBinding _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_921.has_value) {
-                __auto_type binding = _mv_921.value;
+            __auto_type _mv_922 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)j; slop_option_env_VarBinding _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_922.has_value) {
+                __auto_type binding = _mv_922.value;
                 if (!(found) && string_eq(binding.name, name)) {
                     found = 1;
                     result = (slop_option_types_ResolvedType_ptr){.has_value = 1, .value = binding.var_type};
                 }
-            } else if (!_mv_921.has_value) {
+            } else if (!_mv_922.has_value) {
             }
         }
         return result;
@@ -265,17 +265,17 @@ slop_option_types_ResolvedType_ptr env_env_lookup_var(env_TypeEnv* env, slop_str
             if (!(found)) {
                 {
                     __auto_type scope_idx = ((num_scopes) - (1) - (i));
-                    __auto_type _mv_922 = ({ __auto_type _lst = scopes; size_t _idx = (size_t)scope_idx; slop_option_env_CheckerScope_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_922.has_value) {
-                        __auto_type scope_ptr = _mv_922.value;
-                        __auto_type _mv_923 = env_scope_lookup_var(scope_ptr, name);
-                        if (_mv_923.has_value) {
-                            __auto_type var_type = _mv_923.value;
+                    __auto_type _mv_923 = ({ __auto_type _lst = scopes; size_t _idx = (size_t)scope_idx; slop_option_env_CheckerScope_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_923.has_value) {
+                        __auto_type scope_ptr = _mv_923.value;
+                        __auto_type _mv_924 = env_scope_lookup_var(scope_ptr, name);
+                        if (_mv_924.has_value) {
+                            __auto_type var_type = _mv_924.value;
                             found = 1;
                             result = (slop_option_types_ResolvedType_ptr){.has_value = 1, .value = var_type};
-                        } else if (!_mv_923.has_value) {
+                        } else if (!_mv_924.has_value) {
                         }
-                    } else if (!_mv_922.has_value) {
+                    } else if (!_mv_923.has_value) {
                     }
                 }
             }
@@ -291,22 +291,22 @@ void env_env_register_constant(env_TypeEnv* env, slop_string name, types_Resolve
 }
 
 uint8_t env_env_constant_matches_module(env_ConstBinding binding, slop_string mod_name) {
-    __auto_type _mv_924 = binding.module_name;
-    if (_mv_924.has_value) {
-        __auto_type bmod = _mv_924.value;
+    __auto_type _mv_925 = binding.module_name;
+    if (_mv_925.has_value) {
+        __auto_type bmod = _mv_925.value;
         return string_eq(bmod, mod_name);
-    } else if (!_mv_924.has_value) {
+    } else if (!_mv_925.has_value) {
         return 0;
     }
     SLOP_UNREACHABLE();
 }
 
 uint8_t env_env_constant_is_builtin(env_ConstBinding binding) {
-    __auto_type _mv_925 = binding.module_name;
-    if (!_mv_925.has_value) {
+    __auto_type _mv_926 = binding.module_name;
+    if (!_mv_926.has_value) {
         return 1;
-    } else if (_mv_925.has_value) {
-        __auto_type _ = _mv_925.value;
+    } else if (_mv_926.has_value) {
+        __auto_type _ = _mv_926.value;
         return 0;
     }
     SLOP_UNREACHABLE();
@@ -320,13 +320,13 @@ uint8_t env_env_lookup_constant_in_module(env_TypeEnv* env, slop_string mod_name
         uint8_t found = 0;
         for (int64_t i = 0; i < len; i++) {
             if (!(found)) {
-                __auto_type _mv_926 = ({ __auto_type _lst = constants; size_t _idx = (size_t)i; slop_option_env_ConstBinding _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_926.has_value) {
-                    __auto_type binding = _mv_926.value;
+                __auto_type _mv_927 = ({ __auto_type _lst = constants; size_t _idx = (size_t)i; slop_option_env_ConstBinding _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_927.has_value) {
+                    __auto_type binding = _mv_927.value;
                     if (string_eq(binding.name, const_name) && env_env_constant_matches_module(binding, mod_name)) {
                         found = 1;
                     }
-                } else if (!_mv_926.has_value) {
+                } else if (!_mv_927.has_value) {
                 }
             }
         }
@@ -342,28 +342,28 @@ slop_option_types_ResolvedType_ptr env_env_lookup_constant(env_TypeEnv* env, slo
         __auto_type current_mod = env_env_get_module(env);
         uint8_t found = 0;
         types_ResolvedType* found_type = NULL;
-        __auto_type _mv_927 = current_mod;
-        if (_mv_927.has_value) {
-            __auto_type mod = _mv_927.value;
+        __auto_type _mv_928 = current_mod;
+        if (_mv_928.has_value) {
+            __auto_type mod = _mv_928.value;
             for (int64_t i = 0; i < len; i++) {
                 if (!(found)) {
-                    __auto_type _mv_928 = ({ __auto_type _lst = constants; size_t _idx = (size_t)i; slop_option_env_ConstBinding _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_928.has_value) {
-                        __auto_type binding = _mv_928.value;
+                    __auto_type _mv_929 = ({ __auto_type _lst = constants; size_t _idx = (size_t)i; slop_option_env_ConstBinding _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_929.has_value) {
+                        __auto_type binding = _mv_929.value;
                         if (string_eq(binding.name, name) && env_env_constant_matches_module(binding, mod)) {
                             found = 1;
                             found_type = binding.const_type;
                         }
-                    } else if (!_mv_928.has_value) {
+                    } else if (!_mv_929.has_value) {
                     }
                 }
             }
-        } else if (!_mv_927.has_value) {
+        } else if (!_mv_928.has_value) {
         }
         if (!(found)) {
-            __auto_type _mv_929 = env_env_resolve_import(env, name);
-            if (_mv_929.has_value) {
-                __auto_type qualified_name = _mv_929.value;
+            __auto_type _mv_930 = env_env_resolve_import(env, name);
+            if (_mv_930.has_value) {
+                __auto_type qualified_name = _mv_930.value;
                 {
                     __auto_type colon_pos = env_find_colon_pos(qualified_name);
                     if (colon_pos != -1) {
@@ -371,34 +371,34 @@ slop_option_types_ResolvedType_ptr env_env_lookup_constant(env_TypeEnv* env, slo
                             __auto_type mod_part = (slop_string){.len = ((uint64_t)(colon_pos)), .data = qualified_name.data};
                             for (int64_t i = 0; i < len; i++) {
                                 if (!(found)) {
-                                    __auto_type _mv_930 = ({ __auto_type _lst = constants; size_t _idx = (size_t)i; slop_option_env_ConstBinding _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_930.has_value) {
-                                        __auto_type binding = _mv_930.value;
+                                    __auto_type _mv_931 = ({ __auto_type _lst = constants; size_t _idx = (size_t)i; slop_option_env_ConstBinding _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_931.has_value) {
+                                        __auto_type binding = _mv_931.value;
                                         if (string_eq(binding.name, name) && env_env_constant_matches_module(binding, mod_part)) {
                                             found = 1;
                                             found_type = binding.const_type;
                                         }
-                                    } else if (!_mv_930.has_value) {
+                                    } else if (!_mv_931.has_value) {
                                     }
                                 }
                             }
                         }
                     }
                 }
-            } else if (!_mv_929.has_value) {
+            } else if (!_mv_930.has_value) {
             }
         }
         if (!(found)) {
             for (int64_t i = 0; i < len; i++) {
                 if (!(found)) {
-                    __auto_type _mv_931 = ({ __auto_type _lst = constants; size_t _idx = (size_t)i; slop_option_env_ConstBinding _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_931.has_value) {
-                        __auto_type binding = _mv_931.value;
+                    __auto_type _mv_932 = ({ __auto_type _lst = constants; size_t _idx = (size_t)i; slop_option_env_ConstBinding _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_932.has_value) {
+                        __auto_type binding = _mv_932.value;
                         if (string_eq(binding.name, name) && env_env_constant_is_builtin(binding)) {
                             found = 1;
                             found_type = binding.const_type;
                         }
-                    } else if (!_mv_931.has_value) {
+                    } else if (!_mv_932.has_value) {
                     }
                 }
             }
@@ -425,14 +425,14 @@ slop_option_types_ResolvedType_ptr env_env_lookup_type_direct(env_TypeEnv* env, 
         uint8_t found = 0;
         slop_option_types_ResolvedType_ptr result = (slop_option_types_ResolvedType_ptr){.has_value = false};
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_932 = ({ __auto_type _lst = types; size_t _idx = (size_t)i; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_932.has_value) {
-                __auto_type t = _mv_932.value;
+            __auto_type _mv_933 = ({ __auto_type _lst = types; size_t _idx = (size_t)i; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_933.has_value) {
+                __auto_type t = _mv_933.value;
                 if (!(found) && string_eq((*t).name, name)) {
                     found = 1;
                     result = (slop_option_types_ResolvedType_ptr){.has_value = 1, .value = t};
                 }
-            } else if (!_mv_932.has_value) {
+            } else if (!_mv_933.has_value) {
             }
         }
         return result;
@@ -475,27 +475,27 @@ slop_option_types_ResolvedType_ptr env_lookup_type_by_qualified_name(env_TypeEnv
 
 slop_option_types_ResolvedType_ptr env_env_lookup_type(env_TypeEnv* env, slop_string name) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_933 = env_env_lookup_type_direct(env, name);
-    if (_mv_933.has_value) {
-        __auto_type t = _mv_933.value;
+    __auto_type _mv_934 = env_env_lookup_type_direct(env, name);
+    if (_mv_934.has_value) {
+        __auto_type t = _mv_934.value;
         if (env_env_is_type_visible(env, t)) {
             return (slop_option_types_ResolvedType_ptr){.has_value = 1, .value = t};
         } else {
-            __auto_type _mv_934 = env_env_resolve_import(env, name);
-            if (_mv_934.has_value) {
-                __auto_type qualified_name = _mv_934.value;
+            __auto_type _mv_935 = env_env_resolve_import(env, name);
+            if (_mv_935.has_value) {
+                __auto_type qualified_name = _mv_935.value;
                 return env_lookup_type_by_qualified_name(env, qualified_name);
-            } else if (!_mv_934.has_value) {
+            } else if (!_mv_935.has_value) {
                 return (slop_option_types_ResolvedType_ptr){.has_value = false};
             }
             SLOP_UNREACHABLE();
         }
-    } else if (!_mv_933.has_value) {
-        __auto_type _mv_935 = env_env_resolve_import(env, name);
-        if (_mv_935.has_value) {
-            __auto_type qualified_name = _mv_935.value;
+    } else if (!_mv_934.has_value) {
+        __auto_type _mv_936 = env_env_resolve_import(env, name);
+        if (_mv_936.has_value) {
+            __auto_type qualified_name = _mv_936.value;
             return env_lookup_type_by_qualified_name(env, qualified_name);
-        } else if (!_mv_935.has_value) {
+        } else if (!_mv_936.has_value) {
             return (slop_option_types_ResolvedType_ptr){.has_value = false};
         }
         SLOP_UNREACHABLE();
@@ -511,21 +511,21 @@ slop_option_types_ResolvedType_ptr env_env_lookup_type_qualified(env_TypeEnv* en
         uint8_t found = 0;
         slop_option_types_ResolvedType_ptr result = (slop_option_types_ResolvedType_ptr){.has_value = false};
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_936 = ({ __auto_type _lst = types; size_t _idx = (size_t)i; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_936.has_value) {
-                __auto_type t = _mv_936.value;
+            __auto_type _mv_937 = ({ __auto_type _lst = types; size_t _idx = (size_t)i; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_937.has_value) {
+                __auto_type t = _mv_937.value;
                 if (!(found)) {
-                    __auto_type _mv_937 = (*t).module_name;
-                    if (_mv_937.has_value) {
-                        __auto_type mod = _mv_937.value;
+                    __auto_type _mv_938 = (*t).module_name;
+                    if (_mv_938.has_value) {
+                        __auto_type mod = _mv_938.value;
                         if (string_eq(mod, module_name) && string_eq((*t).name, type_name)) {
                             found = 1;
                             result = (slop_option_types_ResolvedType_ptr){.has_value = 1, .value = t};
                         }
-                    } else if (!_mv_937.has_value) {
+                    } else if (!_mv_938.has_value) {
                     }
                 }
-            } else if (!_mv_936.has_value) {
+            } else if (!_mv_937.has_value) {
             }
         }
         return result;
@@ -535,16 +535,16 @@ slop_option_types_ResolvedType_ptr env_env_lookup_type_qualified(env_TypeEnv* en
 uint8_t env_env_is_type_visible(env_TypeEnv* env, types_ResolvedType* t) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((t != NULL)), "(!= t nil)");
-    __auto_type _mv_938 = (*t).module_name;
-    if (!_mv_938.has_value) {
+    __auto_type _mv_939 = (*t).module_name;
+    if (!_mv_939.has_value) {
         return 1;
-    } else if (_mv_938.has_value) {
-        __auto_type mod = _mv_938.value;
-        __auto_type _mv_939 = env_env_get_module(env);
-        if (_mv_939.has_value) {
-            __auto_type current = _mv_939.value;
+    } else if (_mv_939.has_value) {
+        __auto_type mod = _mv_939.value;
+        __auto_type _mv_940 = env_env_get_module(env);
+        if (_mv_940.has_value) {
+            __auto_type current = _mv_940.value;
             return string_eq(mod, current);
-        } else if (!_mv_939.has_value) {
+        } else if (!_mv_940.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -555,16 +555,16 @@ uint8_t env_env_is_type_visible(env_TypeEnv* env, types_ResolvedType* t) {
 uint8_t env_env_is_function_visible(env_TypeEnv* env, types_FnSignature* sig) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((sig != NULL)), "(!= sig nil)");
-    __auto_type _mv_940 = (*sig).module_name;
-    if (!_mv_940.has_value) {
+    __auto_type _mv_941 = (*sig).module_name;
+    if (!_mv_941.has_value) {
         return 1;
-    } else if (_mv_940.has_value) {
-        __auto_type mod = _mv_940.value;
-        __auto_type _mv_941 = env_env_get_module(env);
-        if (_mv_941.has_value) {
-            __auto_type current = _mv_941.value;
+    } else if (_mv_941.has_value) {
+        __auto_type mod = _mv_941.value;
+        __auto_type _mv_942 = env_env_get_module(env);
+        if (_mv_942.has_value) {
+            __auto_type current = _mv_942.value;
             return string_eq(mod, current);
-        } else if (!_mv_941.has_value) {
+        } else if (!_mv_942.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -586,14 +586,14 @@ slop_option_types_FnSignature_ptr env_env_lookup_function_direct(env_TypeEnv* en
         uint8_t found = 0;
         slop_option_types_FnSignature_ptr result = (slop_option_types_FnSignature_ptr){.has_value = false};
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_942 = ({ __auto_type _lst = functions; size_t _idx = (size_t)i; slop_option_types_FnSignature_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_942.has_value) {
-                __auto_type sig = _mv_942.value;
+            __auto_type _mv_943 = ({ __auto_type _lst = functions; size_t _idx = (size_t)i; slop_option_types_FnSignature_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_943.has_value) {
+                __auto_type sig = _mv_943.value;
                 if (!(found) && (string_eq((*sig).name, name) || string_eq((*sig).c_name, name))) {
                     found = 1;
                     result = (slop_option_types_FnSignature_ptr){.has_value = 1, .value = sig};
                 }
-            } else if (!_mv_942.has_value) {
+            } else if (!_mv_943.has_value) {
             }
         }
         return result;
@@ -602,45 +602,45 @@ slop_option_types_FnSignature_ptr env_env_lookup_function_direct(env_TypeEnv* en
 
 slop_option_types_FnSignature_ptr env_env_lookup_function(env_TypeEnv* env, slop_string name) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_943 = env_env_lookup_function_direct(env, name);
-    if (_mv_943.has_value) {
-        __auto_type sig = _mv_943.value;
+    __auto_type _mv_944 = env_env_lookup_function_direct(env, name);
+    if (_mv_944.has_value) {
+        __auto_type sig = _mv_944.value;
         if (env_env_is_function_visible(env, sig)) {
             return (slop_option_types_FnSignature_ptr){.has_value = 1, .value = sig};
         } else {
-            __auto_type _mv_944 = env_env_resolve_import(env, name);
-            if (_mv_944.has_value) {
-                __auto_type import_qualified = _mv_944.value;
+            __auto_type _mv_945 = env_env_resolve_import(env, name);
+            if (_mv_945.has_value) {
+                __auto_type import_qualified = _mv_945.value;
                 return env_env_lookup_function_direct(env, import_qualified);
-            } else if (!_mv_944.has_value) {
-                __auto_type _mv_945 = env_env_get_module(env);
-                if (_mv_945.has_value) {
-                    __auto_type mod = _mv_945.value;
+            } else if (!_mv_945.has_value) {
+                __auto_type _mv_946 = env_env_get_module(env);
+                if (_mv_946.has_value) {
+                    __auto_type mod = _mv_946.value;
                     {
                         __auto_type qualified = string_concat(env_env_arena(env), mod, string_concat(env_env_arena(env), SLOP_STR(":"), name));
                         return env_env_lookup_function_direct(env, qualified);
                     }
-                } else if (!_mv_945.has_value) {
+                } else if (!_mv_946.has_value) {
                     return (slop_option_types_FnSignature_ptr){.has_value = false};
                 }
                 SLOP_UNREACHABLE();
             }
             SLOP_UNREACHABLE();
         }
-    } else if (!_mv_943.has_value) {
-        __auto_type _mv_946 = env_env_resolve_import(env, name);
-        if (_mv_946.has_value) {
-            __auto_type import_qualified = _mv_946.value;
+    } else if (!_mv_944.has_value) {
+        __auto_type _mv_947 = env_env_resolve_import(env, name);
+        if (_mv_947.has_value) {
+            __auto_type import_qualified = _mv_947.value;
             return env_env_lookup_function_direct(env, import_qualified);
-        } else if (!_mv_946.has_value) {
-            __auto_type _mv_947 = env_env_get_module(env);
-            if (_mv_947.has_value) {
-                __auto_type mod = _mv_947.value;
+        } else if (!_mv_947.has_value) {
+            __auto_type _mv_948 = env_env_get_module(env);
+            if (_mv_948.has_value) {
+                __auto_type mod = _mv_948.value;
                 {
                     __auto_type qualified = string_concat(env_env_arena(env), mod, string_concat(env_env_arena(env), SLOP_STR(":"), name));
                     return env_env_lookup_function_direct(env, qualified);
                 }
-            } else if (!_mv_947.has_value) {
+            } else if (!_mv_948.has_value) {
                 return (slop_option_types_FnSignature_ptr){.has_value = false};
             }
             SLOP_UNREACHABLE();
@@ -663,14 +663,14 @@ slop_option_string env_env_resolve_import(env_TypeEnv* env, slop_string local_na
         uint8_t found = 0;
         slop_option_string result = (slop_option_string){.has_value = false};
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_948 = ({ __auto_type _lst = imports; size_t _idx = (size_t)i; slop_option_env_ImportEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_948.has_value) {
-                __auto_type entry = _mv_948.value;
+            __auto_type _mv_949 = ({ __auto_type _lst = imports; size_t _idx = (size_t)i; slop_option_env_ImportEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_949.has_value) {
+                __auto_type entry = _mv_949.value;
                 if (!(found) && string_eq(entry.local, local_name)) {
                     found = 1;
                     result = (slop_option_string){.has_value = 1, .value = entry.qualified};
                 }
-            } else if (!_mv_948.has_value) {
+            } else if (!_mv_949.has_value) {
             }
         }
         return result;
@@ -691,22 +691,22 @@ void env_env_register_variant(env_TypeEnv* env, slop_string variant_name, slop_s
 }
 
 uint8_t env_env_variant_matches_module(env_VariantMapping v, slop_string mod_name) {
-    __auto_type _mv_949 = v.module_name;
-    if (_mv_949.has_value) {
-        __auto_type vmod = _mv_949.value;
+    __auto_type _mv_950 = v.module_name;
+    if (_mv_950.has_value) {
+        __auto_type vmod = _mv_950.value;
         return string_eq(vmod, mod_name);
-    } else if (!_mv_949.has_value) {
+    } else if (!_mv_950.has_value) {
         return 0;
     }
     SLOP_UNREACHABLE();
 }
 
 uint8_t env_env_variant_is_builtin(env_VariantMapping v) {
-    __auto_type _mv_950 = v.module_name;
-    if (!_mv_950.has_value) {
+    __auto_type _mv_951 = v.module_name;
+    if (!_mv_951.has_value) {
         return 1;
-    } else if (_mv_950.has_value) {
-        __auto_type _ = _mv_950.value;
+    } else if (_mv_951.has_value) {
+        __auto_type _ = _mv_951.value;
         return 0;
     }
     SLOP_UNREACHABLE();
@@ -720,31 +720,15 @@ slop_option_string env_env_lookup_variant(env_TypeEnv* env, slop_string variant_
         __auto_type current_mod = env_env_get_module(env);
         uint8_t found = 0;
         slop_string found_name = SLOP_STR("");
-        __auto_type _mv_951 = current_mod;
-        if (_mv_951.has_value) {
-            __auto_type mod = _mv_951.value;
-            for (int64_t i = 0; i < len; i++) {
-                if (!(found)) {
-                    __auto_type _mv_952 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_env_VariantMapping _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_952.has_value) {
-                        __auto_type v = _mv_952.value;
-                        if (string_eq(v.variant_name, variant_name) && env_env_variant_matches_module(v, mod)) {
-                            found = 1;
-                            found_name = v.enum_name;
-                        }
-                    } else if (!_mv_952.has_value) {
-                    }
-                }
-            }
-        } else if (!_mv_951.has_value) {
-        }
-        if (!(found)) {
+        __auto_type _mv_952 = current_mod;
+        if (_mv_952.has_value) {
+            __auto_type mod = _mv_952.value;
             for (int64_t i = 0; i < len; i++) {
                 if (!(found)) {
                     __auto_type _mv_953 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_env_VariantMapping _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                     if (_mv_953.has_value) {
                         __auto_type v = _mv_953.value;
-                        if (string_eq(v.variant_name, variant_name) && env_env_variant_is_builtin(v)) {
+                        if (string_eq(v.variant_name, variant_name) && env_env_variant_matches_module(v, mod)) {
                             found = 1;
                             found_name = v.enum_name;
                         }
@@ -752,6 +736,7 @@ slop_option_string env_env_lookup_variant(env_TypeEnv* env, slop_string variant_
                     }
                 }
             }
+        } else if (!_mv_952.has_value) {
         }
         if (!(found)) {
             for (int64_t i = 0; i < len; i++) {
@@ -759,21 +744,36 @@ slop_option_string env_env_lookup_variant(env_TypeEnv* env, slop_string variant_
                     __auto_type _mv_954 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_env_VariantMapping _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                     if (_mv_954.has_value) {
                         __auto_type v = _mv_954.value;
-                        if (string_eq(v.variant_name, variant_name)) {
-                            __auto_type _mv_955 = v.module_name;
-                            if (_mv_955.has_value) {
-                                __auto_type vmod = _mv_955.value;
-                                __auto_type _mv_956 = env_env_resolve_import(env, v.enum_name);
-                                if (_mv_956.has_value) {
-                                    __auto_type _ = _mv_956.value;
-                                    found = 1;
-                                    found_name = v.enum_name;
-                                } else if (!_mv_956.has_value) {
-                                }
-                            } else if (!_mv_955.has_value) {
-                            }
+                        if (string_eq(v.variant_name, variant_name) && env_env_variant_is_builtin(v)) {
+                            found = 1;
+                            found_name = v.enum_name;
                         }
                     } else if (!_mv_954.has_value) {
+                    }
+                }
+            }
+        }
+        if (!(found)) {
+            for (int64_t i = 0; i < len; i++) {
+                if (!(found)) {
+                    __auto_type _mv_955 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_env_VariantMapping _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_955.has_value) {
+                        __auto_type v = _mv_955.value;
+                        if (string_eq(v.variant_name, variant_name)) {
+                            __auto_type _mv_956 = v.module_name;
+                            if (_mv_956.has_value) {
+                                __auto_type vmod = _mv_956.value;
+                                __auto_type _mv_957 = env_env_resolve_import(env, v.enum_name);
+                                if (_mv_957.has_value) {
+                                    __auto_type _ = _mv_957.value;
+                                    found = 1;
+                                    found_name = v.enum_name;
+                                } else if (!_mv_957.has_value) {
+                                }
+                            } else if (!_mv_956.has_value) {
+                            }
+                        }
+                    } else if (!_mv_955.has_value) {
                     }
                 }
             }
@@ -793,9 +793,9 @@ void env_env_check_variant_collisions(env_TypeEnv* env) {
         __auto_type len = ((int64_t)((variants).len));
         __auto_type arena = (*env).arena;
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_957 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_env_VariantMapping _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_957.has_value) {
-                __auto_type v1 = _mv_957.value;
+            __auto_type _mv_958 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_env_VariantMapping _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_958.has_value) {
+                __auto_type v1 = _mv_958.value;
                 {
                     __auto_type name1 = v1.variant_name;
                     __auto_type enum1 = v1.enum_name;
@@ -803,14 +803,14 @@ void env_env_check_variant_collisions(env_TypeEnv* env) {
                     __auto_type found_collision = 0;
                     slop_string collision_enum = SLOP_STR("");
                     for (int64_t j = (i + 1); j < len; j++) {
-                        __auto_type _mv_958 = ({ __auto_type _lst = variants; size_t _idx = (size_t)j; slop_option_env_VariantMapping _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_958.has_value) {
-                            __auto_type v2 = _mv_958.value;
+                        __auto_type _mv_959 = ({ __auto_type _lst = variants; size_t _idx = (size_t)j; slop_option_env_VariantMapping _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_959.has_value) {
+                            __auto_type v2 = _mv_959.value;
                             if (!(found_collision) && (string_eq(v2.variant_name, name1) && (!(string_eq(v2.enum_name, enum1)) && env_env_same_module_opt(mod1, v2.module_name)))) {
                                 found_collision = 1;
                                 collision_enum = v2.enum_name;
                             }
-                        } else if (!_mv_958.has_value) {
+                        } else if (!_mv_959.has_value) {
                         }
                     }
                     if (found_collision) {
@@ -820,30 +820,30 @@ void env_env_check_variant_collisions(env_TypeEnv* env) {
                         }
                     }
                 }
-            } else if (!_mv_957.has_value) {
+            } else if (!_mv_958.has_value) {
             }
         }
     }
 }
 
 uint8_t env_env_same_module_opt(slop_option_string a, slop_option_string b) {
-    __auto_type _mv_959 = a;
-    if (!_mv_959.has_value) {
-        __auto_type _mv_960 = b;
-        if (!_mv_960.has_value) {
+    __auto_type _mv_960 = a;
+    if (!_mv_960.has_value) {
+        __auto_type _mv_961 = b;
+        if (!_mv_961.has_value) {
             return 1;
-        } else if (_mv_960.has_value) {
-            __auto_type _ = _mv_960.value;
+        } else if (_mv_961.has_value) {
+            __auto_type _ = _mv_961.value;
             return 0;
         }
         SLOP_UNREACHABLE();
-    } else if (_mv_959.has_value) {
-        __auto_type amod = _mv_959.value;
-        __auto_type _mv_961 = b;
-        if (!_mv_961.has_value) {
+    } else if (_mv_960.has_value) {
+        __auto_type amod = _mv_960.value;
+        __auto_type _mv_962 = b;
+        if (!_mv_962.has_value) {
             return 0;
-        } else if (_mv_961.has_value) {
-            __auto_type bmod = _mv_961.value;
+        } else if (_mv_962.has_value) {
+            __auto_type bmod = _mv_962.value;
             return string_eq(amod, bmod);
         }
         SLOP_UNREACHABLE();
@@ -1053,13 +1053,13 @@ uint8_t env_env_is_module_loaded(env_TypeEnv* env, slop_string module_path) {
         __auto_type len = ((int64_t)((modules).len));
         uint8_t found = 0;
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_962 = ({ __auto_type _lst = modules; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_962.has_value) {
-                __auto_type path = _mv_962.value;
+            __auto_type _mv_963 = ({ __auto_type _lst = modules; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_963.has_value) {
+                __auto_type path = _mv_963.value;
                 if (!(found) && string_eq(path, module_path)) {
                     found = 1;
                 }
-            } else if (!_mv_962.has_value) {
+            } else if (!_mv_963.has_value) {
             }
         }
         return found;
@@ -1089,13 +1089,13 @@ uint8_t env_env_is_type_param(env_TypeEnv* env, slop_string name) {
         uint8_t found = 0;
         for (int64_t i = 0; i < len; i++) {
             if (!(found)) {
-                __auto_type _mv_963 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_963.has_value) {
-                    __auto_type p = _mv_963.value;
+                __auto_type _mv_964 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_964.has_value) {
+                    __auto_type p = _mv_964.value;
                     if (string_eq(p, name)) {
                         found = 1;
                     }
-                } else if (!_mv_963.has_value) {
+                } else if (!_mv_964.has_value) {
                 }
             }
         }

--- a/bootstrap/compiler/slop_expr.c
+++ b/bootstrap/compiler/slop_expr.c
@@ -8621,14 +8621,15 @@ slop_string expr_transpile_with_arena_expr(context_TranspileContext* ctx, slop_l
                 __auto_type arena_name = ((is_named) ? ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type name_expr = _mv.value; ({ __auto_type _mv = (*name_expr); slop_string _mr = {0}; switch (_mv.tag) { case types_SExpr_sym: { __auto_type s2 = _mv.data.sym; _mr = s2.name; break; } default: { _mr = SLOP_STR("arena"); break; }  } _mr; }); }) : (SLOP_STR("arena")); }) : SLOP_STR("arena"));
                 __auto_type size_idx = ((is_named) ? 3 : 1);
                 __auto_type body_start = ((is_named) ? 4 : 2);
-                __auto_type c_local = ((is_named) ? string_concat(arena, SLOP_STR("_arena_"), arena_name) : SLOP_STR("_arena"));
+                __auto_type c_arena_name = ctype_to_c_name(arena, arena_name);
+                __auto_type c_local = ((is_named) ? string_concat(arena, SLOP_STR("_arena_"), c_arena_name) : SLOP_STR("_arena"));
                 if (is_named && (len < 5)) {
                     context_ctx_add_error_at(ctx, SLOP_STR("with-arena :as requires name, size and body"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("({ (void)0; })");
                 } else {
                     context_ctx_push_scope(ctx);
                     {
-                        __auto_type result_str = ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type size_expr = _mv.value; ({ __auto_type size_c = expr_transpile_expr(ctx, size_expr); __auto_type result = context_ctx_str5(ctx, SLOP_STR("({ slop_arena "), c_local, SLOP_STR(" = slop_arena_new("), size_c, SLOP_STR("); ")); ({ result = context_ctx_str5(ctx, result, SLOP_STR("slop_arena* "), arena_name, SLOP_STR(" = &"), context_ctx_str(ctx, c_local, SLOP_STR("; "))); (void)0; }); context_ctx_bind_var(ctx, (context_VarEntry){arena_name, arena_name, SLOP_STR("slop_arena*"), SLOP_STR(""), 1, 0, 0, SLOP_STR(""), SLOP_STR("")}); ({ __auto_type i = body_start; ({ while ((i < (len - 1))) { ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); if (_mv.has_value) { __auto_type body_expr = _mv.value; ({ __auto_type body_c = expr_transpile_expr(ctx, body_expr); ({ result = context_ctx_str3(ctx, result, body_c, SLOP_STR("; ")); (void)0; }); }); } else { ({ (void)0; }); } (void)0; }); ({ i = (i + 1); (void)0; }); } (void)0; }); }); ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)(len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); if (_mv.has_value) { __auto_type last_expr = _mv.value; ({ __auto_type last_c = expr_transpile_expr(ctx, last_expr); __auto_type free_part = context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), arena_name, SLOP_STR("); ")); ({ result = context_ctx_str5(ctx, result, SLOP_STR("__auto_type _wa_result = "), last_c, SLOP_STR("; "), free_part); (void)0; }); ({ result = context_ctx_str(ctx, result, SLOP_STR("_wa_result; })")); (void)0; }); }); } else { ({ __auto_type free_part = context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), arena_name, SLOP_STR("); ")); ({ result = context_ctx_str3(ctx, result, free_part, SLOP_STR("0; })")); (void)0; }); }); } (void)0; }); result; }); }) : (({ context_ctx_add_error_at(ctx, SLOP_STR("with-arena: missing size"), context_ctx_list_first_line(items), context_ctx_list_first_col(items)); SLOP_STR("({ (void)0; })"); })); });
+                        __auto_type result_str = ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type size_expr = _mv.value; ({ __auto_type size_c = expr_transpile_expr(ctx, size_expr); __auto_type result = context_ctx_str5(ctx, SLOP_STR("({ slop_arena "), c_local, SLOP_STR(" = slop_arena_new("), size_c, SLOP_STR("); ")); ({ result = context_ctx_str5(ctx, result, SLOP_STR("slop_arena* "), c_arena_name, SLOP_STR(" = &"), context_ctx_str(ctx, c_local, SLOP_STR("; "))); (void)0; }); context_ctx_bind_var(ctx, (context_VarEntry){arena_name, c_arena_name, SLOP_STR("slop_arena*"), SLOP_STR(""), 1, 0, 0, SLOP_STR(""), SLOP_STR("")}); ({ __auto_type i = body_start; ({ while ((i < (len - 1))) { ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); if (_mv.has_value) { __auto_type body_expr = _mv.value; ({ __auto_type body_c = expr_transpile_expr(ctx, body_expr); ({ result = context_ctx_str3(ctx, result, body_c, SLOP_STR("; ")); (void)0; }); }); } else { ({ (void)0; }); } (void)0; }); ({ i = (i + 1); (void)0; }); } (void)0; }); }); ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)(len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); if (_mv.has_value) { __auto_type last_expr = _mv.value; ({ __auto_type last_c = expr_transpile_expr(ctx, last_expr); __auto_type free_part = context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), c_arena_name, SLOP_STR("); ")); ({ result = context_ctx_str5(ctx, result, SLOP_STR("__auto_type _wa_result = "), last_c, SLOP_STR("; "), free_part); (void)0; }); ({ result = context_ctx_str(ctx, result, SLOP_STR("_wa_result; })")); (void)0; }); }); } else { ({ __auto_type free_part = context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), c_arena_name, SLOP_STR("); ")); ({ result = context_ctx_str3(ctx, result, free_part, SLOP_STR("0; })")); (void)0; }); }); } (void)0; }); result; }); }) : (({ context_ctx_add_error_at(ctx, SLOP_STR("with-arena: missing size"), context_ctx_list_first_line(items), context_ctx_list_first_col(items)); SLOP_STR("({ (void)0; })"); })); });
                         context_ctx_pop_scope(ctx);
                         return result_str;
                     }
@@ -8938,7 +8939,14 @@ slop_string expr_find_arena_ptr_expr(context_TranspileContext* ctx) {
             __auto_type entry = _mv_542.value;
             return entry.c_name;
         } else if (!_mv_542.has_value) {
-            return SLOP_STR("");
+            __auto_type _mv_543 = context_ctx_find_arena_var(ctx);
+            if (_mv_543.has_value) {
+                __auto_type entry = _mv_543.value;
+                return entry.c_name;
+            } else if (!_mv_543.has_value) {
+                return SLOP_STR("");
+            }
+            SLOP_UNREACHABLE();
         }
         SLOP_UNREACHABLE();
     }
@@ -8969,9 +8977,9 @@ slop_string expr_build_env_initializer(context_TranspileContext* ctx, slop_list_
         __auto_type result = SLOP_STR("{ ");
         int64_t i = 0;
         while (i < count) {
-            __auto_type _mv_543 = ({ __auto_type _lst = free_vars; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_543.has_value) {
-                __auto_type var_name = _mv_543.value;
+            __auto_type _mv_544 = ({ __auto_type _lst = free_vars; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_544.has_value) {
+                __auto_type var_name = _mv_544.value;
                 {
                     __auto_type c_name = ctype_to_c_name(arena, var_name);
                     __auto_type access_expr = ({ __auto_type _mv = ({ __auto_type _lst = captured_accesses; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type acc = _mv.value; acc; }) : (c_name); });
@@ -8981,7 +8989,7 @@ slop_string expr_build_env_initializer(context_TranspileContext* ctx, slop_list_
                         result = context_ctx_str(ctx, result, context_ctx_str5(ctx, SLOP_STR("."), c_name, SLOP_STR(" = "), access_expr, SLOP_STR("")));
                     }
                 }
-            } else if (!_mv_543.has_value) {
+            } else if (!_mv_544.has_value) {
             }
             i = (i + 1);
         }
@@ -9001,28 +9009,28 @@ slop_string expr_build_lambda_params(context_TranspileContext* ctx, slop_list_ty
                 __auto_type result = SLOP_STR("(");
                 int64_t i = 0;
                 while (i < param_count) {
-                    __auto_type _mv_544 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_544.has_value) {
-                        __auto_type param_expr = _mv_544.value;
-                        __auto_type _mv_545 = (*param_expr);
-                        switch (_mv_545.tag) {
+                    __auto_type _mv_545 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_545.has_value) {
+                        __auto_type param_expr = _mv_545.value;
+                        __auto_type _mv_546 = (*param_expr);
+                        switch (_mv_546.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type param_lst = _mv_545.data.lst;
+                                __auto_type param_lst = _mv_546.data.lst;
                                 {
                                     __auto_type param_items = param_lst.items;
                                     if (((int64_t)((param_items).len)) >= 2) {
-                                        __auto_type _mv_546 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_546.has_value) {
-                                            __auto_type name_expr = _mv_546.value;
-                                            __auto_type _mv_547 = (*name_expr);
-                                            switch (_mv_547.tag) {
+                                        __auto_type _mv_547 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_547.has_value) {
+                                            __auto_type name_expr = _mv_547.value;
+                                            __auto_type _mv_548 = (*name_expr);
+                                            switch (_mv_548.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type name_sym = _mv_547.data.sym;
-                                                    __auto_type _mv_548 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_548.has_value) {
-                                                        __auto_type type_expr = _mv_548.value;
+                                                    __auto_type name_sym = _mv_548.data.sym;
+                                                    __auto_type _mv_549 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_549.has_value) {
+                                                        __auto_type type_expr = _mv_549.value;
                                                         {
                                                             __auto_type param_name = ctype_to_c_name(arena, name_sym.name);
                                                             __auto_type param_type = context_to_c_type_prefixed(ctx, type_expr);
@@ -9032,7 +9040,7 @@ slop_string expr_build_lambda_params(context_TranspileContext* ctx, slop_list_ty
                                                                 result = context_ctx_str(ctx, result, context_ctx_str4(ctx, param_type, SLOP_STR(" "), param_name, SLOP_STR("")));
                                                             }
                                                         }
-                                                    } else if (!_mv_548.has_value) {
+                                                    } else if (!_mv_549.has_value) {
                                                     }
                                                     break;
                                                 }
@@ -9040,7 +9048,7 @@ slop_string expr_build_lambda_params(context_TranspileContext* ctx, slop_list_ty
                                                     break;
                                                 }
                                             }
-                                        } else if (!_mv_546.has_value) {
+                                        } else if (!_mv_547.has_value) {
                                         }
                                     }
                                 }
@@ -9050,7 +9058,7 @@ slop_string expr_build_lambda_params(context_TranspileContext* ctx, slop_list_ty
                                 break;
                             }
                         }
-                    } else if (!_mv_544.has_value) {
+                    } else if (!_mv_545.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -9067,28 +9075,28 @@ void expr_bind_lambda_params(context_TranspileContext* ctx, slop_list_types_SExp
         __auto_type param_count = ((int64_t)((params).len));
         int64_t i = 0;
         while (i < param_count) {
-            __auto_type _mv_549 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_549.has_value) {
-                __auto_type param_expr = _mv_549.value;
-                __auto_type _mv_550 = (*param_expr);
-                switch (_mv_550.tag) {
+            __auto_type _mv_550 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_550.has_value) {
+                __auto_type param_expr = _mv_550.value;
+                __auto_type _mv_551 = (*param_expr);
+                switch (_mv_551.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type param_lst = _mv_550.data.lst;
+                        __auto_type param_lst = _mv_551.data.lst;
                         {
                             __auto_type param_items = param_lst.items;
                             if (((int64_t)((param_items).len)) >= 2) {
-                                __auto_type _mv_551 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_551.has_value) {
-                                    __auto_type name_expr = _mv_551.value;
-                                    __auto_type _mv_552 = (*name_expr);
-                                    switch (_mv_552.tag) {
+                                __auto_type _mv_552 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_552.has_value) {
+                                    __auto_type name_expr = _mv_552.value;
+                                    __auto_type _mv_553 = (*name_expr);
+                                    switch (_mv_553.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type name_sym = _mv_552.data.sym;
-                                            __auto_type _mv_553 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_553.has_value) {
-                                                __auto_type type_expr = _mv_553.value;
+                                            __auto_type name_sym = _mv_553.data.sym;
+                                            __auto_type _mv_554 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_554.has_value) {
+                                                __auto_type type_expr = _mv_554.value;
                                                 {
                                                     __auto_type param_name = name_sym.name;
                                                     __auto_type c_name = ctype_to_c_name(arena, param_name);
@@ -9096,7 +9104,7 @@ void expr_bind_lambda_params(context_TranspileContext* ctx, slop_list_types_SExp
                                                     __auto_type is_ptr = expr_is_pointer_type_sexpr(type_expr);
                                                     context_ctx_bind_var(ctx, (context_VarEntry){param_name, c_name, c_type, SLOP_STR(""), is_ptr, 0, 0, SLOP_STR(""), SLOP_STR("")});
                                                 }
-                                            } else if (!_mv_553.has_value) {
+                                            } else if (!_mv_554.has_value) {
                                             }
                                             break;
                                         }
@@ -9104,7 +9112,7 @@ void expr_bind_lambda_params(context_TranspileContext* ctx, slop_list_types_SExp
                                             break;
                                         }
                                     }
-                                } else if (!_mv_551.has_value) {
+                                } else if (!_mv_552.has_value) {
                                 }
                             }
                         }
@@ -9114,7 +9122,7 @@ void expr_bind_lambda_params(context_TranspileContext* ctx, slop_list_types_SExp
                         break;
                     }
                 }
-            } else if (!_mv_549.has_value) {
+            } else if (!_mv_550.has_value) {
             }
             i = (i + 1);
         }
@@ -9122,31 +9130,31 @@ void expr_bind_lambda_params(context_TranspileContext* ctx, slop_list_types_SExp
 }
 
 uint8_t expr_is_pointer_type_sexpr(types_SExpr* type_expr) {
-    __auto_type _mv_554 = (*type_expr);
-    switch (_mv_554.tag) {
+    __auto_type _mv_555 = (*type_expr);
+    switch (_mv_555.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_554.data.lst;
+            __auto_type lst = _mv_555.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_555 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_555.has_value) {
-                        __auto_type head = _mv_555.value;
-                        __auto_type _mv_556 = (*head);
-                        switch (_mv_556.tag) {
+                    __auto_type _mv_556 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_556.has_value) {
+                        __auto_type head = _mv_556.value;
+                        __auto_type _mv_557 = (*head);
+                        switch (_mv_557.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_556.data.sym;
+                                __auto_type sym = _mv_557.data.sym;
                                 return (string_eq(sym.name, SLOP_STR("Ptr")) || string_eq(sym.name, SLOP_STR("ScopedPtr")));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_555.has_value) {
+                    } else if (!_mv_556.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -9175,9 +9183,9 @@ slop_string expr_transpile_lambda_body(context_TranspileContext* ctx, slop_list_
             }
         } else {
             while (i < len) {
-                __auto_type _mv_557 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_557.has_value) {
-                    __auto_type expr = _mv_557.value;
+                __auto_type _mv_558 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_558.has_value) {
+                    __auto_type expr = _mv_558.value;
                     {
                         __auto_type expr_c = expr_transpile_expr(ctx, expr);
                         __auto_type is_last = (i == (len - 1));
@@ -9191,7 +9199,7 @@ slop_string expr_transpile_lambda_body(context_TranspileContext* ctx, slop_list_
                             result = context_ctx_str(ctx, result, context_ctx_str3(ctx, expr_c, SLOP_STR("; "), SLOP_STR("")));
                         }
                     }
-                } else if (!_mv_557.has_value) {
+                } else if (!_mv_558.has_value) {
                 }
                 i = (i + 1);
             }
@@ -9213,42 +9221,42 @@ slop_string expr_build_lambda_function(context_TranspileContext* ctx, slop_strin
 
 uint8_t expr_is_capturing_lambda(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_558 = (*expr);
-    switch (_mv_558.tag) {
+    __auto_type _mv_559 = (*expr);
+    switch (_mv_559.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_558.data.lst;
+            __auto_type lst = _mv_559.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return 0;
                 } else {
-                    __auto_type _mv_559 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_559.has_value) {
-                        __auto_type head = _mv_559.value;
-                        __auto_type _mv_560 = (*head);
-                        switch (_mv_560.tag) {
+                    __auto_type _mv_560 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_560.has_value) {
+                        __auto_type head = _mv_560.value;
+                        __auto_type _mv_561 = (*head);
+                        switch (_mv_561.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_560.data.sym;
+                                __auto_type sym = _mv_561.data.sym;
                                 if (!(string_eq(sym.name, SLOP_STR("fn")))) {
                                     return 0;
                                 } else {
-                                    __auto_type _mv_561 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_561.has_value) {
-                                        __auto_type second = _mv_561.value;
-                                        __auto_type _mv_562 = (*second);
-                                        switch (_mv_562.tag) {
+                                    __auto_type _mv_562 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_562.has_value) {
+                                        __auto_type second = _mv_562.value;
+                                        __auto_type _mv_563 = (*second);
+                                        switch (_mv_563.tag) {
                                             case types_SExpr_lst:
                                             {
-                                                __auto_type _ = _mv_562.data.lst;
+                                                __auto_type _ = _mv_563.data.lst;
                                                 return 1;
                                             }
                                             default: {
                                                 return 0;
                                             }
                                         }
-                                    } else if (!_mv_561.has_value) {
+                                    } else if (!_mv_562.has_value) {
                                         return 0;
                                     }
                                     SLOP_UNREACHABLE();
@@ -9258,7 +9266,7 @@ uint8_t expr_is_capturing_lambda(types_SExpr* expr) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_559.has_value) {
+                    } else if (!_mv_560.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -9276,9 +9284,9 @@ slop_string expr_transpile_spawn_closure(context_TranspileContext* ctx, slop_lis
     SLOP_PRE(((fn_expr != NULL)), "(!= fn-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_563 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_563.has_value) {
-            __auto_type arena_expr = _mv_563.value;
+        __auto_type _mv_564 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_564.has_value) {
+            __auto_type arena_expr = _mv_564.value;
             {
                 __auto_type arena_c = expr_transpile_expr(ctx, arena_expr);
                 __auto_type has_captures = expr_lambda_has_captures(ctx, fn_expr);
@@ -9291,7 +9299,7 @@ slop_string expr_transpile_spawn_closure(context_TranspileContext* ctx, slop_lis
                     return expr_transpile_regular_fn_call(ctx, SLOP_STR("spawn"), items);
                 }
             }
-        } else if (!_mv_563.has_value) {
+        } else if (!_mv_564.has_value) {
             context_ctx_add_error_at(ctx, SLOP_STR("spawn: missing arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             return SLOP_STR("NULL");
         }
@@ -9302,25 +9310,25 @@ slop_string expr_transpile_spawn_closure(context_TranspileContext* ctx, slop_lis
 uint8_t expr_lambda_has_captures(context_TranspileContext* ctx, types_SExpr* fn_expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((fn_expr != NULL)), "(!= fn-expr nil)");
-    __auto_type _mv_564 = (*fn_expr);
-    switch (_mv_564.tag) {
+    __auto_type _mv_565 = (*fn_expr);
+    switch (_mv_565.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_564.data.lst;
+            __auto_type lst = _mv_565.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type arena = (*ctx).arena;
                 if (((int64_t)((items).len)) < 2) {
                     return 0;
                 } else {
-                    __auto_type _mv_565 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_565.has_value) {
-                        __auto_type params_expr = _mv_565.value;
-                        __auto_type _mv_566 = (*params_expr);
-                        switch (_mv_566.tag) {
+                    __auto_type _mv_566 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_566.has_value) {
+                        __auto_type params_expr = _mv_566.value;
+                        __auto_type _mv_567 = (*params_expr);
+                        switch (_mv_567.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type params_lst = _mv_566.data.lst;
+                                __auto_type params_lst = _mv_567.data.lst;
                                 {
                                     __auto_type params = params_lst.items;
                                     __auto_type param_names = expr_extract_param_names(arena, params);
@@ -9333,7 +9341,7 @@ uint8_t expr_lambda_has_captures(context_TranspileContext* ctx, types_SExpr* fn_
                                 return 0;
                             }
                         }
-                    } else if (!_mv_565.has_value) {
+                    } else if (!_mv_566.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -9356,9 +9364,9 @@ slop_string expr_transpile_regular_fn_call(context_TranspileContext* ctx, slop_s
         int64_t i = 1;
         int64_t param_idx = 0;
         while (i < len) {
-            __auto_type _mv_567 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_567.has_value) {
-                __auto_type arg = _mv_567.value;
+            __auto_type _mv_568 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_568.has_value) {
+                __auto_type arg = _mv_568.value;
                 {
                     __auto_type arg_c = expr_transpile_expr(ctx, arg);
                     __auto_type expected_type = ({ __auto_type _mv = func_opt; _mv.has_value ? ({ __auto_type func_entry = _mv.value; ({ __auto_type _mv = ({ __auto_type _lst = func_entry.param_types; size_t _idx = (size_t)param_idx; slop_option_context_FuncParamType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type p = _mv.value; (*p).c_type; }) : (SLOP_STR("")); }); }) : (SLOP_STR("")); });
@@ -9370,7 +9378,7 @@ slop_string expr_transpile_regular_fn_call(context_TranspileContext* ctx, slop_s
                     }
                     param_idx = (param_idx + 1);
                 }
-            } else if (!_mv_567.has_value) {
+            } else if (!_mv_568.has_value) {
             }
             i = (i + 1);
         }
@@ -9385,9 +9393,9 @@ slop_string expr_infer_generic_type_binding(context_TranspileContext* ctx, slop_
         if (((int64_t)((items).len)) < 2) {
             return SLOP_STR("");
         } else {
-            __auto_type _mv_568 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_568.has_value) {
-                __auto_type first_arg = _mv_568.value;
+            __auto_type _mv_569 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_569.has_value) {
+                __auto_type first_arg = _mv_569.value;
                 {
                     __auto_type slop_type = expr_infer_expr_slop_type(ctx, first_arg);
                     if (string_eq(slop_type, SLOP_STR(""))) {
@@ -9399,7 +9407,7 @@ slop_string expr_infer_generic_type_binding(context_TranspileContext* ctx, slop_
                         return expr_extract_type_binding_from_slop_type(arena, slop_type);
                     }
                 }
-            } else if (!_mv_568.has_value) {
+            } else if (!_mv_569.has_value) {
                 return SLOP_STR("");
             }
             SLOP_UNREACHABLE();
@@ -9538,11 +9546,11 @@ slop_list_string expr_find_free_vars(context_TranspileContext* ctx, slop_list_st
         __auto_type len = ((int64_t)((body_items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_569 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_569.has_value) {
-                __auto_type expr = _mv_569.value;
+            __auto_type _mv_570 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_570.has_value) {
+                __auto_type expr = _mv_570.value;
                 expr_collect_symbols_in_expr(ctx, (&all_symbols), pending, expr);
-            } else if (!_mv_569.has_value) {
+            } else if (!_mv_570.has_value) {
             }
             i = (i + 1);
         }
@@ -9550,15 +9558,15 @@ slop_list_string expr_find_free_vars(context_TranspileContext* ctx, slop_list_st
             __auto_type sym_count = ((int64_t)((all_symbols).len));
             int64_t j = 0;
             while (j < sym_count) {
-                __auto_type _mv_570 = ({ __auto_type _lst = all_symbols; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_570.has_value) {
-                    __auto_type sym_name = _mv_570.value;
+                __auto_type _mv_571 = ({ __auto_type _lst = all_symbols; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_571.has_value) {
+                    __auto_type sym_name = _mv_571.value;
                     if (expr_is_free_var(ctx, param_names, pending, sym_name)) {
                         if (!(expr_list_contains_string(free_vars, sym_name))) {
                             ({ __auto_type _lst_p = &(free_vars); __auto_type _item = (sym_name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                         }
                     }
-                } else if (!_mv_570.has_value) {
+                } else if (!_mv_571.has_value) {
                 }
                 j = (j + 1);
             }
@@ -9570,11 +9578,11 @@ slop_list_string expr_find_free_vars(context_TranspileContext* ctx, slop_list_st
 void expr_collect_symbols_in_expr(context_TranspileContext* ctx, slop_list_string* symbols, slop_list_string pending, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_571 = (*expr);
-    switch (_mv_571.tag) {
+    __auto_type _mv_572 = (*expr);
+    switch (_mv_572.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_571.data.sym;
+            __auto_type sym = _mv_572.data.sym;
             {
                 __auto_type name = sym.name;
                 if (!(expr_is_special_keyword(name)) && !(expr_list_contains_string(pending, name))) {
@@ -9585,19 +9593,19 @@ void expr_collect_symbols_in_expr(context_TranspileContext* ctx, slop_list_strin
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_571.data.lst;
+            __auto_type lst = _mv_572.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 if (len > 0) {
-                    __auto_type _mv_572 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_572.has_value) {
-                        __auto_type head = _mv_572.value;
-                        __auto_type _mv_573 = (*head);
-                        switch (_mv_573.tag) {
+                    __auto_type _mv_573 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_573.has_value) {
+                        __auto_type head = _mv_573.value;
+                        __auto_type _mv_574 = (*head);
+                        switch (_mv_574.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type head_sym = _mv_573.data.sym;
+                                __auto_type head_sym = _mv_574.data.sym;
                                 {
                                     __auto_type op = head_sym.name;
                                     if (string_eq(op, SLOP_STR("let"))) {
@@ -9621,7 +9629,7 @@ void expr_collect_symbols_in_expr(context_TranspileContext* ctx, slop_list_strin
                                 break;
                             }
                         }
-                    } else if (!_mv_572.has_value) {
+                    } else if (!_mv_573.has_value) {
                     }
                 }
             }
@@ -9639,11 +9647,11 @@ void expr_collect_symbols_in_list(context_TranspileContext* ctx, slop_list_strin
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_574 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_574.has_value) {
-                __auto_type item = _mv_574.value;
+            __auto_type _mv_575 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_575.has_value) {
+                __auto_type item = _mv_575.value;
                 expr_collect_symbols_in_expr(ctx, symbols, pending, item);
-            } else if (!_mv_574.has_value) {
+            } else if (!_mv_575.has_value) {
             }
             i = (i + 1);
         }
@@ -9656,40 +9664,40 @@ void expr_collect_symbols_in_let(context_TranspileContext* ctx, slop_list_string
         __auto_type arena = (*ctx).arena;
         __auto_type len = ((int64_t)((items).len));
         if (len >= 2) {
-            __auto_type _mv_575 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_575.has_value) {
-                __auto_type bindings_expr = _mv_575.value;
+            __auto_type _mv_576 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_576.has_value) {
+                __auto_type bindings_expr = _mv_576.value;
                 {
                     __auto_type new_names = expr_extract_let_binding_names(arena, bindings_expr);
                     __auto_type updated_pending = expr_list_concat(arena, pending, new_names);
-                    __auto_type _mv_576 = (*bindings_expr);
-                    switch (_mv_576.tag) {
+                    __auto_type _mv_577 = (*bindings_expr);
+                    switch (_mv_577.tag) {
                         case types_SExpr_lst:
                         {
-                            __auto_type bindings_lst = _mv_576.data.lst;
+                            __auto_type bindings_lst = _mv_577.data.lst;
                             {
                                 __auto_type bindings = bindings_lst.items;
                                 __auto_type binding_count = ((int64_t)((bindings).len));
                                 __auto_type i = 0;
                                 while (i < binding_count) {
-                                    __auto_type _mv_577 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_577.has_value) {
-                                        __auto_type binding = _mv_577.value;
-                                        __auto_type _mv_578 = (*binding);
-                                        switch (_mv_578.tag) {
+                                    __auto_type _mv_578 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_578.has_value) {
+                                        __auto_type binding = _mv_578.value;
+                                        __auto_type _mv_579 = (*binding);
+                                        switch (_mv_579.tag) {
                                             case types_SExpr_lst:
                                             {
-                                                __auto_type bind_lst = _mv_578.data.lst;
+                                                __auto_type bind_lst = _mv_579.data.lst;
                                                 {
                                                     __auto_type bind_items = bind_lst.items;
                                                     if (((int64_t)((bind_items).len)) >= 2) {
                                                         {
                                                             __auto_type val_idx = ((expr_is_mut_binding(bind_items)) ? 2 : 1);
-                                                            __auto_type _mv_579 = ({ __auto_type _lst = bind_items; size_t _idx = (size_t)val_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                            if (_mv_579.has_value) {
-                                                                __auto_type val_expr = _mv_579.value;
+                                                            __auto_type _mv_580 = ({ __auto_type _lst = bind_items; size_t _idx = (size_t)val_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                            if (_mv_580.has_value) {
+                                                                __auto_type val_expr = _mv_580.value;
                                                                 expr_collect_symbols_in_expr(ctx, symbols, pending, val_expr);
-                                                            } else if (!_mv_579.has_value) {
+                                                            } else if (!_mv_580.has_value) {
                                                             }
                                                         }
                                                     }
@@ -9700,7 +9708,7 @@ void expr_collect_symbols_in_let(context_TranspileContext* ctx, slop_list_string
                                                 break;
                                             }
                                         }
-                                    } else if (!_mv_577.has_value) {
+                                    } else if (!_mv_578.has_value) {
                                     }
                                     i = (i + 1);
                                 }
@@ -9713,7 +9721,7 @@ void expr_collect_symbols_in_let(context_TranspileContext* ctx, slop_list_string
                     }
                     expr_collect_symbols_in_list(ctx, symbols, updated_pending, items, 2);
                 }
-            } else if (!_mv_575.has_value) {
+            } else if (!_mv_576.has_value) {
             }
         }
     }
@@ -9723,21 +9731,21 @@ uint8_t expr_is_mut_binding(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_580 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_580.has_value) {
-            __auto_type first = _mv_580.value;
-            __auto_type _mv_581 = (*first);
-            switch (_mv_581.tag) {
+        __auto_type _mv_581 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_581.has_value) {
+            __auto_type first = _mv_581.value;
+            __auto_type _mv_582 = (*first);
+            switch (_mv_582.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_581.data.sym;
+                    __auto_type sym = _mv_582.data.sym;
                     return string_eq(sym.name, SLOP_STR("mut"));
                 }
                 default: {
                     return 0;
                 }
             }
-        } else if (!_mv_580.has_value) {
+        } else if (!_mv_581.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -9748,37 +9756,37 @@ slop_list_string expr_extract_let_binding_names(slop_arena* arena, types_SExpr* 
     SLOP_PRE(((bindings_expr != NULL)), "(!= bindings-expr nil)");
     {
         __auto_type names = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
-        __auto_type _mv_582 = (*bindings_expr);
-        switch (_mv_582.tag) {
+        __auto_type _mv_583 = (*bindings_expr);
+        switch (_mv_583.tag) {
             case types_SExpr_lst:
             {
-                __auto_type bindings_lst = _mv_582.data.lst;
+                __auto_type bindings_lst = _mv_583.data.lst;
                 {
                     __auto_type bindings = bindings_lst.items;
                     __auto_type binding_count = ((int64_t)((bindings).len));
                     __auto_type i = 0;
                     while (i < binding_count) {
-                        __auto_type _mv_583 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_583.has_value) {
-                            __auto_type binding = _mv_583.value;
-                            __auto_type _mv_584 = (*binding);
-                            switch (_mv_584.tag) {
+                        __auto_type _mv_584 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_584.has_value) {
+                            __auto_type binding = _mv_584.value;
+                            __auto_type _mv_585 = (*binding);
+                            switch (_mv_585.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type bind_lst = _mv_584.data.lst;
+                                    __auto_type bind_lst = _mv_585.data.lst;
                                     {
                                         __auto_type bind_items = bind_lst.items;
                                         if (((int64_t)((bind_items).len)) >= 1) {
                                             {
                                                 __auto_type name_idx = ((expr_is_mut_binding(bind_items)) ? 1 : 0);
-                                                __auto_type _mv_585 = ({ __auto_type _lst = bind_items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_585.has_value) {
-                                                    __auto_type name_expr = _mv_585.value;
-                                                    __auto_type _mv_586 = (*name_expr);
-                                                    switch (_mv_586.tag) {
+                                                __auto_type _mv_586 = ({ __auto_type _lst = bind_items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_586.has_value) {
+                                                    __auto_type name_expr = _mv_586.value;
+                                                    __auto_type _mv_587 = (*name_expr);
+                                                    switch (_mv_587.tag) {
                                                         case types_SExpr_sym:
                                                         {
-                                                            __auto_type sym = _mv_586.data.sym;
+                                                            __auto_type sym = _mv_587.data.sym;
                                                             ({ __auto_type _lst_p = &(names); __auto_type _item = (sym.name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                             break;
                                                         }
@@ -9786,7 +9794,7 @@ slop_list_string expr_extract_let_binding_names(slop_arena* arena, types_SExpr* 
                                                             break;
                                                         }
                                                     }
-                                                } else if (!_mv_585.has_value) {
+                                                } else if (!_mv_586.has_value) {
                                                 }
                                             }
                                         }
@@ -9797,7 +9805,7 @@ slop_list_string expr_extract_let_binding_names(slop_arena* arena, types_SExpr* 
                                     break;
                                 }
                             }
-                        } else if (!_mv_583.has_value) {
+                        } else if (!_mv_584.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -9817,23 +9825,23 @@ void expr_collect_symbols_in_match(context_TranspileContext* ctx, slop_list_stri
     {
         __auto_type len = ((int64_t)((items).len));
         if (len >= 2) {
-            __auto_type _mv_587 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_587.has_value) {
-                __auto_type scrutinee = _mv_587.value;
+            __auto_type _mv_588 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_588.has_value) {
+                __auto_type scrutinee = _mv_588.value;
                 expr_collect_symbols_in_expr(ctx, symbols, pending, scrutinee);
-            } else if (!_mv_587.has_value) {
+            } else if (!_mv_588.has_value) {
             }
             {
                 int64_t i = 2;
                 while (i < len) {
-                    __auto_type _mv_588 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_588.has_value) {
-                        __auto_type clause = _mv_588.value;
-                        __auto_type _mv_589 = (*clause);
-                        switch (_mv_589.tag) {
+                    __auto_type _mv_589 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_589.has_value) {
+                        __auto_type clause = _mv_589.value;
+                        __auto_type _mv_590 = (*clause);
+                        switch (_mv_590.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type clause_lst = _mv_589.data.lst;
+                                __auto_type clause_lst = _mv_590.data.lst;
                                 {
                                     __auto_type clause_items = clause_lst.items;
                                     expr_collect_symbols_in_list(ctx, symbols, pending, clause_items, 1);
@@ -9844,7 +9852,7 @@ void expr_collect_symbols_in_match(context_TranspileContext* ctx, slop_list_stri
                                 break;
                             }
                         }
-                    } else if (!_mv_588.has_value) {
+                    } else if (!_mv_589.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -9859,14 +9867,14 @@ void expr_collect_symbols_in_for(context_TranspileContext* ctx, slop_list_string
         __auto_type arena = (*ctx).arena;
         __auto_type len = ((int64_t)((items).len));
         if (len >= 2) {
-            __auto_type _mv_590 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_590.has_value) {
-                __auto_type binding = _mv_590.value;
-                __auto_type _mv_591 = (*binding);
-                switch (_mv_591.tag) {
+            __auto_type _mv_591 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_591.has_value) {
+                __auto_type binding = _mv_591.value;
+                __auto_type _mv_592 = (*binding);
+                switch (_mv_592.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type bind_lst = _mv_591.data.lst;
+                        __auto_type bind_lst = _mv_592.data.lst;
                         {
                             __auto_type bind_items = bind_lst.items;
                             expr_collect_symbols_in_list(ctx, symbols, pending, bind_items, 1);
@@ -9881,7 +9889,7 @@ void expr_collect_symbols_in_for(context_TranspileContext* ctx, slop_list_string
                         break;
                     }
                 }
-            } else if (!_mv_590.has_value) {
+            } else if (!_mv_591.has_value) {
             }
         }
     }
@@ -9891,25 +9899,25 @@ slop_list_string expr_extract_for_loop_var_pending(slop_arena* arena, slop_list_
     if (((int64_t)((bind_items).len)) < 1) {
         return pending;
     } else {
-        __auto_type _mv_592 = ({ __auto_type _lst = bind_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_592.has_value) {
-            __auto_type var_expr = _mv_592.value;
-            __auto_type _mv_593 = (*var_expr);
-            switch (_mv_593.tag) {
+        __auto_type _mv_593 = ({ __auto_type _lst = bind_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_593.has_value) {
+            __auto_type var_expr = _mv_593.value;
+            __auto_type _mv_594 = (*var_expr);
+            switch (_mv_594.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type var_sym = _mv_593.data.sym;
+                    __auto_type var_sym = _mv_594.data.sym;
                     {
                         __auto_type result = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
                         __auto_type var_name = var_sym.name;
                         __auto_type plen = ((int64_t)((pending).len));
                         __auto_type i = 0;
                         while (i < plen) {
-                            __auto_type _mv_594 = ({ __auto_type _lst = pending; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_594.has_value) {
-                                __auto_type s = _mv_594.value;
+                            __auto_type _mv_595 = ({ __auto_type _lst = pending; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_595.has_value) {
+                                __auto_type s = _mv_595.value;
                                 ({ __auto_type _lst_p = &(result); __auto_type _item = (s); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                            } else if (!_mv_594.has_value) {
+                            } else if (!_mv_595.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -9921,7 +9929,7 @@ slop_list_string expr_extract_for_loop_var_pending(slop_arena* arena, slop_list_
                     return pending;
                 }
             }
-        } else if (!_mv_592.has_value) {
+        } else if (!_mv_593.has_value) {
             return pending;
         }
         SLOP_UNREACHABLE();
@@ -9939,11 +9947,11 @@ void expr_collect_symbols_in_with_arena(context_TranspileContext* ctx, slop_list
                 __auto_type arena_name = ((is_named) ? ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type name_expr = _mv.value; ({ __auto_type _mv = (*name_expr); slop_string _mr = {0}; switch (_mv.tag) { case types_SExpr_sym: { __auto_type s2 = _mv.data.sym; _mr = s2.name; break; } default: { _mr = SLOP_STR("arena"); break; }  } _mr; }); }) : (SLOP_STR("arena")); }) : SLOP_STR("arena"));
                 __auto_type size_idx = ((is_named) ? 3 : 1);
                 __auto_type body_start = ((is_named) ? 4 : 2);
-                __auto_type _mv_595 = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_595.has_value) {
-                    __auto_type size_expr = _mv_595.value;
+                __auto_type _mv_596 = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_596.has_value) {
+                    __auto_type size_expr = _mv_596.value;
                     expr_collect_symbols_in_expr(ctx, symbols, pending, size_expr);
-                } else if (!_mv_595.has_value) {
+                } else if (!_mv_596.has_value) {
                 }
                 {
                     __auto_type updated_pending = expr_list_concat(arena, pending, ({ __auto_type tmp = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 }); ({ __auto_type _lst_p = &(tmp); __auto_type _item = (arena_name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; }); tmp; }));
@@ -9960,14 +9968,14 @@ void expr_collect_nested_lambda_free_vars(context_TranspileContext* ctx, slop_li
         __auto_type arena = (*ctx).arena;
         __auto_type len = ((int64_t)((items).len));
         if (len >= 2) {
-            __auto_type _mv_596 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_596.has_value) {
-                __auto_type params_expr = _mv_596.value;
-                __auto_type _mv_597 = (*params_expr);
-                switch (_mv_597.tag) {
+            __auto_type _mv_597 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_597.has_value) {
+                __auto_type params_expr = _mv_597.value;
+                __auto_type _mv_598 = (*params_expr);
+                switch (_mv_598.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type params_lst = _mv_597.data.lst;
+                        __auto_type params_lst = _mv_598.data.lst;
                         {
                             __auto_type params = params_lst.items;
                             __auto_type param_names = expr_extract_param_names(arena, params);
@@ -9980,7 +9988,7 @@ void expr_collect_nested_lambda_free_vars(context_TranspileContext* ctx, slop_li
                         break;
                     }
                 }
-            } else if (!_mv_596.has_value) {
+            } else if (!_mv_597.has_value) {
             }
         }
     }
@@ -10001,21 +10009,21 @@ uint8_t expr_is_free_var(context_TranspileContext* ctx, slop_list_string param_n
             if (expr_is_builtin_op(sym_name)) {
                 return 0;
             } else {
-                __auto_type _mv_598 = context_ctx_lookup_func(ctx, sym_name);
-                if (_mv_598.has_value) {
-                    __auto_type _ = _mv_598.value;
+                __auto_type _mv_599 = context_ctx_lookup_func(ctx, sym_name);
+                if (_mv_599.has_value) {
+                    __auto_type _ = _mv_599.value;
                     return 0;
-                } else if (!_mv_598.has_value) {
-                    __auto_type _mv_599 = context_ctx_lookup_type(ctx, sym_name);
-                    if (_mv_599.has_value) {
-                        __auto_type _ = _mv_599.value;
+                } else if (!_mv_599.has_value) {
+                    __auto_type _mv_600 = context_ctx_lookup_type(ctx, sym_name);
+                    if (_mv_600.has_value) {
+                        __auto_type _ = _mv_600.value;
                         return 0;
-                    } else if (!_mv_599.has_value) {
-                        __auto_type _mv_600 = context_ctx_lookup_var(ctx, sym_name);
-                        if (_mv_600.has_value) {
-                            __auto_type _ = _mv_600.value;
+                    } else if (!_mv_600.has_value) {
+                        __auto_type _mv_601 = context_ctx_lookup_var(ctx, sym_name);
+                        if (_mv_601.has_value) {
+                            __auto_type _ = _mv_601.value;
                             return 1;
-                        } else if (!_mv_600.has_value) {
+                        } else if (!_mv_601.has_value) {
                             return 0;
                         }
                         SLOP_UNREACHABLE();
@@ -10038,13 +10046,13 @@ uint8_t expr_list_contains_string(slop_list_string lst, slop_string needle) {
         int64_t i = 0;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_601 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_601.has_value) {
-                __auto_type s = _mv_601.value;
+            __auto_type _mv_602 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_602.has_value) {
+                __auto_type s = _mv_602.value;
                 if (string_eq(s, needle)) {
                     found = 1;
                 }
-            } else if (!_mv_601.has_value) {
+            } else if (!_mv_602.has_value) {
             }
             i = (i + 1);
         }
@@ -10059,21 +10067,21 @@ slop_list_string expr_list_concat(slop_arena* arena, slop_list_string a, slop_li
         __auto_type len_b = ((int64_t)((b).len));
         int64_t i = 0;
         while (i < len_a) {
-            __auto_type _mv_602 = ({ __auto_type _lst = a; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_602.has_value) {
-                __auto_type s = _mv_602.value;
+            __auto_type _mv_603 = ({ __auto_type _lst = a; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_603.has_value) {
+                __auto_type s = _mv_603.value;
                 ({ __auto_type _lst_p = &(result); __auto_type _item = (s); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-            } else if (!_mv_602.has_value) {
+            } else if (!_mv_603.has_value) {
             }
             i = (i + 1);
         }
         i = 0;
         while (i < len_b) {
-            __auto_type _mv_603 = ({ __auto_type _lst = b; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_603.has_value) {
-                __auto_type s = _mv_603.value;
+            __auto_type _mv_604 = ({ __auto_type _lst = b; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_604.has_value) {
+                __auto_type s = _mv_604.value;
                 ({ __auto_type _lst_p = &(result); __auto_type _item = (s); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-            } else if (!_mv_603.has_value) {
+            } else if (!_mv_604.has_value) {
             }
             i = (i + 1);
         }
@@ -10166,33 +10174,33 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
     SLOP_PRE(((coll_expr != NULL)), "(!= coll-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_604 = (*coll_expr);
-        switch (_mv_604.tag) {
+        __auto_type _mv_605 = (*coll_expr);
+        switch (_mv_605.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_604.data.lst;
+                __auto_type lst = _mv_605.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 1) {
                         return SLOP_STR("");
                     } else {
-                        __auto_type _mv_605 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_605.has_value) {
-                            __auto_type head = _mv_605.value;
-                            __auto_type _mv_606 = (*head);
-                            switch (_mv_606.tag) {
+                        __auto_type _mv_606 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_606.has_value) {
+                            __auto_type head = _mv_606.value;
+                            __auto_type _mv_607 = (*head);
+                            switch (_mv_607.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_606.data.sym;
+                                    __auto_type sym = _mv_607.data.sym;
                                     {
                                         __auto_type op = sym.name;
                                         if (string_eq(op, SLOP_STR("map-keys"))) {
                                             if (((int64_t)((items).len)) < 2) {
                                                 return SLOP_STR("");
                                             } else {
-                                                __auto_type _mv_607 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_607.has_value) {
-                                                    __auto_type map_expr = _mv_607.value;
+                                                __auto_type _mv_608 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_608.has_value) {
+                                                    __auto_type map_expr = _mv_608.value;
                                                     {
                                                         __auto_type map_slop_type = expr_infer_expr_slop_type(ctx, map_expr);
                                                         if (string_len(map_slop_type) > 0) {
@@ -10204,7 +10212,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                                             return SLOP_STR("");
                                                         }
                                                     }
-                                                } else if (!_mv_607.has_value) {
+                                                } else if (!_mv_608.has_value) {
                                                     return SLOP_STR("");
                                                 }
                                                 SLOP_UNREACHABLE();
@@ -10213,9 +10221,9 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                             if (((int64_t)((items).len)) < 2) {
                                                 return SLOP_STR("");
                                             } else {
-                                                __auto_type _mv_608 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_608.has_value) {
-                                                    __auto_type set_expr = _mv_608.value;
+                                                __auto_type _mv_609 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_609.has_value) {
+                                                    __auto_type set_expr = _mv_609.value;
                                                     {
                                                         __auto_type set_slop_type = expr_infer_expr_slop_type(ctx, set_expr);
                                                         if (string_len(set_slop_type) > 0) {
@@ -10227,7 +10235,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                                             return SLOP_STR("");
                                                         }
                                                     }
-                                                } else if (!_mv_608.has_value) {
+                                                } else if (!_mv_609.has_value) {
                                                     return SLOP_STR("");
                                                 }
                                                 SLOP_UNREACHABLE();
@@ -10236,9 +10244,9 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                             if (((int64_t)((items).len)) < 2) {
                                                 return SLOP_STR("");
                                             } else {
-                                                __auto_type _mv_609 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_609.has_value) {
-                                                    __auto_type map_expr = _mv_609.value;
+                                                __auto_type _mv_610 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_610.has_value) {
+                                                    __auto_type map_expr = _mv_610.value;
                                                     {
                                                         __auto_type map_slop_type = expr_infer_expr_slop_type(ctx, map_expr);
                                                         if (string_len(map_slop_type) > 0) {
@@ -10250,7 +10258,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                                             return SLOP_STR("");
                                                         }
                                                     }
-                                                } else if (!_mv_609.has_value) {
+                                                } else if (!_mv_610.has_value) {
                                                     return SLOP_STR("");
                                                 }
                                                 SLOP_UNREACHABLE();
@@ -10264,7 +10272,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                     return expr_infer_elem_from_type(ctx, coll_expr);
                                 }
                             }
-                        } else if (!_mv_605.has_value) {
+                        } else if (!_mv_606.has_value) {
                             return SLOP_STR("");
                         }
                         SLOP_UNREACHABLE();

--- a/bootstrap/compiler/slop_infer.c
+++ b/bootstrap/compiler/slop_infer.c
@@ -236,18 +236,18 @@ slop_option_types_ResolvedType_ptr infer_find_binding(slop_list_string bind_name
         __auto_type len = ((int64_t)((bind_names).len));
         slop_option_types_ResolvedType_ptr found = (slop_option_types_ResolvedType_ptr){.has_value = false};
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_1633 = ({ __auto_type _lst = bind_names; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1633.has_value) {
-                __auto_type bn = _mv_1633.value;
+            __auto_type _mv_1634 = ({ __auto_type _lst = bind_names; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1634.has_value) {
+                __auto_type bn = _mv_1634.value;
                 if (string_eq(bn, name)) {
-                    __auto_type _mv_1634 = ({ __auto_type _lst = bind_types; size_t _idx = (size_t)i; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1634.has_value) {
-                        __auto_type bt = _mv_1634.value;
+                    __auto_type _mv_1635 = ({ __auto_type _lst = bind_types; size_t _idx = (size_t)i; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1635.has_value) {
+                        __auto_type bt = _mv_1635.value;
                         found = (slop_option_types_ResolvedType_ptr){.has_value = 1, .value = bt};
-                    } else if (!_mv_1634.has_value) {
+                    } else if (!_mv_1635.has_value) {
                     }
                 }
-            } else if (!_mv_1633.has_value) {
+            } else if (!_mv_1634.has_value) {
             }
         }
         return found;
@@ -262,107 +262,107 @@ void infer_unify_types(slop_arena* arena, types_ResolvedType* formal, types_Reso
         if (f_kind == types_ResolvedTypeKind_rk_typevar) {
             {
                 __auto_type tv_name = (*formal).name;
-                __auto_type _mv_1635 = infer_find_binding(bind_names, bind_types, tv_name);
-                if (_mv_1635.has_value) {
-                    __auto_type existing = _mv_1635.value;
-                } else if (!_mv_1635.has_value) {
+                __auto_type _mv_1636 = infer_find_binding(bind_names, bind_types, tv_name);
+                if (_mv_1636.has_value) {
+                    __auto_type existing = _mv_1636.value;
+                } else if (!_mv_1636.has_value) {
                     ({ __auto_type _lst_p = &(bind_names); __auto_type _item = (tv_name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                     ({ __auto_type _lst_p = &(bind_types); __auto_type _item = (actual); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                 }
             }
         } else if (f_kind == types_ResolvedTypeKind_rk_ptr) {
             if ((*actual).kind == types_ResolvedTypeKind_rk_ptr) {
-                __auto_type _mv_1636 = (*formal).inner_type;
-                if (_mv_1636.has_value) {
-                    __auto_type f_inner = _mv_1636.value;
-                    __auto_type _mv_1637 = (*actual).inner_type;
-                    if (_mv_1637.has_value) {
-                        __auto_type a_inner = _mv_1637.value;
+                __auto_type _mv_1637 = (*formal).inner_type;
+                if (_mv_1637.has_value) {
+                    __auto_type f_inner = _mv_1637.value;
+                    __auto_type _mv_1638 = (*actual).inner_type;
+                    if (_mv_1638.has_value) {
+                        __auto_type a_inner = _mv_1638.value;
                         infer_unify_types(arena, f_inner, a_inner, bind_names, bind_types);
-                    } else if (!_mv_1637.has_value) {
+                    } else if (!_mv_1638.has_value) {
                     }
-                } else if (!_mv_1636.has_value) {
+                } else if (!_mv_1637.has_value) {
                 }
             }
         } else if (f_kind == types_ResolvedTypeKind_rk_chan) {
             if ((*actual).kind == types_ResolvedTypeKind_rk_chan) {
-                __auto_type _mv_1638 = (*formal).inner_type;
-                if (_mv_1638.has_value) {
-                    __auto_type f_inner = _mv_1638.value;
-                    __auto_type _mv_1639 = (*actual).inner_type;
-                    if (_mv_1639.has_value) {
-                        __auto_type a_inner = _mv_1639.value;
+                __auto_type _mv_1639 = (*formal).inner_type;
+                if (_mv_1639.has_value) {
+                    __auto_type f_inner = _mv_1639.value;
+                    __auto_type _mv_1640 = (*actual).inner_type;
+                    if (_mv_1640.has_value) {
+                        __auto_type a_inner = _mv_1640.value;
                         infer_unify_types(arena, f_inner, a_inner, bind_names, bind_types);
-                    } else if (!_mv_1639.has_value) {
+                    } else if (!_mv_1640.has_value) {
                     }
-                } else if (!_mv_1638.has_value) {
+                } else if (!_mv_1639.has_value) {
                 }
             }
         } else if (f_kind == types_ResolvedTypeKind_rk_thread) {
             if ((*actual).kind == types_ResolvedTypeKind_rk_thread) {
-                __auto_type _mv_1640 = (*formal).inner_type;
-                if (_mv_1640.has_value) {
-                    __auto_type f_inner = _mv_1640.value;
-                    __auto_type _mv_1641 = (*actual).inner_type;
-                    if (_mv_1641.has_value) {
-                        __auto_type a_inner = _mv_1641.value;
+                __auto_type _mv_1641 = (*formal).inner_type;
+                if (_mv_1641.has_value) {
+                    __auto_type f_inner = _mv_1641.value;
+                    __auto_type _mv_1642 = (*actual).inner_type;
+                    if (_mv_1642.has_value) {
+                        __auto_type a_inner = _mv_1642.value;
                         infer_unify_types(arena, f_inner, a_inner, bind_names, bind_types);
-                    } else if (!_mv_1641.has_value) {
+                    } else if (!_mv_1642.has_value) {
                     }
-                } else if (!_mv_1640.has_value) {
+                } else if (!_mv_1641.has_value) {
                 }
             }
         } else if (f_kind == types_ResolvedTypeKind_rk_list) {
             if ((*actual).kind == types_ResolvedTypeKind_rk_list) {
-                __auto_type _mv_1642 = (*formal).inner_type;
-                if (_mv_1642.has_value) {
-                    __auto_type f_inner = _mv_1642.value;
-                    __auto_type _mv_1643 = (*actual).inner_type;
-                    if (_mv_1643.has_value) {
-                        __auto_type a_inner = _mv_1643.value;
+                __auto_type _mv_1643 = (*formal).inner_type;
+                if (_mv_1643.has_value) {
+                    __auto_type f_inner = _mv_1643.value;
+                    __auto_type _mv_1644 = (*actual).inner_type;
+                    if (_mv_1644.has_value) {
+                        __auto_type a_inner = _mv_1644.value;
                         infer_unify_types(arena, f_inner, a_inner, bind_names, bind_types);
-                    } else if (!_mv_1643.has_value) {
+                    } else if (!_mv_1644.has_value) {
                     }
-                } else if (!_mv_1642.has_value) {
+                } else if (!_mv_1643.has_value) {
                 }
             }
         } else if (f_kind == types_ResolvedTypeKind_rk_option) {
             if ((*actual).kind == types_ResolvedTypeKind_rk_option) {
-                __auto_type _mv_1644 = (*formal).inner_type;
-                if (_mv_1644.has_value) {
-                    __auto_type f_inner = _mv_1644.value;
-                    __auto_type _mv_1645 = (*actual).inner_type;
-                    if (_mv_1645.has_value) {
-                        __auto_type a_inner = _mv_1645.value;
+                __auto_type _mv_1645 = (*formal).inner_type;
+                if (_mv_1645.has_value) {
+                    __auto_type f_inner = _mv_1645.value;
+                    __auto_type _mv_1646 = (*actual).inner_type;
+                    if (_mv_1646.has_value) {
+                        __auto_type a_inner = _mv_1646.value;
                         infer_unify_types(arena, f_inner, a_inner, bind_names, bind_types);
-                    } else if (!_mv_1645.has_value) {
+                    } else if (!_mv_1646.has_value) {
                     }
-                } else if (!_mv_1644.has_value) {
+                } else if (!_mv_1645.has_value) {
                 }
             }
         } else if (f_kind == types_ResolvedTypeKind_rk_result) {
             if ((*actual).kind == types_ResolvedTypeKind_rk_result) {
-                __auto_type _mv_1646 = (*formal).inner_type;
-                if (_mv_1646.has_value) {
-                    __auto_type f_inner = _mv_1646.value;
-                    __auto_type _mv_1647 = (*actual).inner_type;
-                    if (_mv_1647.has_value) {
-                        __auto_type a_inner = _mv_1647.value;
+                __auto_type _mv_1647 = (*formal).inner_type;
+                if (_mv_1647.has_value) {
+                    __auto_type f_inner = _mv_1647.value;
+                    __auto_type _mv_1648 = (*actual).inner_type;
+                    if (_mv_1648.has_value) {
+                        __auto_type a_inner = _mv_1648.value;
                         infer_unify_types(arena, f_inner, a_inner, bind_names, bind_types);
-                    } else if (!_mv_1647.has_value) {
+                    } else if (!_mv_1648.has_value) {
                     }
-                } else if (!_mv_1646.has_value) {
+                } else if (!_mv_1647.has_value) {
                 }
-                __auto_type _mv_1648 = (*formal).inner_type2;
-                if (_mv_1648.has_value) {
-                    __auto_type f_inner2 = _mv_1648.value;
-                    __auto_type _mv_1649 = (*actual).inner_type2;
-                    if (_mv_1649.has_value) {
-                        __auto_type a_inner2 = _mv_1649.value;
+                __auto_type _mv_1649 = (*formal).inner_type2;
+                if (_mv_1649.has_value) {
+                    __auto_type f_inner2 = _mv_1649.value;
+                    __auto_type _mv_1650 = (*actual).inner_type2;
+                    if (_mv_1650.has_value) {
+                        __auto_type a_inner2 = _mv_1650.value;
                         infer_unify_types(arena, f_inner2, a_inner2, bind_names, bind_types);
-                    } else if (!_mv_1649.has_value) {
+                    } else if (!_mv_1650.has_value) {
                     }
-                } else if (!_mv_1648.has_value) {
+                } else if (!_mv_1649.has_value) {
                 }
             }
         } else {
@@ -377,19 +377,19 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
         if (kind == types_ResolvedTypeKind_rk_typevar) {
             {
                 __auto_type tv_name = (*t).name;
-                __auto_type _mv_1650 = infer_find_binding(bind_names, bind_types, tv_name);
-                if (_mv_1650.has_value) {
-                    __auto_type bound = _mv_1650.value;
+                __auto_type _mv_1651 = infer_find_binding(bind_names, bind_types, tv_name);
+                if (_mv_1651.has_value) {
+                    __auto_type bound = _mv_1651.value;
                     return bound;
-                } else if (!_mv_1650.has_value) {
+                } else if (!_mv_1651.has_value) {
                     return t;
                 }
                 SLOP_UNREACHABLE();
             }
         } else if (kind == types_ResolvedTypeKind_rk_ptr) {
-            __auto_type _mv_1651 = (*t).inner_type;
-            if (_mv_1651.has_value) {
-                __auto_type inner = _mv_1651.value;
+            __auto_type _mv_1652 = (*t).inner_type;
+            if (_mv_1652.has_value) {
+                __auto_type inner = _mv_1652.value;
                 {
                     __auto_type new_inner = infer_substitute_type_vars(arena, inner, bind_names, bind_types);
                     __auto_type inner_name = (*new_inner).name;
@@ -398,56 +398,56 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
                     types_resolved_type_set_inner(new_ptr, new_inner);
                     return new_ptr;
                 }
-            } else if (!_mv_1651.has_value) {
+            } else if (!_mv_1652.has_value) {
                 return t;
             }
             SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_chan) {
-            __auto_type _mv_1652 = (*t).inner_type;
-            if (_mv_1652.has_value) {
-                __auto_type inner = _mv_1652.value;
+            __auto_type _mv_1653 = (*t).inner_type;
+            if (_mv_1653.has_value) {
+                __auto_type inner = _mv_1653.value;
                 {
                     __auto_type new_inner = infer_substitute_type_vars(arena, inner, bind_names, bind_types);
                     __auto_type new_chan = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_chan, SLOP_STR("Chan"), ((slop_option_string){.has_value = false}), SLOP_STR("slop_chan_int*"));
                     types_resolved_type_set_inner(new_chan, new_inner);
                     return new_chan;
                 }
-            } else if (!_mv_1652.has_value) {
+            } else if (!_mv_1653.has_value) {
                 return t;
             }
             SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_thread) {
-            __auto_type _mv_1653 = (*t).inner_type;
-            if (_mv_1653.has_value) {
-                __auto_type inner = _mv_1653.value;
+            __auto_type _mv_1654 = (*t).inner_type;
+            if (_mv_1654.has_value) {
+                __auto_type inner = _mv_1654.value;
                 {
                     __auto_type new_inner = infer_substitute_type_vars(arena, inner, bind_names, bind_types);
                     __auto_type new_thread = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_thread, SLOP_STR("Thread"), ((slop_option_string){.has_value = false}), SLOP_STR("slop_thread_int*"));
                     types_resolved_type_set_inner(new_thread, new_inner);
                     return new_thread;
                 }
-            } else if (!_mv_1653.has_value) {
+            } else if (!_mv_1654.has_value) {
                 return t;
             }
             SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_list) {
-            __auto_type _mv_1654 = (*t).inner_type;
-            if (_mv_1654.has_value) {
-                __auto_type inner = _mv_1654.value;
+            __auto_type _mv_1655 = (*t).inner_type;
+            if (_mv_1655.has_value) {
+                __auto_type inner = _mv_1655.value;
                 {
                     __auto_type new_inner = infer_substitute_type_vars(arena, inner, bind_names, bind_types);
                     __auto_type new_list = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_list, SLOP_STR("List"), ((slop_option_string){.has_value = false}), SLOP_STR("slop_list_t*"));
                     types_resolved_type_set_inner(new_list, new_inner);
                     return new_list;
                 }
-            } else if (!_mv_1654.has_value) {
+            } else if (!_mv_1655.has_value) {
                 return t;
             }
             SLOP_UNREACHABLE();
         } else if (kind == types_ResolvedTypeKind_rk_option) {
-            __auto_type _mv_1655 = (*t).inner_type;
-            if (_mv_1655.has_value) {
-                __auto_type inner = _mv_1655.value;
+            __auto_type _mv_1656 = (*t).inner_type;
+            if (_mv_1656.has_value) {
+                __auto_type inner = _mv_1656.value;
                 {
                     __auto_type new_inner = infer_substitute_type_vars(arena, inner, bind_names, bind_types);
                     __auto_type inner_name = (*new_inner).name;
@@ -456,7 +456,7 @@ types_ResolvedType* infer_substitute_type_vars(slop_arena* arena, types_Resolved
                     types_resolved_type_set_inner(new_opt, new_inner);
                     return new_opt;
                 }
-            } else if (!_mv_1655.has_value) {
+            } else if (!_mv_1656.has_value) {
                 return t;
             }
             SLOP_UNREACHABLE();
@@ -508,22 +508,22 @@ types_ResolvedType* infer_infer_generic_call(env_TypeEnv* env, types_FnSignature
                 {
                     __auto_type limit = (((num_args < num_params)) ? num_args : num_params);
                     for (int64_t i = 0; i < limit; i++) {
-                        __auto_type _mv_1656 = parser_sexpr_list_get(expr, (i + 1));
-                        if (_mv_1656.has_value) {
-                            __auto_type arg_expr = _mv_1656.value;
+                        __auto_type _mv_1657 = parser_sexpr_list_get(expr, (i + 1));
+                        if (_mv_1657.has_value) {
+                            __auto_type arg_expr = _mv_1657.value;
                             {
                                 __auto_type actual_type = infer_infer_expr(env, arg_expr);
-                                __auto_type _mv_1657 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_ParamInfo _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1657.has_value) {
-                                    __auto_type param_info = _mv_1657.value;
+                                __auto_type _mv_1658 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_ParamInfo _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1658.has_value) {
+                                    __auto_type param_info = _mv_1658.value;
                                     {
                                         __auto_type formal_type = param_info.param_type;
                                         infer_unify_types(arena, formal_type, actual_type, bind_names, bind_types);
                                     }
-                                } else if (!_mv_1657.has_value) {
+                                } else if (!_mv_1658.has_value) {
                                 }
                             }
-                        } else if (!_mv_1656.has_value) {
+                        } else if (!_mv_1657.has_value) {
                         }
                     }
                 }
@@ -577,20 +577,20 @@ uint8_t infer_types_compatible_with_range(types_ResolvedType* a, types_ResolvedT
         __auto_type a_kind = (*a).kind;
         __auto_type b_kind = (*b).kind;
         if (a_kind == types_ResolvedTypeKind_rk_range) {
-            __auto_type _mv_1658 = (*a).inner_type;
-            if (_mv_1658.has_value) {
-                __auto_type base = _mv_1658.value;
+            __auto_type _mv_1659 = (*a).inner_type;
+            if (_mv_1659.has_value) {
+                __auto_type base = _mv_1659.value;
                 return string_eq((*base).name, (*b).name);
-            } else if (!_mv_1658.has_value) {
+            } else if (!_mv_1659.has_value) {
                 return 0;
             }
             SLOP_UNREACHABLE();
         } else if (b_kind == types_ResolvedTypeKind_rk_range) {
-            __auto_type _mv_1659 = (*b).inner_type;
-            if (_mv_1659.has_value) {
-                __auto_type base = _mv_1659.value;
+            __auto_type _mv_1660 = (*b).inner_type;
+            if (_mv_1660.has_value) {
+                __auto_type base = _mv_1660.value;
                 return string_eq((*a).name, (*base).name);
-            } else if (!_mv_1659.has_value) {
+            } else if (!_mv_1660.has_value) {
                 return 0;
             }
             SLOP_UNREACHABLE();
@@ -639,29 +639,29 @@ types_ResolvedType* infer_unify_branch_types(env_TypeEnv* env, types_ResolvedTyp
 
 void infer_sexpr_set_resolved_type(types_SExpr* expr, types_ResolvedType* t) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1660 = (*expr);
-    switch (_mv_1660.tag) {
+    __auto_type _mv_1661 = (*expr);
+    switch (_mv_1661.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1660.data.sym;
+            __auto_type sym = _mv_1661.data.sym;
             (*expr) = ((types_SExpr){ .tag = types_SExpr_sym, .data.sym = (types_SExprSymbol){sym.name, sym.line, sym.col, (slop_option_types_ResolvedType_ptr){.has_value = 1, .value = t}} });
             break;
         }
         case types_SExpr_str:
         {
-            __auto_type str = _mv_1660.data.str;
+            __auto_type str = _mv_1661.data.str;
             (*expr) = ((types_SExpr){ .tag = types_SExpr_str, .data.str = (types_SExprString){str.value, str.line, str.col, (slop_option_types_ResolvedType_ptr){.has_value = 1, .value = t}} });
             break;
         }
         case types_SExpr_num:
         {
-            __auto_type num = _mv_1660.data.num;
+            __auto_type num = _mv_1661.data.num;
             (*expr) = ((types_SExpr){ .tag = types_SExpr_num, .data.num = (types_SExprNumber){num.int_value, num.float_value, num.is_float, num.raw, num.line, num.col, (slop_option_types_ResolvedType_ptr){.has_value = 1, .value = t}} });
             break;
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1660.data.lst;
+            __auto_type lst = _mv_1661.data.lst;
             (*expr) = ((types_SExpr){ .tag = types_SExpr_lst, .data.lst = (types_SExprList){lst.items, lst.line, lst.col, (slop_option_types_ResolvedType_ptr){.has_value = 1, .value = t}} });
             break;
         }
@@ -686,11 +686,11 @@ types_ResolvedType* infer_infer_expr_inner(env_TypeEnv* env, types_SExpr* expr) 
     {
         __auto_type line = parser_sexpr_line(expr);
         __auto_type col = parser_sexpr_col(expr);
-        __auto_type _mv_1661 = (*expr);
-        switch (_mv_1661.tag) {
+        __auto_type _mv_1662 = (*expr);
+        switch (_mv_1662.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1661.data.sym;
+                __auto_type sym = _mv_1662.data.sym;
                 {
                     __auto_type name = sym.name;
                     if (string_eq(name, SLOP_STR("true")) || string_eq(name, SLOP_STR("false"))) {
@@ -702,37 +702,37 @@ types_ResolvedType* infer_infer_expr_inner(env_TypeEnv* env, types_SExpr* expr) 
                     } else if (string_eq(name, SLOP_STR("none"))) {
                         return env_env_make_option_type(env, NULL);
                     } else {
-                        __auto_type _mv_1662 = env_env_lookup_var(env, name);
-                        if (_mv_1662.has_value) {
-                            __auto_type t = _mv_1662.value;
+                        __auto_type _mv_1663 = env_env_lookup_var(env, name);
+                        if (_mv_1663.has_value) {
+                            __auto_type t = _mv_1663.value;
                             return t;
-                        } else if (!_mv_1662.has_value) {
-                            __auto_type _mv_1663 = env_env_lookup_constant(env, name);
-                            if (_mv_1663.has_value) {
-                                __auto_type t = _mv_1663.value;
+                        } else if (!_mv_1663.has_value) {
+                            __auto_type _mv_1664 = env_env_lookup_constant(env, name);
+                            if (_mv_1664.has_value) {
+                                __auto_type t = _mv_1664.value;
                                 return t;
-                            } else if (!_mv_1663.has_value) {
-                                __auto_type _mv_1664 = env_env_lookup_function(env, name);
-                                if (_mv_1664.has_value) {
-                                    __auto_type sig = _mv_1664.value;
+                            } else if (!_mv_1664.has_value) {
+                                __auto_type _mv_1665 = env_env_lookup_function(env, name);
+                                if (_mv_1665.has_value) {
+                                    __auto_type sig = _mv_1665.value;
                                     return env_env_make_fn_type(env, sig);
-                                } else if (!_mv_1664.has_value) {
+                                } else if (!_mv_1665.has_value) {
                                     if (infer_string_contains_char(name, 46)) {
                                         {
                                             __auto_type dot_pos = infer_string_index_of(name, 46);
                                             __auto_type arena = env_env_arena(env);
                                             __auto_type base_name = infer_string_substring(arena, name, 0, dot_pos);
                                             __auto_type field_name = infer_string_substring(arena, name, (dot_pos + 1), ((int64_t)(name.len)));
-                                            __auto_type _mv_1665 = env_env_lookup_var(env, base_name);
-                                            if (_mv_1665.has_value) {
-                                                __auto_type obj_type = _mv_1665.value;
+                                            __auto_type _mv_1666 = env_env_lookup_var(env, base_name);
+                                            if (_mv_1666.has_value) {
+                                                __auto_type obj_type = _mv_1666.value;
                                                 return infer_check_field_exists(env, obj_type, field_name, line, col);
-                                            } else if (!_mv_1665.has_value) {
-                                                __auto_type _mv_1666 = env_env_lookup_type(env, base_name);
-                                                if (_mv_1666.has_value) {
-                                                    __auto_type type_info = _mv_1666.value;
+                                            } else if (!_mv_1666.has_value) {
+                                                __auto_type _mv_1667 = env_env_lookup_type(env, base_name);
+                                                if (_mv_1667.has_value) {
+                                                    __auto_type type_info = _mv_1667.value;
                                                     return type_info;
-                                                } else if (!_mv_1666.has_value) {
+                                                } else if (!_mv_1667.has_value) {
                                                     {
                                                         __auto_type msg = string_concat(arena, SLOP_STR("Undefined variable: "), name);
                                                         env_env_add_error(env, msg, line, col);
@@ -744,23 +744,23 @@ types_ResolvedType* infer_infer_expr_inner(env_TypeEnv* env, types_SExpr* expr) 
                                             SLOP_UNREACHABLE();
                                         }
                                     } else {
-                                        __auto_type _mv_1667 = env_env_lookup_type(env, name);
-                                        if (_mv_1667.has_value) {
-                                            __auto_type type_info = _mv_1667.value;
+                                        __auto_type _mv_1668 = env_env_lookup_type(env, name);
+                                        if (_mv_1668.has_value) {
+                                            __auto_type type_info = _mv_1668.value;
                                             return type_info;
-                                        } else if (!_mv_1667.has_value) {
-                                            __auto_type _mv_1668 = env_env_lookup_variant(env, name);
-                                            if (_mv_1668.has_value) {
-                                                __auto_type enum_name = _mv_1668.value;
-                                                __auto_type _mv_1669 = env_env_lookup_type(env, enum_name);
-                                                if (_mv_1669.has_value) {
-                                                    __auto_type t = _mv_1669.value;
+                                        } else if (!_mv_1668.has_value) {
+                                            __auto_type _mv_1669 = env_env_lookup_variant(env, name);
+                                            if (_mv_1669.has_value) {
+                                                __auto_type enum_name = _mv_1669.value;
+                                                __auto_type _mv_1670 = env_env_lookup_type(env, enum_name);
+                                                if (_mv_1670.has_value) {
+                                                    __auto_type t = _mv_1670.value;
                                                     return t;
-                                                } else if (!_mv_1669.has_value) {
+                                                } else if (!_mv_1670.has_value) {
                                                     return env_env_get_int_type(env);
                                                 }
                                                 SLOP_UNREACHABLE();
-                                            } else if (!_mv_1668.has_value) {
+                                            } else if (!_mv_1669.has_value) {
                                                 {
                                                     __auto_type arena = env_env_arena(env);
                                                     __auto_type msg = string_concat(arena, SLOP_STR("Undefined variable: "), name);
@@ -783,7 +783,7 @@ types_ResolvedType* infer_infer_expr_inner(env_TypeEnv* env, types_SExpr* expr) 
             }
             case types_SExpr_num:
             {
-                __auto_type num = _mv_1661.data.num;
+                __auto_type num = _mv_1662.data.num;
                 if (num.is_float) {
                     return env_env_get_float_type(env);
                 } else {
@@ -792,12 +792,12 @@ types_ResolvedType* infer_infer_expr_inner(env_TypeEnv* env, types_SExpr* expr) 
             }
             case types_SExpr_str:
             {
-                __auto_type str = _mv_1661.data.str;
+                __auto_type str = _mv_1662.data.str;
                 return env_env_get_string_type(env);
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1661.data.lst;
+                __auto_type lst = _mv_1662.data.lst;
                 return infer_infer_list_expr(env, expr, lst);
             }
         }
@@ -814,16 +814,16 @@ types_ResolvedType* infer_infer_list_expr(env_TypeEnv* env, types_SExpr* expr, t
         if (len == 0) {
             return env_env_get_unit_type(env);
         } else {
-            __auto_type _mv_1670 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (!_mv_1670.has_value) {
+            __auto_type _mv_1671 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (!_mv_1671.has_value) {
                 return env_env_get_unit_type(env);
-            } else if (_mv_1670.has_value) {
-                __auto_type head = _mv_1670.value;
-                __auto_type _mv_1671 = (*head);
-                switch (_mv_1671.tag) {
+            } else if (_mv_1671.has_value) {
+                __auto_type head = _mv_1671.value;
+                __auto_type _mv_1672 = (*head);
+                switch (_mv_1672.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_1671.data.sym;
+                        __auto_type sym = _mv_1672.data.sym;
                         {
                             __auto_type op = sym.name;
                             return infer_infer_special_form(env, expr, lst, op);
@@ -848,32 +848,32 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
         __auto_type col = parser_sexpr_col(expr);
         if (string_eq(op, SLOP_STR("if"))) {
             if (len >= 4) {
-                __auto_type _mv_1672 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1672.has_value) {
-                    __auto_type cond_expr = _mv_1672.value;
+                __auto_type _mv_1673 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1673.has_value) {
+                    __auto_type cond_expr = _mv_1673.value;
                     {
                         __auto_type _ = infer_infer_expr(env, cond_expr);
                     }
-                } else if (!_mv_1672.has_value) {
+                } else if (!_mv_1673.has_value) {
                 }
-                __auto_type _mv_1673 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1673.has_value) {
-                    __auto_type then_expr = _mv_1673.value;
+                __auto_type _mv_1674 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1674.has_value) {
+                    __auto_type then_expr = _mv_1674.value;
                     {
                         __auto_type then_type = infer_infer_expr(env, then_expr);
-                        __auto_type _mv_1674 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1674.has_value) {
-                            __auto_type else_expr = _mv_1674.value;
+                        __auto_type _mv_1675 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1675.has_value) {
+                            __auto_type else_expr = _mv_1675.value;
                             {
                                 __auto_type else_type = infer_infer_expr(env, else_expr);
                                 return infer_unify_branch_types(env, then_type, else_type, line, col);
                             }
-                        } else if (!_mv_1674.has_value) {
+                        } else if (!_mv_1675.has_value) {
                             return then_type;
                         }
                         SLOP_UNREACHABLE();
                     }
-                } else if (!_mv_1673.has_value) {
+                } else if (!_mv_1674.has_value) {
                     return env_env_get_unit_type(env);
                 }
                 SLOP_UNREACHABLE();
@@ -887,11 +887,11 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
         } else if (string_eq(op, SLOP_STR("do"))) {
             infer_infer_body_exprs(env, expr, 1);
             if (len > 1) {
-                __auto_type _mv_1675 = ({ __auto_type _lst = items; size_t _idx = (size_t)(len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1675.has_value) {
-                    __auto_type last = _mv_1675.value;
+                __auto_type _mv_1676 = ({ __auto_type _lst = items; size_t _idx = (size_t)(len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1676.has_value) {
+                    __auto_type last = _mv_1676.value;
                     return infer_infer_expr(env, last);
-                } else if (!_mv_1675.has_value) {
+                } else if (!_mv_1676.has_value) {
                     return env_env_get_unit_type(env);
                 }
                 SLOP_UNREACHABLE();
@@ -905,56 +905,56 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             return env_env_get_unit_type(env);
         } else if (string_eq(op, SLOP_STR("for"))) {
             if (len >= 2) {
-                __auto_type _mv_1676 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1676.has_value) {
-                    __auto_type binding_form = _mv_1676.value;
+                __auto_type _mv_1677 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1677.has_value) {
+                    __auto_type binding_form = _mv_1677.value;
                     if (parser_sexpr_is_list(binding_form)) {
                         {
                             __auto_type bind_len = parser_sexpr_list_len(binding_form);
                             if (bind_len >= 3) {
-                                __auto_type _mv_1677 = parser_sexpr_list_get(binding_form, 0);
-                                if (_mv_1677.has_value) {
-                                    __auto_type var_expr = _mv_1677.value;
+                                __auto_type _mv_1678 = parser_sexpr_list_get(binding_form, 0);
+                                if (_mv_1678.has_value) {
+                                    __auto_type var_expr = _mv_1678.value;
                                     {
                                         __auto_type var_name = parser_sexpr_get_symbol_name(var_expr);
                                         if (!(string_eq(var_name, SLOP_STR("")))) {
                                             env_env_push_scope(env);
                                             env_env_bind_var(env, var_name, env_env_get_int_type(env));
-                                            __auto_type _mv_1678 = parser_sexpr_list_get(binding_form, 1);
-                                            if (_mv_1678.has_value) {
-                                                __auto_type start_expr = _mv_1678.value;
+                                            __auto_type _mv_1679 = parser_sexpr_list_get(binding_form, 1);
+                                            if (_mv_1679.has_value) {
+                                                __auto_type start_expr = _mv_1679.value;
                                                 {
                                                     __auto_type _ = infer_infer_expr(env, start_expr);
                                                 }
-                                            } else if (!_mv_1678.has_value) {
+                                            } else if (!_mv_1679.has_value) {
                                             }
-                                            __auto_type _mv_1679 = parser_sexpr_list_get(binding_form, 2);
-                                            if (_mv_1679.has_value) {
-                                                __auto_type end_expr = _mv_1679.value;
+                                            __auto_type _mv_1680 = parser_sexpr_list_get(binding_form, 2);
+                                            if (_mv_1680.has_value) {
+                                                __auto_type end_expr = _mv_1680.value;
                                                 {
                                                     __auto_type _ = infer_infer_expr(env, end_expr);
                                                 }
-                                            } else if (!_mv_1679.has_value) {
+                                            } else if (!_mv_1680.has_value) {
                                             }
                                             for (int64_t body_idx = 2; body_idx < len; body_idx++) {
-                                                __auto_type _mv_1680 = ({ __auto_type _lst = items; size_t _idx = (size_t)body_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1680.has_value) {
-                                                    __auto_type body_expr = _mv_1680.value;
+                                                __auto_type _mv_1681 = ({ __auto_type _lst = items; size_t _idx = (size_t)body_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1681.has_value) {
+                                                    __auto_type body_expr = _mv_1681.value;
                                                     {
                                                         __auto_type _ = infer_infer_expr(env, body_expr);
                                                     }
-                                                } else if (!_mv_1680.has_value) {
+                                                } else if (!_mv_1681.has_value) {
                                                 }
                                             }
                                             env_env_pop_scope(env);
                                         }
                                     }
-                                } else if (!_mv_1677.has_value) {
+                                } else if (!_mv_1678.has_value) {
                                 }
                             }
                         }
                     }
-                } else if (!_mv_1676.has_value) {
+                } else if (!_mv_1677.has_value) {
                 }
                 return env_env_get_unit_type(env);
             } else {
@@ -962,24 +962,24 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             }
         } else if (string_eq(op, SLOP_STR("for-each"))) {
             if (len >= 3) {
-                __auto_type _mv_1681 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1681.has_value) {
-                    __auto_type binding_form = _mv_1681.value;
+                __auto_type _mv_1682 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1682.has_value) {
+                    __auto_type binding_form = _mv_1682.value;
                     if (parser_sexpr_is_list(binding_form)) {
                         {
                             __auto_type bind_len = parser_sexpr_list_len(binding_form);
                             if (bind_len >= 2) {
-                                __auto_type _mv_1682 = parser_sexpr_list_get(binding_form, 0);
-                                if (_mv_1682.has_value) {
-                                    __auto_type var_expr = _mv_1682.value;
+                                __auto_type _mv_1683 = parser_sexpr_list_get(binding_form, 0);
+                                if (_mv_1683.has_value) {
+                                    __auto_type var_expr = _mv_1683.value;
                                     {
                                         __auto_type var_name = parser_sexpr_get_symbol_name(var_expr);
                                         if (string_eq(var_name, SLOP_STR(""))) {
                                             return env_env_get_unit_type(env);
                                         } else {
-                                            __auto_type _mv_1683 = parser_sexpr_list_get(binding_form, 1);
-                                            if (_mv_1683.has_value) {
-                                                __auto_type coll_expr = _mv_1683.value;
+                                            __auto_type _mv_1684 = parser_sexpr_list_get(binding_form, 1);
+                                            if (_mv_1684.has_value) {
+                                                __auto_type coll_expr = _mv_1684.value;
                                                 {
                                                     __auto_type coll_type = infer_infer_expr(env, coll_expr);
                                                     __auto_type coll_line = parser_sexpr_line(coll_expr);
@@ -989,26 +989,26 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                                         env_env_push_scope(env);
                                                         env_env_bind_var(env, var_name, elem_type);
                                                         for (int64_t body_idx = 2; body_idx < len; body_idx++) {
-                                                            __auto_type _mv_1684 = ({ __auto_type _lst = items; size_t _idx = (size_t)body_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                            if (_mv_1684.has_value) {
-                                                                __auto_type body_expr = _mv_1684.value;
+                                                            __auto_type _mv_1685 = ({ __auto_type _lst = items; size_t _idx = (size_t)body_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                            if (_mv_1685.has_value) {
+                                                                __auto_type body_expr = _mv_1685.value;
                                                                 {
                                                                     __auto_type _ = infer_infer_expr(env, body_expr);
                                                                 }
-                                                            } else if (!_mv_1684.has_value) {
+                                                            } else if (!_mv_1685.has_value) {
                                                             }
                                                         }
                                                         env_env_pop_scope(env);
                                                         return env_env_get_unit_type(env);
                                                     }
                                                 }
-                                            } else if (!_mv_1683.has_value) {
+                                            } else if (!_mv_1684.has_value) {
                                                 return env_env_get_unit_type(env);
                                             }
                                             SLOP_UNREACHABLE();
                                         }
                                     }
-                                } else if (!_mv_1682.has_value) {
+                                } else if (!_mv_1683.has_value) {
                                     return env_env_get_unit_type(env);
                                 }
                                 SLOP_UNREACHABLE();
@@ -1019,7 +1019,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                     } else {
                         return env_env_get_unit_type(env);
                     }
-                } else if (!_mv_1681.has_value) {
+                } else if (!_mv_1682.has_value) {
                     return env_env_get_unit_type(env);
                 }
                 SLOP_UNREACHABLE();
@@ -1035,23 +1035,23 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
         } else if (string_eq(op, SLOP_STR("fn"))) {
             env_env_push_scope(env);
             if (len >= 2) {
-                __auto_type _mv_1685 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1685.has_value) {
-                    __auto_type params_expr = _mv_1685.value;
+                __auto_type _mv_1686 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1686.has_value) {
+                    __auto_type params_expr = _mv_1686.value;
                     if (parser_sexpr_is_list(params_expr)) {
                         {
                             __auto_type num_params = parser_sexpr_list_len(params_expr);
                             for (int64_t k = 0; k < num_params; k++) {
-                                __auto_type _mv_1686 = parser_sexpr_list_get(params_expr, k);
-                                if (_mv_1686.has_value) {
-                                    __auto_type param_form = _mv_1686.value;
+                                __auto_type _mv_1687 = parser_sexpr_list_get(params_expr, k);
+                                if (_mv_1687.has_value) {
+                                    __auto_type param_form = _mv_1687.value;
                                     infer_bind_param_from_form(env, param_form);
-                                } else if (!_mv_1686.has_value) {
+                                } else if (!_mv_1687.has_value) {
                                 }
                             }
                         }
                     }
-                } else if (!_mv_1685.has_value) {
+                } else if (!_mv_1686.has_value) {
                 }
             }
             {
@@ -1066,16 +1066,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             return infer_infer_with_arena_expr(env, expr);
         } else if (string_eq(op, SLOP_STR("set!"))) {
             if (len >= 4) {
-                __auto_type _mv_1687 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1687.has_value) {
-                    __auto_type val_expr = _mv_1687.value;
-                    {
-                        __auto_type _ = infer_infer_expr(env, val_expr);
-                    }
-                } else if (!_mv_1687.has_value) {
-                }
-            } else if (len >= 3) {
-                __auto_type _mv_1688 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                __auto_type _mv_1688 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                 if (_mv_1688.has_value) {
                     __auto_type val_expr = _mv_1688.value;
                     {
@@ -1083,18 +1074,27 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                     }
                 } else if (!_mv_1688.has_value) {
                 }
+            } else if (len >= 3) {
+                __auto_type _mv_1689 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1689.has_value) {
+                    __auto_type val_expr = _mv_1689.value;
+                    {
+                        __auto_type _ = infer_infer_expr(env, val_expr);
+                    }
+                } else if (!_mv_1689.has_value) {
+                }
             } else {
             }
             return env_env_get_unit_type(env);
         } else if (string_eq(op, SLOP_STR("return"))) {
             if (len >= 2) {
-                __auto_type _mv_1689 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1689.has_value) {
-                    __auto_type ret_expr = _mv_1689.value;
+                __auto_type _mv_1690 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1690.has_value) {
+                    __auto_type ret_expr = _mv_1690.value;
                     {
                         __auto_type _ = infer_infer_expr(env, ret_expr);
                     }
-                } else if (!_mv_1689.has_value) {
+                } else if (!_mv_1690.has_value) {
                 }
             }
             return env_env_get_never_type(env);
@@ -1108,17 +1108,17 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             return env_env_get_int_type(env);
         } else if (string_eq(op, SLOP_STR("deref"))) {
             if (len >= 2) {
-                __auto_type _mv_1690 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1690.has_value) {
-                    __auto_type ptr_expr = _mv_1690.value;
+                __auto_type _mv_1691 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1691.has_value) {
+                    __auto_type ptr_expr = _mv_1691.value;
                     {
                         __auto_type ptr_type = infer_infer_expr(env, ptr_expr);
                         if (types_resolved_type_is_pointer(ptr_type)) {
-                            __auto_type _mv_1691 = (*ptr_type).inner_type;
-                            if (_mv_1691.has_value) {
-                                __auto_type inner = _mv_1691.value;
+                            __auto_type _mv_1692 = (*ptr_type).inner_type;
+                            if (_mv_1692.has_value) {
+                                __auto_type inner = _mv_1692.value;
                                 return inner;
-                            } else if (!_mv_1691.has_value) {
+                            } else if (!_mv_1692.has_value) {
                                 return env_env_get_unit_type(env);
                             }
                             SLOP_UNREACHABLE();
@@ -1126,7 +1126,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             return ptr_type;
                         }
                     }
-                } else if (!_mv_1690.has_value) {
+                } else if (!_mv_1691.has_value) {
                     return env_env_get_unit_type(env);
                 }
                 SLOP_UNREACHABLE();
@@ -1135,14 +1135,14 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             }
         } else if (string_eq(op, SLOP_STR("addr"))) {
             if (len >= 2) {
-                __auto_type _mv_1692 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1692.has_value) {
-                    __auto_type inner_expr = _mv_1692.value;
+                __auto_type _mv_1693 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1693.has_value) {
+                    __auto_type inner_expr = _mv_1693.value;
                     {
                         __auto_type inner_type = infer_infer_expr(env, inner_expr);
                         return env_env_make_ptr_type(env, inner_type);
                     }
-                } else if (!_mv_1692.has_value) {
+                } else if (!_mv_1693.has_value) {
                     return env_env_get_unit_type(env);
                 }
                 SLOP_UNREACHABLE();
@@ -1151,16 +1151,16 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             }
         } else if (string_eq(op, SLOP_STR("cast"))) {
             if (len >= 2) {
-                __auto_type _mv_1693 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1693.has_value) {
-                    __auto_type type_expr = _mv_1693.value;
+                __auto_type _mv_1694 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1694.has_value) {
+                    __auto_type type_expr = _mv_1694.value;
                     {
                         __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                         if (string_eq(type_name, SLOP_STR(""))) {
                             if (parser_sexpr_is_list(type_expr)) {
-                                __auto_type _mv_1694 = parser_sexpr_list_get(type_expr, 0);
-                                if (_mv_1694.has_value) {
-                                    __auto_type head_expr = _mv_1694.value;
+                                __auto_type _mv_1695 = parser_sexpr_list_get(type_expr, 0);
+                                if (_mv_1695.has_value) {
+                                    __auto_type head_expr = _mv_1695.value;
                                     {
                                         __auto_type head_name = parser_sexpr_get_symbol_name(head_expr);
                                         if (string_eq(head_name, SLOP_STR("Int"))) {
@@ -1190,7 +1190,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                             return env_env_get_unknown_type(env);
                                         }
                                     }
-                                } else if (!_mv_1694.has_value) {
+                                } else if (!_mv_1695.has_value) {
                                     return env_env_get_unknown_type(env);
                                 }
                                 SLOP_UNREACHABLE();
@@ -1198,11 +1198,11 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                 return env_env_get_unknown_type(env);
                             }
                         } else {
-                            __auto_type _mv_1695 = env_env_lookup_type(env, type_name);
-                            if (_mv_1695.has_value) {
-                                __auto_type t = _mv_1695.value;
+                            __auto_type _mv_1696 = env_env_lookup_type(env, type_name);
+                            if (_mv_1696.has_value) {
+                                __auto_type t = _mv_1696.value;
                                 return t;
-                            } else if (!_mv_1695.has_value) {
+                            } else if (!_mv_1696.has_value) {
                                 if (string_eq(type_name, SLOP_STR("Int"))) {
                                     return env_env_get_int_type(env);
                                 } else if (string_eq(type_name, SLOP_STR("Bool"))) {
@@ -1218,7 +1218,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             SLOP_UNREACHABLE();
                         }
                     }
-                } else if (!_mv_1693.has_value) {
+                } else if (!_mv_1694.has_value) {
                     return env_env_get_unknown_type(env);
                 }
                 SLOP_UNREACHABLE();
@@ -1227,32 +1227,32 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             }
         } else if (string_eq(op, SLOP_STR("quote"))) {
             if (len >= 2) {
-                __auto_type _mv_1696 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1696.has_value) {
-                    __auto_type variant_expr = _mv_1696.value;
+                __auto_type _mv_1697 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1697.has_value) {
+                    __auto_type variant_expr = _mv_1697.value;
                     {
                         __auto_type variant_name = parser_sexpr_get_symbol_name(variant_expr);
                         if (string_eq(variant_name, SLOP_STR(""))) {
                             return env_env_get_unknown_type(env);
                         } else {
-                            __auto_type _mv_1697 = env_env_lookup_variant(env, variant_name);
-                            if (_mv_1697.has_value) {
-                                __auto_type enum_name = _mv_1697.value;
-                                __auto_type _mv_1698 = env_env_lookup_type(env, enum_name);
-                                if (_mv_1698.has_value) {
-                                    __auto_type enum_type = _mv_1698.value;
+                            __auto_type _mv_1698 = env_env_lookup_variant(env, variant_name);
+                            if (_mv_1698.has_value) {
+                                __auto_type enum_name = _mv_1698.value;
+                                __auto_type _mv_1699 = env_env_lookup_type(env, enum_name);
+                                if (_mv_1699.has_value) {
+                                    __auto_type enum_type = _mv_1699.value;
                                     return enum_type;
-                                } else if (!_mv_1698.has_value) {
+                                } else if (!_mv_1699.has_value) {
                                     return env_env_get_unknown_type(env);
                                 }
                                 SLOP_UNREACHABLE();
-                            } else if (!_mv_1697.has_value) {
+                            } else if (!_mv_1698.has_value) {
                                 return env_env_get_unknown_type(env);
                             }
                             SLOP_UNREACHABLE();
                         }
                     }
-                } else if (!_mv_1696.has_value) {
+                } else if (!_mv_1697.has_value) {
                     return env_env_get_unknown_type(env);
                 }
                 SLOP_UNREACHABLE();
@@ -1263,14 +1263,14 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             return infer_infer_field_access(env, expr, lst, line, col);
         } else if (string_eq(op, SLOP_STR("some"))) {
             if (len >= 2) {
-                __auto_type _mv_1699 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1699.has_value) {
-                    __auto_type inner_expr = _mv_1699.value;
+                __auto_type _mv_1700 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1700.has_value) {
+                    __auto_type inner_expr = _mv_1700.value;
                     {
                         __auto_type inner_type = infer_infer_expr(env, inner_expr);
                         return env_env_make_option_type(env, inner_type);
                     }
-                } else if (!_mv_1699.has_value) {
+                } else if (!_mv_1700.has_value) {
                     return env_env_make_option_type(env, NULL);
                 }
                 SLOP_UNREACHABLE();
@@ -1281,42 +1281,42 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             return env_env_make_option_type(env, NULL);
         } else if (string_eq(op, SLOP_STR("record-new"))) {
             for (int64_t fi = 2; fi < len; fi++) {
-                __auto_type _mv_1700 = ({ __auto_type _lst = items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1700.has_value) {
-                    __auto_type field_pair = _mv_1700.value;
+                __auto_type _mv_1701 = ({ __auto_type _lst = items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1701.has_value) {
+                    __auto_type field_pair = _mv_1701.value;
                     if (parser_sexpr_is_list(field_pair) && (parser_sexpr_list_len(field_pair) >= 2)) {
-                        __auto_type _mv_1701 = parser_sexpr_list_get(field_pair, 1);
-                        if (_mv_1701.has_value) {
-                            __auto_type val_expr = _mv_1701.value;
+                        __auto_type _mv_1702 = parser_sexpr_list_get(field_pair, 1);
+                        if (_mv_1702.has_value) {
+                            __auto_type val_expr = _mv_1702.value;
                             {
                                 __auto_type _ = infer_infer_expr(env, val_expr);
                             }
-                        } else if (!_mv_1701.has_value) {
+                        } else if (!_mv_1702.has_value) {
                         }
                     }
-                } else if (!_mv_1700.has_value) {
+                } else if (!_mv_1701.has_value) {
                 }
             }
             if (len >= 2) {
-                __auto_type _mv_1702 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1702.has_value) {
-                    __auto_type type_expr = _mv_1702.value;
+                __auto_type _mv_1703 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1703.has_value) {
+                    __auto_type type_expr = _mv_1703.value;
                     {
                         __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                         if (string_eq(type_name, SLOP_STR(""))) {
                             return env_env_get_unit_type(env);
                         } else {
-                            __auto_type _mv_1703 = env_env_lookup_type(env, type_name);
-                            if (_mv_1703.has_value) {
-                                __auto_type t = _mv_1703.value;
+                            __auto_type _mv_1704 = env_env_lookup_type(env, type_name);
+                            if (_mv_1704.has_value) {
+                                __auto_type t = _mv_1704.value;
                                 return t;
-                            } else if (!_mv_1703.has_value) {
+                            } else if (!_mv_1704.has_value) {
                                 return env_env_get_unit_type(env);
                             }
                             SLOP_UNREACHABLE();
                         }
                     }
-                } else if (!_mv_1702.has_value) {
+                } else if (!_mv_1703.has_value) {
                     return env_env_get_unit_type(env);
                 }
                 SLOP_UNREACHABLE();
@@ -1325,35 +1325,35 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
             }
         } else if (string_eq(op, SLOP_STR("union-new"))) {
             if (len >= 4) {
-                __auto_type _mv_1704 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1704.has_value) {
-                    __auto_type val_expr = _mv_1704.value;
+                __auto_type _mv_1705 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1705.has_value) {
+                    __auto_type val_expr = _mv_1705.value;
                     {
                         __auto_type _ = infer_infer_expr(env, val_expr);
                     }
-                } else if (!_mv_1704.has_value) {
+                } else if (!_mv_1705.has_value) {
                 }
             }
             if (len >= 2) {
-                __auto_type _mv_1705 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1705.has_value) {
-                    __auto_type type_expr = _mv_1705.value;
+                __auto_type _mv_1706 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1706.has_value) {
+                    __auto_type type_expr = _mv_1706.value;
                     {
                         __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                         if (string_eq(type_name, SLOP_STR(""))) {
                             return env_env_get_unit_type(env);
                         } else {
-                            __auto_type _mv_1706 = env_env_lookup_type(env, type_name);
-                            if (_mv_1706.has_value) {
-                                __auto_type t = _mv_1706.value;
+                            __auto_type _mv_1707 = env_env_lookup_type(env, type_name);
+                            if (_mv_1707.has_value) {
+                                __auto_type t = _mv_1707.value;
                                 return t;
-                            } else if (!_mv_1706.has_value) {
+                            } else if (!_mv_1707.has_value) {
                                 return env_env_get_unit_type(env);
                             }
                             SLOP_UNREACHABLE();
                         }
                     }
-                } else if (!_mv_1705.has_value) {
+                } else if (!_mv_1706.has_value) {
                     return env_env_get_unit_type(env);
                 }
                 SLOP_UNREACHABLE();
@@ -1372,42 +1372,42 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
         } else if (infer_is_chan_buffered_op(op) || infer_is_chan_op(op)) {
             return infer_infer_threading_builtin(env, op, expr, items, len, line, col);
         } else {
-            __auto_type _mv_1707 = env_env_lookup_function(env, op);
-            if (_mv_1707.has_value) {
-                __auto_type sig = _mv_1707.value;
+            __auto_type _mv_1708 = env_env_lookup_function(env, op);
+            if (_mv_1708.has_value) {
+                __auto_type sig = _mv_1708.value;
                 if (infer_has_type_params(sig)) {
                     return infer_infer_generic_call(env, sig, expr, line, col);
                 } else {
                     infer_check_fn_call_args(env, sig, expr, line, col);
                     return (*sig).return_type;
                 }
-            } else if (!_mv_1707.has_value) {
-                __auto_type _mv_1708 = env_env_lookup_type(env, op);
-                if (_mv_1708.has_value) {
-                    __auto_type the_type = _mv_1708.value;
+            } else if (!_mv_1708.has_value) {
+                __auto_type _mv_1709 = env_env_lookup_type(env, op);
+                if (_mv_1709.has_value) {
+                    __auto_type the_type = _mv_1709.value;
                     return the_type;
-                } else if (!_mv_1708.has_value) {
+                } else if (!_mv_1709.has_value) {
                     if (string_eq(op, SLOP_STR("list-get"))) {
                         infer_check_builtin_args(env, SLOP_STR("list-get"), 2, (len - 1), line, col);
                         infer_infer_builtin_args(env, expr);
                         {
                             types_ResolvedType* elem_type = NULL;
                             if (len >= 2) {
-                                __auto_type _mv_1709 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1709.has_value) {
-                                    __auto_type list_arg = _mv_1709.value;
+                                __auto_type _mv_1710 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1710.has_value) {
+                                    __auto_type list_arg = _mv_1710.value;
                                     {
                                         __auto_type list_type = infer_infer_expr(env, list_arg);
                                         if ((*list_type).kind == types_ResolvedTypeKind_rk_list) {
-                                            __auto_type _mv_1710 = (*list_type).inner_type;
-                                            if (_mv_1710.has_value) {
-                                                __auto_type inner = _mv_1710.value;
+                                            __auto_type _mv_1711 = (*list_type).inner_type;
+                                            if (_mv_1711.has_value) {
+                                                __auto_type inner = _mv_1711.value;
                                                 elem_type = inner;
-                                            } else if (!_mv_1710.has_value) {
+                                            } else if (!_mv_1711.has_value) {
                                             }
                                         }
                                     }
-                                } else if (!_mv_1709.has_value) {
+                                } else if (!_mv_1710.has_value) {
                                 }
                             }
                             return env_env_make_option_type(env, elem_type);
@@ -1420,43 +1420,43 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             env_env_add_error(env, SLOP_STR("arena-alloc requires arena and type/size arguments"), line, col);
                             return env_env_get_int_type(env);
                         } else {
-                            __auto_type _mv_1711 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1711.has_value) {
-                                __auto_type type_expr = _mv_1711.value;
+                            __auto_type _mv_1712 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1712.has_value) {
+                                __auto_type type_expr = _mv_1712.value;
                                 {
                                     __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                                     if (string_eq(type_name, SLOP_STR(""))) {
                                         if (parser_sexpr_is_list(type_expr)) {
-                                            __auto_type _mv_1712 = parser_sexpr_list_get(type_expr, 0);
-                                            if (_mv_1712.has_value) {
-                                                __auto_type head_expr = _mv_1712.value;
+                                            __auto_type _mv_1713 = parser_sexpr_list_get(type_expr, 0);
+                                            if (_mv_1713.has_value) {
+                                                __auto_type head_expr = _mv_1713.value;
                                                 if (string_eq(parser_sexpr_get_symbol_name(head_expr), SLOP_STR("sizeof"))) {
-                                                    __auto_type _mv_1713 = parser_sexpr_list_get(type_expr, 1);
-                                                    if (_mv_1713.has_value) {
-                                                        __auto_type sizeof_type_expr = _mv_1713.value;
+                                                    __auto_type _mv_1714 = parser_sexpr_list_get(type_expr, 1);
+                                                    if (_mv_1714.has_value) {
+                                                        __auto_type sizeof_type_expr = _mv_1714.value;
                                                         {
                                                             __auto_type sizeof_type_name = parser_sexpr_get_symbol_name(sizeof_type_expr);
                                                             if (string_eq(sizeof_type_name, SLOP_STR(""))) {
                                                                 return env_env_get_int_type(env);
                                                             } else {
-                                                                __auto_type _mv_1714 = env_env_lookup_type(env, sizeof_type_name);
-                                                                if (_mv_1714.has_value) {
-                                                                    __auto_type resolved = _mv_1714.value;
+                                                                __auto_type _mv_1715 = env_env_lookup_type(env, sizeof_type_name);
+                                                                if (_mv_1715.has_value) {
+                                                                    __auto_type resolved = _mv_1715.value;
                                                                     return env_env_make_ptr_type(env, resolved);
-                                                                } else if (!_mv_1714.has_value) {
+                                                                } else if (!_mv_1715.has_value) {
                                                                     return env_env_get_int_type(env);
                                                                 }
                                                                 SLOP_UNREACHABLE();
                                                             }
                                                         }
-                                                    } else if (!_mv_1713.has_value) {
+                                                    } else if (!_mv_1714.has_value) {
                                                         return env_env_get_int_type(env);
                                                     }
                                                     SLOP_UNREACHABLE();
                                                 } else {
                                                     return env_env_get_int_type(env);
                                                 }
-                                            } else if (!_mv_1712.has_value) {
+                                            } else if (!_mv_1713.has_value) {
                                                 return env_env_get_int_type(env);
                                             }
                                             SLOP_UNREACHABLE();
@@ -1464,11 +1464,11 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                             return env_env_get_int_type(env);
                                         }
                                     } else {
-                                        __auto_type _mv_1715 = env_env_lookup_type(env, type_name);
-                                        if (_mv_1715.has_value) {
-                                            __auto_type resolved = _mv_1715.value;
+                                        __auto_type _mv_1716 = env_env_lookup_type(env, type_name);
+                                        if (_mv_1716.has_value) {
+                                            __auto_type resolved = _mv_1716.value;
                                             return env_env_make_ptr_type(env, resolved);
-                                        } else if (!_mv_1715.has_value) {
+                                        } else if (!_mv_1716.has_value) {
                                             {
                                                 __auto_type arena = env_env_arena(env);
                                                 env_env_add_warning(env, string_concat(arena, SLOP_STR("arena-alloc: unknown type: "), type_name), line, col);
@@ -1478,7 +1478,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                         SLOP_UNREACHABLE();
                                     }
                                 }
-                            } else if (!_mv_1711.has_value) {
+                            } else if (!_mv_1712.has_value) {
                                 return env_env_get_int_type(env);
                             }
                             SLOP_UNREACHABLE();
@@ -1504,16 +1504,16 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             __auto_type arena = env_env_arena(env);
                             __auto_type list_type = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_list, SLOP_STR("List"), ((slop_option_string){.has_value = false}), SLOP_STR("slop_list_t*"));
                             if (len >= 3) {
-                                __auto_type _mv_1716 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1716.has_value) {
-                                    __auto_type type_expr = _mv_1716.value;
+                                __auto_type _mv_1717 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1717.has_value) {
+                                    __auto_type type_expr = _mv_1717.value;
                                     {
                                         __auto_type elem_type = ((parser_sexpr_is_list(type_expr)) ? infer_resolve_complex_type_expr(env, type_expr) : ({ __auto_type tname = parser_sexpr_get_symbol_name(type_expr); ((string_eq(tname, SLOP_STR(""))) ? NULL : infer_resolve_simple_type(env, tname)); }));
                                         if (elem_type != NULL) {
                                             types_resolved_type_set_inner(list_type, elem_type);
                                         }
                                     }
-                                } else if (!_mv_1716.has_value) {
+                                } else if (!_mv_1717.has_value) {
                                 }
                             }
                             return list_type;
@@ -1541,14 +1541,14 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             __auto_type arena = env_env_arena(env);
                             __auto_type result_type = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_result, SLOP_STR("Result"), ((slop_option_string){.has_value = false}), SLOP_STR("Result"));
                             if (len >= 2) {
-                                __auto_type _mv_1717 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1717.has_value) {
-                                    __auto_type val_expr = _mv_1717.value;
+                                __auto_type _mv_1718 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1718.has_value) {
+                                    __auto_type val_expr = _mv_1718.value;
                                     {
                                         __auto_type val_type = infer_infer_expr(env, val_expr);
                                         types_resolved_type_set_inner(result_type, val_type);
                                     }
-                                } else if (!_mv_1717.has_value) {
+                                } else if (!_mv_1718.has_value) {
                                 }
                             }
                             return result_type;
@@ -1558,31 +1558,31 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             __auto_type arena = env_env_arena(env);
                             __auto_type result_type = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_result, SLOP_STR("Result"), ((slop_option_string){.has_value = false}), SLOP_STR("Result"));
                             if (len >= 2) {
-                                __auto_type _mv_1718 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1718.has_value) {
-                                    __auto_type val_expr = _mv_1718.value;
+                                __auto_type _mv_1719 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1719.has_value) {
+                                    __auto_type val_expr = _mv_1719.value;
                                     {
                                         __auto_type val_type = infer_infer_expr(env, val_expr);
                                         types_resolved_type_set_inner2(result_type, val_type);
                                     }
-                                } else if (!_mv_1718.has_value) {
+                                } else if (!_mv_1719.has_value) {
                                 }
                             }
                             return result_type;
                         }
                     } else if (string_eq(op, SLOP_STR("@"))) {
                         if (len >= 2) {
-                            __auto_type _mv_1719 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1719.has_value) {
-                                __auto_type ptr_expr = _mv_1719.value;
+                            __auto_type _mv_1720 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1720.has_value) {
+                                __auto_type ptr_expr = _mv_1720.value;
                                 {
                                     __auto_type ptr_type = infer_infer_expr(env, ptr_expr);
                                     if (types_resolved_type_is_pointer(ptr_type)) {
-                                        __auto_type _mv_1720 = (*ptr_type).inner_type;
-                                        if (_mv_1720.has_value) {
-                                            __auto_type inner = _mv_1720.value;
+                                        __auto_type _mv_1721 = (*ptr_type).inner_type;
+                                        if (_mv_1721.has_value) {
+                                            __auto_type inner = _mv_1721.value;
                                             return inner;
-                                        } else if (!_mv_1720.has_value) {
+                                        } else if (!_mv_1721.has_value) {
                                             return env_env_get_int_type(env);
                                         }
                                         SLOP_UNREACHABLE();
@@ -1590,7 +1590,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                         return env_env_get_int_type(env);
                                     }
                                 }
-                            } else if (!_mv_1719.has_value) {
+                            } else if (!_mv_1720.has_value) {
                                 return env_env_get_int_type(env);
                             }
                             SLOP_UNREACHABLE();
@@ -1608,39 +1608,39 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             types_ResolvedType* key_type = NULL;
                             types_ResolvedType* val_type = NULL;
                             if (len >= 3) {
-                                __auto_type _mv_1721 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1721.has_value) {
-                                    __auto_type type_expr = _mv_1721.value;
+                                __auto_type _mv_1722 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1722.has_value) {
+                                    __auto_type type_expr = _mv_1722.value;
                                     {
                                         __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                                         if (!(string_eq(type_name, SLOP_STR("")))) {
-                                            __auto_type _mv_1722 = env_env_lookup_type(env, type_name);
-                                            if (_mv_1722.has_value) {
-                                                __auto_type t = _mv_1722.value;
+                                            __auto_type _mv_1723 = env_env_lookup_type(env, type_name);
+                                            if (_mv_1723.has_value) {
+                                                __auto_type t = _mv_1723.value;
                                                 key_type = t;
-                                            } else if (!_mv_1722.has_value) {
+                                            } else if (!_mv_1723.has_value) {
                                             }
                                         }
                                     }
-                                } else if (!_mv_1721.has_value) {
+                                } else if (!_mv_1722.has_value) {
                                 }
                             }
                             if (len >= 4) {
-                                __auto_type _mv_1723 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1723.has_value) {
-                                    __auto_type type_expr = _mv_1723.value;
+                                __auto_type _mv_1724 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1724.has_value) {
+                                    __auto_type type_expr = _mv_1724.value;
                                     {
                                         __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                                         if (!(string_eq(type_name, SLOP_STR("")))) {
-                                            __auto_type _mv_1724 = env_env_lookup_type(env, type_name);
-                                            if (_mv_1724.has_value) {
-                                                __auto_type t = _mv_1724.value;
+                                            __auto_type _mv_1725 = env_env_lookup_type(env, type_name);
+                                            if (_mv_1725.has_value) {
+                                                __auto_type t = _mv_1725.value;
                                                 val_type = t;
-                                            } else if (!_mv_1724.has_value) {
+                                            } else if (!_mv_1725.has_value) {
                                             }
                                         }
                                     }
-                                } else if (!_mv_1723.has_value) {
+                                } else if (!_mv_1724.has_value) {
                                 }
                             }
                             {
@@ -1659,19 +1659,19 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                         {
                             types_ResolvedType* val_type = NULL;
                             if (len >= 2) {
-                                __auto_type _mv_1725 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1725.has_value) {
-                                    __auto_type map_expr = _mv_1725.value;
+                                __auto_type _mv_1726 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1726.has_value) {
+                                    __auto_type map_expr = _mv_1726.value;
                                     {
                                         __auto_type map_type = infer_infer_expr(env, map_expr);
-                                        __auto_type _mv_1726 = (*map_type).inner_type2;
-                                        if (_mv_1726.has_value) {
-                                            __auto_type inner = _mv_1726.value;
+                                        __auto_type _mv_1727 = (*map_type).inner_type2;
+                                        if (_mv_1727.has_value) {
+                                            __auto_type inner = _mv_1727.value;
                                             val_type = inner;
-                                        } else if (!_mv_1726.has_value) {
+                                        } else if (!_mv_1727.has_value) {
                                         }
                                     }
-                                } else if (!_mv_1725.has_value) {
+                                } else if (!_mv_1726.has_value) {
                                 }
                             }
                             return env_env_make_option_type(env, val_type);
@@ -1682,9 +1682,9 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                     } else if (string_eq(op, SLOP_STR("map-has"))) {
                         infer_check_builtin_args(env, SLOP_STR("map-has"), 2, (len - 1), line, col);
                         if (len >= 2) {
-                            __auto_type _mv_1727 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1727.has_value) {
-                                __auto_type map_expr = _mv_1727.value;
+                            __auto_type _mv_1728 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1728.has_value) {
+                                __auto_type map_expr = _mv_1728.value;
                                 {
                                     __auto_type map_type = infer_infer_expr(env, map_expr);
                                     __auto_type type_name = (*map_type).name;
@@ -1696,7 +1696,7 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                         }
                                     }
                                 }
-                            } else if (!_mv_1727.has_value) {
+                            } else if (!_mv_1728.has_value) {
                             }
                         }
                         return env_env_get_bool_type(env);
@@ -1706,19 +1706,19 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             __auto_type arena = env_env_arena(env);
                             types_ResolvedType* key_type = NULL;
                             if (len >= 2) {
-                                __auto_type _mv_1728 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1728.has_value) {
-                                    __auto_type map_expr = _mv_1728.value;
+                                __auto_type _mv_1729 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1729.has_value) {
+                                    __auto_type map_expr = _mv_1729.value;
                                     {
                                         __auto_type map_type = infer_infer_expr(env, map_expr);
-                                        __auto_type _mv_1729 = (*map_type).inner_type;
-                                        if (_mv_1729.has_value) {
-                                            __auto_type inner = _mv_1729.value;
+                                        __auto_type _mv_1730 = (*map_type).inner_type;
+                                        if (_mv_1730.has_value) {
+                                            __auto_type inner = _mv_1730.value;
                                             key_type = inner;
-                                        } else if (!_mv_1729.has_value) {
+                                        } else if (!_mv_1730.has_value) {
                                         }
                                     }
-                                } else if (!_mv_1728.has_value) {
+                                } else if (!_mv_1729.has_value) {
                                 }
                             }
                             {
@@ -1743,21 +1743,21 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             __auto_type arena = env_env_arena(env);
                             types_ResolvedType* elem_type = NULL;
                             if (len >= 3) {
-                                __auto_type _mv_1730 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1730.has_value) {
-                                    __auto_type type_expr = _mv_1730.value;
+                                __auto_type _mv_1731 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1731.has_value) {
+                                    __auto_type type_expr = _mv_1731.value;
                                     {
                                         __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                                         if (!(string_eq(type_name, SLOP_STR("")))) {
-                                            __auto_type _mv_1731 = env_env_lookup_type(env, type_name);
-                                            if (_mv_1731.has_value) {
-                                                __auto_type t = _mv_1731.value;
+                                            __auto_type _mv_1732 = env_env_lookup_type(env, type_name);
+                                            if (_mv_1732.has_value) {
+                                                __auto_type t = _mv_1732.value;
                                                 elem_type = t;
-                                            } else if (!_mv_1731.has_value) {
+                                            } else if (!_mv_1732.has_value) {
                                             }
                                         }
                                     }
-                                } else if (!_mv_1730.has_value) {
+                                } else if (!_mv_1731.has_value) {
                                 }
                             }
                             {
@@ -1783,19 +1783,19 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                             __auto_type arena = env_env_arena(env);
                             types_ResolvedType* elem_type = NULL;
                             if (len >= 2) {
-                                __auto_type _mv_1732 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1732.has_value) {
-                                    __auto_type set_expr = _mv_1732.value;
+                                __auto_type _mv_1733 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1733.has_value) {
+                                    __auto_type set_expr = _mv_1733.value;
                                     {
                                         __auto_type set_type = infer_infer_expr(env, set_expr);
-                                        __auto_type _mv_1733 = (*set_type).inner_type;
-                                        if (_mv_1733.has_value) {
-                                            __auto_type inner = _mv_1733.value;
+                                        __auto_type _mv_1734 = (*set_type).inner_type;
+                                        if (_mv_1734.has_value) {
+                                            __auto_type inner = _mv_1734.value;
                                             elem_type = inner;
-                                        } else if (!_mv_1733.has_value) {
+                                        } else if (!_mv_1734.has_value) {
                                         }
                                     }
-                                } else if (!_mv_1732.has_value) {
+                                } else if (!_mv_1733.has_value) {
                                 }
                             }
                             {
@@ -1811,15 +1811,15 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                     } else {
                         {
                             __auto_type arena = env_env_arena(env);
-                            __auto_type _mv_1734 = env_env_lookup_variant(env, op);
-                            if (_mv_1734.has_value) {
-                                __auto_type parent_type = _mv_1734.value;
+                            __auto_type _mv_1735 = env_env_lookup_variant(env, op);
+                            if (_mv_1735.has_value) {
+                                __auto_type parent_type = _mv_1735.value;
                                 {
                                     __auto_type msg = string_concat(arena, SLOP_STR("'"), string_concat(arena, op, string_concat(arena, SLOP_STR("' is a variant of '"), string_concat(arena, parent_type, SLOP_STR("'. Use (union-new Type variant value) syntax")))));
                                     env_env_add_error(env, msg, line, col);
                                     return env_env_get_unknown_type(env);
                                 }
-                            } else if (!_mv_1734.has_value) {
+                            } else if (!_mv_1735.has_value) {
                                 if (strlib_starts_with(op, SLOP_STR("set-")) || (strlib_starts_with(op, SLOP_STR("map-")) || (strlib_starts_with(op, SLOP_STR("list-")) || strlib_starts_with(op, SLOP_STR("arena-"))))) {
                                     {
                                         __auto_type msg = string_concat(arena, SLOP_STR("Unknown builtin: '"), string_concat(arena, op, SLOP_STR("'")));
@@ -1827,12 +1827,12 @@ types_ResolvedType* infer_infer_special_form(env_TypeEnv* env, types_SExpr* expr
                                         return env_env_get_unknown_type(env);
                                     }
                                 } else {
-                                    __auto_type _mv_1735 = env_env_lookup_var(env, op);
-                                    if (_mv_1735.has_value) {
-                                        __auto_type var_type = _mv_1735.value;
+                                    __auto_type _mv_1736 = env_env_lookup_var(env, op);
+                                    if (_mv_1736.has_value) {
+                                        __auto_type var_type = _mv_1736.value;
                                         infer_infer_builtin_args(env, expr);
                                         return var_type;
-                                    } else if (!_mv_1735.has_value) {
+                                    } else if (!_mv_1736.has_value) {
                                         if (infer_string_contains_char(op, 45)) {
                                             {
                                                 __auto_type msg = string_concat(arena, SLOP_STR("Unknown function: '"), string_concat(arena, op, SLOP_STR("' - did you forget to import it?")));
@@ -1898,14 +1898,14 @@ void infer_check_single_arg(env_TypeEnv* env, types_FnSignature* sig, types_SExp
         __auto_type params = (*sig).params;
         __auto_type fn_name = (*sig).name;
         __auto_type arena = env_env_arena(env);
-        __auto_type _mv_1736 = ({ __auto_type _lst = params; size_t _idx = (size_t)arg_idx; slop_option_types_ParamInfo _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1736.has_value) {
-            __auto_type param_info = _mv_1736.value;
+        __auto_type _mv_1737 = ({ __auto_type _lst = params; size_t _idx = (size_t)arg_idx; slop_option_types_ParamInfo _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1737.has_value) {
+            __auto_type param_info = _mv_1737.value;
             {
                 __auto_type expected_type = param_info.param_type;
-                __auto_type _mv_1737 = parser_sexpr_list_get(expr, (arg_idx + 1));
-                if (_mv_1737.has_value) {
-                    __auto_type arg_expr = _mv_1737.value;
+                __auto_type _mv_1738 = parser_sexpr_list_get(expr, (arg_idx + 1));
+                if (_mv_1738.has_value) {
+                    __auto_type arg_expr = _mv_1738.value;
                     {
                         __auto_type actual_type = infer_infer_expr(env, arg_expr);
                         __auto_type expected_name = (*expected_type).name;
@@ -1932,10 +1932,10 @@ void infer_check_single_arg(env_TypeEnv* env, types_FnSignature* sig, types_SExp
                             }
                         }
                     }
-                } else if (!_mv_1737.has_value) {
+                } else if (!_mv_1738.has_value) {
                 }
             }
-        } else if (!_mv_1736.has_value) {
+        } else if (!_mv_1737.has_value) {
         }
     }
 }
@@ -1958,13 +1958,13 @@ void infer_infer_builtin_args(env_TypeEnv* env, types_SExpr* expr) {
         {
             __auto_type len = parser_sexpr_list_len(expr);
             for (int64_t i = 1; i < len; i++) {
-                __auto_type _mv_1738 = parser_sexpr_list_get(expr, i);
-                if (_mv_1738.has_value) {
-                    __auto_type arg_expr = _mv_1738.value;
+                __auto_type _mv_1739 = parser_sexpr_list_get(expr, i);
+                if (_mv_1739.has_value) {
+                    __auto_type arg_expr = _mv_1739.value;
                     {
                         __auto_type _ = infer_infer_expr(env, arg_expr);
                     }
-                } else if (!_mv_1738.has_value) {
+                } else if (!_mv_1739.has_value) {
                 }
             }
         }
@@ -1978,13 +1978,13 @@ void infer_infer_body_exprs(env_TypeEnv* env, types_SExpr* expr, int64_t start_i
         {
             __auto_type len = parser_sexpr_list_len(expr);
             for (int64_t i = start_idx; i < len; i++) {
-                __auto_type _mv_1739 = parser_sexpr_list_get(expr, i);
-                if (_mv_1739.has_value) {
-                    __auto_type body_expr = _mv_1739.value;
+                __auto_type _mv_1740 = parser_sexpr_list_get(expr, i);
+                if (_mv_1740.has_value) {
+                    __auto_type body_expr = _mv_1740.value;
                     {
                         __auto_type _ = infer_infer_expr(env, body_expr);
                     }
-                } else if (!_mv_1739.has_value) {
+                } else if (!_mv_1740.has_value) {
                 }
             }
         }
@@ -1999,23 +1999,23 @@ types_ResolvedType* infer_infer_field_access(env_TypeEnv* env, types_SExpr* expr
         if (len < 3) {
             return env_env_get_unit_type(env);
         } else {
-            __auto_type _mv_1740 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (!_mv_1740.has_value) {
+            __auto_type _mv_1741 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (!_mv_1741.has_value) {
                 return env_env_get_unit_type(env);
-            } else if (_mv_1740.has_value) {
-                __auto_type obj_expr = _mv_1740.value;
+            } else if (_mv_1741.has_value) {
+                __auto_type obj_expr = _mv_1741.value;
                 {
                     __auto_type obj_type = infer_infer_expr(env, obj_expr);
-                    __auto_type _mv_1741 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (!_mv_1741.has_value) {
+                    __auto_type _mv_1742 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (!_mv_1742.has_value) {
                         return env_env_get_unit_type(env);
-                    } else if (_mv_1741.has_value) {
-                        __auto_type field_expr = _mv_1741.value;
-                        __auto_type _mv_1742 = (*field_expr);
-                        switch (_mv_1742.tag) {
+                    } else if (_mv_1742.has_value) {
+                        __auto_type field_expr = _mv_1742.value;
+                        __auto_type _mv_1743 = (*field_expr);
+                        switch (_mv_1743.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type field_sym = _mv_1742.data.sym;
+                                __auto_type field_sym = _mv_1743.data.sym;
                                 {
                                     __auto_type field_name = field_sym.name;
                                     return infer_check_field_exists(env, obj_type, field_name, line, col);
@@ -2048,11 +2048,11 @@ types_ResolvedType* infer_check_field_exists(env_TypeEnv* env, types_ResolvedTyp
             }
         } else {
             if (types_resolved_type_is_record(obj_type)) {
-                __auto_type _mv_1743 = types_resolved_type_get_field_type(obj_type, field_name);
-                if (_mv_1743.has_value) {
-                    __auto_type field_type = _mv_1743.value;
+                __auto_type _mv_1744 = types_resolved_type_get_field_type(obj_type, field_name);
+                if (_mv_1744.has_value) {
+                    __auto_type field_type = _mv_1744.value;
                     return field_type;
-                } else if (!_mv_1743.has_value) {
+                } else if (!_mv_1744.has_value) {
                     {
                         __auto_type msg = string_concat(arena, SLOP_STR("Record '"), string_concat(arena, type_name, string_concat(arena, SLOP_STR("' has no field '"), string_concat(arena, field_name, SLOP_STR("'")))));
                         env_env_add_error(env, msg, line, col);
@@ -2077,11 +2077,11 @@ types_ResolvedType* infer_check_field_exists(env_TypeEnv* env, types_ResolvedTyp
                             return env_env_get_unknown_type(env);
                         } else {
                             if (types_resolved_type_is_pointer(obj_type)) {
-                                __auto_type _mv_1744 = (*obj_type).inner_type;
-                                if (_mv_1744.has_value) {
-                                    __auto_type inner_type = _mv_1744.value;
+                                __auto_type _mv_1745 = (*obj_type).inner_type;
+                                if (_mv_1745.has_value) {
+                                    __auto_type inner_type = _mv_1745.value;
                                     return infer_check_field_exists(env, inner_type, field_name, line, col);
-                                } else if (!_mv_1744.has_value) {
+                                } else if (!_mv_1745.has_value) {
                                     return env_env_get_unknown_type(env);
                                 }
                                 SLOP_UNREACHABLE();
@@ -2115,22 +2115,22 @@ types_ResolvedType* infer_infer_cond_expr(env_TypeEnv* env, types_SExpr* expr, t
         types_ResolvedType* result_type = env_env_get_unit_type(env);
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1745 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1745.has_value) {
-                __auto_type clause = _mv_1745.value;
-                __auto_type _mv_1746 = (*clause);
-                switch (_mv_1746.tag) {
+            __auto_type _mv_1746 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1746.has_value) {
+                __auto_type clause = _mv_1746.value;
+                __auto_type _mv_1747 = (*clause);
+                switch (_mv_1747.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type clause_lst = _mv_1746.data.lst;
+                        __auto_type clause_lst = _mv_1747.data.lst;
                         {
                             __auto_type clause_items = clause_lst.items;
                             __auto_type clause_len = ((int64_t)((clause_items).len));
                             if (clause_len > 1) {
                                 for (int64_t ci = 0; ci < (clause_len - 1); ci++) {
-                                    __auto_type _mv_1747 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)ci; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_1747.has_value) {
-                                        __auto_type clause_elem = _mv_1747.value;
+                                    __auto_type _mv_1748 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)ci; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_1748.has_value) {
+                                        __auto_type clause_elem = _mv_1748.value;
                                         {
                                             __auto_type elem_name = parser_sexpr_get_symbol_name(clause_elem);
                                             if (!(string_eq(elem_name, SLOP_STR("else")))) {
@@ -2139,12 +2139,12 @@ types_ResolvedType* infer_infer_cond_expr(env_TypeEnv* env, types_SExpr* expr, t
                                                 }
                                             }
                                         }
-                                    } else if (!_mv_1747.has_value) {
+                                    } else if (!_mv_1748.has_value) {
                                     }
                                 }
-                                __auto_type _mv_1748 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)(clause_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1748.has_value) {
-                                    __auto_type body = _mv_1748.value;
+                                __auto_type _mv_1749 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)(clause_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1749.has_value) {
+                                    __auto_type body = _mv_1749.value;
                                     {
                                         __auto_type body_type = infer_infer_expr(env, body);
                                         if (!(has_result)) {
@@ -2154,7 +2154,7 @@ types_ResolvedType* infer_infer_cond_expr(env_TypeEnv* env, types_SExpr* expr, t
                                             result_type = infer_unify_branch_types(env, result_type, body_type, line, col);
                                         }
                                     }
-                                } else if (!_mv_1748.has_value) {
+                                } else if (!_mv_1749.has_value) {
                                 }
                             }
                         }
@@ -2164,7 +2164,7 @@ types_ResolvedType* infer_infer_cond_expr(env_TypeEnv* env, types_SExpr* expr, t
                         break;
                     }
                 }
-            } else if (!_mv_1745.has_value) {
+            } else if (!_mv_1746.has_value) {
             }
             i = (i + 1);
         }
@@ -2177,16 +2177,16 @@ void infer_bind_match_pattern(env_TypeEnv* env, types_ResolvedType* scrutinee_ty
     SLOP_PRE(((pattern != NULL)), "(!= pattern nil)");
     if (parser_sexpr_is_list(pattern)) {
         if (parser_sexpr_list_len(pattern) > 0) {
-            __auto_type _mv_1749 = parser_sexpr_list_get(pattern, 0);
-            if (_mv_1749.has_value) {
-                __auto_type variant_expr = _mv_1749.value;
+            __auto_type _mv_1750 = parser_sexpr_list_get(pattern, 0);
+            if (_mv_1750.has_value) {
+                __auto_type variant_expr = _mv_1750.value;
                 {
                     __auto_type variant_name = parser_sexpr_get_symbol_name(variant_expr);
                     if (!(string_eq(variant_name, SLOP_STR("")))) {
                         if (parser_sexpr_list_len(pattern) > 1) {
-                            __auto_type _mv_1750 = parser_sexpr_list_get(pattern, 1);
-                            if (_mv_1750.has_value) {
-                                __auto_type binding_expr = _mv_1750.value;
+                            __auto_type _mv_1751 = parser_sexpr_list_get(pattern, 1);
+                            if (_mv_1751.has_value) {
+                                __auto_type binding_expr = _mv_1751.value;
                                 {
                                     __auto_type binding_name = parser_sexpr_get_symbol_name(binding_expr);
                                     if (!(string_eq(binding_name, SLOP_STR("")))) {
@@ -2197,29 +2197,29 @@ void infer_bind_match_pattern(env_TypeEnv* env, types_ResolvedType* scrutinee_ty
                                                 env_env_bind_var(env, binding_name, env_env_get_generic_type(env));
                                             } else {
                                                 if ((scrutinee_kind == types_ResolvedTypeKind_rk_option) && string_eq(variant_name, SLOP_STR("some"))) {
-                                                    __auto_type _mv_1751 = (*scrutinee_type).inner_type;
-                                                    if (_mv_1751.has_value) {
-                                                        __auto_type inner = _mv_1751.value;
+                                                    __auto_type _mv_1752 = (*scrutinee_type).inner_type;
+                                                    if (_mv_1752.has_value) {
+                                                        __auto_type inner = _mv_1752.value;
                                                         env_env_bind_var(env, binding_name, inner);
-                                                    } else if (!_mv_1751.has_value) {
+                                                    } else if (!_mv_1752.has_value) {
                                                         env_env_bind_var(env, binding_name, env_env_get_generic_type(env));
                                                     }
                                                 } else {
                                                     if (scrutinee_kind == types_ResolvedTypeKind_rk_result) {
                                                         if (string_eq(variant_name, SLOP_STR("ok"))) {
-                                                            __auto_type _mv_1752 = (*scrutinee_type).inner_type;
-                                                            if (_mv_1752.has_value) {
-                                                                __auto_type inner = _mv_1752.value;
+                                                            __auto_type _mv_1753 = (*scrutinee_type).inner_type;
+                                                            if (_mv_1753.has_value) {
+                                                                __auto_type inner = _mv_1753.value;
                                                                 env_env_bind_var(env, binding_name, inner);
-                                                            } else if (!_mv_1752.has_value) {
+                                                            } else if (!_mv_1753.has_value) {
                                                                 env_env_bind_var(env, binding_name, env_env_get_generic_type(env));
                                                             }
                                                         } else if (string_eq(variant_name, SLOP_STR("error"))) {
-                                                            __auto_type _mv_1753 = (*scrutinee_type).inner_type2;
-                                                            if (_mv_1753.has_value) {
-                                                                __auto_type inner2 = _mv_1753.value;
+                                                            __auto_type _mv_1754 = (*scrutinee_type).inner_type2;
+                                                            if (_mv_1754.has_value) {
+                                                                __auto_type inner2 = _mv_1754.value;
                                                                 env_env_bind_var(env, binding_name, inner2);
-                                                            } else if (!_mv_1753.has_value) {
+                                                            } else if (!_mv_1754.has_value) {
                                                                 env_env_bind_var(env, binding_name, env_env_get_generic_type(env));
                                                             }
                                                         } else {
@@ -2230,11 +2230,11 @@ void infer_bind_match_pattern(env_TypeEnv* env, types_ResolvedType* scrutinee_ty
                                                             __auto_type payload_types = types_resolved_type_get_variant_payloads(env_env_arena(env), scrutinee_type, variant_name);
                                                             if (((int64_t)((payload_types).len)) > 0) {
                                                                 if (!(string_eq(binding_name, SLOP_STR("true"))) && !(string_eq(binding_name, SLOP_STR("false")))) {
-                                                                    __auto_type _mv_1754 = ({ __auto_type _lst = payload_types; size_t _idx = (size_t)0; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                    if (_mv_1754.has_value) {
-                                                                        __auto_type first_type = _mv_1754.value;
+                                                                    __auto_type _mv_1755 = ({ __auto_type _lst = payload_types; size_t _idx = (size_t)0; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                    if (_mv_1755.has_value) {
+                                                                        __auto_type first_type = _mv_1755.value;
                                                                         env_env_bind_var(env, binding_name, first_type);
-                                                                    } else if (!_mv_1754.has_value) {
+                                                                    } else if (!_mv_1755.has_value) {
                                                                         env_env_bind_var(env, binding_name, env_env_get_generic_type(env));
                                                                     }
                                                                 }
@@ -2242,20 +2242,20 @@ void infer_bind_match_pattern(env_TypeEnv* env, types_ResolvedType* scrutinee_ty
                                                                     __auto_type pat_len = parser_sexpr_list_len(pattern);
                                                                     __auto_type num_types = ((int64_t)((payload_types).len));
                                                                     for (int64_t pi = 2; pi < pat_len; pi++) {
-                                                                        __auto_type _mv_1755 = parser_sexpr_list_get(pattern, pi);
-                                                                        if (_mv_1755.has_value) {
-                                                                            __auto_type extra_binding = _mv_1755.value;
+                                                                        __auto_type _mv_1756 = parser_sexpr_list_get(pattern, pi);
+                                                                        if (_mv_1756.has_value) {
+                                                                            __auto_type extra_binding = _mv_1756.value;
                                                                             {
                                                                                 __auto_type extra_name = parser_sexpr_get_symbol_name(extra_binding);
                                                                                 if ((!(string_eq(extra_name, SLOP_STR("")))) && (!(string_eq(extra_name, SLOP_STR("_")))) && (!(string_eq(extra_name, SLOP_STR("true")))) && (!(string_eq(extra_name, SLOP_STR("false"))))) {
                                                                                     {
                                                                                         __auto_type type_idx = (pi - 1);
                                                                                         if (type_idx < num_types) {
-                                                                                            __auto_type _mv_1756 = ({ __auto_type _lst = payload_types; size_t _idx = (size_t)type_idx; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                                            if (_mv_1756.has_value) {
-                                                                                                __auto_type pt = _mv_1756.value;
+                                                                                            __auto_type _mv_1757 = ({ __auto_type _lst = payload_types; size_t _idx = (size_t)type_idx; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                                            if (_mv_1757.has_value) {
+                                                                                                __auto_type pt = _mv_1757.value;
                                                                                                 env_env_bind_var(env, extra_name, pt);
-                                                                                            } else if (!_mv_1756.has_value) {
+                                                                                            } else if (!_mv_1757.has_value) {
                                                                                                 env_env_bind_var(env, extra_name, env_env_get_generic_type(env));
                                                                                             }
                                                                                         } else {
@@ -2264,7 +2264,7 @@ void infer_bind_match_pattern(env_TypeEnv* env, types_ResolvedType* scrutinee_ty
                                                                                     }
                                                                                 }
                                                                             }
-                                                                        } else if (!_mv_1755.has_value) {
+                                                                        } else if (!_mv_1756.has_value) {
                                                                         }
                                                                     }
                                                                 }
@@ -2278,12 +2278,12 @@ void infer_bind_match_pattern(env_TypeEnv* env, types_ResolvedType* scrutinee_ty
                                         }
                                     }
                                 }
-                            } else if (!_mv_1750.has_value) {
+                            } else if (!_mv_1751.has_value) {
                             }
                         }
                     }
                 }
-            } else if (!_mv_1749.has_value) {
+            } else if (!_mv_1750.has_value) {
             }
         }
     }
@@ -2293,11 +2293,11 @@ slop_string infer_match_pattern_head(types_SExpr* pattern) {
     SLOP_PRE(((pattern != NULL)), "(!= pattern nil)");
     if (parser_sexpr_is_list(pattern)) {
         if (parser_sexpr_list_len(pattern) > 0) {
-            __auto_type _mv_1757 = parser_sexpr_list_get(pattern, 0);
-            if (_mv_1757.has_value) {
-                __auto_type head = _mv_1757.value;
+            __auto_type _mv_1758 = parser_sexpr_list_get(pattern, 0);
+            if (_mv_1758.has_value) {
+                __auto_type head = _mv_1758.value;
                 return parser_sexpr_get_symbol_name(head);
-            } else if (!_mv_1757.has_value) {
+            } else if (!_mv_1758.has_value) {
                 return SLOP_STR("");
             }
             SLOP_UNREACHABLE();
@@ -2319,13 +2319,13 @@ uint8_t infer_string_list_contains(slop_list_string names, slop_string name) {
         int64_t i = 0;
         uint8_t found = 0;
         while ((i < n) && !(found)) {
-            __auto_type _mv_1758 = ({ __auto_type _lst = names; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1758.has_value) {
-                __auto_type existing = _mv_1758.value;
+            __auto_type _mv_1759 = ({ __auto_type _lst = names; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1759.has_value) {
+                __auto_type existing = _mv_1759.value;
                 if (string_eq(existing, name)) {
                     found = 1;
                 }
-            } else if (!_mv_1758.has_value) {
+            } else if (!_mv_1759.has_value) {
             }
             i = (i + 1);
         }
@@ -2344,11 +2344,11 @@ slop_list_string infer_match_expected_variants(slop_arena* arena, types_Resolved
                 __auto_type n = ((int64_t)((variants).len));
                 int64_t i = 0;
                 while (i < n) {
-                    __auto_type _mv_1759 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_types_ResolvedVariant _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1759.has_value) {
-                        __auto_type v = _mv_1759.value;
+                    __auto_type _mv_1760 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_types_ResolvedVariant _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1760.has_value) {
+                        __auto_type v = _mv_1760.value;
                         ({ __auto_type _lst_p = &(result); __auto_type _item = (v.name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                    } else if (!_mv_1759.has_value) {
+                    } else if (!_mv_1760.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -2383,13 +2383,13 @@ void infer_check_match_exhaustive(env_TypeEnv* env, types_ResolvedType* scrutine
                     uint8_t all_known = 1;
                     __auto_type missing = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
                     while (i < n) {
-                        __auto_type _mv_1760 = ({ __auto_type _lst = covered; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1760.has_value) {
-                            __auto_type head = _mv_1760.value;
+                        __auto_type _mv_1761 = ({ __auto_type _lst = covered; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1761.has_value) {
+                            __auto_type head = _mv_1761.value;
                             if (!(infer_string_list_contains(expected, head))) {
                                 all_known = 0;
                             }
-                        } else if (!_mv_1760.has_value) {
+                        } else if (!_mv_1761.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -2398,13 +2398,13 @@ void infer_check_match_exhaustive(env_TypeEnv* env, types_ResolvedType* scrutine
                             __auto_type e_len = ((int64_t)((expected).len));
                             int64_t j = 0;
                             while (j < e_len) {
-                                __auto_type _mv_1761 = ({ __auto_type _lst = expected; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1761.has_value) {
-                                    __auto_type want = _mv_1761.value;
+                                __auto_type _mv_1762 = ({ __auto_type _lst = expected; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1762.has_value) {
+                                    __auto_type want = _mv_1762.value;
                                     if (!(infer_string_list_contains(covered, want))) {
                                         ({ __auto_type _lst_p = &(missing); __auto_type _item = (want); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
-                                } else if (!_mv_1761.has_value) {
+                                } else if (!_mv_1762.has_value) {
                                 }
                                 j = (j + 1);
                             }
@@ -2441,21 +2441,21 @@ types_ResolvedType* infer_infer_match_expr(env_TypeEnv* env, types_SExpr* expr, 
         __auto_type scrutinee_type = (((len >= 2)) ? ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type scrutinee = _mv.value; infer_infer_expr(env, scrutinee); }) : (env_env_get_unit_type(env)); }) : env_env_get_unit_type(env));
         int64_t i = 2;
         while (i < len) {
-            __auto_type _mv_1762 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1762.has_value) {
-                __auto_type clause = _mv_1762.value;
-                __auto_type _mv_1763 = (*clause);
-                switch (_mv_1763.tag) {
+            __auto_type _mv_1763 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1763.has_value) {
+                __auto_type clause = _mv_1763.value;
+                __auto_type _mv_1764 = (*clause);
+                switch (_mv_1764.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type clause_lst = _mv_1763.data.lst;
+                        __auto_type clause_lst = _mv_1764.data.lst;
                         {
                             __auto_type clause_items = clause_lst.items;
                             __auto_type clause_len = ((int64_t)((clause_items).len));
                             if (clause_len > 0) {
-                                __auto_type _mv_1764 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1764.has_value) {
-                                    __auto_type pattern = _mv_1764.value;
+                                __auto_type _mv_1765 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1765.has_value) {
+                                    __auto_type pattern = _mv_1765.value;
                                     {
                                         __auto_type head = infer_match_pattern_head(pattern);
                                         if (infer_is_wildcard_head(head)) {
@@ -2464,30 +2464,30 @@ types_ResolvedType* infer_infer_match_expr(env_TypeEnv* env, types_SExpr* expr, 
                                             ({ __auto_type _lst_p = &(covered); __auto_type _item = (head); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(match_arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                         }
                                     }
-                                } else if (!_mv_1764.has_value) {
+                                } else if (!_mv_1765.has_value) {
                                 }
                             }
                             if (clause_len > 1) {
                                 env_env_push_scope(env);
-                                __auto_type _mv_1765 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1765.has_value) {
-                                    __auto_type pattern = _mv_1765.value;
+                                __auto_type _mv_1766 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1766.has_value) {
+                                    __auto_type pattern = _mv_1766.value;
                                     infer_bind_match_pattern(env, scrutinee_type, pattern);
-                                } else if (!_mv_1765.has_value) {
+                                } else if (!_mv_1766.has_value) {
                                 }
                                 for (int64_t bi = 1; bi < (clause_len - 1); bi++) {
-                                    __auto_type _mv_1766 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_1766.has_value) {
-                                        __auto_type body_expr = _mv_1766.value;
+                                    __auto_type _mv_1767 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_1767.has_value) {
+                                        __auto_type body_expr = _mv_1767.value;
                                         {
                                             __auto_type _ = infer_infer_expr(env, body_expr);
                                         }
-                                    } else if (!_mv_1766.has_value) {
+                                    } else if (!_mv_1767.has_value) {
                                     }
                                 }
-                                __auto_type _mv_1767 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)(clause_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1767.has_value) {
-                                    __auto_type body = _mv_1767.value;
+                                __auto_type _mv_1768 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)(clause_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1768.has_value) {
+                                    __auto_type body = _mv_1768.value;
                                     {
                                         __auto_type body_type = infer_infer_expr(env, body);
                                         if (!(has_result)) {
@@ -2497,7 +2497,7 @@ types_ResolvedType* infer_infer_match_expr(env_TypeEnv* env, types_SExpr* expr, 
                                             result_type = infer_unify_branch_types(env, result_type, body_type, line, col);
                                         }
                                     }
-                                } else if (!_mv_1767.has_value) {
+                                } else if (!_mv_1768.has_value) {
                                 }
                                 env_env_pop_scope(env);
                             }
@@ -2508,7 +2508,7 @@ types_ResolvedType* infer_infer_match_expr(env_TypeEnv* env, types_SExpr* expr, 
                         break;
                     }
                 }
-            } else if (!_mv_1762.has_value) {
+            } else if (!_mv_1763.has_value) {
             }
             i = (i + 1);
         }
@@ -2521,22 +2521,22 @@ void infer_check_return_type(env_TypeEnv* env, types_SExpr* fn_form, slop_string
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((fn_form != NULL)), "(!= fn-form nil)");
     SLOP_PRE(((inferred_type != NULL)), "(!= inferred-type nil)");
-    __auto_type _mv_1768 = (*fn_form);
-    switch (_mv_1768.tag) {
+    __auto_type _mv_1769 = (*fn_form);
+    switch (_mv_1769.tag) {
         case types_SExpr_lst:
         {
-            __auto_type fn_lst = _mv_1768.data.lst;
+            __auto_type fn_lst = _mv_1769.data.lst;
             {
                 __auto_type items = fn_lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 for (int64_t i = 3; i < len; i++) {
-                    __auto_type _mv_1769 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1769.has_value) {
-                        __auto_type item = _mv_1769.value;
+                    __auto_type _mv_1770 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1770.has_value) {
+                        __auto_type item = _mv_1770.value;
                         if (parser_is_form(item, SLOP_STR("@spec"))) {
                             infer_check_spec_return_type(env, item, fn_name, inferred_type, fn_line, fn_col);
                         }
-                    } else if (!_mv_1769.has_value) {
+                    } else if (!_mv_1770.has_value) {
                     }
                 }
             }
@@ -2551,18 +2551,18 @@ void infer_check_return_type(env_TypeEnv* env, types_SExpr* fn_form, slop_string
 void infer_check_spec_return_type(env_TypeEnv* env, types_SExpr* spec_form, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((spec_form != NULL)), "(!= spec-form nil)");
-    __auto_type _mv_1770 = (*spec_form);
-    switch (_mv_1770.tag) {
+    __auto_type _mv_1771 = (*spec_form);
+    switch (_mv_1771.tag) {
         case types_SExpr_lst:
         {
-            __auto_type spec_lst = _mv_1770.data.lst;
+            __auto_type spec_lst = _mv_1771.data.lst;
             {
                 __auto_type spec_items = spec_lst.items;
-                __auto_type _mv_1771 = ({ __auto_type _lst = spec_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1771.has_value) {
-                    __auto_type spec_body = _mv_1771.value;
+                __auto_type _mv_1772 = ({ __auto_type _lst = spec_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1772.has_value) {
+                    __auto_type spec_body = _mv_1772.value;
                     infer_check_spec_body_return(env, spec_body, fn_name, inferred_type, fn_line, fn_col);
-                } else if (!_mv_1771.has_value) {
+                } else if (!_mv_1772.has_value) {
                 }
             }
             break;
@@ -2576,19 +2576,19 @@ void infer_check_spec_return_type(env_TypeEnv* env, types_SExpr* spec_form, slop
 void infer_check_spec_body_return(env_TypeEnv* env, types_SExpr* spec_body, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((spec_body != NULL)), "(!= spec-body nil)");
-    __auto_type _mv_1772 = (*spec_body);
-    switch (_mv_1772.tag) {
+    __auto_type _mv_1773 = (*spec_body);
+    switch (_mv_1773.tag) {
         case types_SExpr_lst:
         {
-            __auto_type body_lst = _mv_1772.data.lst;
+            __auto_type body_lst = _mv_1773.data.lst;
             {
                 __auto_type body_items = body_lst.items;
                 __auto_type body_len = ((int64_t)((body_items).len));
-                __auto_type _mv_1773 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1773.has_value) {
-                    __auto_type ret_expr = _mv_1773.value;
+                __auto_type _mv_1774 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1774.has_value) {
+                    __auto_type ret_expr = _mv_1774.value;
                     infer_check_return_expr(env, ret_expr, fn_name, inferred_type, fn_line, fn_col);
-                } else if (!_mv_1773.has_value) {
+                } else if (!_mv_1774.has_value) {
                 }
             }
             break;
@@ -2610,11 +2610,11 @@ uint8_t infer_is_integer_type(slop_string name) {
 void infer_check_return_expr(env_TypeEnv* env, types_SExpr* ret_expr, slop_string fn_name, types_ResolvedType* inferred_type, int64_t fn_line, int64_t fn_col) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((ret_expr != NULL)), "(!= ret-expr nil)");
-    __auto_type _mv_1774 = (*ret_expr);
-    switch (_mv_1774.tag) {
+    __auto_type _mv_1775 = (*ret_expr);
+    switch (_mv_1775.tag) {
         case types_SExpr_sym:
         {
-            __auto_type ret_sym = _mv_1774.data.sym;
+            __auto_type ret_sym = _mv_1775.data.sym;
             {
                 __auto_type declared_name = ret_sym.name;
                 __auto_type inferred_name = (*inferred_type).name;
@@ -2638,16 +2638,16 @@ void infer_bind_param_from_form(env_TypeEnv* env, types_SExpr* param_form) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((param_form != NULL)), "(!= param-form nil)");
     if (parser_sexpr_is_list(param_form) && (parser_sexpr_list_len(param_form) >= 2)) {
-        __auto_type _mv_1775 = parser_sexpr_list_get(param_form, 0);
-        if (_mv_1775.has_value) {
-            __auto_type first_expr = _mv_1775.value;
+        __auto_type _mv_1776 = parser_sexpr_list_get(param_form, 0);
+        if (_mv_1776.has_value) {
+            __auto_type first_expr = _mv_1776.value;
             {
                 __auto_type first_name = parser_sexpr_get_symbol_name(first_expr);
                 if ((string_eq(first_name, SLOP_STR("in"))) || (string_eq(first_name, SLOP_STR("out"))) || (string_eq(first_name, SLOP_STR("mut")))) {
                     if (parser_sexpr_list_len(param_form) >= 3) {
-                        __auto_type _mv_1776 = parser_sexpr_list_get(param_form, 1);
-                        if (_mv_1776.has_value) {
-                            __auto_type name_expr = _mv_1776.value;
+                        __auto_type _mv_1777 = parser_sexpr_list_get(param_form, 1);
+                        if (_mv_1777.has_value) {
+                            __auto_type name_expr = _mv_1777.value;
                             {
                                 __auto_type param_name = parser_sexpr_get_symbol_name(name_expr);
                                 if (!(string_eq(param_name, SLOP_STR("")))) {
@@ -2657,7 +2657,7 @@ void infer_bind_param_from_form(env_TypeEnv* env, types_SExpr* param_form) {
                                     }
                                 }
                             }
-                        } else if (!_mv_1776.has_value) {
+                        } else if (!_mv_1777.has_value) {
                         }
                     }
                 } else {
@@ -2669,7 +2669,7 @@ void infer_bind_param_from_form(env_TypeEnv* env, types_SExpr* param_form) {
                     }
                 }
             }
-        } else if (!_mv_1775.has_value) {
+        } else if (!_mv_1776.has_value) {
         }
     }
 }
@@ -2679,9 +2679,9 @@ types_ResolvedType* infer_get_param_type_from_form(env_TypeEnv* env, types_SExpr
     SLOP_PRE(((param_form != NULL)), "(!= param-form nil)");
     {
         __auto_type type_pos = ({ __auto_type _mv = parser_sexpr_list_get(param_form, 0); _mv.has_value ? ({ __auto_type first_expr = _mv.value; ({ __auto_type first_name = parser_sexpr_get_symbol_name(first_expr); ((((string_eq(first_name, SLOP_STR("in"))) || (string_eq(first_name, SLOP_STR("out"))) || (string_eq(first_name, SLOP_STR("mut"))))) ? 2 : 1); }); }) : (1); });
-        __auto_type _mv_1777 = parser_sexpr_list_get(param_form, type_pos);
-        if (_mv_1777.has_value) {
-            __auto_type type_expr = _mv_1777.value;
+        __auto_type _mv_1778 = parser_sexpr_list_get(param_form, type_pos);
+        if (_mv_1778.has_value) {
+            __auto_type type_expr = _mv_1778.value;
             {
                 __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                 if (string_eq(type_name, SLOP_STR(""))) {
@@ -2694,7 +2694,7 @@ types_ResolvedType* infer_get_param_type_from_form(env_TypeEnv* env, types_SExpr
                     return infer_resolve_simple_type(env, type_name);
                 }
             }
-        } else if (!_mv_1777.has_value) {
+        } else if (!_mv_1778.has_value) {
             return env_env_get_unknown_type(env);
         }
         SLOP_UNREACHABLE();
@@ -2704,9 +2704,9 @@ types_ResolvedType* infer_get_param_type_from_form(env_TypeEnv* env, types_SExpr
 types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExpr* type_expr) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_1778 = parser_sexpr_list_get(type_expr, 0);
-    if (_mv_1778.has_value) {
-        __auto_type head_expr = _mv_1778.value;
+    __auto_type _mv_1779 = parser_sexpr_list_get(type_expr, 0);
+    if (_mv_1779.has_value) {
+        __auto_type head_expr = _mv_1779.value;
         {
             __auto_type head_name = parser_sexpr_get_symbol_name(head_expr);
             if (string_eq(head_name, SLOP_STR("Option"))) {
@@ -2734,16 +2734,16 @@ types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExp
                     __auto_type map_type = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_map, SLOP_STR("Map"), ((slop_option_string){.has_value = false}), SLOP_STR("slop_map*"));
                     types_resolved_type_set_inner(map_type, key_type);
                     if (parser_sexpr_list_len(type_expr) >= 3) {
-                        __auto_type _mv_1779 = parser_sexpr_list_get(type_expr, 2);
-                        if (_mv_1779.has_value) {
-                            __auto_type val_expr = _mv_1779.value;
+                        __auto_type _mv_1780 = parser_sexpr_list_get(type_expr, 2);
+                        if (_mv_1780.has_value) {
+                            __auto_type val_expr = _mv_1780.value;
                             {
                                 __auto_type val_type = infer_resolve_simple_type(env, parser_sexpr_get_symbol_name(val_expr));
                                 if (val_type != NULL) {
                                     types_resolved_type_set_inner2(map_type, val_type);
                                 }
                             }
-                        } else if (!_mv_1779.has_value) {
+                        } else if (!_mv_1780.has_value) {
                         }
                     }
                     return map_type;
@@ -2777,9 +2777,9 @@ types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExp
                     __auto_type arena = env_env_arena(env);
                     __auto_type result_type = types_resolved_type_new(arena, types_ResolvedTypeKind_rk_result, SLOP_STR("Result"), ((slop_option_string){.has_value = false}), SLOP_STR("Result"));
                     if (parser_sexpr_list_len(type_expr) >= 2) {
-                        __auto_type _mv_1780 = parser_sexpr_list_get(type_expr, 1);
-                        if (_mv_1780.has_value) {
-                            __auto_type ok_expr = _mv_1780.value;
+                        __auto_type _mv_1781 = parser_sexpr_list_get(type_expr, 1);
+                        if (_mv_1781.has_value) {
+                            __auto_type ok_expr = _mv_1781.value;
                             {
                                 __auto_type ok_name = parser_sexpr_get_symbol_name(ok_expr);
                                 {
@@ -2787,13 +2787,13 @@ types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExp
                                     types_resolved_type_set_inner(result_type, ok_type);
                                 }
                             }
-                        } else if (!_mv_1780.has_value) {
+                        } else if (!_mv_1781.has_value) {
                         }
                     }
                     if (parser_sexpr_list_len(type_expr) >= 3) {
-                        __auto_type _mv_1781 = parser_sexpr_list_get(type_expr, 2);
-                        if (_mv_1781.has_value) {
-                            __auto_type err_expr = _mv_1781.value;
+                        __auto_type _mv_1782 = parser_sexpr_list_get(type_expr, 2);
+                        if (_mv_1782.has_value) {
+                            __auto_type err_expr = _mv_1782.value;
                             {
                                 __auto_type err_name = parser_sexpr_get_symbol_name(err_expr);
                                 {
@@ -2801,23 +2801,23 @@ types_ResolvedType* infer_resolve_complex_type_expr(env_TypeEnv* env, types_SExp
                                     types_resolved_type_set_inner2(result_type, err_type);
                                 }
                             }
-                        } else if (!_mv_1781.has_value) {
+                        } else if (!_mv_1782.has_value) {
                         }
                     }
                     return result_type;
                 }
             } else {
-                __auto_type _mv_1782 = env_env_lookup_type(env, head_name);
-                if (_mv_1782.has_value) {
-                    __auto_type t = _mv_1782.value;
+                __auto_type _mv_1783 = env_env_lookup_type(env, head_name);
+                if (_mv_1783.has_value) {
+                    __auto_type t = _mv_1783.value;
                     return t;
-                } else if (!_mv_1782.has_value) {
+                } else if (!_mv_1783.has_value) {
                     return env_env_get_unknown_type(env);
                 }
                 SLOP_UNREACHABLE();
             }
         }
-    } else if (!_mv_1778.has_value) {
+    } else if (!_mv_1779.has_value) {
         return env_env_get_unknown_type(env);
     }
     SLOP_UNREACHABLE();
@@ -2828,9 +2828,9 @@ types_ResolvedType* infer_resolve_option_inner_type(env_TypeEnv* env, types_SExp
     if (parser_sexpr_list_len(type_expr) < 2) {
         return env_env_get_unknown_type(env);
     } else {
-        __auto_type _mv_1783 = parser_sexpr_list_get(type_expr, 1);
-        if (_mv_1783.has_value) {
-            __auto_type inner_expr = _mv_1783.value;
+        __auto_type _mv_1784 = parser_sexpr_list_get(type_expr, 1);
+        if (_mv_1784.has_value) {
+            __auto_type inner_expr = _mv_1784.value;
             {
                 __auto_type inner_name = parser_sexpr_get_symbol_name(inner_expr);
                 if (string_eq(inner_name, SLOP_STR(""))) {
@@ -2839,7 +2839,7 @@ types_ResolvedType* infer_resolve_option_inner_type(env_TypeEnv* env, types_SExp
                     return infer_resolve_simple_type(env, inner_name);
                 }
             }
-        } else if (!_mv_1783.has_value) {
+        } else if (!_mv_1784.has_value) {
             return env_env_get_unknown_type(env);
         }
         SLOP_UNREACHABLE();
@@ -2851,9 +2851,9 @@ types_ResolvedType* infer_resolve_ptr_inner_type(env_TypeEnv* env, types_SExpr* 
     if (parser_sexpr_list_len(type_expr) < 2) {
         return env_env_get_unit_type(env);
     } else {
-        __auto_type _mv_1784 = parser_sexpr_list_get(type_expr, 1);
-        if (_mv_1784.has_value) {
-            __auto_type inner_expr = _mv_1784.value;
+        __auto_type _mv_1785 = parser_sexpr_list_get(type_expr, 1);
+        if (_mv_1785.has_value) {
+            __auto_type inner_expr = _mv_1785.value;
             {
                 __auto_type inner_name = parser_sexpr_get_symbol_name(inner_expr);
                 if (string_eq(inner_name, SLOP_STR(""))) {
@@ -2866,7 +2866,7 @@ types_ResolvedType* infer_resolve_ptr_inner_type(env_TypeEnv* env, types_SExpr* 
                     return infer_resolve_simple_type(env, inner_name);
                 }
             }
-        } else if (!_mv_1784.has_value) {
+        } else if (!_mv_1785.has_value) {
             return env_env_get_unit_type(env);
         }
         SLOP_UNREACHABLE();
@@ -2875,11 +2875,11 @@ types_ResolvedType* infer_resolve_ptr_inner_type(env_TypeEnv* env, types_SExpr* 
 
 types_ResolvedType* infer_resolve_type_lenient(env_TypeEnv* env, slop_string type_name) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_1785 = env_env_lookup_type(env, type_name);
-    if (_mv_1785.has_value) {
-        __auto_type t = _mv_1785.value;
+    __auto_type _mv_1786 = env_env_lookup_type(env, type_name);
+    if (_mv_1786.has_value) {
+        __auto_type t = _mv_1786.value;
         return t;
-    } else if (!_mv_1785.has_value) {
+    } else if (!_mv_1786.has_value) {
         {
             __auto_type arena = env_env_arena(env);
             if (string_eq(type_name, SLOP_STR("Int"))) {
@@ -2902,11 +2902,11 @@ types_ResolvedType* infer_resolve_type_lenient(env_TypeEnv* env, slop_string typ
 
 types_ResolvedType* infer_resolve_simple_type(env_TypeEnv* env, slop_string type_name) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
-    __auto_type _mv_1786 = env_env_lookup_type(env, type_name);
-    if (_mv_1786.has_value) {
-        __auto_type t = _mv_1786.value;
+    __auto_type _mv_1787 = env_env_lookup_type(env, type_name);
+    if (_mv_1787.has_value) {
+        __auto_type t = _mv_1787.value;
         return t;
-    } else if (!_mv_1786.has_value) {
+    } else if (!_mv_1787.has_value) {
         {
             __auto_type arena = env_env_arena(env);
             if (string_eq(type_name, SLOP_STR("Int"))) {
@@ -2964,24 +2964,24 @@ void infer_bind_let_binding(env_TypeEnv* env, types_SExpr* binding_form) {
     SLOP_PRE(((env != NULL)), "(!= env nil)");
     SLOP_PRE(((binding_form != NULL)), "(!= binding-form nil)");
     if (parser_sexpr_is_list(binding_form) && (parser_sexpr_list_len(binding_form) >= 2)) {
-        __auto_type _mv_1787 = parser_sexpr_list_get(binding_form, 0);
-        if (_mv_1787.has_value) {
-            __auto_type first_expr = _mv_1787.value;
+        __auto_type _mv_1788 = parser_sexpr_list_get(binding_form, 0);
+        if (_mv_1788.has_value) {
+            __auto_type first_expr = _mv_1788.value;
             {
                 __auto_type first_name = parser_sexpr_get_symbol_name(first_expr);
                 if (string_eq(first_name, SLOP_STR("mut"))) {
                     if (parser_sexpr_list_len(binding_form) >= 3) {
-                        __auto_type _mv_1788 = parser_sexpr_list_get(binding_form, 1);
-                        if (_mv_1788.has_value) {
-                            __auto_type name_expr = _mv_1788.value;
+                        __auto_type _mv_1789 = parser_sexpr_list_get(binding_form, 1);
+                        if (_mv_1789.has_value) {
+                            __auto_type name_expr = _mv_1789.value;
                             {
                                 __auto_type var_name = parser_sexpr_get_symbol_name(name_expr);
                                 if (!(string_eq(var_name, SLOP_STR("")))) {
                                     {
                                         __auto_type binding_len = parser_sexpr_list_len(binding_form);
-                                        __auto_type _mv_1789 = parser_sexpr_list_get(binding_form, (binding_len - 1));
-                                        if (_mv_1789.has_value) {
-                                            __auto_type val_expr = _mv_1789.value;
+                                        __auto_type _mv_1790 = parser_sexpr_list_get(binding_form, (binding_len - 1));
+                                        if (_mv_1790.has_value) {
+                                            __auto_type val_expr = _mv_1790.value;
                                             {
                                                 __auto_type val_type = infer_infer_expr(env, val_expr);
                                                 __auto_type val_type_name = (*val_type).name;
@@ -3003,12 +3003,12 @@ void infer_bind_let_binding(env_TypeEnv* env, types_SExpr* binding_form) {
                                                     env_env_bind_var(env, var_name, val_type);
                                                 }
                                             }
-                                        } else if (!_mv_1789.has_value) {
+                                        } else if (!_mv_1790.has_value) {
                                         }
                                     }
                                 }
                             }
-                        } else if (!_mv_1788.has_value) {
+                        } else if (!_mv_1789.has_value) {
                         }
                     }
                 } else {
@@ -3016,17 +3016,7 @@ void infer_bind_let_binding(env_TypeEnv* env, types_SExpr* binding_form) {
                         {
                             __auto_type binding_len = parser_sexpr_list_len(binding_form);
                             if (binding_len == 3) {
-                                __auto_type _mv_1790 = parser_sexpr_list_get(binding_form, 2);
-                                if (_mv_1790.has_value) {
-                                    __auto_type val_expr = _mv_1790.value;
-                                    {
-                                        __auto_type val_type = infer_infer_expr(env, val_expr);
-                                        env_env_bind_var(env, first_name, val_type);
-                                    }
-                                } else if (!_mv_1790.has_value) {
-                                }
-                            } else {
-                                __auto_type _mv_1791 = parser_sexpr_list_get(binding_form, 1);
+                                __auto_type _mv_1791 = parser_sexpr_list_get(binding_form, 2);
                                 if (_mv_1791.has_value) {
                                     __auto_type val_expr = _mv_1791.value;
                                     {
@@ -3035,12 +3025,22 @@ void infer_bind_let_binding(env_TypeEnv* env, types_SExpr* binding_form) {
                                     }
                                 } else if (!_mv_1791.has_value) {
                                 }
+                            } else {
+                                __auto_type _mv_1792 = parser_sexpr_list_get(binding_form, 1);
+                                if (_mv_1792.has_value) {
+                                    __auto_type val_expr = _mv_1792.value;
+                                    {
+                                        __auto_type val_type = infer_infer_expr(env, val_expr);
+                                        env_env_bind_var(env, first_name, val_type);
+                                    }
+                                } else if (!_mv_1792.has_value) {
+                                }
                             }
                         }
                     }
                 }
             }
-        } else if (!_mv_1787.has_value) {
+        } else if (!_mv_1788.has_value) {
         }
     }
 }
@@ -3050,23 +3050,23 @@ types_ResolvedType* infer_infer_let_expr(env_TypeEnv* env, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     env_env_push_scope(env);
     if (parser_sexpr_is_list(expr)) {
-        __auto_type _mv_1792 = parser_sexpr_list_get(expr, 1);
-        if (_mv_1792.has_value) {
-            __auto_type bindings_expr = _mv_1792.value;
+        __auto_type _mv_1793 = parser_sexpr_list_get(expr, 1);
+        if (_mv_1793.has_value) {
+            __auto_type bindings_expr = _mv_1793.value;
             if (parser_sexpr_is_list(bindings_expr)) {
                 {
                     __auto_type num_bindings = parser_sexpr_list_len(bindings_expr);
                     for (int64_t i = 0; i < num_bindings; i++) {
-                        __auto_type _mv_1793 = parser_sexpr_list_get(bindings_expr, i);
-                        if (_mv_1793.has_value) {
-                            __auto_type binding = _mv_1793.value;
+                        __auto_type _mv_1794 = parser_sexpr_list_get(bindings_expr, i);
+                        if (_mv_1794.has_value) {
+                            __auto_type binding = _mv_1794.value;
                             infer_bind_let_binding(env, binding);
-                        } else if (!_mv_1793.has_value) {
+                        } else if (!_mv_1794.has_value) {
                         }
                     }
                 }
             }
-        } else if (!_mv_1792.has_value) {
+        } else if (!_mv_1793.has_value) {
         }
     }
     {
@@ -3094,14 +3094,14 @@ types_ResolvedType* infer_infer_with_arena_expr(env_TypeEnv* env, types_SExpr* e
                     env_env_add_error(env, SLOP_STR("with-arena :as requires name and size"), parser_sexpr_line(expr), parser_sexpr_col(expr));
                     return env_env_get_unit_type(env);
                 } else {
-                    __auto_type _mv_1794 = parser_sexpr_list_get(expr, size_idx);
-                    if (_mv_1794.has_value) {
-                        __auto_type size_expr = _mv_1794.value;
-                        __auto_type _mv_1795 = (*size_expr);
-                        switch (_mv_1795.tag) {
+                    __auto_type _mv_1795 = parser_sexpr_list_get(expr, size_idx);
+                    if (_mv_1795.has_value) {
+                        __auto_type size_expr = _mv_1795.value;
+                        __auto_type _mv_1796 = (*size_expr);
+                        switch (_mv_1796.tag) {
                             case types_SExpr_num:
                             {
-                                __auto_type num = _mv_1795.data.num;
+                                __auto_type num = _mv_1796.data.num;
                                 if (num.int_value <= 0) {
                                     env_env_add_error(env, SLOP_STR("with-arena size must be positive"), num.line, num.col);
                                 } else {
@@ -3112,18 +3112,18 @@ types_ResolvedType* infer_infer_with_arena_expr(env_TypeEnv* env, types_SExpr* e
                                 break;
                             }
                         }
-                    } else if (!_mv_1794.has_value) {
+                    } else if (!_mv_1795.has_value) {
                     }
                     env_env_push_scope(env);
                     env_env_bind_var(env, arena_name, env_env_get_arena_type(env));
                     {
                         types_ResolvedType* result_type = env_env_get_unit_type(env);
                         for (int64_t i = body_start; i < len; i++) {
-                            __auto_type _mv_1796 = parser_sexpr_list_get(expr, i);
-                            if (_mv_1796.has_value) {
-                                __auto_type body_expr = _mv_1796.value;
+                            __auto_type _mv_1797 = parser_sexpr_list_get(expr, i);
+                            if (_mv_1797.has_value) {
+                                __auto_type body_expr = _mv_1797.value;
                                 result_type = infer_infer_expr(env, body_expr);
-                            } else if (!_mv_1796.has_value) {
+                            } else if (!_mv_1797.has_value) {
                             }
                         }
                         env_env_pop_scope(env);
@@ -3143,9 +3143,9 @@ slop_string infer_get_fn_name(types_SExpr* fn_form) {
         if (parser_sexpr_list_len(fn_form) < 2) {
             return SLOP_STR("unknown");
         } else {
-            __auto_type _mv_1797 = parser_sexpr_list_get(fn_form, 1);
-            if (_mv_1797.has_value) {
-                __auto_type name_expr = _mv_1797.value;
+            __auto_type _mv_1798 = parser_sexpr_list_get(fn_form, 1);
+            if (_mv_1798.has_value) {
+                __auto_type name_expr = _mv_1798.value;
                 {
                     __auto_type name = parser_sexpr_get_symbol_name(name_expr);
                     if (string_eq(name, SLOP_STR(""))) {
@@ -3154,7 +3154,7 @@ slop_string infer_get_fn_name(types_SExpr* fn_form) {
                         return name;
                     }
                 }
-            } else if (!_mv_1797.has_value) {
+            } else if (!_mv_1798.has_value) {
                 return SLOP_STR("unknown");
             }
             SLOP_UNREACHABLE();
@@ -3167,19 +3167,19 @@ types_ResolvedType* infer_resolve_hole_type(env_TypeEnv* env, slop_list_types_SE
     if (len < 2) {
         return env_env_get_unit_type(env);
     } else {
-        __auto_type _mv_1798 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1798.has_value) {
-            __auto_type type_expr = _mv_1798.value;
+        __auto_type _mv_1799 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1799.has_value) {
+            __auto_type type_expr = _mv_1799.value;
             {
                 __auto_type type_name = parser_sexpr_get_symbol_name(type_expr);
                 if (string_eq(type_name, SLOP_STR(""))) {
                     return env_env_get_unit_type(env);
                 } else {
-                    __auto_type _mv_1799 = env_env_lookup_type(env, type_name);
-                    if (_mv_1799.has_value) {
-                        __auto_type t = _mv_1799.value;
+                    __auto_type _mv_1800 = env_env_lookup_type(env, type_name);
+                    if (_mv_1800.has_value) {
+                        __auto_type t = _mv_1800.value;
                         return t;
-                    } else if (!_mv_1799.has_value) {
+                    } else if (!_mv_1800.has_value) {
                         if (string_eq(type_name, SLOP_STR("Int"))) {
                             return env_env_get_int_type(env);
                         } else if (string_eq(type_name, SLOP_STR("Bool"))) {
@@ -3195,7 +3195,7 @@ types_ResolvedType* infer_resolve_hole_type(env_TypeEnv* env, slop_list_types_SE
                     SLOP_UNREACHABLE();
                 }
             }
-        } else if (!_mv_1798.has_value) {
+        } else if (!_mv_1799.has_value) {
             return env_env_get_unit_type(env);
         }
         SLOP_UNREACHABLE();
@@ -3206,21 +3206,21 @@ slop_string infer_get_hole_prompt(slop_list_types_SExpr_ptr items, int64_t len) 
     if (len < 3) {
         return SLOP_STR("(no description)");
     } else {
-        __auto_type _mv_1800 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1800.has_value) {
-            __auto_type prompt_expr = _mv_1800.value;
-            __auto_type _mv_1801 = (*prompt_expr);
-            switch (_mv_1801.tag) {
+        __auto_type _mv_1801 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1801.has_value) {
+            __auto_type prompt_expr = _mv_1801.value;
+            __auto_type _mv_1802 = (*prompt_expr);
+            switch (_mv_1802.tag) {
                 case types_SExpr_str:
                 {
-                    __auto_type str = _mv_1801.data.str;
+                    __auto_type str = _mv_1802.data.str;
                     return str.value;
                 }
                 default: {
                     return SLOP_STR("(no description)");
                 }
             }
-        } else if (!_mv_1800.has_value) {
+        } else if (!_mv_1801.has_value) {
             return SLOP_STR("(no description)");
         }
         SLOP_UNREACHABLE();
@@ -3239,35 +3239,35 @@ int64_t infer_find_last_body_idx(slop_list_types_SExpr_ptr items) {
 }
 
 uint8_t infer_is_c_name_related(slop_list_types_SExpr_ptr items, int64_t idx) {
-    __auto_type _mv_1802 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-    if (_mv_1802.has_value) {
-        __auto_type item = _mv_1802.value;
-        __auto_type _mv_1803 = (*item);
-        switch (_mv_1803.tag) {
+    __auto_type _mv_1803 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+    if (_mv_1803.has_value) {
+        __auto_type item = _mv_1803.value;
+        __auto_type _mv_1804 = (*item);
+        switch (_mv_1804.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1803.data.sym;
+                __auto_type sym = _mv_1804.data.sym;
                 return string_eq(sym.name, SLOP_STR(":c-name"));
             }
             case types_SExpr_str:
             {
-                __auto_type _ = _mv_1803.data.str;
+                __auto_type _ = _mv_1804.data.str;
                 if (idx > 0) {
-                    __auto_type _mv_1804 = ({ __auto_type _lst = items; size_t _idx = (size_t)(idx - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1804.has_value) {
-                        __auto_type prev = _mv_1804.value;
-                        __auto_type _mv_1805 = (*prev);
-                        switch (_mv_1805.tag) {
+                    __auto_type _mv_1805 = ({ __auto_type _lst = items; size_t _idx = (size_t)(idx - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1805.has_value) {
+                        __auto_type prev = _mv_1805.value;
+                        __auto_type _mv_1806 = (*prev);
+                        switch (_mv_1806.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1805.data.sym;
+                                __auto_type sym = _mv_1806.data.sym;
                                 return string_eq(sym.name, SLOP_STR(":c-name"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1804.has_value) {
+                    } else if (!_mv_1805.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -3279,7 +3279,7 @@ uint8_t infer_is_c_name_related(slop_list_types_SExpr_ptr items, int64_t idx) {
                 return 0;
             }
         }
-    } else if (!_mv_1802.has_value) {
+    } else if (!_mv_1803.has_value) {
         return 0;
     }
     SLOP_UNREACHABLE();
@@ -3288,21 +3288,21 @@ uint8_t infer_is_c_name_related(slop_list_types_SExpr_ptr items, int64_t idx) {
 uint8_t infer_is_annotation_expr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     if (parser_sexpr_is_list(expr)) {
-        __auto_type _mv_1806 = parser_sexpr_list_get(expr, 0);
-        if (_mv_1806.has_value) {
-            __auto_type head = _mv_1806.value;
-            __auto_type _mv_1807 = (*head);
-            switch (_mv_1807.tag) {
+        __auto_type _mv_1807 = parser_sexpr_list_get(expr, 0);
+        if (_mv_1807.has_value) {
+            __auto_type head = _mv_1807.value;
+            __auto_type _mv_1808 = (*head);
+            switch (_mv_1808.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_1807.data.sym;
+                    __auto_type sym = _mv_1808.data.sym;
                     return strlib_starts_with(sym.name, SLOP_STR("@"));
                 }
                 default: {
                     return 0;
                 }
             }
-        } else if (!_mv_1806.has_value) {
+        } else if (!_mv_1807.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -3313,14 +3313,14 @@ uint8_t infer_is_annotation_expr(types_SExpr* expr) {
 
 uint8_t infer_is_checkable_annotation(types_SExpr* expr) {
     if (parser_sexpr_is_list(expr)) {
-        __auto_type _mv_1808 = parser_sexpr_list_get(expr, 0);
-        if (_mv_1808.has_value) {
-            __auto_type head = _mv_1808.value;
-            __auto_type _mv_1809 = (*head);
-            switch (_mv_1809.tag) {
+        __auto_type _mv_1809 = parser_sexpr_list_get(expr, 0);
+        if (_mv_1809.has_value) {
+            __auto_type head = _mv_1809.value;
+            __auto_type _mv_1810 = (*head);
+            switch (_mv_1810.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_1809.data.sym;
+                    __auto_type sym = _mv_1810.data.sym;
                     {
                         __auto_type name = sym.name;
                         return ((string_eq(name, SLOP_STR("@pre"))) || (string_eq(name, SLOP_STR("@post"))) || (string_eq(name, SLOP_STR("@assume"))) || (string_eq(name, SLOP_STR("@assert"))));
@@ -3330,7 +3330,7 @@ uint8_t infer_is_checkable_annotation(types_SExpr* expr) {
                     return 0;
                 }
             }
-        } else if (!_mv_1808.has_value) {
+        } else if (!_mv_1809.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -3354,23 +3354,23 @@ types_ResolvedType* infer_infer_fn_body(env_TypeEnv* env, types_SExpr* fn_form) 
             {
                 __auto_type params_len = parser_sexpr_list_len(fn_form);
                 if (params_len > 2) {
-                    __auto_type _mv_1810 = parser_sexpr_list_get(fn_form, 2);
-                    if (_mv_1810.has_value) {
-                        __auto_type params_expr = _mv_1810.value;
+                    __auto_type _mv_1811 = parser_sexpr_list_get(fn_form, 2);
+                    if (_mv_1811.has_value) {
+                        __auto_type params_expr = _mv_1811.value;
                         if (parser_sexpr_is_list(params_expr)) {
                             {
                                 __auto_type num_params = parser_sexpr_list_len(params_expr);
                                 for (int64_t k = 0; k < num_params; k++) {
-                                    __auto_type _mv_1811 = parser_sexpr_list_get(params_expr, k);
-                                    if (_mv_1811.has_value) {
-                                        __auto_type param_form = _mv_1811.value;
+                                    __auto_type _mv_1812 = parser_sexpr_list_get(params_expr, k);
+                                    if (_mv_1812.has_value) {
+                                        __auto_type param_form = _mv_1812.value;
                                         infer_bind_param_from_form(env, param_form);
-                                    } else if (!_mv_1811.has_value) {
+                                    } else if (!_mv_1812.has_value) {
                                     }
                                 }
                             }
                         }
-                    } else if (!_mv_1810.has_value) {
+                    } else if (!_mv_1811.has_value) {
                     }
                 }
             }
@@ -3392,34 +3392,34 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
         {
             __auto_type num_patterns = ((int64_t)((patterns).len));
             for (int64_t i = 0; i < num_patterns; i++) {
-                __auto_type _mv_1812 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1812.has_value) {
-                    __auto_type pattern_case = _mv_1812.value;
-                    __auto_type _mv_1813 = (*pattern_case);
-                    switch (_mv_1813.tag) {
+                __auto_type _mv_1813 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1813.has_value) {
+                    __auto_type pattern_case = _mv_1813.value;
+                    __auto_type _mv_1814 = (*pattern_case);
+                    switch (_mv_1814.tag) {
                         case types_SExpr_lst:
                         {
-                            __auto_type pattern_list = _mv_1813.data.lst;
+                            __auto_type pattern_list = _mv_1814.data.lst;
                             if (((int64_t)((pattern_list.items).len)) > 0) {
-                                __auto_type _mv_1814 = ({ __auto_type _lst = pattern_list.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1814.has_value) {
-                                    __auto_type pattern_expr = _mv_1814.value;
-                                    __auto_type _mv_1815 = (*pattern_expr);
-                                    switch (_mv_1815.tag) {
+                                __auto_type _mv_1815 = ({ __auto_type _lst = pattern_list.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1815.has_value) {
+                                    __auto_type pattern_expr = _mv_1815.value;
+                                    __auto_type _mv_1816 = (*pattern_expr);
+                                    switch (_mv_1816.tag) {
                                         case types_SExpr_lst:
                                         {
-                                            __auto_type variant_list = _mv_1815.data.lst;
+                                            __auto_type variant_list = _mv_1816.data.lst;
                                             {
                                                 __auto_type variant_items = variant_list.items;
                                                 if (((int64_t)((variant_items).len)) > 0) {
-                                                    __auto_type _mv_1816 = ({ __auto_type _lst = variant_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1816.has_value) {
-                                                        __auto_type variant_name_expr = _mv_1816.value;
-                                                        __auto_type _mv_1817 = (*variant_name_expr);
-                                                        switch (_mv_1817.tag) {
+                                                    __auto_type _mv_1817 = ({ __auto_type _lst = variant_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1817.has_value) {
+                                                        __auto_type variant_name_expr = _mv_1817.value;
+                                                        __auto_type _mv_1818 = (*variant_name_expr);
+                                                        switch (_mv_1818.tag) {
                                                             case types_SExpr_sym:
                                                             {
-                                                                __auto_type variant_sym = _mv_1817.data.sym;
+                                                                __auto_type variant_sym = _mv_1818.data.sym;
                                                                 {
                                                                     __auto_type variant_name = variant_sym.name;
                                                                     {
@@ -3429,24 +3429,24 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                                                                             {
                                                                                 __auto_type num_vt = ((int64_t)((variant_items).len));
                                                                                 for (int64_t vi = 1; vi < num_vt; vi++) {
-                                                                                    __auto_type _mv_1818 = ({ __auto_type _lst = variant_items; size_t _idx = (size_t)vi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                                    if (_mv_1818.has_value) {
-                                                                                        __auto_type binding_expr = _mv_1818.value;
-                                                                                        __auto_type _mv_1819 = (*binding_expr);
-                                                                                        switch (_mv_1819.tag) {
+                                                                                    __auto_type _mv_1819 = ({ __auto_type _lst = variant_items; size_t _idx = (size_t)vi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                                    if (_mv_1819.has_value) {
+                                                                                        __auto_type binding_expr = _mv_1819.value;
+                                                                                        __auto_type _mv_1820 = (*binding_expr);
+                                                                                        switch (_mv_1820.tag) {
                                                                                             case types_SExpr_sym:
                                                                                             {
-                                                                                                __auto_type binding_sym = _mv_1819.data.sym;
+                                                                                                __auto_type binding_sym = _mv_1820.data.sym;
                                                                                                 {
                                                                                                     __auto_type bname = binding_sym.name;
                                                                                                     __auto_type type_idx = (vi - 1);
                                                                                                     if (!(string_eq(bname, SLOP_STR("_"))) && !(string_eq(bname, SLOP_STR("")))) {
                                                                                                         if (type_idx < num_pt) {
-                                                                                                            __auto_type _mv_1820 = ({ __auto_type _lst = payload_types; size_t _idx = (size_t)type_idx; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                                                            if (_mv_1820.has_value) {
-                                                                                                                __auto_type pt = _mv_1820.value;
+                                                                                                            __auto_type _mv_1821 = ({ __auto_type _lst = payload_types; size_t _idx = (size_t)type_idx; slop_option_types_ResolvedType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                                                            if (_mv_1821.has_value) {
+                                                                                                                __auto_type pt = _mv_1821.value;
                                                                                                                 env_env_bind_var(env, bname, pt);
-                                                                                                            } else if (!_mv_1820.has_value) {
+                                                                                                            } else if (!_mv_1821.has_value) {
                                                                                                                 env_env_bind_var(env, bname, env_env_get_generic_type(env));
                                                                                                             }
                                                                                                         } else {
@@ -3460,15 +3460,15 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                                                                                                 break;
                                                                                             }
                                                                                         }
-                                                                                    } else if (!_mv_1818.has_value) {
+                                                                                    } else if (!_mv_1819.has_value) {
                                                                                     }
                                                                                 }
                                                                             }
                                                                         } else {
-                                                                            __auto_type _mv_1821 = types_resolved_type_get_variant_index(scrutinee_type, variant_name);
-                                                                            if (_mv_1821.has_value) {
-                                                                                __auto_type _ = _mv_1821.value;
-                                                                            } else if (!_mv_1821.has_value) {
+                                                                            __auto_type _mv_1822 = types_resolved_type_get_variant_index(scrutinee_type, variant_name);
+                                                                            if (_mv_1822.has_value) {
+                                                                                __auto_type _ = _mv_1822.value;
+                                                                            } else if (!_mv_1822.has_value) {
                                                                             }
                                                                         }
                                                                     }
@@ -3479,7 +3479,7 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                                                                 break;
                                                             }
                                                         }
-                                                    } else if (!_mv_1816.has_value) {
+                                                    } else if (!_mv_1817.has_value) {
                                                     }
                                                 }
                                             }
@@ -3489,7 +3489,7 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1814.has_value) {
+                                } else if (!_mv_1815.has_value) {
                                 }
                             }
                             break;
@@ -3498,7 +3498,7 @@ void infer_check_match_patterns(env_TypeEnv* env, types_ResolvedType* scrutinee_
                             break;
                         }
                     }
-                } else if (!_mv_1812.has_value) {
+                } else if (!_mv_1813.has_value) {
                 }
             }
         }

--- a/bootstrap/compiler/slop_match.c
+++ b/bootstrap/compiler/slop_match.c
@@ -74,9 +74,9 @@ uint8_t match_is_option_match(slop_list_types_SExpr_ptr patterns) {
         uint8_t has_none = 0;
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_646 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_646.has_value) {
-                __auto_type pat_expr = _mv_646.value;
+            __auto_type _mv_647 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_647.has_value) {
+                __auto_type pat_expr = _mv_647.value;
                 {
                     __auto_type tag = match_get_pattern_tag(pat_expr);
                     if (string_eq(tag, SLOP_STR("some"))) {
@@ -86,7 +86,7 @@ uint8_t match_is_option_match(slop_list_types_SExpr_ptr patterns) {
                     } else {
                     }
                 }
-            } else if (!_mv_646.has_value) {
+            } else if (!_mv_647.has_value) {
             }
             i = (i + 1);
         }
@@ -101,9 +101,9 @@ uint8_t match_is_result_match(slop_list_types_SExpr_ptr patterns) {
         uint8_t has_error = 0;
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_647 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_647.has_value) {
-                __auto_type pat_expr = _mv_647.value;
+            __auto_type _mv_648 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_648.has_value) {
+                __auto_type pat_expr = _mv_648.value;
                 {
                     __auto_type tag = match_get_pattern_tag(pat_expr);
                     if (string_eq(tag, SLOP_STR("ok"))) {
@@ -113,7 +113,7 @@ uint8_t match_is_result_match(slop_list_types_SExpr_ptr patterns) {
                     } else {
                     }
                 }
-            } else if (!_mv_647.has_value) {
+            } else if (!_mv_648.has_value) {
             }
             i = (i + 1);
         }
@@ -127,14 +127,14 @@ uint8_t match_is_enum_match(slop_list_types_SExpr_ptr patterns) {
         uint8_t all_symbols = 1;
         int64_t i = 0;
         while ((i < len) && all_symbols) {
-            __auto_type _mv_648 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_648.has_value) {
-                __auto_type pat_expr = _mv_648.value;
-                __auto_type _mv_649 = (*pat_expr);
-                switch (_mv_649.tag) {
+            __auto_type _mv_649 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_649.has_value) {
+                __auto_type pat_expr = _mv_649.value;
+                __auto_type _mv_650 = (*pat_expr);
+                switch (_mv_650.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type _ = _mv_649.data.sym;
+                        __auto_type _ = _mv_650.data.sym;
                         break;
                     }
                     default: {
@@ -142,7 +142,7 @@ uint8_t match_is_enum_match(slop_list_types_SExpr_ptr patterns) {
                         break;
                     }
                 }
-            } else if (!_mv_648.has_value) {
+            } else if (!_mv_649.has_value) {
             }
             i = (i + 1);
         }
@@ -156,20 +156,20 @@ uint8_t match_is_literal_match(slop_list_types_SExpr_ptr patterns) {
         uint8_t has_literal = 0;
         int64_t i = 0;
         while ((i < len) && !(has_literal)) {
-            __auto_type _mv_650 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_650.has_value) {
-                __auto_type pat_expr = _mv_650.value;
-                __auto_type _mv_651 = (*pat_expr);
-                switch (_mv_651.tag) {
+            __auto_type _mv_651 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_651.has_value) {
+                __auto_type pat_expr = _mv_651.value;
+                __auto_type _mv_652 = (*pat_expr);
+                switch (_mv_652.tag) {
                     case types_SExpr_num:
                     {
-                        __auto_type _ = _mv_651.data.num;
+                        __auto_type _ = _mv_652.data.num;
                         has_literal = 1;
                         break;
                     }
                     case types_SExpr_str:
                     {
-                        __auto_type _ = _mv_651.data.str;
+                        __auto_type _ = _mv_652.data.str;
                         has_literal = 1;
                         break;
                     }
@@ -177,7 +177,7 @@ uint8_t match_is_literal_match(slop_list_types_SExpr_ptr patterns) {
                         break;
                     }
                 }
-            } else if (!_mv_650.has_value) {
+            } else if (!_mv_651.has_value) {
             }
             i = (i + 1);
         }
@@ -192,21 +192,21 @@ uint8_t match_is_union_match(context_TranspileContext* ctx, slop_list_types_SExp
         uint8_t has_union_variant = 0;
         int64_t i = 0;
         while ((i < len) && !(has_union_variant)) {
-            __auto_type _mv_652 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_652.has_value) {
-                __auto_type pat_expr = _mv_652.value;
+            __auto_type _mv_653 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_653.has_value) {
+                __auto_type pat_expr = _mv_653.value;
                 {
                     __auto_type tag = match_get_pattern_tag(pat_expr);
                     if ((!(string_eq(tag, SLOP_STR("")))) && (!(string_eq(tag, SLOP_STR("some")))) && (!(string_eq(tag, SLOP_STR("none")))) && (!(string_eq(tag, SLOP_STR("ok")))) && (!(string_eq(tag, SLOP_STR("error")))) && (!(string_eq(tag, SLOP_STR("else")))) && (!(string_eq(tag, SLOP_STR("_"))))) {
-                        __auto_type _mv_653 = context_ctx_lookup_enum_variant(ctx, tag);
-                        if (_mv_653.has_value) {
-                            __auto_type _ = _mv_653.value;
+                        __auto_type _mv_654 = context_ctx_lookup_enum_variant(ctx, tag);
+                        if (_mv_654.has_value) {
+                            __auto_type _ = _mv_654.value;
                             has_union_variant = 1;
-                        } else if (!_mv_653.has_value) {
+                        } else if (!_mv_654.has_value) {
                         }
                     }
                 }
-            } else if (!_mv_652.has_value) {
+            } else if (!_mv_653.has_value) {
             }
             i = (i + 1);
         }
@@ -216,31 +216,31 @@ uint8_t match_is_union_match(context_TranspileContext* ctx, slop_list_types_SExp
 
 slop_string match_get_pattern_tag(types_SExpr* pat_expr) {
     SLOP_PRE(((pat_expr != NULL)), "(!= pat-expr nil)");
-    __auto_type _mv_654 = (*pat_expr);
-    switch (_mv_654.tag) {
+    __auto_type _mv_655 = (*pat_expr);
+    switch (_mv_655.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_654.data.lst;
+            __auto_type lst = _mv_655.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return SLOP_STR("");
                 } else {
-                    __auto_type _mv_655 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_655.has_value) {
-                        __auto_type head = _mv_655.value;
-                        __auto_type _mv_656 = (*head);
-                        switch (_mv_656.tag) {
+                    __auto_type _mv_656 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_656.has_value) {
+                        __auto_type head = _mv_656.value;
+                        __auto_type _mv_657 = (*head);
+                        switch (_mv_657.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_656.data.sym;
+                                __auto_type sym = _mv_657.data.sym;
                                 return sym.name;
                             }
                             default: {
                                 return SLOP_STR("");
                             }
                         }
-                    } else if (!_mv_655.has_value) {
+                    } else if (!_mv_656.has_value) {
                         return SLOP_STR("");
                     }
                     SLOP_UNREACHABLE();
@@ -249,7 +249,7 @@ slop_string match_get_pattern_tag(types_SExpr* pat_expr) {
         }
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_654.data.sym;
+            __auto_type sym = _mv_655.data.sym;
             return sym.name;
         }
         default: {
@@ -260,31 +260,31 @@ slop_string match_get_pattern_tag(types_SExpr* pat_expr) {
 
 slop_option_string match_extract_binding_name(types_SExpr* pat_expr) {
     SLOP_PRE(((pat_expr != NULL)), "(!= pat-expr nil)");
-    __auto_type _mv_657 = (*pat_expr);
-    switch (_mv_657.tag) {
+    __auto_type _mv_658 = (*pat_expr);
+    switch (_mv_658.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_657.data.lst;
+            __auto_type lst = _mv_658.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return (slop_option_string){.has_value = false};
                 } else {
-                    __auto_type _mv_658 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_658.has_value) {
-                        __auto_type binding = _mv_658.value;
-                        __auto_type _mv_659 = (*binding);
-                        switch (_mv_659.tag) {
+                    __auto_type _mv_659 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_659.has_value) {
+                        __auto_type binding = _mv_659.value;
+                        __auto_type _mv_660 = (*binding);
+                        switch (_mv_660.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_659.data.sym;
+                                __auto_type sym = _mv_660.data.sym;
                                 return (slop_option_string){.has_value = 1, .value = sym.name};
                             }
                             default: {
                                 return (slop_option_string){.has_value = false};
                             }
                         }
-                    } else if (!_mv_658.has_value) {
+                    } else if (!_mv_659.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
                     SLOP_UNREACHABLE();
@@ -299,11 +299,11 @@ slop_option_string match_extract_binding_name(types_SExpr* pat_expr) {
 
 int64_t match_count_pattern_bindings(types_SExpr* pat_expr) {
     SLOP_PRE(((pat_expr != NULL)), "(!= pat-expr nil)");
-    __auto_type _mv_660 = (*pat_expr);
-    switch (_mv_660.tag) {
+    __auto_type _mv_661 = (*pat_expr);
+    switch (_mv_661.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_660.data.lst;
+            __auto_type lst = _mv_661.data.lst;
             {
                 __auto_type len = ((int64_t)((lst.items).len));
                 if (len > 1) {
@@ -324,20 +324,20 @@ void match_transpile_match(context_TranspileContext* ctx, types_SExpr* expr, uin
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_661 = (*expr);
-        switch (_mv_661.tag) {
+        __auto_type _mv_662 = (*expr);
+        switch (_mv_662.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_661.data.lst;
+                __auto_type lst = _mv_662.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 3) {
                         context_ctx_add_error_at(ctx, SLOP_STR("invalid match: need value and at least one branch"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     } else {
-                        __auto_type _mv_662 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_662.has_value) {
-                            __auto_type scrutinee = _mv_662.value;
+                        __auto_type _mv_663 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_663.has_value) {
+                            __auto_type scrutinee = _mv_663.value;
                             {
                                 __auto_type scrutinee_c = expr_transpile_expr(ctx, scrutinee);
                                 __auto_type patterns = match_collect_patterns(ctx, items);
@@ -371,7 +371,7 @@ void match_transpile_match(context_TranspileContext* ctx, types_SExpr* expr, uin
                                     match_transpile_generic_match(ctx, scrutinee_var, items, is_return);
                                 }
                             }
-                        } else if (!_mv_662.has_value) {
+                        } else if (!_mv_663.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing match scrutinee"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                     }
@@ -394,22 +394,22 @@ slop_list_types_SExpr_ptr match_collect_patterns(context_TranspileContext* ctx, 
         __auto_type result = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
         int64_t i = 2;
         while (i < len) {
-            __auto_type _mv_663 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_663.has_value) {
-                __auto_type branch = _mv_663.value;
-                __auto_type _mv_664 = (*branch);
-                switch (_mv_664.tag) {
+            __auto_type _mv_664 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_664.has_value) {
+                __auto_type branch = _mv_664.value;
+                __auto_type _mv_665 = (*branch);
+                switch (_mv_665.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type branch_lst = _mv_664.data.lst;
+                        __auto_type branch_lst = _mv_665.data.lst;
                         {
                             __auto_type branch_items = branch_lst.items;
                             if (((int64_t)((branch_items).len)) >= 1) {
-                                __auto_type _mv_665 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_665.has_value) {
-                                    __auto_type pattern = _mv_665.value;
+                                __auto_type _mv_666 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_666.has_value) {
+                                    __auto_type pattern = _mv_666.value;
                                     ({ __auto_type _lst_p = &(result); __auto_type _item = (pattern); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                                } else if (!_mv_665.has_value) {
+                                } else if (!_mv_666.has_value) {
                                 }
                             }
                         }
@@ -419,7 +419,7 @@ slop_list_types_SExpr_ptr match_collect_patterns(context_TranspileContext* ctx, 
                         break;
                     }
                 }
-            } else if (!_mv_663.has_value) {
+            } else if (!_mv_664.has_value) {
             }
             i = (i + 1);
         }
@@ -436,20 +436,20 @@ void match_transpile_option_match(context_TranspileContext* ctx, slop_string scr
         uint8_t first = 1;
         uint8_t has_else = 0;
         while (i < len) {
-            __auto_type _mv_666 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_666.has_value) {
-                __auto_type branch = _mv_666.value;
-                __auto_type _mv_667 = (*branch);
-                switch (_mv_667.tag) {
+            __auto_type _mv_667 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_667.has_value) {
+                __auto_type branch = _mv_667.value;
+                __auto_type _mv_668 = (*branch);
+                switch (_mv_668.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type branch_lst = _mv_667.data.lst;
+                        __auto_type branch_lst = _mv_668.data.lst;
                         {
                             __auto_type branch_items = branch_lst.items;
                             if (((int64_t)((branch_items).len)) >= 2) {
-                                __auto_type _mv_668 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_668.has_value) {
-                                    __auto_type pattern = _mv_668.value;
+                                __auto_type _mv_669 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_669.has_value) {
+                                    __auto_type pattern = _mv_669.value;
                                     {
                                         __auto_type tag = match_get_pattern_tag(pattern);
                                         if (string_eq(tag, SLOP_STR("some"))) {
@@ -465,7 +465,7 @@ void match_transpile_option_match(context_TranspileContext* ctx, slop_string scr
                                         } else {
                                         }
                                     }
-                                } else if (!_mv_668.has_value) {
+                                } else if (!_mv_669.has_value) {
                                 }
                             }
                         }
@@ -475,7 +475,7 @@ void match_transpile_option_match(context_TranspileContext* ctx, slop_string scr
                         break;
                     }
                 }
-            } else if (!_mv_666.has_value) {
+            } else if (!_mv_667.has_value) {
             }
             i = (i + 1);
         }
@@ -498,9 +498,9 @@ void match_emit_option_some_branch(context_TranspileContext* ctx, slop_string sc
         }
         context_ctx_indent(ctx);
         context_ctx_push_scope(ctx);
-        __auto_type _mv_669 = match_extract_binding_name(pattern);
-        if (_mv_669.has_value) {
-            __auto_type binding_name = _mv_669.value;
+        __auto_type _mv_670 = match_extract_binding_name(pattern);
+        if (_mv_670.has_value) {
+            __auto_type binding_name = _mv_670.value;
             {
                 __auto_type c_name = ctype_to_c_name(arena, binding_name);
                 __auto_type inner_slop_type = expr_infer_option_inner_slop_type(ctx, scrutinee_expr);
@@ -509,7 +509,7 @@ void match_emit_option_some_branch(context_TranspileContext* ctx, slop_string sc
                 context_ctx_emit(ctx, context_ctx_str4(ctx, SLOP_STR("__auto_type "), c_name, SLOP_STR(" = "), context_ctx_str(ctx, scrutinee_c, SLOP_STR(".value;"))));
                 context_ctx_bind_var(ctx, (context_VarEntry){binding_name, c_name, inner_c_type, inner_slop_type, is_ptr, 0, 0, SLOP_STR(""), SLOP_STR("")});
             }
-        } else if (!_mv_669.has_value) {
+        } else if (!_mv_670.has_value) {
         }
         match_emit_branch_body(ctx, branch_items, is_return);
         context_ctx_pop_scope(ctx);
@@ -539,20 +539,20 @@ void match_transpile_result_match(context_TranspileContext* ctx, slop_string scr
         uint8_t first = 1;
         uint8_t has_else = 0;
         while (i < len) {
-            __auto_type _mv_670 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_670.has_value) {
-                __auto_type branch = _mv_670.value;
-                __auto_type _mv_671 = (*branch);
-                switch (_mv_671.tag) {
+            __auto_type _mv_671 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_671.has_value) {
+                __auto_type branch = _mv_671.value;
+                __auto_type _mv_672 = (*branch);
+                switch (_mv_672.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type branch_lst = _mv_671.data.lst;
+                        __auto_type branch_lst = _mv_672.data.lst;
                         {
                             __auto_type branch_items = branch_lst.items;
                             if (((int64_t)((branch_items).len)) >= 2) {
-                                __auto_type _mv_672 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_672.has_value) {
-                                    __auto_type pattern = _mv_672.value;
+                                __auto_type _mv_673 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_673.has_value) {
+                                    __auto_type pattern = _mv_673.value;
                                     {
                                         __auto_type tag = match_get_pattern_tag(pattern);
                                         if (string_eq(tag, SLOP_STR("ok"))) {
@@ -568,7 +568,7 @@ void match_transpile_result_match(context_TranspileContext* ctx, slop_string scr
                                         } else {
                                         }
                                     }
-                                } else if (!_mv_672.has_value) {
+                                } else if (!_mv_673.has_value) {
                                 }
                             }
                         }
@@ -578,7 +578,7 @@ void match_transpile_result_match(context_TranspileContext* ctx, slop_string scr
                         break;
                     }
                 }
-            } else if (!_mv_670.has_value) {
+            } else if (!_mv_671.has_value) {
             }
             i = (i + 1);
         }
@@ -602,9 +602,9 @@ void match_emit_result_ok_branch(context_TranspileContext* ctx, slop_string scru
         }
         context_ctx_indent(ctx);
         context_ctx_push_scope(ctx);
-        __auto_type _mv_673 = match_extract_binding_name(pattern);
-        if (_mv_673.has_value) {
-            __auto_type binding_name = _mv_673.value;
+        __auto_type _mv_674 = match_extract_binding_name(pattern);
+        if (_mv_674.has_value) {
+            __auto_type binding_name = _mv_674.value;
             {
                 __auto_type c_name = ctype_to_c_name(arena, binding_name);
                 __auto_type ok_slop_type = expr_infer_result_ok_slop_type(ctx, scrutinee_expr);
@@ -613,7 +613,7 @@ void match_emit_result_ok_branch(context_TranspileContext* ctx, slop_string scru
                 context_ctx_emit(ctx, context_ctx_str4(ctx, SLOP_STR("__auto_type "), c_name, SLOP_STR(" = "), context_ctx_str(ctx, scrutinee_c, SLOP_STR(".data.ok;"))));
                 context_ctx_bind_var(ctx, (context_VarEntry){binding_name, c_name, ok_c_type, ok_slop_type, is_ptr, 0, 0, SLOP_STR(""), SLOP_STR("")});
             }
-        } else if (!_mv_673.has_value) {
+        } else if (!_mv_674.has_value) {
         }
         match_emit_branch_body(ctx, branch_items, is_return);
         context_ctx_pop_scope(ctx);
@@ -634,9 +634,9 @@ void match_emit_result_error_branch(context_TranspileContext* ctx, slop_string s
         }
         context_ctx_indent(ctx);
         context_ctx_push_scope(ctx);
-        __auto_type _mv_674 = match_extract_binding_name(pattern);
-        if (_mv_674.has_value) {
-            __auto_type binding_name = _mv_674.value;
+        __auto_type _mv_675 = match_extract_binding_name(pattern);
+        if (_mv_675.has_value) {
+            __auto_type binding_name = _mv_675.value;
             {
                 __auto_type c_name = ctype_to_c_name(arena, binding_name);
                 __auto_type err_slop_type = expr_infer_result_err_slop_type(ctx, scrutinee_expr);
@@ -645,7 +645,7 @@ void match_emit_result_error_branch(context_TranspileContext* ctx, slop_string s
                 context_ctx_emit(ctx, context_ctx_str4(ctx, SLOP_STR("__auto_type "), c_name, SLOP_STR(" = "), context_ctx_str(ctx, scrutinee_c, SLOP_STR(".data.err;"))));
                 context_ctx_bind_var(ctx, (context_VarEntry){binding_name, c_name, err_c_type, err_slop_type, is_ptr, 0, 0, SLOP_STR(""), SLOP_STR("")});
             }
-        } else if (!_mv_674.has_value) {
+        } else if (!_mv_675.has_value) {
         }
         match_emit_branch_body(ctx, branch_items, is_return);
         context_ctx_pop_scope(ctx);
@@ -663,20 +663,20 @@ void match_transpile_enum_match(context_TranspileContext* ctx, slop_string scrut
         context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("switch ("), scrutinee_c, SLOP_STR(") {")));
         context_ctx_indent(ctx);
         while (i < len) {
-            __auto_type _mv_675 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_675.has_value) {
-                __auto_type branch = _mv_675.value;
-                __auto_type _mv_676 = (*branch);
-                switch (_mv_676.tag) {
+            __auto_type _mv_676 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_676.has_value) {
+                __auto_type branch = _mv_676.value;
+                __auto_type _mv_677 = (*branch);
+                switch (_mv_677.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type branch_lst = _mv_676.data.lst;
+                        __auto_type branch_lst = _mv_677.data.lst;
                         {
                             __auto_type branch_items = branch_lst.items;
                             if (((int64_t)((branch_items).len)) >= 2) {
-                                __auto_type _mv_677 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_677.has_value) {
-                                    __auto_type pattern = _mv_677.value;
+                                __auto_type _mv_678 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_678.has_value) {
+                                    __auto_type pattern = _mv_678.value;
                                     {
                                         __auto_type tag = match_get_pattern_tag(pattern);
                                         if (string_eq(tag, SLOP_STR("else")) || string_eq(tag, SLOP_STR("_"))) {
@@ -684,7 +684,7 @@ void match_transpile_enum_match(context_TranspileContext* ctx, slop_string scrut
                                         }
                                     }
                                     match_emit_enum_case(ctx, pattern, branch_items, is_return);
-                                } else if (!_mv_677.has_value) {
+                                } else if (!_mv_678.has_value) {
                                 }
                             }
                         }
@@ -694,7 +694,7 @@ void match_transpile_enum_match(context_TranspileContext* ctx, slop_string scrut
                         break;
                     }
                 }
-            } else if (!_mv_675.has_value) {
+            } else if (!_mv_676.has_value) {
             }
             i = (i + 1);
         }
@@ -718,9 +718,9 @@ void match_emit_enum_case(context_TranspileContext* ctx, types_SExpr* pattern, s
             context_ctx_dedent(ctx);
             context_ctx_emit(ctx, SLOP_STR("}"));
         } else {
-            __auto_type _mv_678 = context_ctx_lookup_enum_variant(ctx, tag);
-            if (_mv_678.has_value) {
-                __auto_type type_name = _mv_678.value;
+            __auto_type _mv_679 = context_ctx_lookup_enum_variant(ctx, tag);
+            if (_mv_679.has_value) {
+                __auto_type type_name = _mv_679.value;
                 {
                     __auto_type c_case = context_ctx_str3(ctx, type_name, SLOP_STR("_"), ctype_to_c_name(arena, tag));
                     context_ctx_emit(ctx, context_ctx_str(ctx, SLOP_STR("case "), context_ctx_str(ctx, c_case, SLOP_STR(": {"))));
@@ -730,7 +730,7 @@ void match_emit_enum_case(context_TranspileContext* ctx, types_SExpr* pattern, s
                     context_ctx_dedent(ctx);
                     context_ctx_emit(ctx, SLOP_STR("}"));
                 }
-            } else if (!_mv_678.has_value) {
+            } else if (!_mv_679.has_value) {
                 context_ctx_add_error_at(ctx, context_ctx_str3(ctx, SLOP_STR("unknown enum variant '"), tag, SLOP_STR("' in match")), context_ctx_sexpr_line(pattern), context_ctx_sexpr_col(pattern));
                 context_ctx_emit(ctx, context_ctx_str(ctx, SLOP_STR("/* unknown enum variant: "), context_ctx_str(ctx, tag, SLOP_STR(" */"))));
             }
@@ -747,26 +747,26 @@ void match_transpile_literal_match(context_TranspileContext* ctx, slop_string sc
         uint8_t first = 1;
         uint8_t has_else = 0;
         while (i < len) {
-            __auto_type _mv_679 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_679.has_value) {
-                __auto_type branch = _mv_679.value;
-                __auto_type _mv_680 = (*branch);
-                switch (_mv_680.tag) {
+            __auto_type _mv_680 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_680.has_value) {
+                __auto_type branch = _mv_680.value;
+                __auto_type _mv_681 = (*branch);
+                switch (_mv_681.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type branch_lst = _mv_680.data.lst;
+                        __auto_type branch_lst = _mv_681.data.lst;
                         {
                             __auto_type branch_items = branch_lst.items;
                             if (((int64_t)((branch_items).len)) >= 2) {
-                                __auto_type _mv_681 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_681.has_value) {
-                                    __auto_type pattern = _mv_681.value;
+                                __auto_type _mv_682 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_682.has_value) {
+                                    __auto_type pattern = _mv_682.value;
                                     if (string_eq(match_get_pattern_tag(pattern), SLOP_STR("else"))) {
                                         has_else = 1;
                                     }
                                     match_emit_literal_case(ctx, scrutinee_c, pattern, branch_items, is_return, first);
                                     first = 0;
-                                } else if (!_mv_681.has_value) {
+                                } else if (!_mv_682.has_value) {
                                 }
                             }
                         }
@@ -776,7 +776,7 @@ void match_transpile_literal_match(context_TranspileContext* ctx, slop_string sc
                         break;
                     }
                 }
-            } else if (!_mv_679.has_value) {
+            } else if (!_mv_680.has_value) {
             }
             i = (i + 1);
         }
@@ -832,20 +832,20 @@ void match_transpile_union_match(context_TranspileContext* ctx, slop_string scru
             context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("switch ("), scrutinee_c, SLOP_STR(".tag) {")));
             context_ctx_indent(ctx);
             while (i < len) {
-                __auto_type _mv_682 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_682.has_value) {
-                    __auto_type branch = _mv_682.value;
-                    __auto_type _mv_683 = (*branch);
-                    switch (_mv_683.tag) {
+                __auto_type _mv_683 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_683.has_value) {
+                    __auto_type branch = _mv_683.value;
+                    __auto_type _mv_684 = (*branch);
+                    switch (_mv_684.tag) {
                         case types_SExpr_lst:
                         {
-                            __auto_type branch_lst = _mv_683.data.lst;
+                            __auto_type branch_lst = _mv_684.data.lst;
                             {
                                 __auto_type branch_items = branch_lst.items;
                                 if (((int64_t)((branch_items).len)) >= 2) {
-                                    __auto_type _mv_684 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_684.has_value) {
-                                        __auto_type pattern = _mv_684.value;
+                                    __auto_type _mv_685 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_685.has_value) {
+                                        __auto_type pattern = _mv_685.value;
                                         {
                                             __auto_type tag = match_get_pattern_tag(pattern);
                                             if (string_eq(tag, SLOP_STR("else")) || string_eq(tag, SLOP_STR("_"))) {
@@ -859,16 +859,16 @@ void match_transpile_union_match(context_TranspileContext* ctx, slop_string scru
                                                 context_ctx_dedent(ctx);
                                                 context_ctx_emit(ctx, SLOP_STR("}"));
                                             } else {
-                                                __auto_type _mv_685 = context_ctx_lookup_enum_variant(ctx, tag);
-                                                if (_mv_685.has_value) {
-                                                    __auto_type union_type_name = _mv_685.value;
+                                                __auto_type _mv_686 = context_ctx_lookup_enum_variant(ctx, tag);
+                                                if (_mv_686.has_value) {
+                                                    __auto_type union_type_name = _mv_686.value;
                                                     match_emit_union_case(ctx, scrutinee_c, pattern, tag, union_type_name, branch_items, is_return);
-                                                } else if (!_mv_685.has_value) {
+                                                } else if (!_mv_686.has_value) {
                                                     context_ctx_add_error(ctx, context_ctx_str3(ctx, SLOP_STR("unknown union variant in match: "), tag, SLOP_STR(" (not registered as enum variant)")));
                                                 }
                                             }
                                         }
-                                    } else if (!_mv_684.has_value) {
+                                    } else if (!_mv_685.has_value) {
                                     }
                                 }
                             }
@@ -878,7 +878,7 @@ void match_transpile_union_match(context_TranspileContext* ctx, slop_string scru
                             break;
                         }
                     }
-                } else if (!_mv_682.has_value) {
+                } else if (!_mv_683.has_value) {
                 }
                 i = (i + 1);
             }
@@ -905,18 +905,18 @@ void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_
             __auto_type count_key = context_ctx_str3(ctx, tag, SLOP_STR("__count"), SLOP_STR(""));
             __auto_type multi_field_count = ({ __auto_type _mv = context_ctx_lookup_field_type(ctx, union_type_name, count_key); _mv.has_value ? ({ __auto_type ct = _mv.value; ct; }) : (SLOP_STR("")); });
             if (!(string_eq(multi_field_count, SLOP_STR("")))) {
-                __auto_type _mv_686 = (*pattern);
-                switch (_mv_686.tag) {
+                __auto_type _mv_687 = (*pattern);
+                switch (_mv_687.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type pat_lst = _mv_686.data.lst;
+                        __auto_type pat_lst = _mv_687.data.lst;
                         {
                             __auto_type pat_items = pat_lst.items;
                             __auto_type pat_len = ((int64_t)((pat_items).len));
                             for (int64_t bi = 1; bi < pat_len; bi++) {
-                                __auto_type _mv_687 = ({ __auto_type _lst = pat_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_687.has_value) {
-                                    __auto_type binding_expr = _mv_687.value;
+                                __auto_type _mv_688 = ({ __auto_type _lst = pat_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_688.has_value) {
+                                    __auto_type binding_expr = _mv_688.value;
                                     {
                                         __auto_type binding_name = parser_sexpr_get_symbol_name(binding_expr);
                                         if (!(string_eq(binding_name, SLOP_STR(""))) && !(string_eq(binding_name, SLOP_STR("_")))) {
@@ -932,7 +932,7 @@ void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_
                                             }
                                         }
                                     }
-                                } else if (!_mv_687.has_value) {
+                                } else if (!_mv_688.has_value) {
                                 }
                             }
                         }
@@ -943,9 +943,9 @@ void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_
                     }
                 }
             } else {
-                __auto_type _mv_688 = match_extract_binding_name(pattern);
-                if (_mv_688.has_value) {
-                    __auto_type binding_name = _mv_688.value;
+                __auto_type _mv_689 = match_extract_binding_name(pattern);
+                if (_mv_689.has_value) {
+                    __auto_type binding_name = _mv_689.value;
                     {
                         __auto_type c_binding = ctype_to_c_name(arena, binding_name);
                         __auto_type payload_c_type = ({ __auto_type _mv = context_ctx_lookup_field_type(ctx, union_type_name, tag); _mv.has_value ? ({ __auto_type ct = _mv.value; ct; }) : (SLOP_STR("auto")); });
@@ -953,7 +953,7 @@ void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_
                         context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("__auto_type "), c_binding, SLOP_STR(" = "), scrutinee_c, context_ctx_str3(ctx, SLOP_STR(".data."), c_tag, SLOP_STR(";"))));
                         context_ctx_bind_var(ctx, (context_VarEntry){binding_name, c_binding, payload_c_type, payload_slop_type, 0, 0, 0, SLOP_STR(""), SLOP_STR("")});
                     }
-                } else if (!_mv_688.has_value) {
+                } else if (!_mv_689.has_value) {
                 }
             }
         }
@@ -997,14 +997,14 @@ void match_emit_branch_body(context_TranspileContext* ctx, slop_list_types_SExpr
         __auto_type len = ((int64_t)((branch_items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_689 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_689.has_value) {
-                __auto_type body_expr = _mv_689.value;
+            __auto_type _mv_690 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_690.has_value) {
+                __auto_type body_expr = _mv_690.value;
                 {
                     __auto_type is_last = (i == (len - 1));
                     match_emit_branch_body_item(ctx, body_expr, is_return, is_last);
                 }
-            } else if (!_mv_689.has_value) {
+            } else if (!_mv_690.has_value) {
             }
             i = (i + 1);
         }
@@ -1016,24 +1016,24 @@ void match_emit_branch_body_item(context_TranspileContext* ctx, types_SExpr* bod
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_690 = (*body_expr);
-        switch (_mv_690.tag) {
+        __auto_type _mv_691 = (*body_expr);
+        switch (_mv_691.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_690.data.lst;
+                __auto_type lst = _mv_691.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 1) {
                         context_ctx_emit(ctx, SLOP_STR("/* empty list */;"));
                     } else {
-                        __auto_type _mv_691 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_691.has_value) {
-                            __auto_type head_expr = _mv_691.value;
-                            __auto_type _mv_692 = (*head_expr);
-                            switch (_mv_692.tag) {
+                        __auto_type _mv_692 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_692.has_value) {
+                            __auto_type head_expr = _mv_692.value;
+                            __auto_type _mv_693 = (*head_expr);
+                            switch (_mv_693.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_692.data.sym;
+                                    __auto_type sym = _mv_693.data.sym;
                                     {
                                         __auto_type op = sym.name;
                                         if (string_eq(op, SLOP_STR("let"))) {
@@ -1080,7 +1080,7 @@ void match_emit_branch_body_item(context_TranspileContext* ctx, types_SExpr* bod
                                     break;
                                 }
                             }
-                        } else if (!_mv_691.has_value) {
+                        } else if (!_mv_692.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("empty"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         }
                     }
@@ -1112,23 +1112,23 @@ void match_emit_inline_let(context_TranspileContext* ctx, slop_list_types_SExpr_
             context_ctx_emit(ctx, SLOP_STR("{"));
             context_ctx_indent(ctx);
             context_ctx_push_scope(ctx);
-            __auto_type _mv_693 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_693.has_value) {
-                __auto_type bindings_expr = _mv_693.value;
+            __auto_type _mv_694 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_694.has_value) {
+                __auto_type bindings_expr = _mv_694.value;
                 match_emit_inline_bindings(ctx, bindings_expr);
-            } else if (!_mv_693.has_value) {
+            } else if (!_mv_694.has_value) {
             }
             {
                 int64_t i = 2;
                 while (i < len) {
-                    __auto_type _mv_694 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_694.has_value) {
-                        __auto_type body_item = _mv_694.value;
+                    __auto_type _mv_695 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_695.has_value) {
+                        __auto_type body_item = _mv_695.value;
                         {
                             __auto_type body_last = (i == (len - 1));
                             match_emit_branch_body_item(ctx, body_item, is_return, (is_last && body_last));
                         }
-                    } else if (!_mv_694.has_value) {
+                    } else if (!_mv_695.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -1145,21 +1145,21 @@ void match_emit_inline_bindings(context_TranspileContext* ctx, types_SExpr* bind
     SLOP_PRE(((bindings_expr != NULL)), "(!= bindings-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_695 = (*bindings_expr);
-        switch (_mv_695.tag) {
+        __auto_type _mv_696 = (*bindings_expr);
+        switch (_mv_696.tag) {
             case types_SExpr_lst:
             {
-                __auto_type bindings_lst = _mv_695.data.lst;
+                __auto_type bindings_lst = _mv_696.data.lst;
                 {
                     __auto_type bindings = bindings_lst.items;
                     __auto_type len = ((int64_t)((bindings).len));
                     __auto_type i = 0;
                     while (i < len) {
-                        __auto_type _mv_696 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_696.has_value) {
-                            __auto_type binding = _mv_696.value;
+                        __auto_type _mv_697 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_697.has_value) {
+                            __auto_type binding = _mv_697.value;
                             match_emit_single_inline_binding(ctx, binding);
-                        } else if (!_mv_696.has_value) {
+                        } else if (!_mv_697.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -1178,11 +1178,11 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
     SLOP_PRE(((binding != NULL)), "(!= binding nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_697 = (*binding);
-        switch (_mv_697.tag) {
+        __auto_type _mv_698 = (*binding);
+        switch (_mv_698.tag) {
             case types_SExpr_lst:
             {
-                __auto_type binding_lst = _mv_697.data.lst;
+                __auto_type binding_lst = _mv_698.data.lst;
                 {
                     __auto_type items = binding_lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -1192,14 +1192,14 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
                         if ((len - start_idx) < 2) {
                             context_ctx_add_error_at(ctx, SLOP_STR("invalid binding"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                         } else {
-                            __auto_type _mv_698 = ({ __auto_type _lst = items; size_t _idx = (size_t)start_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_698.has_value) {
-                                __auto_type name_expr = _mv_698.value;
-                                __auto_type _mv_699 = (*name_expr);
-                                switch (_mv_699.tag) {
+                            __auto_type _mv_699 = ({ __auto_type _lst = items; size_t _idx = (size_t)start_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_699.has_value) {
+                                __auto_type name_expr = _mv_699.value;
+                                __auto_type _mv_700 = (*name_expr);
+                                switch (_mv_700.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type name_sym = _mv_699.data.sym;
+                                        __auto_type name_sym = _mv_700.data.sym;
                                         {
                                             __auto_type raw_name = name_sym.name;
                                             __auto_type c_name = ctype_to_c_name(arena, raw_name);
@@ -1207,13 +1207,13 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
                                                 {
                                                     __auto_type type_idx = (start_idx + 1);
                                                     __auto_type val_idx = (start_idx + 2);
-                                                    __auto_type _mv_700 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_700.has_value) {
-                                                        __auto_type type_expr = _mv_700.value;
+                                                    __auto_type _mv_701 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_701.has_value) {
+                                                        __auto_type type_expr = _mv_701.value;
                                                         if (match_is_type_expr(type_expr)) {
-                                                            __auto_type _mv_701 = ({ __auto_type _lst = items; size_t _idx = (size_t)val_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                            if (_mv_701.has_value) {
-                                                                __auto_type val_expr = _mv_701.value;
+                                                            __auto_type _mv_702 = ({ __auto_type _lst = items; size_t _idx = (size_t)val_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                            if (_mv_702.has_value) {
+                                                                __auto_type val_expr = _mv_702.value;
                                                                 {
                                                                     __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                                     __auto_type is_ptr = strlib_ends_with(c_type, SLOP_STR("*"));
@@ -1224,23 +1224,23 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
                                                                         context_ctx_bind_var(ctx, (context_VarEntry){raw_name, c_name, c_type, slop_type_str, is_ptr, has_mut, 0, SLOP_STR(""), SLOP_STR("")});
                                                                     }
                                                                 }
-                                                            } else if (!_mv_701.has_value) {
+                                                            } else if (!_mv_702.has_value) {
                                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing value"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                             }
                                                         } else {
-                                                            __auto_type _mv_702 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                            if (_mv_702.has_value) {
-                                                                __auto_type val_expr = _mv_702.value;
+                                                            __auto_type _mv_703 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                            if (_mv_703.has_value) {
+                                                                __auto_type val_expr = _mv_703.value;
                                                                 {
                                                                     __auto_type val_c = expr_transpile_expr(ctx, val_expr);
                                                                     __auto_type inferred_slop_type = expr_infer_expr_slop_type(ctx, val_expr);
                                                                     __auto_type ptr_type_opt = match_get_arena_alloc_ptr_type_inline(ctx, val_expr);
-                                                                    __auto_type _mv_703 = ptr_type_opt;
-                                                                    if (_mv_703.has_value) {
-                                                                        __auto_type ptr_type = _mv_703.value;
+                                                                    __auto_type _mv_704 = ptr_type_opt;
+                                                                    if (_mv_704.has_value) {
+                                                                        __auto_type ptr_type = _mv_704.value;
                                                                         context_ctx_emit(ctx, context_ctx_str4(ctx, SLOP_STR("__auto_type "), c_name, SLOP_STR(" = "), context_ctx_str(ctx, val_c, SLOP_STR(";"))));
                                                                         context_ctx_bind_var(ctx, (context_VarEntry){raw_name, c_name, ptr_type, inferred_slop_type, 1, has_mut, 0, SLOP_STR(""), SLOP_STR("")});
-                                                                    } else if (!_mv_703.has_value) {
+                                                                    } else if (!_mv_704.has_value) {
                                                                         {
                                                                             __auto_type inferred_type = expr_infer_expr_c_type(ctx, val_expr);
                                                                             __auto_type is_ptr = strlib_ends_with(inferred_type, SLOP_STR("*"));
@@ -1249,30 +1249,30 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
                                                                         }
                                                                     }
                                                                 }
-                                                            } else if (!_mv_702.has_value) {
+                                                            } else if (!_mv_703.has_value) {
                                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing value"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                             }
                                                         }
-                                                    } else if (!_mv_700.has_value) {
+                                                    } else if (!_mv_701.has_value) {
                                                         context_ctx_add_error_at(ctx, SLOP_STR("missing type/value"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                     }
                                                 }
                                             } else {
                                                 {
                                                     __auto_type val_idx = (start_idx + 1);
-                                                    __auto_type _mv_704 = ({ __auto_type _lst = items; size_t _idx = (size_t)val_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_704.has_value) {
-                                                        __auto_type val_expr = _mv_704.value;
+                                                    __auto_type _mv_705 = ({ __auto_type _lst = items; size_t _idx = (size_t)val_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_705.has_value) {
+                                                        __auto_type val_expr = _mv_705.value;
                                                         {
                                                             __auto_type val_c = expr_transpile_expr(ctx, val_expr);
                                                             __auto_type inferred_slop_type = expr_infer_expr_slop_type(ctx, val_expr);
                                                             __auto_type ptr_type_opt = match_get_arena_alloc_ptr_type_inline(ctx, val_expr);
-                                                            __auto_type _mv_705 = ptr_type_opt;
-                                                            if (_mv_705.has_value) {
-                                                                __auto_type ptr_type = _mv_705.value;
+                                                            __auto_type _mv_706 = ptr_type_opt;
+                                                            if (_mv_706.has_value) {
+                                                                __auto_type ptr_type = _mv_706.value;
                                                                 context_ctx_emit(ctx, context_ctx_str4(ctx, SLOP_STR("__auto_type "), c_name, SLOP_STR(" = "), context_ctx_str(ctx, val_c, SLOP_STR(";"))));
                                                                 context_ctx_bind_var(ctx, (context_VarEntry){raw_name, c_name, ptr_type, inferred_slop_type, 1, has_mut, 0, SLOP_STR(""), SLOP_STR("")});
-                                                            } else if (!_mv_705.has_value) {
+                                                            } else if (!_mv_706.has_value) {
                                                                 {
                                                                     __auto_type inferred_type = expr_infer_expr_c_type(ctx, val_expr);
                                                                     __auto_type is_ptr = strlib_ends_with(inferred_type, SLOP_STR("*"));
@@ -1281,7 +1281,7 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
                                                                 }
                                                             }
                                                         }
-                                                    } else if (!_mv_704.has_value) {
+                                                    } else if (!_mv_705.has_value) {
                                                         context_ctx_add_error_at(ctx, SLOP_STR("missing value"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                     }
                                                 }
@@ -1294,7 +1294,7 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
                                         break;
                                     }
                                 }
-                            } else if (!_mv_698.has_value) {
+                            } else if (!_mv_699.has_value) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("missing binding name"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                             }
                         }
@@ -1314,21 +1314,21 @@ uint8_t match_binding_starts_with_mut(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_706 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_706.has_value) {
-            __auto_type first = _mv_706.value;
-            __auto_type _mv_707 = (*first);
-            switch (_mv_707.tag) {
+        __auto_type _mv_707 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_707.has_value) {
+            __auto_type first = _mv_707.value;
+            __auto_type _mv_708 = (*first);
+            switch (_mv_708.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_707.data.sym;
+                    __auto_type sym = _mv_708.data.sym;
                     return string_eq(sym.name, SLOP_STR("mut"));
                 }
                 default: {
                     return 0;
                 }
             }
-        } else if (!_mv_706.has_value) {
+        } else if (!_mv_707.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -1337,11 +1337,11 @@ uint8_t match_binding_starts_with_mut(slop_list_types_SExpr_ptr items) {
 
 uint8_t match_is_type_expr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_708 = (*expr);
-    switch (_mv_708.tag) {
+    __auto_type _mv_709 = (*expr);
+    switch (_mv_709.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_708.data.sym;
+            __auto_type sym = _mv_709.data.sym;
             {
                 __auto_type name = sym.name;
                 if (string_len(name) == 0) {
@@ -1356,7 +1356,7 @@ uint8_t match_is_type_expr(types_SExpr* expr) {
         }
         case types_SExpr_lst:
         {
-            __auto_type _ = _mv_708.data.lst;
+            __auto_type _ = _mv_709.data.lst;
             return 1;
         }
         default: {
@@ -1367,34 +1367,34 @@ uint8_t match_is_type_expr(types_SExpr* expr) {
 
 uint8_t match_is_none_form_inline(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_709 = (*expr);
-    switch (_mv_709.tag) {
+    __auto_type _mv_710 = (*expr);
+    switch (_mv_710.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_709.data.sym;
+            __auto_type sym = _mv_710.data.sym;
             return string_eq(sym.name, SLOP_STR("none"));
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_709.data.lst;
+            __auto_type lst = _mv_710.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) == 1) {
-                    __auto_type _mv_710 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_710.has_value) {
-                        __auto_type head = _mv_710.value;
-                        __auto_type _mv_711 = (*head);
-                        switch (_mv_711.tag) {
+                    __auto_type _mv_711 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_711.has_value) {
+                        __auto_type head = _mv_711.value;
+                        __auto_type _mv_712 = (*head);
+                        switch (_mv_712.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_711.data.sym;
+                                __auto_type sym = _mv_712.data.sym;
                                 return string_eq(sym.name, SLOP_STR("none"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_710.has_value) {
+                    } else if (!_mv_711.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1419,28 +1419,28 @@ slop_option_string match_get_arena_alloc_ptr_type_inline(context_TranspileContex
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_712 = (*expr);
-        switch (_mv_712.tag) {
+        __auto_type _mv_713 = (*expr);
+        switch (_mv_713.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_712.data.lst;
+                __auto_type lst = _mv_713.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_713 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_713.has_value) {
-                            __auto_type head_ptr = _mv_713.value;
-                            __auto_type _mv_714 = (*head_ptr);
-                            switch (_mv_714.tag) {
+                        __auto_type _mv_714 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_714.has_value) {
+                            __auto_type head_ptr = _mv_714.value;
+                            __auto_type _mv_715 = (*head_ptr);
+                            switch (_mv_715.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type head_sym = _mv_714.data.sym;
+                                    __auto_type head_sym = _mv_715.data.sym;
                                     if (string_eq(head_sym.name, SLOP_STR("arena-alloc"))) {
-                                        __auto_type _mv_715 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_715.has_value) {
-                                            __auto_type size_expr = _mv_715.value;
+                                        __auto_type _mv_716 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_716.has_value) {
+                                            __auto_type size_expr = _mv_716.value;
                                             return match_extract_sizeof_type_inline(ctx, size_expr);
-                                        } else if (!_mv_715.has_value) {
+                                        } else if (!_mv_716.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
                                         SLOP_UNREACHABLE();
@@ -1452,7 +1452,7 @@ slop_option_string match_get_arena_alloc_ptr_type_inline(context_TranspileContex
                                     return (slop_option_string){.has_value = false};
                                 }
                             }
-                        } else if (!_mv_713.has_value) {
+                        } else if (!_mv_714.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -1473,18 +1473,18 @@ slop_option_string match_extract_sizeof_type_inline(context_TranspileContext* ct
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_716 = (*expr);
-        switch (_mv_716.tag) {
+        __auto_type _mv_717 = (*expr);
+        switch (_mv_717.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_716.data.sym;
+                __auto_type sym = _mv_717.data.sym;
                 {
                     __auto_type type_name = sym.name;
-                    __auto_type _mv_717 = context_ctx_lookup_type(ctx, type_name);
-                    if (_mv_717.has_value) {
-                        __auto_type entry = _mv_717.value;
+                    __auto_type _mv_718 = context_ctx_lookup_type(ctx, type_name);
+                    if (_mv_718.has_value) {
+                        __auto_type entry = _mv_718.value;
                         return (slop_option_string){.has_value = 1, .value = context_ctx_str(ctx, entry.c_name, SLOP_STR("*"))};
-                    } else if (!_mv_717.has_value) {
+                    } else if (!_mv_718.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
                     SLOP_UNREACHABLE();
@@ -1492,27 +1492,27 @@ slop_option_string match_extract_sizeof_type_inline(context_TranspileContext* ct
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_716.data.lst;
+                __auto_type lst = _mv_717.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_718 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_718.has_value) {
-                            __auto_type head_ptr = _mv_718.value;
-                            __auto_type _mv_719 = (*head_ptr);
-                            switch (_mv_719.tag) {
+                        __auto_type _mv_719 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_719.has_value) {
+                            __auto_type head_ptr = _mv_719.value;
+                            __auto_type _mv_720 = (*head_ptr);
+                            switch (_mv_720.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type head_sym = _mv_719.data.sym;
+                                    __auto_type head_sym = _mv_720.data.sym;
                                     if (string_eq(head_sym.name, SLOP_STR("sizeof"))) {
-                                        __auto_type _mv_720 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_720.has_value) {
-                                            __auto_type type_expr = _mv_720.value;
+                                        __auto_type _mv_721 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_721.has_value) {
+                                            __auto_type type_expr = _mv_721.value;
                                             {
                                                 __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                 return (slop_option_string){.has_value = 1, .value = context_ctx_str(ctx, c_type, SLOP_STR("*"))};
                                             }
-                                        } else if (!_mv_720.has_value) {
+                                        } else if (!_mv_721.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
                                         SLOP_UNREACHABLE();
@@ -1524,7 +1524,7 @@ slop_option_string match_extract_sizeof_type_inline(context_TranspileContext* ct
                                     return (slop_option_string){.has_value = false};
                                 }
                             }
-                        } else if (!_mv_718.has_value) {
+                        } else if (!_mv_719.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -1546,14 +1546,14 @@ void match_emit_inline_do(context_TranspileContext* ctx, slop_list_types_SExpr_p
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_721 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_721.has_value) {
-                __auto_type item = _mv_721.value;
+            __auto_type _mv_722 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_722.has_value) {
+                __auto_type item = _mv_722.value;
                 {
                     __auto_type item_last = (i == (len - 1));
                     match_emit_branch_body_item(ctx, item, is_return, (is_last && item_last));
                 }
-            } else if (!_mv_721.has_value) {
+            } else if (!_mv_722.has_value) {
             }
             i = (i + 1);
         }
@@ -1568,32 +1568,32 @@ void match_emit_inline_if(context_TranspileContext* ctx, slop_list_types_SExpr_p
         if (len < 3) {
             context_ctx_add_error_at(ctx, SLOP_STR("invalid if"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         } else {
-            __auto_type _mv_722 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_722.has_value) {
-                __auto_type cond_expr = _mv_722.value;
+            __auto_type _mv_723 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_723.has_value) {
+                __auto_type cond_expr = _mv_723.value;
                 {
                     __auto_type cond_c = context_ctx_strip_cond_parens(ctx, expr_transpile_expr(ctx, cond_expr));
                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("if ("), cond_c, SLOP_STR(") {")));
                 }
-            } else if (!_mv_722.has_value) {
+            } else if (!_mv_723.has_value) {
                 context_ctx_emit(ctx, SLOP_STR("if (/* missing */) {"));
             }
             context_ctx_indent(ctx);
-            __auto_type _mv_723 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_723.has_value) {
-                __auto_type then_expr = _mv_723.value;
+            __auto_type _mv_724 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_724.has_value) {
+                __auto_type then_expr = _mv_724.value;
                 match_emit_branch_body_item(ctx, then_expr, is_return, 1);
-            } else if (!_mv_723.has_value) {
+            } else if (!_mv_724.has_value) {
             }
             context_ctx_dedent(ctx);
             if (len >= 4) {
                 context_ctx_emit(ctx, SLOP_STR("} else {"));
                 context_ctx_indent(ctx);
-                __auto_type _mv_724 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_724.has_value) {
-                    __auto_type else_expr = _mv_724.value;
+                __auto_type _mv_725 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_725.has_value) {
+                    __auto_type else_expr = _mv_725.value;
                     match_emit_branch_body_item(ctx, else_expr, is_return, 1);
-                } else if (!_mv_724.has_value) {
+                } else if (!_mv_725.has_value) {
                 }
                 context_ctx_dedent(ctx);
                 context_ctx_emit(ctx, SLOP_STR("}"));
@@ -1612,14 +1612,14 @@ void match_emit_inline_while(context_TranspileContext* ctx, slop_list_types_SExp
         if (len < 3) {
             context_ctx_add_error_at(ctx, SLOP_STR("invalid while"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         } else {
-            __auto_type _mv_725 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_725.has_value) {
-                __auto_type cond_expr = _mv_725.value;
+            __auto_type _mv_726 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_726.has_value) {
+                __auto_type cond_expr = _mv_726.value;
                 {
                     __auto_type cond_c = context_ctx_strip_cond_parens(ctx, expr_transpile_expr(ctx, cond_expr));
                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("while ("), cond_c, SLOP_STR(") {")));
                 }
-            } else if (!_mv_725.has_value) {
+            } else if (!_mv_726.has_value) {
                 context_ctx_emit(ctx, SLOP_STR("while (/* missing */) {"));
             }
             context_ctx_indent(ctx);
@@ -1632,18 +1632,18 @@ void match_emit_inline_while(context_TranspileContext* ctx, slop_list_types_SExp
 
 slop_option_string match_get_var_c_type_inline(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
-    __auto_type _mv_726 = (*expr);
-    switch (_mv_726.tag) {
+    __auto_type _mv_727 = (*expr);
+    switch (_mv_727.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_726.data.sym;
+            __auto_type sym = _mv_727.data.sym;
             {
                 __auto_type name = sym.name;
-                __auto_type _mv_727 = context_ctx_lookup_var(ctx, name);
-                if (_mv_727.has_value) {
-                    __auto_type var_entry = _mv_727.value;
+                __auto_type _mv_728 = context_ctx_lookup_var(ctx, name);
+                if (_mv_728.has_value) {
+                    __auto_type var_entry = _mv_728.value;
                     return (slop_option_string){.has_value = 1, .value = var_entry.c_type};
-                } else if (!_mv_727.has_value) {
+                } else if (!_mv_728.has_value) {
                     return (slop_option_string){.has_value = false};
                 }
                 SLOP_UNREACHABLE();
@@ -1659,28 +1659,28 @@ slop_option_types_SExpr_ptr match_get_some_value_inline(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         slop_option_types_SExpr_ptr result = (slop_option_types_SExpr_ptr){.has_value = false};
-        __auto_type _mv_728 = (*expr);
-        switch (_mv_728.tag) {
+        __auto_type _mv_729 = (*expr);
+        switch (_mv_729.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_728.data.lst;
+                __auto_type lst = _mv_729.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_729 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_729.has_value) {
-                            __auto_type head = _mv_729.value;
-                            __auto_type _mv_730 = (*head);
-                            switch (_mv_730.tag) {
+                        __auto_type _mv_730 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_730.has_value) {
+                            __auto_type head = _mv_730.value;
+                            __auto_type _mv_731 = (*head);
+                            switch (_mv_731.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_730.data.sym;
+                                    __auto_type sym = _mv_731.data.sym;
                                     if (string_eq(sym.name, SLOP_STR("some"))) {
-                                        __auto_type _mv_731 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_731.has_value) {
-                                            __auto_type val = _mv_731.value;
+                                        __auto_type _mv_732 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_732.has_value) {
+                                            __auto_type val = _mv_732.value;
                                             result = (slop_option_types_SExpr_ptr){.has_value = 1, .value = val};
-                                        } else if (!_mv_731.has_value) {
+                                        } else if (!_mv_732.has_value) {
                                         }
                                     }
                                     break;
@@ -1689,7 +1689,7 @@ slop_option_types_SExpr_ptr match_get_some_value_inline(types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_729.has_value) {
+                        } else if (!_mv_730.has_value) {
                         }
                     }
                 }
@@ -1710,18 +1710,18 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
         __auto_type len = ((int64_t)((items).len));
         if (expr_set_is_self_assign(items)) {
         } else if (len == 5) {
-            __auto_type _mv_732 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_732.has_value) {
-                __auto_type target_expr = _mv_732.value;
-                __auto_type _mv_733 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_733.has_value) {
-                    __auto_type field_expr = _mv_733.value;
-                    __auto_type _mv_734 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_734.has_value) {
-                        __auto_type type_expr = _mv_734.value;
-                        __auto_type _mv_735 = ({ __auto_type _lst = items; size_t _idx = (size_t)4; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_735.has_value) {
-                            __auto_type value_expr = _mv_735.value;
+            __auto_type _mv_733 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_733.has_value) {
+                __auto_type target_expr = _mv_733.value;
+                __auto_type _mv_734 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_734.has_value) {
+                    __auto_type field_expr = _mv_734.value;
+                    __auto_type _mv_735 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_735.has_value) {
+                        __auto_type type_expr = _mv_735.value;
+                        __auto_type _mv_736 = ({ __auto_type _lst = items; size_t _idx = (size_t)4; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_736.has_value) {
+                            __auto_type value_expr = _mv_736.value;
                             {
                                 __auto_type field_name = match_get_field_name_inline(ctx, field_expr);
                                 __auto_type c_type = ctype_to_c_type(arena, type_expr);
@@ -1731,14 +1731,14 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
                                         if (match_is_none_form_inline(value_expr)) {
                                             context_ctx_emit(ctx, context_ctx_str(ctx, target_access, context_ctx_str(ctx, field_name, context_ctx_str3(ctx, SLOP_STR(" = ("), c_type, SLOP_STR("){.has_value = false};")))));
                                         } else {
-                                            __auto_type _mv_736 = match_get_some_value_inline(value_expr);
-                                            if (_mv_736.has_value) {
-                                                __auto_type inner_val = _mv_736.value;
+                                            __auto_type _mv_737 = match_get_some_value_inline(value_expr);
+                                            if (_mv_737.has_value) {
+                                                __auto_type inner_val = _mv_737.value;
                                                 {
                                                     __auto_type val_c = expr_transpile_expr(ctx, inner_val);
                                                     context_ctx_emit(ctx, context_ctx_str(ctx, target_access, context_ctx_str(ctx, field_name, context_ctx_str5(ctx, SLOP_STR(" = ("), c_type, SLOP_STR("){.has_value = 1, .value = "), val_c, SLOP_STR("};")))));
                                                 }
-                                            } else if (!_mv_736.has_value) {
+                                            } else if (!_mv_737.has_value) {
                                                 {
                                                     __auto_type val_c = expr_transpile_expr(ctx, value_expr);
                                                     context_ctx_emit(ctx, context_ctx_str(ctx, target_access, context_ctx_str(ctx, field_name, context_ctx_str(ctx, SLOP_STR(" = "), context_ctx_str(ctx, val_c, SLOP_STR(";"))))));
@@ -1753,28 +1753,28 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
                                     }
                                 }
                             }
-                        } else if (!_mv_735.has_value) {
+                        } else if (!_mv_736.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing set! value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         }
-                    } else if (!_mv_734.has_value) {
+                    } else if (!_mv_735.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing set! type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     }
-                } else if (!_mv_733.has_value) {
+                } else if (!_mv_734.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("missing set! field"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 }
-            } else if (!_mv_732.has_value) {
+            } else if (!_mv_733.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing set! target"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             }
         } else if (len == 4) {
-            __auto_type _mv_737 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_737.has_value) {
-                __auto_type target_expr = _mv_737.value;
-                __auto_type _mv_738 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_738.has_value) {
-                    __auto_type field_expr = _mv_738.value;
-                    __auto_type _mv_739 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_739.has_value) {
-                        __auto_type value_expr = _mv_739.value;
+            __auto_type _mv_738 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_738.has_value) {
+                __auto_type target_expr = _mv_738.value;
+                __auto_type _mv_739 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_739.has_value) {
+                    __auto_type field_expr = _mv_739.value;
+                    __auto_type _mv_740 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_740.has_value) {
+                        __auto_type value_expr = _mv_740.value;
                         {
                             __auto_type field_name = match_get_field_name_inline(ctx, field_expr);
                             __auto_type value_c = expr_transpile_expr(ctx, value_expr);
@@ -1790,39 +1790,39 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
                                 }
                             }
                         }
-                    } else if (!_mv_739.has_value) {
+                    } else if (!_mv_740.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing set! value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     }
-                } else if (!_mv_738.has_value) {
+                } else if (!_mv_739.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("missing set! field"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 }
-            } else if (!_mv_737.has_value) {
+            } else if (!_mv_738.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing set! target"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             }
         } else if (len >= 3) {
-            __auto_type _mv_740 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_740.has_value) {
-                __auto_type target_expr = _mv_740.value;
-                __auto_type _mv_741 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_741.has_value) {
-                    __auto_type val_expr = _mv_741.value;
+            __auto_type _mv_741 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_741.has_value) {
+                __auto_type target_expr = _mv_741.value;
+                __auto_type _mv_742 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_742.has_value) {
+                    __auto_type val_expr = _mv_742.value;
                     {
                         __auto_type target_c = expr_transpile_expr(ctx, target_expr);
                         __auto_type target_type_opt = match_get_var_c_type_inline(ctx, target_expr);
-                        __auto_type _mv_742 = target_type_opt;
-                        if (_mv_742.has_value) {
-                            __auto_type target_type = _mv_742.value;
+                        __auto_type _mv_743 = target_type_opt;
+                        if (_mv_743.has_value) {
+                            __auto_type target_type = _mv_743.value;
                             if (strlib_starts_with(target_type, SLOP_STR("slop_option_"))) {
                                 {
                                     __auto_type some_val_opt = match_get_some_value_inline(val_expr);
-                                    __auto_type _mv_743 = some_val_opt;
-                                    if (_mv_743.has_value) {
-                                        __auto_type inner_expr = _mv_743.value;
+                                    __auto_type _mv_744 = some_val_opt;
+                                    if (_mv_744.has_value) {
+                                        __auto_type inner_expr = _mv_744.value;
                                         {
                                             __auto_type inner_c = expr_transpile_expr(ctx, inner_expr);
                                             context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str5(ctx, SLOP_STR(" = ("), target_type, SLOP_STR("){.has_value = 1, .value = "), inner_c, SLOP_STR("};"))));
                                         }
-                                    } else if (!_mv_743.has_value) {
+                                    } else if (!_mv_744.has_value) {
                                         {
                                             __auto_type val_c = expr_transpile_expr(ctx, val_expr);
                                             if (string_eq(val_c, SLOP_STR("none"))) {
@@ -1839,23 +1839,23 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
                                     context_ctx_emit(ctx, context_ctx_str4(ctx, target_c, SLOP_STR(" = "), val_c, SLOP_STR(";")));
                                 }
                             }
-                        } else if (!_mv_742.has_value) {
+                        } else if (!_mv_743.has_value) {
                             {
                                 __auto_type some_val_opt = match_get_some_value_inline(val_expr);
-                                __auto_type _mv_744 = some_val_opt;
-                                if (_mv_744.has_value) {
-                                    __auto_type inner_expr = _mv_744.value;
+                                __auto_type _mv_745 = some_val_opt;
+                                if (_mv_745.has_value) {
+                                    __auto_type inner_expr = _mv_745.value;
                                     {
                                         __auto_type inner_c = expr_transpile_expr(ctx, inner_expr);
                                         __auto_type inner_type = expr_infer_expr_c_type(ctx, inner_expr);
                                         __auto_type option_type = expr_c_type_to_option_type_name(ctx, inner_type);
                                         context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str5(ctx, SLOP_STR(" = ("), option_type, SLOP_STR("){.has_value = 1, .value = "), inner_c, SLOP_STR("};"))));
                                     }
-                                } else if (!_mv_744.has_value) {
+                                } else if (!_mv_745.has_value) {
                                     if (match_is_none_form_inline(val_expr)) {
-                                        __auto_type _mv_745 = context_ctx_get_current_return_type(ctx);
-                                        if (_mv_745.has_value) {
-                                            __auto_type ret_type = _mv_745.value;
+                                        __auto_type _mv_746 = context_ctx_get_current_return_type(ctx);
+                                        if (_mv_746.has_value) {
+                                            __auto_type ret_type = _mv_746.value;
                                             if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
                                                 context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str3(ctx, SLOP_STR(" = ("), ret_type, SLOP_STR("){.has_value = false};"))));
                                             } else {
@@ -1864,7 +1864,7 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
                                                     context_ctx_emit(ctx, context_ctx_str4(ctx, target_c, SLOP_STR(" = "), val_c, SLOP_STR(";")));
                                                 }
                                             }
-                                        } else if (!_mv_745.has_value) {
+                                        } else if (!_mv_746.has_value) {
                                             {
                                                 __auto_type val_c = expr_transpile_expr(ctx, val_expr);
                                                 context_ctx_emit(ctx, context_ctx_str4(ctx, target_c, SLOP_STR(" = "), val_c, SLOP_STR(";")));
@@ -1880,10 +1880,10 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
                             }
                         }
                     }
-                } else if (!_mv_741.has_value) {
+                } else if (!_mv_742.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("missing set! value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 }
-            } else if (!_mv_740.has_value) {
+            } else if (!_mv_741.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing set! target"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             }
         } else {
@@ -1894,31 +1894,31 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
 
 uint8_t match_is_deref_inline(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_746 = (*expr);
-    switch (_mv_746.tag) {
+    __auto_type _mv_747 = (*expr);
+    switch (_mv_747.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_746.data.lst;
+            __auto_type lst = _mv_747.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return 0;
                 } else {
-                    __auto_type _mv_747 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_747.has_value) {
-                        __auto_type head = _mv_747.value;
-                        __auto_type _mv_748 = (*head);
-                        switch (_mv_748.tag) {
+                    __auto_type _mv_748 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_748.has_value) {
+                        __auto_type head = _mv_748.value;
+                        __auto_type _mv_749 = (*head);
+                        switch (_mv_749.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_748.data.sym;
+                                __auto_type sym = _mv_749.data.sym;
                                 return string_eq(sym.name, SLOP_STR("deref"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_747.has_value) {
+                    } else if (!_mv_748.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1933,18 +1933,18 @@ uint8_t match_is_deref_inline(types_SExpr* expr) {
 
 slop_string match_get_deref_inner_inline(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_749 = (*expr);
-    switch (_mv_749.tag) {
+    __auto_type _mv_750 = (*expr);
+    switch (_mv_750.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_749.data.lst;
+            __auto_type lst = _mv_750.data.lst;
             {
                 __auto_type items = lst.items;
-                __auto_type _mv_750 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_750.has_value) {
-                    __auto_type inner = _mv_750.value;
+                __auto_type _mv_751 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_751.has_value) {
+                    __auto_type inner = _mv_751.value;
                     return expr_transpile_expr(ctx, inner);
-                } else if (!_mv_750.has_value) {
+                } else if (!_mv_751.has_value) {
                     return SLOP_STR("/* missing deref arg */");
                 }
                 SLOP_UNREACHABLE();
@@ -1961,11 +1961,11 @@ slop_string match_get_field_name_inline(context_TranspileContext* ctx, types_SEx
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_751 = (*expr);
-        switch (_mv_751.tag) {
+        __auto_type _mv_752 = (*expr);
+        switch (_mv_752.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_751.data.sym;
+                __auto_type sym = _mv_752.data.sym;
                 return ctype_to_c_name(arena, sym.name);
             }
             default: {
@@ -1983,14 +1983,14 @@ void match_emit_inline_when(context_TranspileContext* ctx, slop_list_types_SExpr
         if (len < 2) {
             context_ctx_add_error_at(ctx, SLOP_STR("invalid when"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         } else {
-            __auto_type _mv_752 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_752.has_value) {
-                __auto_type cond_expr = _mv_752.value;
+            __auto_type _mv_753 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_753.has_value) {
+                __auto_type cond_expr = _mv_753.value;
                 {
                     __auto_type cond_c = context_ctx_strip_cond_parens(ctx, expr_transpile_expr(ctx, cond_expr));
                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("if ("), cond_c, SLOP_STR(") {")));
                 }
-            } else if (!_mv_752.has_value) {
+            } else if (!_mv_753.has_value) {
                 context_ctx_emit(ctx, SLOP_STR("if (/* missing */) {"));
             }
             context_ctx_indent(ctx);
@@ -2010,28 +2010,28 @@ void match_emit_inline_cond(context_TranspileContext* ctx, slop_list_types_SExpr
         uint8_t first = 1;
         uint8_t has_else = 0;
         while (i < len) {
-            __auto_type _mv_753 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_753.has_value) {
-                __auto_type clause_expr = _mv_753.value;
-                __auto_type _mv_754 = (*clause_expr);
-                switch (_mv_754.tag) {
+            __auto_type _mv_754 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_754.has_value) {
+                __auto_type clause_expr = _mv_754.value;
+                __auto_type _mv_755 = (*clause_expr);
+                switch (_mv_755.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type clause_lst = _mv_754.data.lst;
+                        __auto_type clause_lst = _mv_755.data.lst;
                         {
                             __auto_type clause_items = clause_lst.items;
                             __auto_type clause_len = ((int64_t)((clause_items).len));
                             if (clause_len < 1) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("invalid cond clause"), context_ctx_sexpr_line(clause_expr), context_ctx_sexpr_col(clause_expr));
                             } else {
-                                __auto_type _mv_755 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_755.has_value) {
-                                    __auto_type test_expr = _mv_755.value;
-                                    __auto_type _mv_756 = (*test_expr);
-                                    switch (_mv_756.tag) {
+                                __auto_type _mv_756 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_756.has_value) {
+                                    __auto_type test_expr = _mv_756.value;
+                                    __auto_type _mv_757 = (*test_expr);
+                                    switch (_mv_757.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_756.data.sym;
+                                            __auto_type sym = _mv_757.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("else"))) {
                                                 has_else = 1;
                                                 context_ctx_emit(ctx, SLOP_STR("} else {"));
@@ -2070,7 +2070,7 @@ void match_emit_inline_cond(context_TranspileContext* ctx, slop_list_types_SExpr
                                             break;
                                         }
                                     }
-                                } else if (!_mv_755.has_value) {
+                                } else if (!_mv_756.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing test"), context_ctx_sexpr_line(clause_expr), context_ctx_sexpr_col(clause_expr));
                                 }
                             }
@@ -2082,7 +2082,7 @@ void match_emit_inline_cond(context_TranspileContext* ctx, slop_list_types_SExpr
                         break;
                     }
                 }
-            } else if (!_mv_753.has_value) {
+            } else if (!_mv_754.has_value) {
             }
             i = (i + 1);
         }
@@ -2099,14 +2099,14 @@ void match_emit_inline_cond_body(context_TranspileContext* ctx, slop_list_types_
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_757 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_757.has_value) {
-                __auto_type body_expr = _mv_757.value;
+            __auto_type _mv_758 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_758.has_value) {
+                __auto_type body_expr = _mv_758.value;
                 {
                     __auto_type body_is_last = (i == (len - 1));
                     match_emit_branch_body_item(ctx, body_expr, is_return, (is_last && body_is_last));
                 }
-            } else if (!_mv_757.has_value) {
+            } else if (!_mv_758.has_value) {
             }
             i = (i + 1);
         }
@@ -2126,41 +2126,42 @@ void match_emit_inline_with_arena(context_TranspileContext* ctx, slop_list_types
                 __auto_type arena_name = ((is_named) ? ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type name_expr = _mv.value; parser_sexpr_get_symbol_name(name_expr); }) : (SLOP_STR("arena")); }) : SLOP_STR("arena"));
                 __auto_type size_idx = ((is_named) ? 3 : 1);
                 __auto_type body_start = ((is_named) ? 4 : 2);
-                __auto_type c_local = ((is_named) ? string_concat(ctx_arena, SLOP_STR("_arena_"), arena_name) : SLOP_STR("_arena"));
+                __auto_type c_arena_name = ctype_to_c_name(ctx_arena, arena_name);
+                __auto_type c_local = ((is_named) ? string_concat(ctx_arena, SLOP_STR("_arena_"), c_arena_name) : SLOP_STR("_arena"));
                 if (is_named && (len < 4)) {
                     context_ctx_add_error_at(ctx, SLOP_STR("with-arena :as requires name and size"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 } else {
                     context_ctx_emit(ctx, SLOP_STR("{"));
                     context_ctx_indent(ctx);
                     context_ctx_push_scope(ctx);
-                    __auto_type _mv_758 = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_758.has_value) {
-                        __auto_type size_expr = _mv_758.value;
+                    __auto_type _mv_759 = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_759.has_value) {
+                        __auto_type size_expr = _mv_759.value;
                         {
                             __auto_type size_c = expr_transpile_expr(ctx, size_expr);
                             context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("slop_arena "), c_local, SLOP_STR(" = slop_arena_new("), size_c, SLOP_STR(");")));
-                            context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("slop_arena* "), arena_name, SLOP_STR(" = &"), c_local, SLOP_STR(";")));
+                            context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("slop_arena* "), c_arena_name, SLOP_STR(" = &"), c_local, SLOP_STR(";")));
                         }
-                    } else if (!_mv_758.has_value) {
+                    } else if (!_mv_759.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing size"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     }
-                    context_ctx_bind_var(ctx, (context_VarEntry){arena_name, arena_name, SLOP_STR("slop_arena*"), SLOP_STR(""), 1, 0, 0, SLOP_STR(""), SLOP_STR("")});
+                    context_ctx_bind_var(ctx, (context_VarEntry){arena_name, c_arena_name, SLOP_STR("slop_arena*"), SLOP_STR(""), 1, 0, 0, SLOP_STR(""), SLOP_STR("")});
                     {
                         int64_t i = body_start;
                         while (i < len) {
-                            __auto_type _mv_759 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_759.has_value) {
-                                __auto_type body_expr = _mv_759.value;
+                            __auto_type _mv_760 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_760.has_value) {
+                                __auto_type body_expr = _mv_760.value;
                                 {
                                     __auto_type is_last = (i == (len - 1));
                                     match_emit_branch_body_item(ctx, body_expr, (is_return && is_last), is_last);
                                 }
-                            } else if (!_mv_759.has_value) {
+                            } else if (!_mv_760.has_value) {
                             }
                             i = (i + 1);
                         }
                     }
-                    context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), arena_name, SLOP_STR(");")));
+                    context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), c_arena_name, SLOP_STR(");")));
                     context_ctx_pop_scope(ctx);
                     context_ctx_dedent(ctx);
                     context_ctx_emit(ctx, SLOP_STR("}"));
@@ -2176,11 +2177,11 @@ void match_emit_inline_body_items(context_TranspileContext* ctx, slop_list_types
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_760 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_760.has_value) {
-                __auto_type body_expr = _mv_760.value;
+            __auto_type _mv_761 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_761.has_value) {
+                __auto_type body_expr = _mv_761.value;
                 match_emit_branch_body_item(ctx, body_expr, 0, 0);
-            } else if (!_mv_760.has_value) {
+            } else if (!_mv_761.has_value) {
             }
             i = (i + 1);
         }
@@ -2195,36 +2196,36 @@ void match_emit_inline_for(context_TranspileContext* ctx, slop_list_types_SExpr_
         if (len < 2) {
             context_ctx_add_error_at(ctx, SLOP_STR("invalid for: need binding"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         } else {
-            __auto_type _mv_761 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_761.has_value) {
-                __auto_type binding_expr = _mv_761.value;
-                __auto_type _mv_762 = (*binding_expr);
-                switch (_mv_762.tag) {
+            __auto_type _mv_762 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_762.has_value) {
+                __auto_type binding_expr = _mv_762.value;
+                __auto_type _mv_763 = (*binding_expr);
+                switch (_mv_763.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type binding_lst = _mv_762.data.lst;
+                        __auto_type binding_lst = _mv_763.data.lst;
                         {
                             __auto_type binding_items = binding_lst.items;
                             __auto_type binding_len = ((int64_t)((binding_items).len));
                             if (binding_len < 3) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("for binding needs (var start end)"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                             } else {
-                                __auto_type _mv_763 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_763.has_value) {
-                                    __auto_type var_expr = _mv_763.value;
-                                    __auto_type _mv_764 = (*var_expr);
-                                    switch (_mv_764.tag) {
+                                __auto_type _mv_764 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_764.has_value) {
+                                    __auto_type var_expr = _mv_764.value;
+                                    __auto_type _mv_765 = (*var_expr);
+                                    switch (_mv_765.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type var_sym = _mv_764.data.sym;
+                                            __auto_type var_sym = _mv_765.data.sym;
                                             {
                                                 __auto_type var_name = ctype_to_c_name(arena, var_sym.name);
-                                                __auto_type _mv_765 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_765.has_value) {
-                                                    __auto_type start_expr = _mv_765.value;
-                                                    __auto_type _mv_766 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_766.has_value) {
-                                                        __auto_type end_expr = _mv_766.value;
+                                                __auto_type _mv_766 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_766.has_value) {
+                                                    __auto_type start_expr = _mv_766.value;
+                                                    __auto_type _mv_767 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_767.has_value) {
+                                                        __auto_type end_expr = _mv_767.value;
                                                         {
                                                             __auto_type start_c = expr_transpile_expr(ctx, start_expr);
                                                             __auto_type end_c = expr_transpile_expr(ctx, end_expr);
@@ -2237,10 +2238,10 @@ void match_emit_inline_for(context_TranspileContext* ctx, slop_list_types_SExpr_
                                                             context_ctx_dedent(ctx);
                                                             context_ctx_emit(ctx, SLOP_STR("}"));
                                                         }
-                                                    } else if (!_mv_766.has_value) {
+                                                    } else if (!_mv_767.has_value) {
                                                         context_ctx_add_error_at(ctx, SLOP_STR("missing end"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                                     }
-                                                } else if (!_mv_765.has_value) {
+                                                } else if (!_mv_766.has_value) {
                                                     context_ctx_add_error_at(ctx, SLOP_STR("missing start"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                                 }
                                             }
@@ -2251,7 +2252,7 @@ void match_emit_inline_for(context_TranspileContext* ctx, slop_list_types_SExpr_
                                             break;
                                         }
                                     }
-                                } else if (!_mv_763.has_value) {
+                                } else if (!_mv_764.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing var"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                 }
                             }
@@ -2263,7 +2264,7 @@ void match_emit_inline_for(context_TranspileContext* ctx, slop_list_types_SExpr_
                         break;
                     }
                 }
-            } else if (!_mv_761.has_value) {
+            } else if (!_mv_762.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing binding"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             }
         }
@@ -2338,38 +2339,38 @@ void match_emit_inline_for_each_map_kv(context_TranspileContext* ctx, slop_list_
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_767 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_767.has_value) {
-            __auto_type kv_list_expr = _mv_767.value;
-            __auto_type _mv_768 = (*kv_list_expr);
-            switch (_mv_768.tag) {
+        __auto_type _mv_768 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_768.has_value) {
+            __auto_type kv_list_expr = _mv_768.value;
+            __auto_type _mv_769 = (*kv_list_expr);
+            switch (_mv_769.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type kv_lst = _mv_768.data.lst;
+                    __auto_type kv_lst = _mv_769.data.lst;
                     {
                         __auto_type kv_items = kv_lst.items;
                         if (((int64_t)((kv_items).len)) < 2) {
                             context_ctx_add_error(ctx, SLOP_STR("Map for-each needs ((k v) map)"));
                         } else {
-                            __auto_type _mv_769 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_769.has_value) {
-                                __auto_type k_expr = _mv_769.value;
-                                __auto_type _mv_770 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_770.has_value) {
-                                    __auto_type v_expr = _mv_770.value;
-                                    __auto_type _mv_771 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_771.has_value) {
-                                        __auto_type map_expr = _mv_771.value;
-                                        __auto_type _mv_772 = (*k_expr);
-                                        switch (_mv_772.tag) {
+                            __auto_type _mv_770 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_770.has_value) {
+                                __auto_type k_expr = _mv_770.value;
+                                __auto_type _mv_771 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_771.has_value) {
+                                    __auto_type v_expr = _mv_771.value;
+                                    __auto_type _mv_772 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_772.has_value) {
+                                        __auto_type map_expr = _mv_772.value;
+                                        __auto_type _mv_773 = (*k_expr);
+                                        switch (_mv_773.tag) {
                                             case types_SExpr_sym:
                                             {
-                                                __auto_type k_sym = _mv_772.data.sym;
-                                                __auto_type _mv_773 = (*v_expr);
-                                                switch (_mv_773.tag) {
+                                                __auto_type k_sym = _mv_773.data.sym;
+                                                __auto_type _mv_774 = (*v_expr);
+                                                switch (_mv_774.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type v_sym = _mv_773.data.sym;
+                                                        __auto_type v_sym = _mv_774.data.sym;
                                                         {
                                                             __auto_type k_name = ctype_to_c_name(arena, k_sym.name);
                                                             __auto_type v_name = ctype_to_c_name(arena, v_sym.name);
@@ -2425,13 +2426,13 @@ void match_emit_inline_for_each_map_kv(context_TranspileContext* ctx, slop_list_
                                                 break;
                                             }
                                         }
-                                    } else if (!_mv_771.has_value) {
+                                    } else if (!_mv_772.has_value) {
                                         context_ctx_add_error(ctx, SLOP_STR("Missing map expression"));
                                     }
-                                } else if (!_mv_770.has_value) {
+                                } else if (!_mv_771.has_value) {
                                     context_ctx_add_error(ctx, SLOP_STR("Missing value binding"));
                                 }
-                            } else if (!_mv_769.has_value) {
+                            } else if (!_mv_770.has_value) {
                                 context_ctx_add_error(ctx, SLOP_STR("Missing key binding"));
                             }
                         }
@@ -2443,7 +2444,7 @@ void match_emit_inline_for_each_map_kv(context_TranspileContext* ctx, slop_list_
                     break;
                 }
             }
-        } else if (!_mv_767.has_value) {
+        } else if (!_mv_768.has_value) {
             context_ctx_add_error(ctx, SLOP_STR("Missing binding"));
         }
     }
@@ -2457,39 +2458,39 @@ void match_emit_inline_for_each(context_TranspileContext* ctx, slop_list_types_S
         if (len < 2) {
             context_ctx_add_error_at(ctx, SLOP_STR("invalid for-each: need binding"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         } else {
-            __auto_type _mv_774 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_774.has_value) {
-                __auto_type binding_expr = _mv_774.value;
-                __auto_type _mv_775 = (*binding_expr);
-                switch (_mv_775.tag) {
+            __auto_type _mv_775 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_775.has_value) {
+                __auto_type binding_expr = _mv_775.value;
+                __auto_type _mv_776 = (*binding_expr);
+                switch (_mv_776.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type binding_lst = _mv_775.data.lst;
+                        __auto_type binding_lst = _mv_776.data.lst;
                         {
                             __auto_type binding_items = binding_lst.items;
                             __auto_type binding_len = ((int64_t)((binding_items).len));
                             if (binding_len < 2) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("for-each binding needs (var coll)"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                             } else {
-                                __auto_type _mv_776 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_776.has_value) {
-                                    __auto_type first_elem = _mv_776.value;
-                                    __auto_type _mv_777 = (*first_elem);
-                                    switch (_mv_777.tag) {
+                                __auto_type _mv_777 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_777.has_value) {
+                                    __auto_type first_elem = _mv_777.value;
+                                    __auto_type _mv_778 = (*first_elem);
+                                    switch (_mv_778.tag) {
                                         case types_SExpr_lst:
                                         {
-                                            __auto_type _ = _mv_777.data.lst;
+                                            __auto_type _ = _mv_778.data.lst;
                                             match_emit_inline_for_each_map_kv(ctx, binding_items, items, len);
                                             break;
                                         }
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type var_sym = _mv_777.data.sym;
+                                            __auto_type var_sym = _mv_778.data.sym;
                                             {
                                                 __auto_type var_name = ctype_to_c_name(arena, var_sym.name);
-                                                __auto_type _mv_778 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_778.has_value) {
-                                                    __auto_type coll_expr = _mv_778.value;
+                                                __auto_type _mv_779 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_779.has_value) {
+                                                    __auto_type coll_expr = _mv_779.value;
                                                     {
                                                         __auto_type coll_slop_type = expr_infer_expr_slop_type(ctx, coll_expr);
                                                         __auto_type resolved_type = expr_resolve_type_alias(ctx, coll_slop_type);
@@ -2528,7 +2529,7 @@ void match_emit_inline_for_each(context_TranspileContext* ctx, slop_list_types_S
                                                             }
                                                         }
                                                     }
-                                                } else if (!_mv_778.has_value) {
+                                                } else if (!_mv_779.has_value) {
                                                     context_ctx_add_error_at(ctx, SLOP_STR("missing collection"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                                 }
                                             }
@@ -2539,7 +2540,7 @@ void match_emit_inline_for_each(context_TranspileContext* ctx, slop_list_types_S
                                             break;
                                         }
                                     }
-                                } else if (!_mv_776.has_value) {
+                                } else if (!_mv_777.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing var"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                 }
                             }
@@ -2551,7 +2552,7 @@ void match_emit_inline_for_each(context_TranspileContext* ctx, slop_list_types_S
                         break;
                     }
                 }
-            } else if (!_mv_774.has_value) {
+            } else if (!_mv_775.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing binding"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             }
         }
@@ -2565,11 +2566,11 @@ void match_emit_inline_return(context_TranspileContext* ctx, slop_list_types_SEx
         if (len < 2) {
             context_ctx_emit(ctx, SLOP_STR("return;"));
         } else {
-            __auto_type _mv_779 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_779.has_value) {
-                __auto_type val_expr = _mv_779.value;
+            __auto_type _mv_780 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_780.has_value) {
+                __auto_type val_expr = _mv_780.value;
                 match_emit_typed_return_expr(ctx, val_expr);
-            } else if (!_mv_779.has_value) {
+            } else if (!_mv_780.has_value) {
                 context_ctx_emit(ctx, SLOP_STR("return;"));
             }
         }
@@ -2587,61 +2588,61 @@ void match_emit_return_typed(context_TranspileContext* ctx, slop_string code) {
 void match_emit_typed_return_expr(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_780 = (*expr);
-    switch (_mv_780.tag) {
+    __auto_type _mv_781 = (*expr);
+    switch (_mv_781.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_780.data.lst;
+            __auto_type lst = _mv_781.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                 } else {
-                    __auto_type _mv_781 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_781.has_value) {
-                        __auto_type head = _mv_781.value;
-                        __auto_type _mv_782 = (*head);
-                        switch (_mv_782.tag) {
+                    __auto_type _mv_782 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_782.has_value) {
+                        __auto_type head = _mv_782.value;
+                        __auto_type _mv_783 = (*head);
+                        switch (_mv_783.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_782.data.sym;
+                                __auto_type sym = _mv_783.data.sym;
                                 {
                                     __auto_type op = sym.name;
                                     if (string_eq(op, SLOP_STR("some"))) {
-                                        __auto_type _mv_783 = context_ctx_get_current_return_type(ctx);
-                                        if (_mv_783.has_value) {
-                                            __auto_type ret_type = _mv_783.value;
+                                        __auto_type _mv_784 = context_ctx_get_current_return_type(ctx);
+                                        if (_mv_784.has_value) {
+                                            __auto_type ret_type = _mv_784.value;
                                             if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
                                                 if (((int64_t)((items).len)) < 2) {
                                                     match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                                                 } else {
-                                                    __auto_type _mv_784 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_784.has_value) {
-                                                        __auto_type inner_expr = _mv_784.value;
+                                                    __auto_type _mv_785 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_785.has_value) {
+                                                        __auto_type inner_expr = _mv_785.value;
                                                         {
                                                             __auto_type inner_c = expr_transpile_expr(ctx, inner_expr);
                                                             context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("return ("), ret_type, SLOP_STR("){.has_value = 1, .value = "), inner_c, SLOP_STR("};")));
                                                         }
-                                                    } else if (!_mv_784.has_value) {
+                                                    } else if (!_mv_785.has_value) {
                                                         match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                                                     }
                                                 }
                                             } else {
                                                 match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                                             }
-                                        } else if (!_mv_783.has_value) {
+                                        } else if (!_mv_784.has_value) {
                                             match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                                         }
                                     } else if (string_eq(op, SLOP_STR("none"))) {
-                                        __auto_type _mv_785 = context_ctx_get_current_return_type(ctx);
-                                        if (_mv_785.has_value) {
-                                            __auto_type ret_type = _mv_785.value;
+                                        __auto_type _mv_786 = context_ctx_get_current_return_type(ctx);
+                                        if (_mv_786.has_value) {
+                                            __auto_type ret_type = _mv_786.value;
                                             if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
                                                 context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("return ("), ret_type, SLOP_STR("){.has_value = false};")));
                                             } else {
                                                 match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                                             }
-                                        } else if (!_mv_785.has_value) {
+                                        } else if (!_mv_786.has_value) {
                                             match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                                         }
                                     } else {
@@ -2655,7 +2656,7 @@ void match_emit_typed_return_expr(context_TranspileContext* ctx, types_SExpr* ex
                                 break;
                             }
                         }
-                    } else if (!_mv_781.has_value) {
+                    } else if (!_mv_782.has_value) {
                         match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                     }
                 }
@@ -2671,11 +2672,11 @@ void match_emit_typed_return_expr(context_TranspileContext* ctx, types_SExpr* ex
 
 uint8_t match_is_pattern_literal(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_786 = (*expr);
-    switch (_mv_786.tag) {
+    __auto_type _mv_787 = (*expr);
+    switch (_mv_787.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_786.data.sym;
+            __auto_type sym = _mv_787.data.sym;
             {
                 __auto_type name = sym.name;
                 return (string_eq(name, SLOP_STR("true")) || string_eq(name, SLOP_STR("false")));
@@ -2683,7 +2684,7 @@ uint8_t match_is_pattern_literal(types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type _ = _mv_786.data.num;
+            __auto_type _ = _mv_787.data.num;
             return 1;
         }
         default: {
@@ -2694,11 +2695,11 @@ uint8_t match_is_pattern_literal(types_SExpr* expr) {
 
 slop_string match_pattern_literal_to_c(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_787 = (*expr);
-    switch (_mv_787.tag) {
+    __auto_type _mv_788 = (*expr);
+    switch (_mv_788.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_787.data.sym;
+            __auto_type sym = _mv_788.data.sym;
             {
                 __auto_type name = sym.name;
                 if (string_eq(name, SLOP_STR("true"))) {
@@ -2712,7 +2713,7 @@ slop_string match_pattern_literal_to_c(types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type n = _mv_787.data.num;
+            __auto_type n = _mv_788.data.num;
             return n.raw;
         }
         default: {
@@ -2723,24 +2724,24 @@ slop_string match_pattern_literal_to_c(types_SExpr* expr) {
 
 uint8_t match_has_literal_in_union_arm(types_SExpr* pat_expr) {
     SLOP_PRE(((pat_expr != NULL)), "(!= pat-expr nil)");
-    __auto_type _mv_788 = (*pat_expr);
-    switch (_mv_788.tag) {
+    __auto_type _mv_789 = (*pat_expr);
+    switch (_mv_789.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_788.data.lst;
+            __auto_type lst = _mv_789.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type found = 0;
                 for (int64_t i = 1; i < len; i++) {
                     if (!(found)) {
-                        __auto_type _mv_789 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_789.has_value) {
-                            __auto_type item = _mv_789.value;
+                        __auto_type _mv_790 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_790.has_value) {
+                            __auto_type item = _mv_790.value;
                             if (match_is_pattern_literal(item)) {
                                 found = 1;
                             }
-                        } else if (!_mv_789.has_value) {
+                        } else if (!_mv_790.has_value) {
                         }
                     }
                 }
@@ -2759,13 +2760,13 @@ uint8_t match_has_literal_in_patterns(slop_list_types_SExpr_ptr patterns) {
         uint8_t found = 0;
         int64_t i = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_790 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_790.has_value) {
-                __auto_type pat_expr = _mv_790.value;
+            __auto_type _mv_791 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_791.has_value) {
+                __auto_type pat_expr = _mv_791.value;
                 if (match_has_literal_in_union_arm(pat_expr)) {
                     found = 1;
                 }
-            } else if (!_mv_790.has_value) {
+            } else if (!_mv_791.has_value) {
             }
             i = (i + 1);
         }
@@ -2778,19 +2779,19 @@ slop_string match_build_literal_guard_cond(context_TranspileContext* ctx, slop_s
     SLOP_PRE(((pattern != NULL)), "(!= pattern nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_791 = (*pattern);
-        switch (_mv_791.tag) {
+        __auto_type _mv_792 = (*pattern);
+        switch (_mv_792.tag) {
             case types_SExpr_lst:
             {
-                __auto_type pat_lst = _mv_791.data.lst;
+                __auto_type pat_lst = _mv_792.data.lst;
                 {
                     __auto_type pat_items = pat_lst.items;
                     __auto_type pat_len = ((int64_t)((pat_items).len));
                     __auto_type cond = tag_cond;
                     for (int64_t bi = 1; bi < pat_len; bi++) {
-                        __auto_type _mv_792 = ({ __auto_type _lst = pat_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_792.has_value) {
-                            __auto_type item = _mv_792.value;
+                        __auto_type _mv_793 = ({ __auto_type _lst = pat_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_793.has_value) {
+                            __auto_type item = _mv_793.value;
                             if (match_is_pattern_literal(item)) {
                                 {
                                     __auto_type lit_c = match_pattern_literal_to_c(item);
@@ -2809,7 +2810,7 @@ slop_string match_build_literal_guard_cond(context_TranspileContext* ctx, slop_s
                                     }
                                 }
                             }
-                        } else if (!_mv_792.has_value) {
+                        } else if (!_mv_793.has_value) {
                         }
                     }
                     return cond;
@@ -2828,18 +2829,18 @@ void match_emit_union_literal_bindings(context_TranspileContext* ctx, slop_strin
     {
         __auto_type arena = (*ctx).arena;
         if (is_multi) {
-            __auto_type _mv_793 = (*pattern);
-            switch (_mv_793.tag) {
+            __auto_type _mv_794 = (*pattern);
+            switch (_mv_794.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type pat_lst = _mv_793.data.lst;
+                    __auto_type pat_lst = _mv_794.data.lst;
                     {
                         __auto_type pat_items = pat_lst.items;
                         __auto_type pat_len = ((int64_t)((pat_items).len));
                         for (int64_t bi = 1; bi < pat_len; bi++) {
-                            __auto_type _mv_794 = ({ __auto_type _lst = pat_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_794.has_value) {
-                                __auto_type binding_expr = _mv_794.value;
+                            __auto_type _mv_795 = ({ __auto_type _lst = pat_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_795.has_value) {
+                                __auto_type binding_expr = _mv_795.value;
                                 if (!(match_is_pattern_literal(binding_expr))) {
                                     {
                                         __auto_type binding_name = parser_sexpr_get_symbol_name(binding_expr);
@@ -2857,7 +2858,7 @@ void match_emit_union_literal_bindings(context_TranspileContext* ctx, slop_strin
                                         }
                                     }
                                 }
-                            } else if (!_mv_794.has_value) {
+                            } else if (!_mv_795.has_value) {
                             }
                         }
                     }
@@ -2868,9 +2869,9 @@ void match_emit_union_literal_bindings(context_TranspileContext* ctx, slop_strin
                 }
             }
         } else {
-            __auto_type _mv_795 = match_extract_binding_name(pattern);
-            if (_mv_795.has_value) {
-                __auto_type binding_name = _mv_795.value;
+            __auto_type _mv_796 = match_extract_binding_name(pattern);
+            if (_mv_796.has_value) {
+                __auto_type binding_name = _mv_796.value;
                 if ((!(string_eq(binding_name, SLOP_STR("true")))) && (!(string_eq(binding_name, SLOP_STR("false")))) && (!(string_eq(binding_name, SLOP_STR("_"))))) {
                     {
                         __auto_type c_binding = ctype_to_c_name(arena, binding_name);
@@ -2880,7 +2881,7 @@ void match_emit_union_literal_bindings(context_TranspileContext* ctx, slop_strin
                         context_ctx_bind_var(ctx, (context_VarEntry){binding_name, c_binding, payload_c_type, payload_slop_type, 0, 0, 0, SLOP_STR(""), SLOP_STR("")});
                     }
                 }
-            } else if (!_mv_795.has_value) {
+            } else if (!_mv_796.has_value) {
             }
         }
     }
@@ -2895,20 +2896,20 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
         uint8_t first = 1;
         uint8_t has_else = 0;
         while (i < len) {
-            __auto_type _mv_796 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_796.has_value) {
-                __auto_type branch = _mv_796.value;
-                __auto_type _mv_797 = (*branch);
-                switch (_mv_797.tag) {
+            __auto_type _mv_797 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_797.has_value) {
+                __auto_type branch = _mv_797.value;
+                __auto_type _mv_798 = (*branch);
+                switch (_mv_798.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type branch_lst = _mv_797.data.lst;
+                        __auto_type branch_lst = _mv_798.data.lst;
                         {
                             __auto_type branch_items = branch_lst.items;
                             if (((int64_t)((branch_items).len)) >= 2) {
-                                __auto_type _mv_798 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_798.has_value) {
-                                    __auto_type pattern = _mv_798.value;
+                                __auto_type _mv_799 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_799.has_value) {
+                                    __auto_type pattern = _mv_799.value;
                                     {
                                         __auto_type tag = match_get_pattern_tag(pattern);
                                         if (string_eq(tag, SLOP_STR("else")) || string_eq(tag, SLOP_STR("_"))) {
@@ -2923,9 +2924,9 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
                                             context_ctx_dedent(ctx);
                                             first = 0;
                                         } else {
-                                            __auto_type _mv_799 = context_ctx_lookup_enum_variant(ctx, tag);
-                                            if (_mv_799.has_value) {
-                                                __auto_type union_type_name = _mv_799.value;
+                                            __auto_type _mv_800 = context_ctx_lookup_enum_variant(ctx, tag);
+                                            if (_mv_800.has_value) {
+                                                __auto_type union_type_name = _mv_800.value;
                                                 {
                                                     __auto_type c_tag = ctype_to_c_name(arena, tag);
                                                     __auto_type tag_cond = context_ctx_str5(ctx, scrutinee_c, SLOP_STR(".tag == "), union_type_name, SLOP_STR("_"), c_tag);
@@ -2946,12 +2947,12 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
                                                     context_ctx_dedent(ctx);
                                                     first = 0;
                                                 }
-                                            } else if (!_mv_799.has_value) {
+                                            } else if (!_mv_800.has_value) {
                                                 context_ctx_add_error(ctx, context_ctx_str3(ctx, SLOP_STR("unknown union variant in match: "), tag, SLOP_STR(" (not registered as enum variant)")));
                                             }
                                         }
                                     }
-                                } else if (!_mv_798.has_value) {
+                                } else if (!_mv_799.has_value) {
                                 }
                             }
                         }
@@ -2961,7 +2962,7 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
                         break;
                     }
                 }
-            } else if (!_mv_796.has_value) {
+            } else if (!_mv_797.has_value) {
             }
             i = (i + 1);
         }

--- a/bootstrap/compiler/slop_parser.c
+++ b/bootstrap/compiler/slop_parser.c
@@ -346,15 +346,15 @@ slop_result_list_parser_Token_parser_ParseError parser_tokenize(slop_arena* aren
         uint8_t has_error = 0;
         __auto_type error_val = (parser_ParseError){SLOP_STR(""), 0, 0};
         while (!(done) && !(has_error)) {
-            __auto_type _mv_610 = parser_lexer_next_token(arena, (&state));
-            if (_mv_610.is_ok) {
-                __auto_type tok = _mv_610.data.ok;
+            __auto_type _mv_611 = parser_lexer_next_token(arena, (&state));
+            if (_mv_611.is_ok) {
+                __auto_type tok = _mv_611.data.ok;
                 ({ __auto_type _lst_p = &(tokens); __auto_type _item = (tok); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                 if (tok.kind == parser_TokenType_tok_eof) {
                     done = 1;
                 }
-            } else if (!_mv_610.is_ok) {
-                __auto_type e = _mv_610.data.err;
+            } else if (!_mv_611.is_ok) {
+                __auto_type e = _mv_611.data.err;
                 has_error = 1;
                 error_val = e;
             }
@@ -376,11 +376,11 @@ uint8_t parser_parser_at_end(parser_ParserState* state) {
 }
 
 parser_Token parser_parser_peek(parser_ParserState* state) {
-    __auto_type _mv_611 = ({ __auto_type _lst = (*state).tokens; size_t _idx = (size_t)(*state).pos; slop_option_parser_Token _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-    if (_mv_611.has_value) {
-        __auto_type tok = _mv_611.value;
+    __auto_type _mv_612 = ({ __auto_type _lst = (*state).tokens; size_t _idx = (size_t)(*state).pos; slop_option_parser_Token _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+    if (_mv_612.has_value) {
+        __auto_type tok = _mv_612.value;
         return tok;
-    } else if (!_mv_611.has_value) {
+    } else if (!_mv_612.has_value) {
         return (parser_Token){parser_TokenType_tok_eof, SLOP_STR(""), 1, 1};
     }
     SLOP_UNREACHABLE();
@@ -431,9 +431,9 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_expr(slop_arena* aren
             }
         } else if (tok.kind == parser_TokenType_tok_quote) {
             parser_parser_advance(state);
-            __auto_type _mv_612 = parser_parse_expr(arena, state);
-            if (_mv_612.is_ok) {
-                __auto_type quoted_expr = _mv_612.data.ok;
+            __auto_type _mv_613 = parser_parse_expr(arena, state);
+            if (_mv_613.is_ok) {
+                __auto_type quoted_expr = _mv_613.data.ok;
                 {
                     __auto_type node = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                     __auto_type quote_sym = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
@@ -444,8 +444,8 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_expr(slop_arena* aren
                     (*node) = ((types_SExpr){ .tag = types_SExpr_lst, .data.lst = (types_SExprList){items, tok.line, tok.col, ((slop_option_types_ResolvedType_ptr){.has_value = false})} });
                     return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = node });
                 }
-            } else if (!_mv_612.is_ok) {
-                __auto_type e = _mv_612.data.err;
+            } else if (!_mv_613.is_ok) {
+                __auto_type e = _mv_613.data.err;
                 return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
             }
             SLOP_UNREACHABLE();
@@ -521,12 +521,12 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_list(slop_arena* aren
                         has_error = 1;
                         error_val = (parser_ParseError){SLOP_STR("Unterminated list"), start_tok.line, start_tok.col};
                     } else {
-                        __auto_type _mv_613 = parser_parse_expr(arena, state);
-                        if (_mv_613.is_ok) {
-                            __auto_type expr = _mv_613.data.ok;
+                        __auto_type _mv_614 = parser_parse_expr(arena, state);
+                        if (_mv_614.is_ok) {
+                            __auto_type expr = _mv_614.data.ok;
                             ({ __auto_type _lst_p = &(items); __auto_type _item = (expr); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                        } else if (!_mv_613.is_ok) {
-                            __auto_type e = _mv_613.data.err;
+                        } else if (!_mv_614.is_ok) {
+                            __auto_type e = _mv_614.data.err;
                             has_error = 1;
                             error_val = e;
                         }
@@ -580,18 +580,18 @@ int64_t parser_get_precedence(slop_string op) {
 
 slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_paren_group(slop_arena* arena, parser_ParserState* state) {
     parser_parser_advance(state);
-    __auto_type _mv_614 = parser_parse_infix_prec(arena, state, 0);
-    if (!_mv_614.is_ok) {
-        __auto_type e = _mv_614.data.err;
+    __auto_type _mv_615 = parser_parse_infix_prec(arena, state, 0);
+    if (!_mv_615.is_ok) {
+        __auto_type e = _mv_615.data.err;
         return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-    } else if (_mv_614.is_ok) {
-        __auto_type expr = _mv_614.data.ok;
-        __auto_type _mv_615 = parser_parser_expect(state, parser_TokenType_tok_rparen);
-        if (!_mv_615.is_ok) {
-            __auto_type e = _mv_615.data.err;
+    } else if (_mv_615.is_ok) {
+        __auto_type expr = _mv_615.data.ok;
+        __auto_type _mv_616 = parser_parser_expect(state, parser_TokenType_tok_rparen);
+        if (!_mv_616.is_ok) {
+            __auto_type e = _mv_616.data.err;
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-        } else if (_mv_615.is_ok) {
-            __auto_type _ = _mv_615.data.ok;
+        } else if (_mv_616.is_ok) {
+            __auto_type _ = _mv_616.data.ok;
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = expr });
         }
         SLOP_UNREACHABLE();
@@ -616,12 +616,12 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
         } else if (tok.kind == parser_TokenType_tok_symbol) {
             if (string_eq(tok.value, SLOP_STR("not"))) {
                 parser_parser_advance(state);
-                __auto_type _mv_616 = parser_parse_infix_primary(arena, state);
-                if (!_mv_616.is_ok) {
-                    __auto_type e = _mv_616.data.err;
+                __auto_type _mv_617 = parser_parse_infix_primary(arena, state);
+                if (!_mv_617.is_ok) {
+                    __auto_type e = _mv_617.data.err;
                     return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-                } else if (_mv_616.is_ok) {
-                    __auto_type operand = _mv_616.data.ok;
+                } else if (_mv_617.is_ok) {
+                    __auto_type operand = _mv_617.data.ok;
                     {
                         __auto_type node = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                         __auto_type not_sym = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
@@ -644,12 +644,12 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
             }
         } else if ((tok.kind == parser_TokenType_tok_operator) && string_eq(tok.value, SLOP_STR("-"))) {
             parser_parser_advance(state);
-            __auto_type _mv_617 = parser_parse_infix_primary(arena, state);
-            if (!_mv_617.is_ok) {
-                __auto_type e = _mv_617.data.err;
+            __auto_type _mv_618 = parser_parse_infix_primary(arena, state);
+            if (!_mv_618.is_ok) {
+                __auto_type e = _mv_618.data.err;
                 return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-            } else if (_mv_617.is_ok) {
-                __auto_type operand = _mv_617.data.ok;
+            } else if (_mv_618.is_ok) {
+                __auto_type operand = _mv_618.data.ok;
                 {
                     __auto_type node = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                     __auto_type minus_sym = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
@@ -671,13 +671,13 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
             {
                 __auto_type saved_pos = (*state).pos;
                 parser_parser_advance(state);
-                __auto_type _mv_618 = parser_parse_infix_primary(arena, state);
-                if (!_mv_618.is_ok) {
-                    __auto_type _ = _mv_618.data.err;
+                __auto_type _mv_619 = parser_parse_infix_primary(arena, state);
+                if (!_mv_619.is_ok) {
+                    __auto_type _ = _mv_619.data.err;
                     (*state).pos = saved_pos;
                     return parser_parse_list(arena, state);
-                } else if (_mv_618.is_ok) {
-                    __auto_type _ = _mv_618.data.ok;
+                } else if (_mv_619.is_ok) {
+                    __auto_type _ = _mv_619.data.ok;
                     {
                         __auto_type next_tok = parser_parser_peek(state);
                         if ((next_tok.kind == parser_TokenType_tok_operator) || ((next_tok.kind == parser_TokenType_tok_symbol) && (string_eq(next_tok.value, SLOP_STR("and")) || string_eq(next_tok.value, SLOP_STR("or"))))) {
@@ -693,12 +693,12 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
             }
         } else if (tok.kind == parser_TokenType_tok_quote) {
             parser_parser_advance(state);
-            __auto_type _mv_619 = parser_parse_infix_primary(arena, state);
-            if (!_mv_619.is_ok) {
-                __auto_type e = _mv_619.data.err;
+            __auto_type _mv_620 = parser_parse_infix_primary(arena, state);
+            if (!_mv_620.is_ok) {
+                __auto_type e = _mv_620.data.err;
                 return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-            } else if (_mv_619.is_ok) {
-                __auto_type quoted_expr = _mv_619.data.ok;
+            } else if (_mv_620.is_ok) {
+                __auto_type quoted_expr = _mv_620.data.ok;
                 {
                     __auto_type node = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                     __auto_type quote_sym = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
@@ -718,12 +718,12 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
 }
 
 slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_prec(slop_arena* arena, parser_ParserState* state, int64_t min_prec) {
-    __auto_type _mv_620 = parser_parse_infix_primary(arena, state);
-    if (!_mv_620.is_ok) {
-        __auto_type e = _mv_620.data.err;
+    __auto_type _mv_621 = parser_parse_infix_primary(arena, state);
+    if (!_mv_621.is_ok) {
+        __auto_type e = _mv_621.data.err;
         return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-    } else if (_mv_620.is_ok) {
-        __auto_type left = _mv_620.data.ok;
+    } else if (_mv_621.is_ok) {
+        __auto_type left = _mv_621.data.ok;
         {
             __auto_type result = left;
             __auto_type done = 0;
@@ -741,13 +741,13 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_prec(slop_arena
                                 {
                                     __auto_type op_tok = tok;
                                     parser_parser_advance(state);
-                                    __auto_type _mv_621 = parser_parse_infix_prec(arena, state, (op_prec + 1));
-                                    if (!_mv_621.is_ok) {
-                                        __auto_type e = _mv_621.data.err;
+                                    __auto_type _mv_622 = parser_parse_infix_prec(arena, state, (op_prec + 1));
+                                    if (!_mv_622.is_ok) {
+                                        __auto_type e = _mv_622.data.err;
                                         has_error = 1;
                                         error_val = e;
-                                    } else if (_mv_621.is_ok) {
-                                        __auto_type right = _mv_621.data.ok;
+                                    } else if (_mv_622.is_ok) {
+                                        __auto_type right = _mv_622.data.ok;
                                         {
                                             __auto_type node = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                                             __auto_type op_sym = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
@@ -787,12 +787,12 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix(slop_arena* are
         {
             __auto_type result = parser_parse_infix_prec(arena, state, 0);
             (*state).in_infix = 0;
-            __auto_type _mv_622 = result;
-            if (!_mv_622.is_ok) {
-                __auto_type e = _mv_622.data.err;
+            __auto_type _mv_623 = result;
+            if (!_mv_623.is_ok) {
+                __auto_type e = _mv_623.data.err;
                 return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-            } else if (_mv_622.is_ok) {
-                __auto_type expr = _mv_622.data.ok;
+            } else if (_mv_623.is_ok) {
+                __auto_type expr = _mv_623.data.ok;
                 {
                     __auto_type tok = parser_parser_peek(state);
                     if (tok.kind == parser_TokenType_tok_rbrace) {
@@ -809,9 +809,9 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix(slop_arena* are
 }
 
 slop_result_list_types_SExpr_ptr_parser_ParseError parser_parse(slop_arena* arena, slop_string source) {
-    __auto_type _mv_623 = parser_tokenize(arena, source);
-    if (_mv_623.is_ok) {
-        __auto_type tokens = _mv_623.data.ok;
+    __auto_type _mv_624 = parser_tokenize(arena, source);
+    if (_mv_624.is_ok) {
+        __auto_type tokens = _mv_624.data.ok;
         {
             __auto_type state = parser_parser_new(tokens);
             __auto_type result = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
@@ -824,12 +824,12 @@ slop_result_list_types_SExpr_ptr_parser_ParseError parser_parse(slop_arena* aren
                     if (tok.kind == parser_TokenType_tok_eof) {
                         done = 1;
                     } else {
-                        __auto_type _mv_624 = parser_parse_expr(arena, (&state));
-                        if (_mv_624.is_ok) {
-                            __auto_type expr = _mv_624.data.ok;
+                        __auto_type _mv_625 = parser_parse_expr(arena, (&state));
+                        if (_mv_625.is_ok) {
+                            __auto_type expr = _mv_625.data.ok;
                             ({ __auto_type _lst_p = &(result); __auto_type _item = (expr); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                        } else if (!_mv_624.is_ok) {
-                            __auto_type e = _mv_624.data.err;
+                        } else if (!_mv_625.is_ok) {
+                            __auto_type e = _mv_625.data.err;
                             has_error = 1;
                             error_val = e;
                         }
@@ -842,34 +842,34 @@ slop_result_list_types_SExpr_ptr_parser_ParseError parser_parse(slop_arena* aren
                 return ((slop_result_list_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = result });
             }
         }
-    } else if (!_mv_623.is_ok) {
-        __auto_type e = _mv_623.data.err;
+    } else if (!_mv_624.is_ok) {
+        __auto_type e = _mv_624.data.err;
         return ((slop_result_list_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
     }
     SLOP_UNREACHABLE();
 }
 
 int64_t parser_sexpr_line(types_SExpr* expr) {
-    __auto_type _mv_625 = (*expr);
-    switch (_mv_625.tag) {
+    __auto_type _mv_626 = (*expr);
+    switch (_mv_626.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_625.data.sym;
+            __auto_type s = _mv_626.data.sym;
             return s.line;
         }
         case types_SExpr_str:
         {
-            __auto_type s = _mv_625.data.str;
+            __auto_type s = _mv_626.data.str;
             return s.line;
         }
         case types_SExpr_num:
         {
-            __auto_type n = _mv_625.data.num;
+            __auto_type n = _mv_626.data.num;
             return n.line;
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_625.data.lst;
+            __auto_type l = _mv_626.data.lst;
             return l.line;
         }
     }
@@ -877,26 +877,26 @@ int64_t parser_sexpr_line(types_SExpr* expr) {
 }
 
 int64_t parser_sexpr_col(types_SExpr* expr) {
-    __auto_type _mv_626 = (*expr);
-    switch (_mv_626.tag) {
+    __auto_type _mv_627 = (*expr);
+    switch (_mv_627.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_626.data.sym;
+            __auto_type s = _mv_627.data.sym;
             return s.col;
         }
         case types_SExpr_str:
         {
-            __auto_type s = _mv_626.data.str;
+            __auto_type s = _mv_627.data.str;
             return s.col;
         }
         case types_SExpr_num:
         {
-            __auto_type n = _mv_626.data.num;
+            __auto_type n = _mv_627.data.num;
             return n.col;
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_626.data.lst;
+            __auto_type l = _mv_627.data.lst;
             return l.col;
         }
     }
@@ -904,11 +904,11 @@ int64_t parser_sexpr_col(types_SExpr* expr) {
 }
 
 uint8_t parser_sexpr_is_symbol_with_name(types_SExpr* expr, slop_string name) {
-    __auto_type _mv_627 = (*expr);
-    switch (_mv_627.tag) {
+    __auto_type _mv_628 = (*expr);
+    switch (_mv_628.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_627.data.sym;
+            __auto_type sym = _mv_628.data.sym;
             return string_eq(sym.name, name);
         }
         default: {
@@ -918,19 +918,19 @@ uint8_t parser_sexpr_is_symbol_with_name(types_SExpr* expr, slop_string name) {
 }
 
 uint8_t parser_is_form(types_SExpr* expr, slop_string keyword) {
-    __auto_type _mv_628 = (*expr);
-    switch (_mv_628.tag) {
+    __auto_type _mv_629 = (*expr);
+    switch (_mv_629.tag) {
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_628.data.lst;
+            __auto_type l = _mv_629.data.lst;
             if (((int64_t)((l.items).len)) == 0) {
                 return 0;
             } else {
-                __auto_type _mv_629 = ({ __auto_type _lst = l.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_629.has_value) {
-                    __auto_type first = _mv_629.value;
+                __auto_type _mv_630 = ({ __auto_type _lst = l.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_630.has_value) {
+                    __auto_type first = _mv_630.value;
                     return parser_sexpr_is_symbol_with_name(first, keyword);
-                } else if (!_mv_629.has_value) {
+                } else if (!_mv_630.has_value) {
                     return 0;
                 }
                 SLOP_UNREACHABLE();
@@ -943,11 +943,11 @@ uint8_t parser_is_form(types_SExpr* expr, slop_string keyword) {
 }
 
 int64_t parser_sexpr_list_len(types_SExpr* expr) {
-    __auto_type _mv_630 = (*expr);
-    switch (_mv_630.tag) {
+    __auto_type _mv_631 = (*expr);
+    switch (_mv_631.tag) {
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_630.data.lst;
+            __auto_type l = _mv_631.data.lst;
             return ((int64_t)((l.items).len));
         }
         default: {
@@ -957,11 +957,11 @@ int64_t parser_sexpr_list_len(types_SExpr* expr) {
 }
 
 slop_option_types_SExpr_ptr parser_sexpr_list_get(types_SExpr* expr, int64_t index) {
-    __auto_type _mv_631 = (*expr);
-    switch (_mv_631.tag) {
+    __auto_type _mv_632 = (*expr);
+    switch (_mv_632.tag) {
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_631.data.lst;
+            __auto_type l = _mv_632.data.lst;
             return ({ __auto_type _lst = l.items; size_t _idx = (size_t)index; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
         }
         default: {
@@ -971,11 +971,11 @@ slop_option_types_SExpr_ptr parser_sexpr_list_get(types_SExpr* expr, int64_t ind
 }
 
 uint8_t parser_sexpr_is_list(types_SExpr* expr) {
-    __auto_type _mv_632 = (*expr);
-    switch (_mv_632.tag) {
+    __auto_type _mv_633 = (*expr);
+    switch (_mv_633.tag) {
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_632.data.lst;
+            __auto_type l = _mv_633.data.lst;
             return 1;
         }
         default: {
@@ -985,11 +985,11 @@ uint8_t parser_sexpr_is_list(types_SExpr* expr) {
 }
 
 slop_string parser_sexpr_get_symbol_name(types_SExpr* expr) {
-    __auto_type _mv_633 = (*expr);
-    switch (_mv_633.tag) {
+    __auto_type _mv_634 = (*expr);
+    switch (_mv_634.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_633.data.sym;
+            __auto_type sym = _mv_634.data.sym;
             return sym.name;
         }
         default: {
@@ -1003,11 +1003,11 @@ slop_string parser_sexpr_symbol_name(types_SExpr* expr) {
 }
 
 uint8_t parser_sexpr_is_symbol(types_SExpr* expr) {
-    __auto_type _mv_634 = (*expr);
-    switch (_mv_634.tag) {
+    __auto_type _mv_635 = (*expr);
+    switch (_mv_635.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_634.data.sym;
+            __auto_type s = _mv_635.data.sym;
             return 1;
         }
         default: {
@@ -1017,11 +1017,11 @@ uint8_t parser_sexpr_is_symbol(types_SExpr* expr) {
 }
 
 uint8_t parser_sexpr_is_number(types_SExpr* expr) {
-    __auto_type _mv_635 = (*expr);
-    switch (_mv_635.tag) {
+    __auto_type _mv_636 = (*expr);
+    switch (_mv_636.tag) {
         case types_SExpr_num:
         {
-            __auto_type n = _mv_635.data.num;
+            __auto_type n = _mv_636.data.num;
             return 1;
         }
         default: {
@@ -1031,11 +1031,11 @@ uint8_t parser_sexpr_is_number(types_SExpr* expr) {
 }
 
 uint8_t parser_sexpr_is_string(types_SExpr* expr) {
-    __auto_type _mv_636 = (*expr);
-    switch (_mv_636.tag) {
+    __auto_type _mv_637 = (*expr);
+    switch (_mv_637.tag) {
         case types_SExpr_str:
         {
-            __auto_type s = _mv_636.data.str;
+            __auto_type s = _mv_637.data.str;
             return 1;
         }
         default: {
@@ -1045,11 +1045,11 @@ uint8_t parser_sexpr_is_string(types_SExpr* expr) {
 }
 
 slop_string parser_sexpr_number_string(types_SExpr* expr) {
-    __auto_type _mv_637 = (*expr);
-    switch (_mv_637.tag) {
+    __auto_type _mv_638 = (*expr);
+    switch (_mv_638.tag) {
         case types_SExpr_num:
         {
-            __auto_type n = _mv_637.data.num;
+            __auto_type n = _mv_638.data.num;
             return n.raw;
         }
         default: {
@@ -1059,11 +1059,11 @@ slop_string parser_sexpr_number_string(types_SExpr* expr) {
 }
 
 slop_string parser_sexpr_string_value(types_SExpr* expr) {
-    __auto_type _mv_638 = (*expr);
-    switch (_mv_638.tag) {
+    __auto_type _mv_639 = (*expr);
+    switch (_mv_639.tag) {
         case types_SExpr_str:
         {
-            __auto_type s = _mv_638.data.str;
+            __auto_type s = _mv_639.data.str;
             return s.value;
         }
         default: {
@@ -1078,34 +1078,34 @@ slop_list_types_SExpr_ptr parser_find_holes(slop_arena* arena, types_SExpr* expr
         if (parser_is_form(expr, SLOP_STR("hole"))) {
             ({ __auto_type _lst_p = &(result); __auto_type _item = (expr); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
         }
-        __auto_type _mv_639 = (*expr);
-        switch (_mv_639.tag) {
+        __auto_type _mv_640 = (*expr);
+        switch (_mv_640.tag) {
             case types_SExpr_lst:
             {
-                __auto_type l = _mv_639.data.lst;
+                __auto_type l = _mv_640.data.lst;
                 {
                     __auto_type items = l.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type i = 0;
                     while (i < len) {
-                        __auto_type _mv_640 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_640.has_value) {
-                            __auto_type child = _mv_640.value;
+                        __auto_type _mv_641 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_641.has_value) {
+                            __auto_type child = _mv_641.value;
                             {
                                 __auto_type child_holes = parser_find_holes(arena, child);
                                 __auto_type child_len = ((int64_t)((child_holes).len));
                                 __auto_type j = 0;
                                 while (j < child_len) {
-                                    __auto_type _mv_641 = ({ __auto_type _lst = child_holes; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_641.has_value) {
-                                        __auto_type h = _mv_641.value;
+                                    __auto_type _mv_642 = ({ __auto_type _lst = child_holes; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_642.has_value) {
+                                        __auto_type h = _mv_642.value;
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (h); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                                    } else if (!_mv_641.has_value) {
+                                    } else if (!_mv_642.has_value) {
                                     }
                                     j = (j + 1);
                                 }
                             }
-                        } else if (!_mv_640.has_value) {
+                        } else if (!_mv_641.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -1121,16 +1121,16 @@ slop_list_types_SExpr_ptr parser_find_holes(slop_arena* arena, types_SExpr* expr
 }
 
 slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
-    __auto_type _mv_642 = (*expr);
-    switch (_mv_642.tag) {
+    __auto_type _mv_643 = (*expr);
+    switch (_mv_643.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_642.data.sym;
+            __auto_type sym = _mv_643.data.sym;
             return parser_string_copy(arena, sym.name);
         }
         case types_SExpr_str:
         {
-            __auto_type str = _mv_642.data.str;
+            __auto_type str = _mv_643.data.str;
             {
                 __auto_type val = str.value;
                 __auto_type slen = ((int64_t)(val.len));
@@ -1171,7 +1171,7 @@ slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type num = _mv_642.data.num;
+            __auto_type num = _mv_643.data.num;
             if (num.is_float) {
                 return parser_string_copy(arena, SLOP_STR("<float>"));
             } else {
@@ -1180,7 +1180,7 @@ slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_642.data.lst;
+            __auto_type lst = _mv_643.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
@@ -1191,9 +1191,9 @@ slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
                         __auto_type result = parser_string_copy(arena, SLOP_STR("("));
                         __auto_type i = 0;
                         while (i < len) {
-                            __auto_type _mv_643 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_643.has_value) {
-                                __auto_type child = _mv_643.value;
+                            __auto_type _mv_644 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_644.has_value) {
+                                __auto_type child = _mv_644.value;
                                 {
                                     __auto_type child_str = parser_pretty_print(arena, child);
                                     if (i > 0) {
@@ -1201,7 +1201,7 @@ slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
                                     }
                                     result = string_concat(arena, result, child_str);
                                 }
-                            } else if (!_mv_643.has_value) {
+                            } else if (!_mv_644.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -1266,9 +1266,9 @@ slop_string parser_json_print_list(slop_arena* arena, slop_list_types_SExpr_ptr 
                 __auto_type result = parser_string_copy(arena, SLOP_STR("["));
                 int64_t i = 0;
                 while (i < len) {
-                    __auto_type _mv_644 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_644.has_value) {
-                        __auto_type child = _mv_644.value;
+                    __auto_type _mv_645 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_645.has_value) {
+                        __auto_type child = _mv_645.value;
                         {
                             __auto_type child_json = parser_json_print(arena, child);
                             if (i > 0) {
@@ -1276,7 +1276,7 @@ slop_string parser_json_print_list(slop_arena* arena, slop_list_types_SExpr_ptr 
                             }
                             result = string_concat(arena, result, child_json);
                         }
-                    } else if (!_mv_644.has_value) {
+                    } else if (!_mv_645.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -1287,11 +1287,11 @@ slop_string parser_json_print_list(slop_arena* arena, slop_list_types_SExpr_ptr 
 }
 
 slop_string parser_json_print(slop_arena* arena, types_SExpr* expr) {
-    __auto_type _mv_645 = (*expr);
-    switch (_mv_645.tag) {
+    __auto_type _mv_646 = (*expr);
+    switch (_mv_646.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_645.data.sym;
+            __auto_type sym = _mv_646.data.sym;
             {
                 __auto_type escaped = parser_json_escape_string(arena, sym.name);
                 __auto_type line_str = int_to_string(arena, sym.line);
@@ -1301,7 +1301,7 @@ slop_string parser_json_print(slop_arena* arena, types_SExpr* expr) {
         }
         case types_SExpr_str:
         {
-            __auto_type str = _mv_645.data.str;
+            __auto_type str = _mv_646.data.str;
             {
                 __auto_type escaped = parser_json_escape_string(arena, str.value);
                 __auto_type line_str = int_to_string(arena, str.line);
@@ -1311,7 +1311,7 @@ slop_string parser_json_print(slop_arena* arena, types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type num = _mv_645.data.num;
+            __auto_type num = _mv_646.data.num;
             {
                 __auto_type line_str = int_to_string(arena, num.line);
                 __auto_type col_str = int_to_string(arena, num.col);
@@ -1330,7 +1330,7 @@ slop_string parser_json_print(slop_arena* arena, types_SExpr* expr) {
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_645.data.lst;
+            __auto_type lst = _mv_646.data.lst;
             {
                 __auto_type items_json = parser_json_print_list(arena, lst.items);
                 __auto_type line_str = int_to_string(arena, lst.line);

--- a/bootstrap/compiler/slop_path.c
+++ b/bootstrap/compiler/slop_path.c
@@ -12,15 +12,15 @@ slop_string path_path_dirname(slop_arena* arena, slop_string path) {
         if (len == 0) {
             return SLOP_STR(".");
         } else {
-            __auto_type _mv_1251 = strlib_last_index_of(path, SLOP_STR("/"));
-            if (_mv_1251.has_value) {
-                __auto_type idx = _mv_1251.value;
+            __auto_type _mv_1252 = strlib_last_index_of(path, SLOP_STR("/"));
+            if (_mv_1252.has_value) {
+                __auto_type idx = _mv_1252.value;
                 if (idx == 0) {
                     return SLOP_STR("/");
                 } else {
                     return strlib_substring(arena, path, 0, ((int64_t)(idx)));
                 }
-            } else if (!_mv_1251.has_value) {
+            } else if (!_mv_1252.has_value) {
                 return SLOP_STR(".");
             }
             SLOP_UNREACHABLE();
@@ -51,9 +51,9 @@ slop_string path_path_basename(slop_arena* arena, slop_string path) {
         if (len == 0) {
             return SLOP_STR("");
         } else {
-            __auto_type _mv_1252 = strlib_last_index_of(path, SLOP_STR("/"));
-            if (_mv_1252.has_value) {
-                __auto_type idx = _mv_1252.value;
+            __auto_type _mv_1253 = strlib_last_index_of(path, SLOP_STR("/"));
+            if (_mv_1253.has_value) {
+                __auto_type idx = _mv_1253.value;
                 {
                     __auto_type start = (idx + 1);
                     __auto_type remaining = (len - start);
@@ -63,7 +63,7 @@ slop_string path_path_basename(slop_arena* arena, slop_string path) {
                         return strlib_substring(arena, path, ((int64_t)(start)), ((int64_t)(remaining)));
                     }
                 }
-            } else if (!_mv_1252.has_value) {
+            } else if (!_mv_1253.has_value) {
                 return path;
             }
             SLOP_UNREACHABLE();
@@ -77,9 +77,9 @@ slop_string path_path_extension(slop_arena* arena, slop_string path) {
         if (len == 0) {
             return SLOP_STR("");
         } else {
-            __auto_type _mv_1253 = strlib_last_index_of(path, SLOP_STR("."));
-            if (_mv_1253.has_value) {
-                __auto_type idx = _mv_1253.value;
+            __auto_type _mv_1254 = strlib_last_index_of(path, SLOP_STR("."));
+            if (_mv_1254.has_value) {
+                __auto_type idx = _mv_1254.value;
                 {
                     __auto_type ext_len = (len - idx);
                     if (ext_len <= 0) {
@@ -88,7 +88,7 @@ slop_string path_path_extension(slop_arena* arena, slop_string path) {
                         return strlib_substring(arena, path, ((int64_t)(idx)), ((int64_t)(ext_len)));
                     }
                 }
-            } else if (!_mv_1253.has_value) {
+            } else if (!_mv_1254.has_value) {
                 return SLOP_STR("");
             }
             SLOP_UNREACHABLE();

--- a/bootstrap/compiler/slop_resolve.c
+++ b/bootstrap/compiler/slop_resolve.c
@@ -12,16 +12,16 @@ void resolve_resolve_imports(env_TypeEnv* env, slop_list_types_SExpr_ptr ast) {
     {
         __auto_type len = ((int64_t)((ast).len));
         for (int64_t i = 0; i < len; i++) {
-            __auto_type _mv_1822 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1822.has_value) {
-                __auto_type expr = _mv_1822.value;
+            __auto_type _mv_1823 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1823.has_value) {
+                __auto_type expr = _mv_1823.value;
                 if (parser_is_form(expr, SLOP_STR("import"))) {
                     resolve_resolve_import_stmt(env, expr);
                 } else if (parser_is_form(expr, SLOP_STR("module"))) {
                     resolve_resolve_module_imports(env, expr);
                 } else {
                 }
-            } else if (!_mv_1822.has_value) {
+            } else if (!_mv_1823.has_value) {
             }
         }
     }
@@ -34,13 +34,13 @@ void resolve_resolve_module_imports(env_TypeEnv* env, types_SExpr* module_form) 
         {
             __auto_type len = parser_sexpr_list_len(module_form);
             for (int64_t i = 2; i < len; i++) {
-                __auto_type _mv_1823 = parser_sexpr_list_get(module_form, i);
-                if (_mv_1823.has_value) {
-                    __auto_type item = _mv_1823.value;
+                __auto_type _mv_1824 = parser_sexpr_list_get(module_form, i);
+                if (_mv_1824.has_value) {
+                    __auto_type item = _mv_1824.value;
                     if (parser_is_form(item, SLOP_STR("import"))) {
                         resolve_resolve_import_stmt(env, item);
                     }
-                } else if (!_mv_1823.has_value) {
+                } else if (!_mv_1824.has_value) {
                 }
             }
         }
@@ -53,41 +53,41 @@ void resolve_resolve_import_stmt(env_TypeEnv* env, types_SExpr* import_form) {
     SLOP_PRE((parser_is_form(import_form, SLOP_STR("import"))), "(is-form import-form \"import\")");
     {
         __auto_type arena = env_env_arena(env);
-        __auto_type _mv_1824 = (*import_form);
-        switch (_mv_1824.tag) {
+        __auto_type _mv_1825 = (*import_form);
+        switch (_mv_1825.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1824.data.lst;
+                __auto_type lst = _mv_1825.data.lst;
                 {
                     __auto_type items = lst.items;
-                    __auto_type _mv_1825 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1825.has_value) {
-                        __auto_type mod_name_expr = _mv_1825.value;
-                        __auto_type _mv_1826 = (*mod_name_expr);
-                        switch (_mv_1826.tag) {
+                    __auto_type _mv_1826 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1826.has_value) {
+                        __auto_type mod_name_expr = _mv_1826.value;
+                        __auto_type _mv_1827 = (*mod_name_expr);
+                        switch (_mv_1827.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type mod_sym = _mv_1826.data.sym;
-                                __auto_type _mv_1827 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1827.has_value) {
-                                    __auto_type names_expr = _mv_1827.value;
-                                    __auto_type _mv_1828 = (*names_expr);
-                                    switch (_mv_1828.tag) {
+                                __auto_type mod_sym = _mv_1827.data.sym;
+                                __auto_type _mv_1828 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1828.has_value) {
+                                    __auto_type names_expr = _mv_1828.value;
+                                    __auto_type _mv_1829 = (*names_expr);
+                                    switch (_mv_1829.tag) {
                                         case types_SExpr_lst:
                                         {
-                                            __auto_type names_lst = _mv_1828.data.lst;
+                                            __auto_type names_lst = _mv_1829.data.lst;
                                             {
                                                 __auto_type name_items = names_lst.items;
                                                 __auto_type name_len = ((int64_t)((name_items).len));
                                                 for (int64_t j = 0; j < name_len; j++) {
-                                                    __auto_type _mv_1829 = ({ __auto_type _lst = name_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1829.has_value) {
-                                                        __auto_type name_expr = _mv_1829.value;
-                                                        __auto_type _mv_1830 = (*name_expr);
-                                                        switch (_mv_1830.tag) {
+                                                    __auto_type _mv_1830 = ({ __auto_type _lst = name_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1830.has_value) {
+                                                        __auto_type name_expr = _mv_1830.value;
+                                                        __auto_type _mv_1831 = (*name_expr);
+                                                        switch (_mv_1831.tag) {
                                                             case types_SExpr_sym:
                                                             {
-                                                                __auto_type name_sym = _mv_1830.data.sym;
+                                                                __auto_type name_sym = _mv_1831.data.sym;
                                                                 {
                                                                     __auto_type local_name = name_sym.name;
                                                                     __auto_type actual_module = ({ __auto_type _mv = env_env_lookup_type_direct(env, local_name); _mv.has_value ? ({ __auto_type t = _mv.value; ({ __auto_type _mv = (*t).module_name; _mv.has_value ? ({ __auto_type mod = _mv.value; mod; }) : (mod_sym.name); }); }) : (mod_sym.name); });
@@ -103,7 +103,7 @@ void resolve_resolve_import_stmt(env_TypeEnv* env, types_SExpr* import_form) {
                                                                 break;
                                                             }
                                                         }
-                                                    } else if (!_mv_1829.has_value) {
+                                                    } else if (!_mv_1830.has_value) {
                                                     }
                                                 }
                                             }
@@ -113,7 +113,7 @@ void resolve_resolve_import_stmt(env_TypeEnv* env, types_SExpr* import_form) {
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1827.has_value) {
+                                } else if (!_mv_1828.has_value) {
                                 }
                                 break;
                             }
@@ -121,7 +121,7 @@ void resolve_resolve_import_stmt(env_TypeEnv* env, types_SExpr* import_form) {
                                 break;
                             }
                         }
-                    } else if (!_mv_1825.has_value) {
+                    } else if (!_mv_1826.has_value) {
                     }
                 }
                 break;
@@ -150,9 +150,9 @@ slop_option_string resolve_resolve_module_file(slop_arena* arena, slop_string mo
     if (!(resolve_contains_slash(module_name))) {
         return (slop_option_string){.has_value = false};
     } else {
-        __auto_type _mv_1831 = from_file;
-        if (_mv_1831.has_value) {
-            __auto_type current_path = _mv_1831.value;
+        __auto_type _mv_1832 = from_file;
+        if (_mv_1832.has_value) {
+            __auto_type current_path = _mv_1832.value;
             {
                 __auto_type dir = path_path_dirname(arena, current_path);
                 __auto_type rel_path = string_concat(arena, module_name, SLOP_STR(".slop"));
@@ -163,7 +163,7 @@ slop_option_string resolve_resolve_module_file(slop_arena* arena, slop_string mo
                     return (slop_option_string){.has_value = false};
                 }
             }
-        } else if (!_mv_1831.has_value) {
+        } else if (!_mv_1832.has_value) {
             return (slop_option_string){.has_value = false};
         }
         SLOP_UNREACHABLE();

--- a/bootstrap/compiler/slop_stmt.c
+++ b/bootstrap/compiler/slop_stmt.c
@@ -38,25 +38,25 @@ void stmt_emit_return_with_typed_none(context_TranspileContext* ctx, slop_string
 
 slop_string stmt_sexpr_to_type_string(slop_arena* arena, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_800 = (*expr);
-    switch (_mv_800.tag) {
+    __auto_type _mv_801 = (*expr);
+    switch (_mv_801.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_800.data.sym;
+            __auto_type sym = _mv_801.data.sym;
             return sym.name;
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_800.data.lst;
+            __auto_type lst = _mv_801.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type result = SLOP_STR("(");
                 __auto_type i = 0;
                 while (i < len) {
-                    __auto_type _mv_801 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_801.has_value) {
-                        __auto_type item_expr = _mv_801.value;
+                    __auto_type _mv_802 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_802.has_value) {
+                        __auto_type item_expr = _mv_802.value;
                         {
                             __auto_type item_str = ctype_sexpr_to_type_string(arena, item_expr);
                             if (i > 0) {
@@ -65,7 +65,7 @@ slop_string stmt_sexpr_to_type_string(slop_arena* arena, types_SExpr* expr) {
                                 result = string_concat(arena, result, item_str);
                             }
                         }
-                    } else if (!_mv_801.has_value) {
+                    } else if (!_mv_802.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -83,39 +83,39 @@ slop_option_string stmt_get_arena_alloc_ptr_type(context_TranspileContext* ctx, 
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_802 = (*expr);
-        switch (_mv_802.tag) {
+        __auto_type _mv_803 = (*expr);
+        switch (_mv_803.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_802.data.lst;
+                __auto_type lst = _mv_803.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_803 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_803.has_value) {
-                            __auto_type head_ptr = _mv_803.value;
-                            __auto_type _mv_804 = (*head_ptr);
-                            switch (_mv_804.tag) {
+                        __auto_type _mv_804 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_804.has_value) {
+                            __auto_type head_ptr = _mv_804.value;
+                            __auto_type _mv_805 = (*head_ptr);
+                            switch (_mv_805.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type head_sym = _mv_804.data.sym;
+                                    __auto_type head_sym = _mv_805.data.sym;
                                     {
                                         __auto_type op = head_sym.name;
                                         if (string_eq(op, SLOP_STR("arena-alloc"))) {
-                                            __auto_type _mv_805 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_805.has_value) {
-                                                __auto_type size_expr = _mv_805.value;
+                                            __auto_type _mv_806 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_806.has_value) {
+                                                __auto_type size_expr = _mv_806.value;
                                                 return stmt_extract_sizeof_type_opt(ctx, size_expr);
-                                            } else if (!_mv_805.has_value) {
+                                            } else if (!_mv_806.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
                                             SLOP_UNREACHABLE();
                                         } else if (string_eq(op, SLOP_STR("cast")) && (((int64_t)((items).len)) >= 3)) {
-                                            __auto_type _mv_806 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_806.has_value) {
-                                                __auto_type inner_expr = _mv_806.value;
+                                            __auto_type _mv_807 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_807.has_value) {
+                                                __auto_type inner_expr = _mv_807.value;
                                                 return stmt_get_arena_alloc_ptr_type(ctx, inner_expr);
-                                            } else if (!_mv_806.has_value) {
+                                            } else if (!_mv_807.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
                                             SLOP_UNREACHABLE();
@@ -128,7 +128,7 @@ slop_option_string stmt_get_arena_alloc_ptr_type(context_TranspileContext* ctx, 
                                     return (slop_option_string){.has_value = false};
                                 }
                             }
-                        } else if (!_mv_803.has_value) {
+                        } else if (!_mv_804.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -149,18 +149,18 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_807 = (*expr);
-        switch (_mv_807.tag) {
+        __auto_type _mv_808 = (*expr);
+        switch (_mv_808.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_807.data.sym;
+                __auto_type sym = _mv_808.data.sym;
                 {
                     __auto_type type_name = sym.name;
-                    __auto_type _mv_808 = context_ctx_lookup_type(ctx, type_name);
-                    if (_mv_808.has_value) {
-                        __auto_type entry = _mv_808.value;
+                    __auto_type _mv_809 = context_ctx_lookup_type(ctx, type_name);
+                    if (_mv_809.has_value) {
+                        __auto_type entry = _mv_809.value;
                         return (slop_option_string){.has_value = 1, .value = context_ctx_str(ctx, entry.c_name, SLOP_STR("*"))};
-                    } else if (!_mv_808.has_value) {
+                    } else if (!_mv_809.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
                     SLOP_UNREACHABLE();
@@ -168,27 +168,27 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_807.data.lst;
+                __auto_type lst = _mv_808.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_809 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_809.has_value) {
-                            __auto_type head_ptr = _mv_809.value;
-                            __auto_type _mv_810 = (*head_ptr);
-                            switch (_mv_810.tag) {
+                        __auto_type _mv_810 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_810.has_value) {
+                            __auto_type head_ptr = _mv_810.value;
+                            __auto_type _mv_811 = (*head_ptr);
+                            switch (_mv_811.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type head_sym = _mv_810.data.sym;
+                                    __auto_type head_sym = _mv_811.data.sym;
                                     if (string_eq(head_sym.name, SLOP_STR("sizeof"))) {
-                                        __auto_type _mv_811 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_811.has_value) {
-                                            __auto_type type_expr = _mv_811.value;
+                                        __auto_type _mv_812 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_812.has_value) {
+                                            __auto_type type_expr = _mv_812.value;
                                             {
                                                 __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                 return (slop_option_string){.has_value = 1, .value = context_ctx_str(ctx, c_type, SLOP_STR("*"))};
                                             }
-                                        } else if (!_mv_811.has_value) {
+                                        } else if (!_mv_812.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
                                         SLOP_UNREACHABLE();
@@ -200,7 +200,7 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
                                     return (slop_option_string){.has_value = false};
                                 }
                             }
-                        } else if (!_mv_809.has_value) {
+                        } else if (!_mv_810.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -218,24 +218,24 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
 
 uint8_t stmt_is_stmt_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_812 = (*expr);
-    switch (_mv_812.tag) {
+    __auto_type _mv_813 = (*expr);
+    switch (_mv_813.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_812.data.lst;
+            __auto_type lst = _mv_813.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_813 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_813.has_value) {
-                        __auto_type head_expr = _mv_813.value;
-                        __auto_type _mv_814 = (*head_expr);
-                        switch (_mv_814.tag) {
+                    __auto_type _mv_814 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_814.has_value) {
+                        __auto_type head_expr = _mv_814.value;
+                        __auto_type _mv_815 = (*head_expr);
+                        switch (_mv_815.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_814.data.sym;
+                                __auto_type sym = _mv_815.data.sym;
                                 {
                                     __auto_type name = sym.name;
                                     return ((string_eq(name, SLOP_STR("let"))) || (string_eq(name, SLOP_STR("let*"))) || (string_eq(name, SLOP_STR("if"))) || (string_eq(name, SLOP_STR("when"))) || (string_eq(name, SLOP_STR("while"))) || (string_eq(name, SLOP_STR("for"))) || (string_eq(name, SLOP_STR("for-each"))) || (string_eq(name, SLOP_STR("set!"))) || (string_eq(name, SLOP_STR("do"))) || (string_eq(name, SLOP_STR("match"))) || (string_eq(name, SLOP_STR("cond"))) || (string_eq(name, SLOP_STR("with-arena"))));
@@ -245,7 +245,7 @@ uint8_t stmt_is_stmt_form(types_SExpr* expr) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_813.has_value) {
+                    } else if (!_mv_814.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -263,11 +263,11 @@ void stmt_transpile_let(context_TranspileContext* ctx, types_SExpr* expr, uint8_
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_815 = (*expr);
-        switch (_mv_815.tag) {
+        __auto_type _mv_816 = (*expr);
+        switch (_mv_816.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_815.data.lst;
+                __auto_type lst = _mv_816.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -277,14 +277,14 @@ void stmt_transpile_let(context_TranspileContext* ctx, types_SExpr* expr, uint8_
                         context_ctx_emit(ctx, SLOP_STR("{"));
                         context_ctx_indent(ctx);
                         context_ctx_push_scope(ctx);
-                        __auto_type _mv_816 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_816.has_value) {
-                            __auto_type bindings_expr = _mv_816.value;
-                            __auto_type _mv_817 = (*bindings_expr);
-                            switch (_mv_817.tag) {
+                        __auto_type _mv_817 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_817.has_value) {
+                            __auto_type bindings_expr = _mv_817.value;
+                            __auto_type _mv_818 = (*bindings_expr);
+                            switch (_mv_818.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type bindings_lst = _mv_817.data.lst;
+                                    __auto_type bindings_lst = _mv_818.data.lst;
                                     stmt_transpile_bindings(ctx, bindings_lst.items);
                                     break;
                                 }
@@ -293,20 +293,20 @@ void stmt_transpile_let(context_TranspileContext* ctx, types_SExpr* expr, uint8_
                                     break;
                                 }
                             }
-                        } else if (!_mv_816.has_value) {
+                        } else if (!_mv_817.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing bindings"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                         {
                             __auto_type i = 2;
                             while (i < len) {
-                                __auto_type _mv_818 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_818.has_value) {
-                                    __auto_type body_expr = _mv_818.value;
+                                __auto_type _mv_819 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_819.has_value) {
+                                    __auto_type body_expr = _mv_819.value;
                                     {
                                         __auto_type is_last = (i == (len - 1));
                                         stmt_transpile_stmt(ctx, body_expr, (is_return && is_last));
                                     }
-                                } else if (!_mv_818.has_value) {
+                                } else if (!_mv_819.has_value) {
                                 }
                                 i = (i + 1);
                             }
@@ -333,11 +333,11 @@ void stmt_transpile_bindings(context_TranspileContext* ctx, slop_list_types_SExp
         __auto_type len = ((int64_t)((bindings).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_819 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_819.has_value) {
-                __auto_type binding_expr = _mv_819.value;
+            __auto_type _mv_820 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_820.has_value) {
+                __auto_type binding_expr = _mv_820.value;
                 stmt_transpile_single_binding(ctx, binding_expr);
-            } else if (!_mv_819.has_value) {
+            } else if (!_mv_820.has_value) {
             }
             i = (i + 1);
         }
@@ -349,11 +349,11 @@ void stmt_transpile_single_binding(context_TranspileContext* ctx, types_SExpr* b
     SLOP_PRE(((binding != NULL)), "(!= binding nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_820 = (*binding);
-        switch (_mv_820.tag) {
+        __auto_type _mv_821 = (*binding);
+        switch (_mv_821.tag) {
             case types_SExpr_lst:
             {
-                __auto_type binding_lst = _mv_820.data.lst;
+                __auto_type binding_lst = _mv_821.data.lst;
                 {
                     __auto_type items = binding_lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -363,24 +363,24 @@ void stmt_transpile_single_binding(context_TranspileContext* ctx, types_SExpr* b
                         if ((len - start_idx) < 2) {
                             context_ctx_add_error_at(ctx, SLOP_STR("invalid binding: need name and value"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                         } else {
-                            __auto_type _mv_821 = ({ __auto_type _lst = items; size_t _idx = (size_t)start_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_821.has_value) {
-                                __auto_type name_expr = _mv_821.value;
-                                __auto_type _mv_822 = (*name_expr);
-                                switch (_mv_822.tag) {
+                            __auto_type _mv_822 = ({ __auto_type _lst = items; size_t _idx = (size_t)start_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_822.has_value) {
+                                __auto_type name_expr = _mv_822.value;
+                                __auto_type _mv_823 = (*name_expr);
+                                switch (_mv_823.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type name_sym = _mv_822.data.sym;
+                                        __auto_type name_sym = _mv_823.data.sym;
                                         {
                                             __auto_type raw_name = name_sym.name;
                                             __auto_type var_name = ctype_to_c_name(arena, raw_name);
                                             if ((len - start_idx) >= 3) {
-                                                __auto_type _mv_823 = ({ __auto_type _lst = items; size_t _idx = (size_t)(start_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_823.has_value) {
-                                                    __auto_type type_expr = _mv_823.value;
-                                                    __auto_type _mv_824 = ({ __auto_type _lst = items; size_t _idx = (size_t)(start_idx + 2); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_824.has_value) {
-                                                        __auto_type init_expr = _mv_824.value;
+                                                __auto_type _mv_824 = ({ __auto_type _lst = items; size_t _idx = (size_t)(start_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_824.has_value) {
+                                                    __auto_type type_expr = _mv_824.value;
+                                                    __auto_type _mv_825 = ({ __auto_type _lst = items; size_t _idx = (size_t)(start_idx + 2); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_825.has_value) {
+                                                        __auto_type init_expr = _mv_825.value;
                                                         {
                                                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                             {
@@ -392,26 +392,26 @@ void stmt_transpile_single_binding(context_TranspileContext* ctx, types_SExpr* b
                                                                 }
                                                             }
                                                         }
-                                                    } else if (!_mv_824.has_value) {
+                                                    } else if (!_mv_825.has_value) {
                                                         context_ctx_add_error_at(ctx, SLOP_STR("missing init"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                     }
-                                                } else if (!_mv_823.has_value) {
+                                                } else if (!_mv_824.has_value) {
                                                     context_ctx_add_error_at(ctx, SLOP_STR("missing type"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                 }
                                             } else {
-                                                __auto_type _mv_825 = ({ __auto_type _lst = items; size_t _idx = (size_t)(start_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_825.has_value) {
-                                                    __auto_type init_expr = _mv_825.value;
+                                                __auto_type _mv_826 = ({ __auto_type _lst = items; size_t _idx = (size_t)(start_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_826.has_value) {
+                                                    __auto_type init_expr = _mv_826.value;
                                                     {
                                                         __auto_type init_c = expr_transpile_expr(ctx, init_expr);
                                                         __auto_type inferred_slop_type = expr_infer_expr_slop_type(ctx, init_expr);
                                                         __auto_type ptr_type_opt = stmt_get_arena_alloc_ptr_type(ctx, init_expr);
-                                                        __auto_type _mv_826 = ptr_type_opt;
-                                                        if (_mv_826.has_value) {
-                                                            __auto_type ptr_type = _mv_826.value;
+                                                        __auto_type _mv_827 = ptr_type_opt;
+                                                        if (_mv_827.has_value) {
+                                                            __auto_type ptr_type = _mv_827.value;
                                                             context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("__auto_type "), var_name, SLOP_STR(" = "), init_c, SLOP_STR(";")));
                                                             context_ctx_bind_var(ctx, (context_VarEntry){raw_name, var_name, ptr_type, inferred_slop_type, 1, has_mut, 0, SLOP_STR(""), SLOP_STR("")});
-                                                        } else if (!_mv_826.has_value) {
+                                                        } else if (!_mv_827.has_value) {
                                                             {
                                                                 __auto_type inferred_type = expr_infer_expr_c_type(ctx, init_expr);
                                                                 __auto_type lambda_info = context_ctx_get_last_lambda_info(ctx);
@@ -428,7 +428,7 @@ void stmt_transpile_single_binding(context_TranspileContext* ctx, types_SExpr* b
                                                             }
                                                         }
                                                     }
-                                                } else if (!_mv_825.has_value) {
+                                                } else if (!_mv_826.has_value) {
                                                     context_ctx_add_error_at(ctx, SLOP_STR("missing init"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                 }
                                             }
@@ -440,7 +440,7 @@ void stmt_transpile_single_binding(context_TranspileContext* ctx, types_SExpr* b
                                         break;
                                     }
                                 }
-                            } else if (!_mv_821.has_value) {
+                            } else if (!_mv_822.has_value) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("missing binding name"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                             }
                         }
@@ -460,21 +460,21 @@ uint8_t stmt_binding_has_mut(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_827 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_827.has_value) {
-            __auto_type first = _mv_827.value;
-            __auto_type _mv_828 = (*first);
-            switch (_mv_828.tag) {
+        __auto_type _mv_828 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_828.has_value) {
+            __auto_type first = _mv_828.value;
+            __auto_type _mv_829 = (*first);
+            switch (_mv_829.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_828.data.sym;
+                    __auto_type sym = _mv_829.data.sym;
                     return string_eq(sym.name, SLOP_STR("mut"));
                 }
                 default: {
                     return 0;
                 }
             }
-        } else if (!_mv_827.has_value) {
+        } else if (!_mv_828.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -517,28 +517,28 @@ slop_option_types_SExpr_ptr stmt_get_some_value(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         slop_option_types_SExpr_ptr result = (slop_option_types_SExpr_ptr){.has_value = false};
-        __auto_type _mv_829 = (*expr);
-        switch (_mv_829.tag) {
+        __auto_type _mv_830 = (*expr);
+        switch (_mv_830.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_829.data.lst;
+                __auto_type lst = _mv_830.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_830 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_830.has_value) {
-                            __auto_type head_expr = _mv_830.value;
-                            __auto_type _mv_831 = (*head_expr);
-                            switch (_mv_831.tag) {
+                        __auto_type _mv_831 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_831.has_value) {
+                            __auto_type head_expr = _mv_831.value;
+                            __auto_type _mv_832 = (*head_expr);
+                            switch (_mv_832.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_831.data.sym;
+                                    __auto_type sym = _mv_832.data.sym;
                                     if (string_eq(sym.name, SLOP_STR("some"))) {
-                                        __auto_type _mv_832 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_832.has_value) {
-                                            __auto_type val = _mv_832.value;
+                                        __auto_type _mv_833 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_833.has_value) {
+                                            __auto_type val = _mv_833.value;
                                             result = (slop_option_types_SExpr_ptr){.has_value = 1, .value = val};
-                                        } else if (!_mv_832.has_value) {
+                                        } else if (!_mv_833.has_value) {
                                         }
                                     }
                                     break;
@@ -547,7 +547,7 @@ slop_option_types_SExpr_ptr stmt_get_some_value(types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_830.has_value) {
+                        } else if (!_mv_831.has_value) {
                         }
                     }
                 }
@@ -563,34 +563,34 @@ slop_option_types_SExpr_ptr stmt_get_some_value(types_SExpr* expr) {
 
 uint8_t stmt_is_none_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_833 = (*expr);
-    switch (_mv_833.tag) {
+    __auto_type _mv_834 = (*expr);
+    switch (_mv_834.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_833.data.sym;
+            __auto_type sym = _mv_834.data.sym;
             return string_eq(sym.name, SLOP_STR("none"));
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_833.data.lst;
+            __auto_type lst = _mv_834.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) == 1) {
-                    __auto_type _mv_834 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_834.has_value) {
-                        __auto_type head = _mv_834.value;
-                        __auto_type _mv_835 = (*head);
-                        switch (_mv_835.tag) {
+                    __auto_type _mv_835 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_835.has_value) {
+                        __auto_type head = _mv_835.value;
+                        __auto_type _mv_836 = (*head);
+                        switch (_mv_836.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_835.data.sym;
+                                __auto_type sym = _mv_836.data.sym;
                                 return string_eq(sym.name, SLOP_STR("none"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_834.has_value) {
+                    } else if (!_mv_835.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -608,39 +608,39 @@ uint8_t stmt_is_none_form(types_SExpr* expr) {
 void stmt_transpile_if(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_836 = (*expr);
-    switch (_mv_836.tag) {
+    __auto_type _mv_837 = (*expr);
+    switch (_mv_837.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_836.data.lst;
+            __auto_type lst = _mv_837.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 if (len < 3) {
                     context_ctx_add_error_at(ctx, SLOP_STR("invalid if: need condition and then-branch"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                 } else {
-                    __auto_type _mv_837 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_837.has_value) {
-                        __auto_type cond_expr = _mv_837.value;
+                    __auto_type _mv_838 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_838.has_value) {
+                        __auto_type cond_expr = _mv_838.value;
                         {
                             __auto_type cond_c = context_ctx_strip_cond_parens(ctx, expr_transpile_expr(ctx, cond_expr));
                             context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("if ("), cond_c, SLOP_STR(") {")));
                             context_ctx_indent(ctx);
-                            __auto_type _mv_838 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_838.has_value) {
-                                __auto_type then_expr = _mv_838.value;
+                            __auto_type _mv_839 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_839.has_value) {
+                                __auto_type then_expr = _mv_839.value;
                                 stmt_transpile_stmt(ctx, then_expr, is_return);
-                            } else if (!_mv_838.has_value) {
+                            } else if (!_mv_839.has_value) {
                             }
                             context_ctx_dedent(ctx);
                             if (len >= 4) {
                                 context_ctx_emit(ctx, SLOP_STR("} else {"));
                                 context_ctx_indent(ctx);
-                                __auto_type _mv_839 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_839.has_value) {
-                                    __auto_type else_expr = _mv_839.value;
+                                __auto_type _mv_840 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_840.has_value) {
+                                    __auto_type else_expr = _mv_840.value;
                                     stmt_transpile_stmt(ctx, else_expr, is_return);
-                                } else if (!_mv_839.has_value) {
+                                } else if (!_mv_840.has_value) {
                                 }
                                 context_ctx_dedent(ctx);
                                 context_ctx_emit(ctx, SLOP_STR("}"));
@@ -648,7 +648,7 @@ void stmt_transpile_if(context_TranspileContext* ctx, types_SExpr* expr, uint8_t
                                 context_ctx_emit(ctx, SLOP_STR("}"));
                             }
                         }
-                    } else if (!_mv_837.has_value) {
+                    } else if (!_mv_838.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing if condition"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     }
                 }
@@ -665,20 +665,20 @@ void stmt_transpile_if(context_TranspileContext* ctx, types_SExpr* expr, uint8_t
 void stmt_transpile_when(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_840 = (*expr);
-    switch (_mv_840.tag) {
+    __auto_type _mv_841 = (*expr);
+    switch (_mv_841.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_840.data.lst;
+            __auto_type lst = _mv_841.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 if (len < 3) {
                     context_ctx_add_error_at(ctx, SLOP_STR("invalid when: need condition and body"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                 } else {
-                    __auto_type _mv_841 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_841.has_value) {
-                        __auto_type cond_expr = _mv_841.value;
+                    __auto_type _mv_842 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_842.has_value) {
+                        __auto_type cond_expr = _mv_842.value;
                         {
                             __auto_type cond_c = context_ctx_strip_cond_parens(ctx, expr_transpile_expr(ctx, cond_expr));
                             context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("if ("), cond_c, SLOP_STR(") {")));
@@ -686,11 +686,11 @@ void stmt_transpile_when(context_TranspileContext* ctx, types_SExpr* expr) {
                             {
                                 __auto_type i = 2;
                                 while (i < len) {
-                                    __auto_type _mv_842 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_842.has_value) {
-                                        __auto_type body_expr = _mv_842.value;
+                                    __auto_type _mv_843 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_843.has_value) {
+                                        __auto_type body_expr = _mv_843.value;
                                         stmt_transpile_stmt(ctx, body_expr, 0);
-                                    } else if (!_mv_842.has_value) {
+                                    } else if (!_mv_843.has_value) {
                                     }
                                     i = (i + 1);
                                 }
@@ -698,7 +698,7 @@ void stmt_transpile_when(context_TranspileContext* ctx, types_SExpr* expr) {
                             context_ctx_dedent(ctx);
                             context_ctx_emit(ctx, SLOP_STR("}"));
                         }
-                    } else if (!_mv_841.has_value) {
+                    } else if (!_mv_842.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing when condition"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     }
                 }
@@ -715,20 +715,20 @@ void stmt_transpile_when(context_TranspileContext* ctx, types_SExpr* expr) {
 void stmt_transpile_while(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_843 = (*expr);
-    switch (_mv_843.tag) {
+    __auto_type _mv_844 = (*expr);
+    switch (_mv_844.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_843.data.lst;
+            __auto_type lst = _mv_844.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 if (len < 3) {
                     context_ctx_add_error_at(ctx, SLOP_STR("invalid while: need condition and body"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                 } else {
-                    __auto_type _mv_844 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_844.has_value) {
-                        __auto_type cond_expr = _mv_844.value;
+                    __auto_type _mv_845 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_845.has_value) {
+                        __auto_type cond_expr = _mv_845.value;
                         {
                             __auto_type cond_c = context_ctx_strip_cond_parens(ctx, expr_transpile_expr(ctx, cond_expr));
                             context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("while ("), cond_c, SLOP_STR(") {")));
@@ -736,11 +736,11 @@ void stmt_transpile_while(context_TranspileContext* ctx, types_SExpr* expr) {
                             {
                                 __auto_type i = 2;
                                 while (i < len) {
-                                    __auto_type _mv_845 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_845.has_value) {
-                                        __auto_type body_expr = _mv_845.value;
+                                    __auto_type _mv_846 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_846.has_value) {
+                                        __auto_type body_expr = _mv_846.value;
                                         stmt_transpile_stmt(ctx, body_expr, 0);
-                                    } else if (!_mv_845.has_value) {
+                                    } else if (!_mv_846.has_value) {
                                     }
                                     i = (i + 1);
                                 }
@@ -748,7 +748,7 @@ void stmt_transpile_while(context_TranspileContext* ctx, types_SExpr* expr) {
                             context_ctx_dedent(ctx);
                             context_ctx_emit(ctx, SLOP_STR("}"));
                         }
-                    } else if (!_mv_844.has_value) {
+                    } else if (!_mv_845.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing while condition"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     }
                 }
@@ -767,11 +767,11 @@ void stmt_transpile_set(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_846 = (*expr);
-        switch (_mv_846.tag) {
+        __auto_type _mv_847 = (*expr);
+        switch (_mv_847.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_846.data.lst;
+                __auto_type lst = _mv_847.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -781,29 +781,29 @@ void stmt_transpile_set(context_TranspileContext* ctx, types_SExpr* expr) {
                     } else if (len == 4) {
                         stmt_transpile_field_set(ctx, items);
                     } else if (len == 3) {
-                        __auto_type _mv_847 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_847.has_value) {
-                            __auto_type target_expr = _mv_847.value;
-                            __auto_type _mv_848 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_848.has_value) {
-                                __auto_type value_expr = _mv_848.value;
+                        __auto_type _mv_848 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_848.has_value) {
+                            __auto_type target_expr = _mv_848.value;
+                            __auto_type _mv_849 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_849.has_value) {
+                                __auto_type value_expr = _mv_849.value;
                                 {
                                     __auto_type target_c = expr_transpile_expr(ctx, target_expr);
                                     __auto_type target_type_opt = stmt_get_var_c_type(ctx, target_expr);
-                                    __auto_type _mv_849 = target_type_opt;
-                                    if (_mv_849.has_value) {
-                                        __auto_type target_type = _mv_849.value;
+                                    __auto_type _mv_850 = target_type_opt;
+                                    if (_mv_850.has_value) {
+                                        __auto_type target_type = _mv_850.value;
                                         if (strlib_starts_with(target_type, SLOP_STR("slop_option_"))) {
                                             {
                                                 __auto_type some_val_opt = stmt_get_some_value(value_expr);
-                                                __auto_type _mv_850 = some_val_opt;
-                                                if (_mv_850.has_value) {
-                                                    __auto_type val_expr = _mv_850.value;
+                                                __auto_type _mv_851 = some_val_opt;
+                                                if (_mv_851.has_value) {
+                                                    __auto_type val_expr = _mv_851.value;
                                                     {
                                                         __auto_type val_c = expr_transpile_expr(ctx, val_expr);
                                                         context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str5(ctx, SLOP_STR(" = ("), target_type, SLOP_STR("){.has_value = 1, .value = "), val_c, SLOP_STR("};"))));
                                                     }
-                                                } else if (!_mv_850.has_value) {
+                                                } else if (!_mv_851.has_value) {
                                                     if (stmt_is_none_form(value_expr)) {
                                                         context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str3(ctx, SLOP_STR(" = ("), target_type, SLOP_STR("){.has_value = false};"))));
                                                     } else {
@@ -820,23 +820,23 @@ void stmt_transpile_set(context_TranspileContext* ctx, types_SExpr* expr) {
                                                 context_ctx_emit(ctx, context_ctx_str4(ctx, target_c, SLOP_STR(" = "), value_c, SLOP_STR(";")));
                                             }
                                         }
-                                    } else if (!_mv_849.has_value) {
+                                    } else if (!_mv_850.has_value) {
                                         {
                                             __auto_type some_val_opt = stmt_get_some_value(value_expr);
-                                            __auto_type _mv_851 = some_val_opt;
-                                            if (_mv_851.has_value) {
-                                                __auto_type inner_expr = _mv_851.value;
+                                            __auto_type _mv_852 = some_val_opt;
+                                            if (_mv_852.has_value) {
+                                                __auto_type inner_expr = _mv_852.value;
                                                 {
                                                     __auto_type inner_c = expr_transpile_expr(ctx, inner_expr);
                                                     __auto_type inner_type = expr_infer_expr_c_type(ctx, inner_expr);
                                                     __auto_type option_type = expr_c_type_to_option_type_name(ctx, inner_type);
                                                     context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str5(ctx, SLOP_STR(" = ("), option_type, SLOP_STR("){.has_value = 1, .value = "), inner_c, SLOP_STR("};"))));
                                                 }
-                                            } else if (!_mv_851.has_value) {
+                                            } else if (!_mv_852.has_value) {
                                                 if (stmt_is_none_form(value_expr)) {
-                                                    __auto_type _mv_852 = context_ctx_get_current_return_type(ctx);
-                                                    if (_mv_852.has_value) {
-                                                        __auto_type ret_type = _mv_852.value;
+                                                    __auto_type _mv_853 = context_ctx_get_current_return_type(ctx);
+                                                    if (_mv_853.has_value) {
+                                                        __auto_type ret_type = _mv_853.value;
                                                         if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
                                                             context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str3(ctx, SLOP_STR(" = ("), ret_type, SLOP_STR("){.has_value = false};"))));
                                                         } else {
@@ -845,7 +845,7 @@ void stmt_transpile_set(context_TranspileContext* ctx, types_SExpr* expr) {
                                                                 context_ctx_emit(ctx, context_ctx_str4(ctx, target_c, SLOP_STR(" = "), value_c, SLOP_STR(";")));
                                                             }
                                                         }
-                                                    } else if (!_mv_852.has_value) {
+                                                    } else if (!_mv_853.has_value) {
                                                         {
                                                             __auto_type value_c = expr_transpile_expr(ctx, value_expr);
                                                             context_ctx_emit(ctx, context_ctx_str4(ctx, target_c, SLOP_STR(" = "), value_c, SLOP_STR(";")));
@@ -861,10 +861,10 @@ void stmt_transpile_set(context_TranspileContext* ctx, types_SExpr* expr) {
                                         }
                                     }
                                 }
-                            } else if (!_mv_848.has_value) {
+                            } else if (!_mv_849.has_value) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("missing set! value"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                             }
-                        } else if (!_mv_847.has_value) {
+                        } else if (!_mv_848.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing set! target"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                     } else {
@@ -883,18 +883,18 @@ void stmt_transpile_set(context_TranspileContext* ctx, types_SExpr* expr) {
 
 slop_option_string stmt_get_var_c_type(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
-    __auto_type _mv_853 = (*expr);
-    switch (_mv_853.tag) {
+    __auto_type _mv_854 = (*expr);
+    switch (_mv_854.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_853.data.sym;
+            __auto_type sym = _mv_854.data.sym;
             {
                 __auto_type name = sym.name;
-                __auto_type _mv_854 = context_ctx_lookup_var(ctx, name);
-                if (_mv_854.has_value) {
-                    __auto_type var_entry = _mv_854.value;
+                __auto_type _mv_855 = context_ctx_lookup_var(ctx, name);
+                if (_mv_855.has_value) {
+                    __auto_type var_entry = _mv_855.value;
                     return (slop_option_string){.has_value = 1, .value = var_entry.c_type};
-                } else if (!_mv_854.has_value) {
+                } else if (!_mv_855.has_value) {
                     return (slop_option_string){.has_value = false};
                 }
                 SLOP_UNREACHABLE();
@@ -909,18 +909,18 @@ slop_option_string stmt_get_var_c_type(context_TranspileContext* ctx, types_SExp
 uint8_t stmt_is_pointer_target(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_855 = (*expr);
-    switch (_mv_855.tag) {
+    __auto_type _mv_856 = (*expr);
+    switch (_mv_856.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_855.data.sym;
+            __auto_type sym = _mv_856.data.sym;
             {
                 __auto_type name = sym.name;
-                __auto_type _mv_856 = context_ctx_lookup_var(ctx, name);
-                if (_mv_856.has_value) {
-                    __auto_type var_entry = _mv_856.value;
+                __auto_type _mv_857 = context_ctx_lookup_var(ctx, name);
+                if (_mv_857.has_value) {
+                    __auto_type var_entry = _mv_857.value;
                     return (var_entry.is_pointer || ({ __auto_type c_type = var_entry.c_type; strlib_ends_with(c_type, SLOP_STR("*")); }));
-                } else if (!_mv_856.has_value) {
+                } else if (!_mv_857.has_value) {
                     return 0;
                 }
                 SLOP_UNREACHABLE();
@@ -936,15 +936,15 @@ void stmt_transpile_field_set(context_TranspileContext* ctx, slop_list_types_SEx
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_857 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_857.has_value) {
-            __auto_type target_expr = _mv_857.value;
-            __auto_type _mv_858 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_858.has_value) {
-                __auto_type field_expr = _mv_858.value;
-                __auto_type _mv_859 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_859.has_value) {
-                    __auto_type value_expr = _mv_859.value;
+        __auto_type _mv_858 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_858.has_value) {
+            __auto_type target_expr = _mv_858.value;
+            __auto_type _mv_859 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_859.has_value) {
+                __auto_type field_expr = _mv_859.value;
+                __auto_type _mv_860 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_860.has_value) {
+                    __auto_type value_expr = _mv_860.value;
                     {
                         __auto_type field_name = stmt_get_symbol_name(arena, field_expr);
                         __auto_type value_c = expr_transpile_expr(ctx, value_expr);
@@ -966,13 +966,13 @@ void stmt_transpile_field_set(context_TranspileContext* ctx, slop_list_types_SEx
                             }
                         }
                     }
-                } else if (!_mv_859.has_value) {
+                } else if (!_mv_860.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("missing set! value"), context_ctx_sexpr_line(target_expr), context_ctx_sexpr_col(target_expr));
                 }
-            } else if (!_mv_858.has_value) {
+            } else if (!_mv_859.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing set! field"), context_ctx_sexpr_line(target_expr), context_ctx_sexpr_col(target_expr));
             }
-        } else if (!_mv_857.has_value) {
+        } else if (!_mv_858.has_value) {
             context_ctx_add_error_at(ctx, SLOP_STR("missing set! target"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         }
     }
@@ -982,18 +982,18 @@ void stmt_transpile_typed_field_set(context_TranspileContext* ctx, slop_list_typ
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_860 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_860.has_value) {
-            __auto_type target_expr = _mv_860.value;
-            __auto_type _mv_861 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_861.has_value) {
-                __auto_type field_expr = _mv_861.value;
-                __auto_type _mv_862 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_862.has_value) {
-                    __auto_type type_expr = _mv_862.value;
-                    __auto_type _mv_863 = ({ __auto_type _lst = items; size_t _idx = (size_t)4; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_863.has_value) {
-                        __auto_type value_expr = _mv_863.value;
+        __auto_type _mv_861 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_861.has_value) {
+            __auto_type target_expr = _mv_861.value;
+            __auto_type _mv_862 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_862.has_value) {
+                __auto_type field_expr = _mv_862.value;
+                __auto_type _mv_863 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_863.has_value) {
+                    __auto_type type_expr = _mv_863.value;
+                    __auto_type _mv_864 = ({ __auto_type _lst = items; size_t _idx = (size_t)4; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_864.has_value) {
+                        __auto_type value_expr = _mv_864.value;
                         {
                             __auto_type field_name = stmt_get_symbol_name(arena, field_expr);
                             __auto_type c_type = ctype_to_c_type(arena, type_expr);
@@ -1003,14 +1003,14 @@ void stmt_transpile_typed_field_set(context_TranspileContext* ctx, slop_list_typ
                                     if (stmt_is_none_form(value_expr)) {
                                         context_ctx_emit(ctx, context_ctx_str(ctx, target_access, context_ctx_str(ctx, field_name, context_ctx_str3(ctx, SLOP_STR(" = ("), c_type, SLOP_STR("){.has_value = false};")))));
                                     } else {
-                                        __auto_type _mv_864 = stmt_get_some_value(value_expr);
-                                        if (_mv_864.has_value) {
-                                            __auto_type inner_val = _mv_864.value;
+                                        __auto_type _mv_865 = stmt_get_some_value(value_expr);
+                                        if (_mv_865.has_value) {
+                                            __auto_type inner_val = _mv_865.value;
                                             {
                                                 __auto_type val_c = expr_transpile_expr(ctx, inner_val);
                                                 context_ctx_emit(ctx, context_ctx_str(ctx, target_access, context_ctx_str(ctx, field_name, context_ctx_str5(ctx, SLOP_STR(" = ("), c_type, SLOP_STR("){.has_value = 1, .value = "), val_c, SLOP_STR("};")))));
                                             }
-                                        } else if (!_mv_864.has_value) {
+                                        } else if (!_mv_865.has_value) {
                                             {
                                                 __auto_type val_c = expr_transpile_expr(ctx, value_expr);
                                                 context_ctx_emit(ctx, context_ctx_str(ctx, target_access, context_ctx_str(ctx, field_name, context_ctx_str(ctx, SLOP_STR(" = "), context_ctx_str(ctx, val_c, SLOP_STR(";"))))));
@@ -1025,16 +1025,16 @@ void stmt_transpile_typed_field_set(context_TranspileContext* ctx, slop_list_typ
                                 }
                             }
                         }
-                    } else if (!_mv_863.has_value) {
+                    } else if (!_mv_864.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing set! value"), context_ctx_sexpr_line(type_expr), context_ctx_sexpr_col(type_expr));
                     }
-                } else if (!_mv_862.has_value) {
+                } else if (!_mv_863.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("missing set! type"), context_ctx_sexpr_line(field_expr), context_ctx_sexpr_col(field_expr));
                 }
-            } else if (!_mv_861.has_value) {
+            } else if (!_mv_862.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing set! field"), context_ctx_sexpr_line(target_expr), context_ctx_sexpr_col(target_expr));
             }
-        } else if (!_mv_860.has_value) {
+        } else if (!_mv_861.has_value) {
             context_ctx_add_error_at(ctx, SLOP_STR("missing set! target"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         }
     }
@@ -1042,31 +1042,31 @@ void stmt_transpile_typed_field_set(context_TranspileContext* ctx, slop_list_typ
 
 uint8_t stmt_is_deref_expr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_865 = (*expr);
-    switch (_mv_865.tag) {
+    __auto_type _mv_866 = (*expr);
+    switch (_mv_866.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_865.data.lst;
+            __auto_type lst = _mv_866.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_866 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_866.has_value) {
-                        __auto_type head = _mv_866.value;
-                        __auto_type _mv_867 = (*head);
-                        switch (_mv_867.tag) {
+                    __auto_type _mv_867 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_867.has_value) {
+                        __auto_type head = _mv_867.value;
+                        __auto_type _mv_868 = (*head);
+                        switch (_mv_868.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_867.data.sym;
+                                __auto_type sym = _mv_868.data.sym;
                                 return string_eq(sym.name, SLOP_STR("deref"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_866.has_value) {
+                    } else if (!_mv_867.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1081,18 +1081,18 @@ uint8_t stmt_is_deref_expr(types_SExpr* expr) {
 
 types_SExpr* stmt_get_deref_inner(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_868 = (*expr);
-    switch (_mv_868.tag) {
+    __auto_type _mv_869 = (*expr);
+    switch (_mv_869.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_868.data.lst;
+            __auto_type lst = _mv_869.data.lst;
             {
                 __auto_type items = lst.items;
-                __auto_type _mv_869 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_869.has_value) {
-                    __auto_type inner = _mv_869.value;
+                __auto_type _mv_870 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_870.has_value) {
+                    __auto_type inner = _mv_870.value;
                     return inner;
-                } else if (!_mv_869.has_value) {
+                } else if (!_mv_870.has_value) {
                     return expr;
                 }
                 SLOP_UNREACHABLE();
@@ -1106,11 +1106,11 @@ types_SExpr* stmt_get_deref_inner(types_SExpr* expr) {
 
 slop_string stmt_get_symbol_name(slop_arena* arena, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_870 = (*expr);
-    switch (_mv_870.tag) {
+    __auto_type _mv_871 = (*expr);
+    switch (_mv_871.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_870.data.sym;
+            __auto_type sym = _mv_871.data.sym;
             return ctype_to_c_name(arena, sym.name);
         }
         default: {
@@ -1122,24 +1122,24 @@ slop_string stmt_get_symbol_name(slop_arena* arena, types_SExpr* expr) {
 void stmt_transpile_do(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_871 = (*expr);
-    switch (_mv_871.tag) {
+    __auto_type _mv_872 = (*expr);
+    switch (_mv_872.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_871.data.lst;
+            __auto_type lst = _mv_872.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type i = 1;
                 while (i < len) {
-                    __auto_type _mv_872 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_872.has_value) {
-                        __auto_type body_expr = _mv_872.value;
+                    __auto_type _mv_873 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_873.has_value) {
+                        __auto_type body_expr = _mv_873.value;
                         {
                             __auto_type is_last = (i == (len - 1));
                             stmt_transpile_stmt(ctx, body_expr, (is_return && is_last));
                         }
-                    } else if (!_mv_872.has_value) {
+                    } else if (!_mv_873.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -1155,11 +1155,11 @@ void stmt_transpile_do(context_TranspileContext* ctx, types_SExpr* expr, uint8_t
 void stmt_transpile_with_arena(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_873 = (*expr);
-    switch (_mv_873.tag) {
+    __auto_type _mv_874 = (*expr);
+    switch (_mv_874.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_873.data.lst;
+            __auto_type lst = _mv_874.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
@@ -1171,16 +1171,17 @@ void stmt_transpile_with_arena(context_TranspileContext* ctx, types_SExpr* expr,
                         __auto_type arena_name = ((is_named) ? ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type name_expr = _mv.value; parser_sexpr_get_symbol_name(name_expr); }) : (SLOP_STR("arena")); }) : SLOP_STR("arena"));
                         __auto_type size_idx = ((is_named) ? 3 : 1);
                         __auto_type body_start = ((is_named) ? 4 : 2);
-                        __auto_type c_local = ((is_named) ? string_concat((*ctx).arena, SLOP_STR("_arena_"), arena_name) : SLOP_STR("_arena"));
+                        __auto_type c_arena_name = ctype_to_c_name((*ctx).arena, arena_name);
+                        __auto_type c_local = ((is_named) ? string_concat((*ctx).arena, SLOP_STR("_arena_"), c_arena_name) : SLOP_STR("_arena"));
                         if (is_named && (len < 4)) {
                             context_ctx_add_error_at(ctx, SLOP_STR("with-arena :as requires name and size"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         } else {
                             context_ctx_emit(ctx, SLOP_STR("{"));
                             context_ctx_indent(ctx);
                             context_ctx_push_scope(ctx);
-                            __auto_type _mv_874 = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_874.has_value) {
-                                __auto_type size_expr = _mv_874.value;
+                            __auto_type _mv_875 = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_875.has_value) {
+                                __auto_type size_expr = _mv_875.value;
                                 {
                                     __auto_type size_c = expr_transpile_expr(ctx, size_expr);
                                     context_ctx_emit(ctx, SLOP_STR("#ifdef SLOP_DEBUG"));
@@ -1190,28 +1191,28 @@ void stmt_transpile_with_arena(context_TranspileContext* ctx, types_SExpr* expr,
                                     context_ctx_emit(ctx, SLOP_STR("#ifdef SLOP_DEBUG"));
                                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("SLOP_PRE("), c_local, SLOP_STR(".base != NULL, \"arena allocation failed\");")));
                                     context_ctx_emit(ctx, SLOP_STR("#endif"));
-                                    context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("slop_arena* "), arena_name, SLOP_STR(" = &"), c_local, SLOP_STR(";")));
+                                    context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("slop_arena* "), c_arena_name, SLOP_STR(" = &"), c_local, SLOP_STR(";")));
                                 }
-                            } else if (!_mv_874.has_value) {
+                            } else if (!_mv_875.has_value) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("missing size"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                             }
-                            context_ctx_bind_var(ctx, (context_VarEntry){arena_name, arena_name, SLOP_STR("slop_arena*"), SLOP_STR(""), 1, 0, 0, SLOP_STR(""), SLOP_STR("")});
+                            context_ctx_bind_var(ctx, (context_VarEntry){arena_name, c_arena_name, SLOP_STR("slop_arena*"), SLOP_STR(""), 1, 0, 0, SLOP_STR(""), SLOP_STR("")});
                             {
                                 __auto_type i = body_start;
                                 while (i < len) {
-                                    __auto_type _mv_875 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_875.has_value) {
-                                        __auto_type body_expr = _mv_875.value;
+                                    __auto_type _mv_876 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_876.has_value) {
+                                        __auto_type body_expr = _mv_876.value;
                                         {
                                             __auto_type is_last = (i == (len - 1));
                                             stmt_transpile_stmt(ctx, body_expr, (is_return && is_last));
                                         }
-                                    } else if (!_mv_875.has_value) {
+                                    } else if (!_mv_876.has_value) {
                                     }
                                     i = (i + 1);
                                 }
                             }
-                            context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), arena_name, SLOP_STR(");")));
+                            context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), c_arena_name, SLOP_STR(");")));
                             context_ctx_pop_scope(ctx);
                             context_ctx_dedent(ctx);
                             context_ctx_emit(ctx, SLOP_STR("}"));
@@ -1231,39 +1232,39 @@ void stmt_transpile_with_arena(context_TranspileContext* ctx, types_SExpr* expr,
 void stmt_transpile_cond(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_876 = (*expr);
-    switch (_mv_876.tag) {
+    __auto_type _mv_877 = (*expr);
+    switch (_mv_877.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_876.data.lst;
+            __auto_type lst = _mv_877.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type i = 1;
                 __auto_type first = 1;
                 while (i < len) {
-                    __auto_type _mv_877 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_877.has_value) {
-                        __auto_type clause_expr = _mv_877.value;
-                        __auto_type _mv_878 = (*clause_expr);
-                        switch (_mv_878.tag) {
+                    __auto_type _mv_878 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_878.has_value) {
+                        __auto_type clause_expr = _mv_878.value;
+                        __auto_type _mv_879 = (*clause_expr);
+                        switch (_mv_879.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type clause_lst = _mv_878.data.lst;
+                                __auto_type clause_lst = _mv_879.data.lst;
                                 {
                                     __auto_type clause_items = clause_lst.items;
                                     __auto_type clause_len = ((int64_t)((clause_items).len));
                                     if (clause_len < 1) {
                                         context_ctx_add_error_at(ctx, SLOP_STR("invalid cond clause"), context_ctx_sexpr_line(clause_expr), context_ctx_sexpr_col(clause_expr));
                                     } else {
-                                        __auto_type _mv_879 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_879.has_value) {
-                                            __auto_type test_expr = _mv_879.value;
-                                            __auto_type _mv_880 = (*test_expr);
-                                            switch (_mv_880.tag) {
+                                        __auto_type _mv_880 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_880.has_value) {
+                                            __auto_type test_expr = _mv_880.value;
+                                            __auto_type _mv_881 = (*test_expr);
+                                            switch (_mv_881.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_880.data.sym;
+                                                    __auto_type sym = _mv_881.data.sym;
                                                     if (string_eq(sym.name, SLOP_STR("else"))) {
                                                         context_ctx_emit(ctx, SLOP_STR("} else {"));
                                                         context_ctx_indent(ctx);
@@ -1301,7 +1302,7 @@ void stmt_transpile_cond(context_TranspileContext* ctx, types_SExpr* expr, uint8
                                                     break;
                                                 }
                                             }
-                                        } else if (!_mv_879.has_value) {
+                                        } else if (!_mv_880.has_value) {
                                             context_ctx_add_error_at(ctx, SLOP_STR("missing test"), context_ctx_sexpr_line(clause_expr), context_ctx_sexpr_col(clause_expr));
                                         }
                                     }
@@ -1313,7 +1314,7 @@ void stmt_transpile_cond(context_TranspileContext* ctx, types_SExpr* expr, uint8
                                 break;
                             }
                         }
-                    } else if (!_mv_877.has_value) {
+                    } else if (!_mv_878.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -1336,14 +1337,14 @@ void stmt_transpile_cond_body(context_TranspileContext* ctx, slop_list_types_SEx
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_881 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_881.has_value) {
-                __auto_type body_expr = _mv_881.value;
+            __auto_type _mv_882 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_882.has_value) {
+                __auto_type body_expr = _mv_882.value;
                 {
                     __auto_type is_last = (i == (len - 1));
                     stmt_transpile_stmt(ctx, body_expr, (is_return && is_last));
                 }
-            } else if (!_mv_881.has_value) {
+            } else if (!_mv_882.has_value) {
             }
             i = (i + 1);
         }
@@ -1355,47 +1356,47 @@ void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_882 = (*expr);
-        switch (_mv_882.tag) {
+        __auto_type _mv_883 = (*expr);
+        switch (_mv_883.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_882.data.lst;
+                __auto_type lst = _mv_883.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 2) {
                         context_ctx_add_error_at(ctx, SLOP_STR("invalid for: need binding"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     } else {
-                        __auto_type _mv_883 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_883.has_value) {
-                            __auto_type binding_expr = _mv_883.value;
-                            __auto_type _mv_884 = (*binding_expr);
-                            switch (_mv_884.tag) {
+                        __auto_type _mv_884 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_884.has_value) {
+                            __auto_type binding_expr = _mv_884.value;
+                            __auto_type _mv_885 = (*binding_expr);
+                            switch (_mv_885.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type binding_lst = _mv_884.data.lst;
+                                    __auto_type binding_lst = _mv_885.data.lst;
                                     {
                                         __auto_type binding_items = binding_lst.items;
                                         __auto_type binding_len = ((int64_t)((binding_items).len));
                                         if (binding_len < 3) {
                                             context_ctx_add_error_at(ctx, SLOP_STR("for binding needs (var start end)"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                         } else {
-                                            __auto_type _mv_885 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_885.has_value) {
-                                                __auto_type var_expr = _mv_885.value;
-                                                __auto_type _mv_886 = (*var_expr);
-                                                switch (_mv_886.tag) {
+                                            __auto_type _mv_886 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_886.has_value) {
+                                                __auto_type var_expr = _mv_886.value;
+                                                __auto_type _mv_887 = (*var_expr);
+                                                switch (_mv_887.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type var_sym = _mv_886.data.sym;
+                                                        __auto_type var_sym = _mv_887.data.sym;
                                                         {
                                                             __auto_type var_name = ctype_to_c_name(arena, var_sym.name);
-                                                            __auto_type _mv_887 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                            if (_mv_887.has_value) {
-                                                                __auto_type start_expr = _mv_887.value;
-                                                                __auto_type _mv_888 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                if (_mv_888.has_value) {
-                                                                    __auto_type end_expr = _mv_888.value;
+                                                            __auto_type _mv_888 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                            if (_mv_888.has_value) {
+                                                                __auto_type start_expr = _mv_888.value;
+                                                                __auto_type _mv_889 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                if (_mv_889.has_value) {
+                                                                    __auto_type end_expr = _mv_889.value;
                                                                     {
                                                                         __auto_type start_c = expr_transpile_expr(ctx, start_expr);
                                                                         __auto_type end_c = expr_transpile_expr(ctx, end_expr);
@@ -1406,11 +1407,11 @@ void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr) {
                                                                         {
                                                                             __auto_type i = 2;
                                                                             while (i < len) {
-                                                                                __auto_type _mv_889 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                                if (_mv_889.has_value) {
-                                                                                    __auto_type body_expr = _mv_889.value;
+                                                                                __auto_type _mv_890 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                                if (_mv_890.has_value) {
+                                                                                    __auto_type body_expr = _mv_890.value;
                                                                                     stmt_transpile_stmt(ctx, body_expr, 0);
-                                                                                } else if (!_mv_889.has_value) {
+                                                                                } else if (!_mv_890.has_value) {
                                                                                 }
                                                                                 i = (i + 1);
                                                                             }
@@ -1419,10 +1420,10 @@ void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr) {
                                                                         context_ctx_dedent(ctx);
                                                                         context_ctx_emit(ctx, SLOP_STR("}"));
                                                                     }
-                                                                } else if (!_mv_888.has_value) {
+                                                                } else if (!_mv_889.has_value) {
                                                                     context_ctx_add_error_at(ctx, SLOP_STR("missing end"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                                                 }
-                                                            } else if (!_mv_887.has_value) {
+                                                            } else if (!_mv_888.has_value) {
                                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing start"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                                             }
                                                         }
@@ -1433,7 +1434,7 @@ void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr) {
                                                         break;
                                                     }
                                                 }
-                                            } else if (!_mv_885.has_value) {
+                                            } else if (!_mv_886.has_value) {
                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing var"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                             }
                                         }
@@ -1445,7 +1446,7 @@ void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_883.has_value) {
+                        } else if (!_mv_884.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing binding"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                     }
@@ -1484,11 +1485,11 @@ void stmt_transpile_for_each_set(context_TranspileContext* ctx, slop_string var_
         {
             int64_t i = 2;
             while (i < len) {
-                __auto_type _mv_890 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_890.has_value) {
-                    __auto_type body_expr = _mv_890.value;
+                __auto_type _mv_891 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_891.has_value) {
+                    __auto_type body_expr = _mv_891.value;
                     stmt_transpile_stmt(ctx, body_expr, 0);
-                } else if (!_mv_890.has_value) {
+                } else if (!_mv_891.has_value) {
                 }
                 i = (i + 1);
             }
@@ -1527,11 +1528,11 @@ void stmt_transpile_for_each_map_keys(context_TranspileContext* ctx, slop_string
         {
             int64_t i = 2;
             while (i < len) {
-                __auto_type _mv_891 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_891.has_value) {
-                    __auto_type body_expr = _mv_891.value;
+                __auto_type _mv_892 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_892.has_value) {
+                    __auto_type body_expr = _mv_892.value;
                     stmt_transpile_stmt(ctx, body_expr, 0);
-                } else if (!_mv_891.has_value) {
+                } else if (!_mv_892.has_value) {
                 }
                 i = (i + 1);
             }
@@ -1550,38 +1551,38 @@ void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_typ
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_892 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_892.has_value) {
-            __auto_type kv_list_expr = _mv_892.value;
-            __auto_type _mv_893 = (*kv_list_expr);
-            switch (_mv_893.tag) {
+        __auto_type _mv_893 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_893.has_value) {
+            __auto_type kv_list_expr = _mv_893.value;
+            __auto_type _mv_894 = (*kv_list_expr);
+            switch (_mv_894.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type kv_lst = _mv_893.data.lst;
+                    __auto_type kv_lst = _mv_894.data.lst;
                     {
                         __auto_type kv_items = kv_lst.items;
                         if (((int64_t)((kv_items).len)) < 2) {
                             context_ctx_add_error(ctx, SLOP_STR("Map for-each needs ((k v) map)"));
                         } else {
-                            __auto_type _mv_894 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_894.has_value) {
-                                __auto_type k_expr = _mv_894.value;
-                                __auto_type _mv_895 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_895.has_value) {
-                                    __auto_type v_expr = _mv_895.value;
-                                    __auto_type _mv_896 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_896.has_value) {
-                                        __auto_type map_expr = _mv_896.value;
-                                        __auto_type _mv_897 = (*k_expr);
-                                        switch (_mv_897.tag) {
+                            __auto_type _mv_895 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_895.has_value) {
+                                __auto_type k_expr = _mv_895.value;
+                                __auto_type _mv_896 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_896.has_value) {
+                                    __auto_type v_expr = _mv_896.value;
+                                    __auto_type _mv_897 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_897.has_value) {
+                                        __auto_type map_expr = _mv_897.value;
+                                        __auto_type _mv_898 = (*k_expr);
+                                        switch (_mv_898.tag) {
                                             case types_SExpr_sym:
                                             {
-                                                __auto_type k_sym = _mv_897.data.sym;
-                                                __auto_type _mv_898 = (*v_expr);
-                                                switch (_mv_898.tag) {
+                                                __auto_type k_sym = _mv_898.data.sym;
+                                                __auto_type _mv_899 = (*v_expr);
+                                                switch (_mv_899.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type v_sym = _mv_898.data.sym;
+                                                        __auto_type v_sym = _mv_899.data.sym;
                                                         {
                                                             __auto_type k_name = ctype_to_c_name(arena, k_sym.name);
                                                             __auto_type v_name = ctype_to_c_name(arena, v_sym.name);
@@ -1617,11 +1618,11 @@ void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_typ
                                                             {
                                                                 __auto_type i = 2;
                                                                 while (i < len) {
-                                                                    __auto_type _mv_899 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                    if (_mv_899.has_value) {
-                                                                        __auto_type body_expr = _mv_899.value;
+                                                                    __auto_type _mv_900 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                    if (_mv_900.has_value) {
+                                                                        __auto_type body_expr = _mv_900.value;
                                                                         stmt_transpile_stmt(ctx, body_expr, 0);
-                                                                    } else if (!_mv_899.has_value) {
+                                                                    } else if (!_mv_900.has_value) {
                                                                     }
                                                                     i = (i + 1);
                                                                 }
@@ -1648,13 +1649,13 @@ void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_typ
                                                 break;
                                             }
                                         }
-                                    } else if (!_mv_896.has_value) {
+                                    } else if (!_mv_897.has_value) {
                                         context_ctx_add_error(ctx, SLOP_STR("Missing map expression"));
                                     }
-                                } else if (!_mv_895.has_value) {
+                                } else if (!_mv_896.has_value) {
                                     context_ctx_add_error(ctx, SLOP_STR("Missing value binding"));
                                 }
-                            } else if (!_mv_894.has_value) {
+                            } else if (!_mv_895.has_value) {
                                 context_ctx_add_error(ctx, SLOP_STR("Missing key binding"));
                             }
                         }
@@ -1666,7 +1667,7 @@ void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_typ
                     break;
                 }
             }
-        } else if (!_mv_892.has_value) {
+        } else if (!_mv_893.has_value) {
             context_ctx_add_error(ctx, SLOP_STR("Missing binding"));
         }
     }
@@ -1677,50 +1678,50 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_900 = (*expr);
-        switch (_mv_900.tag) {
+        __auto_type _mv_901 = (*expr);
+        switch (_mv_901.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_900.data.lst;
+                __auto_type lst = _mv_901.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 2) {
                         context_ctx_add_error_at(ctx, SLOP_STR("invalid for-each: need binding"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     } else {
-                        __auto_type _mv_901 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_901.has_value) {
-                            __auto_type binding_expr = _mv_901.value;
-                            __auto_type _mv_902 = (*binding_expr);
-                            switch (_mv_902.tag) {
+                        __auto_type _mv_902 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_902.has_value) {
+                            __auto_type binding_expr = _mv_902.value;
+                            __auto_type _mv_903 = (*binding_expr);
+                            switch (_mv_903.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type binding_lst = _mv_902.data.lst;
+                                    __auto_type binding_lst = _mv_903.data.lst;
                                     {
                                         __auto_type binding_items = binding_lst.items;
                                         __auto_type binding_len = ((int64_t)((binding_items).len));
                                         if (binding_len < 2) {
                                             context_ctx_add_error_at(ctx, SLOP_STR("for-each binding needs (var coll)"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                         } else {
-                                            __auto_type _mv_903 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_903.has_value) {
-                                                __auto_type first_elem = _mv_903.value;
-                                                __auto_type _mv_904 = (*first_elem);
-                                                switch (_mv_904.tag) {
+                                            __auto_type _mv_904 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_904.has_value) {
+                                                __auto_type first_elem = _mv_904.value;
+                                                __auto_type _mv_905 = (*first_elem);
+                                                switch (_mv_905.tag) {
                                                     case types_SExpr_lst:
                                                     {
-                                                        __auto_type _ = _mv_904.data.lst;
+                                                        __auto_type _ = _mv_905.data.lst;
                                                         stmt_transpile_for_each_map_kv(ctx, binding_items, items, len);
                                                         break;
                                                     }
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type var_sym = _mv_904.data.sym;
+                                                        __auto_type var_sym = _mv_905.data.sym;
                                                         {
                                                             __auto_type var_name = ctype_to_c_name(arena, var_sym.name);
-                                                            __auto_type _mv_905 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                            if (_mv_905.has_value) {
-                                                                __auto_type coll_expr = _mv_905.value;
+                                                            __auto_type _mv_906 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                            if (_mv_906.has_value) {
+                                                                __auto_type coll_expr = _mv_906.value;
                                                                 {
                                                                     __auto_type coll_slop_type = expr_infer_expr_slop_type(ctx, coll_expr);
                                                                     __auto_type resolved_type = expr_resolve_type_alias(ctx, coll_slop_type);
@@ -1753,11 +1754,11 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
                                                                             {
                                                                                 __auto_type i = 2;
                                                                                 while (i < len) {
-                                                                                    __auto_type _mv_906 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                                    if (_mv_906.has_value) {
-                                                                                        __auto_type body_expr = _mv_906.value;
+                                                                                    __auto_type _mv_907 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                                    if (_mv_907.has_value) {
+                                                                                        __auto_type body_expr = _mv_907.value;
                                                                                         stmt_transpile_stmt(ctx, body_expr, 0);
-                                                                                    } else if (!_mv_906.has_value) {
+                                                                                    } else if (!_mv_907.has_value) {
                                                                                     }
                                                                                     i = (i + 1);
                                                                                 }
@@ -1770,7 +1771,7 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
                                                                         }
                                                                     }
                                                                 }
-                                                            } else if (!_mv_905.has_value) {
+                                                            } else if (!_mv_906.has_value) {
                                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing collection"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                                             }
                                                         }
@@ -1781,7 +1782,7 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
                                                         break;
                                                     }
                                                 }
-                                            } else if (!_mv_903.has_value) {
+                                            } else if (!_mv_904.has_value) {
                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing var"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                             }
                                         }
@@ -1793,7 +1794,7 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_901.has_value) {
+                        } else if (!_mv_902.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing binding"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                     }
@@ -1811,24 +1812,24 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
 void stmt_transpile_stmt(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_907 = (*expr);
-    switch (_mv_907.tag) {
+    __auto_type _mv_908 = (*expr);
+    switch (_mv_908.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_907.data.lst;
+            __auto_type lst = _mv_908.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     context_ctx_add_error_at(ctx, SLOP_STR("empty list"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                 } else {
-                    __auto_type _mv_908 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_908.has_value) {
-                        __auto_type head_expr = _mv_908.value;
-                        __auto_type _mv_909 = (*head_expr);
-                        switch (_mv_909.tag) {
+                    __auto_type _mv_909 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_909.has_value) {
+                        __auto_type head_expr = _mv_909.value;
+                        __auto_type _mv_910 = (*head_expr);
+                        switch (_mv_910.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_909.data.sym;
+                                __auto_type sym = _mv_910.data.sym;
                                 {
                                     __auto_type op = sym.name;
                                     if (string_eq(op, SLOP_STR("let")) || string_eq(op, SLOP_STR("let*"))) {
@@ -1857,11 +1858,11 @@ void stmt_transpile_stmt(context_TranspileContext* ctx, types_SExpr* expr, uint8
                                         if (((int64_t)((items).len)) < 2) {
                                             context_ctx_emit(ctx, SLOP_STR("return;"));
                                         } else {
-                                            __auto_type _mv_910 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_910.has_value) {
-                                                __auto_type val_expr = _mv_910.value;
+                                            __auto_type _mv_911 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_911.has_value) {
+                                                __auto_type val_expr = _mv_911.value;
                                                 stmt_emit_typed_return_expr(ctx, val_expr);
-                                            } else if (!_mv_910.has_value) {
+                                            } else if (!_mv_911.has_value) {
                                                 context_ctx_emit(ctx, SLOP_STR("return;"));
                                             }
                                         }
@@ -1893,7 +1894,7 @@ void stmt_transpile_stmt(context_TranspileContext* ctx, types_SExpr* expr, uint8
                                 break;
                             }
                         }
-                    } else if (!_mv_908.has_value) {
+                    } else if (!_mv_909.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("empty"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     }
                 }
@@ -1916,61 +1917,61 @@ void stmt_transpile_stmt(context_TranspileContext* ctx, types_SExpr* expr, uint8
 void stmt_emit_typed_return_expr(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_911 = (*expr);
-    switch (_mv_911.tag) {
+    __auto_type _mv_912 = (*expr);
+    switch (_mv_912.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_911.data.lst;
+            __auto_type lst = _mv_912.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                 } else {
-                    __auto_type _mv_912 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_912.has_value) {
-                        __auto_type head = _mv_912.value;
-                        __auto_type _mv_913 = (*head);
-                        switch (_mv_913.tag) {
+                    __auto_type _mv_913 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_913.has_value) {
+                        __auto_type head = _mv_913.value;
+                        __auto_type _mv_914 = (*head);
+                        switch (_mv_914.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_913.data.sym;
+                                __auto_type sym = _mv_914.data.sym;
                                 {
                                     __auto_type op = sym.name;
                                     if (string_eq(op, SLOP_STR("some"))) {
-                                        __auto_type _mv_914 = context_ctx_get_current_return_type(ctx);
-                                        if (_mv_914.has_value) {
-                                            __auto_type ret_type = _mv_914.value;
+                                        __auto_type _mv_915 = context_ctx_get_current_return_type(ctx);
+                                        if (_mv_915.has_value) {
+                                            __auto_type ret_type = _mv_915.value;
                                             if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
                                                 if (((int64_t)((items).len)) < 2) {
                                                     stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                                                 } else {
-                                                    __auto_type _mv_915 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_915.has_value) {
-                                                        __auto_type inner_expr = _mv_915.value;
+                                                    __auto_type _mv_916 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_916.has_value) {
+                                                        __auto_type inner_expr = _mv_916.value;
                                                         {
                                                             __auto_type inner_c = expr_transpile_expr(ctx, inner_expr);
                                                             context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("return ("), ret_type, SLOP_STR("){.has_value = 1, .value = "), inner_c, SLOP_STR("};")));
                                                         }
-                                                    } else if (!_mv_915.has_value) {
+                                                    } else if (!_mv_916.has_value) {
                                                         stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                                                     }
                                                 }
                                             } else {
                                                 stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                                             }
-                                        } else if (!_mv_914.has_value) {
+                                        } else if (!_mv_915.has_value) {
                                             stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                                         }
                                     } else if (string_eq(op, SLOP_STR("none"))) {
-                                        __auto_type _mv_916 = context_ctx_get_current_return_type(ctx);
-                                        if (_mv_916.has_value) {
-                                            __auto_type ret_type = _mv_916.value;
+                                        __auto_type _mv_917 = context_ctx_get_current_return_type(ctx);
+                                        if (_mv_917.has_value) {
+                                            __auto_type ret_type = _mv_917.value;
                                             if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
                                                 context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("return ("), ret_type, SLOP_STR("){.has_value = false};")));
                                             } else {
                                                 stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                                             }
-                                        } else if (!_mv_916.has_value) {
+                                        } else if (!_mv_917.has_value) {
                                             stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                                         }
                                     } else {
@@ -1984,7 +1985,7 @@ void stmt_emit_typed_return_expr(context_TranspileContext* ctx, types_SExpr* exp
                                 break;
                             }
                         }
-                    } else if (!_mv_912.has_value) {
+                    } else if (!_mv_913.has_value) {
                         stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                     }
                 }
@@ -2003,22 +2004,22 @@ void stmt_emit_return_with_typed_none(context_TranspileContext* ctx, slop_string
     {
         __auto_type final_code = code;
         if (string_eq(code, SLOP_STR("none"))) {
-            __auto_type _mv_917 = context_ctx_get_current_return_type(ctx);
-            if (_mv_917.has_value) {
-                __auto_type ret_type = _mv_917.value;
-                if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
-                    final_code = context_ctx_str3(ctx, SLOP_STR("("), ret_type, SLOP_STR("){.has_value = false}"));
-                }
-            } else if (!_mv_917.has_value) {
-            }
-        } else {
             __auto_type _mv_918 = context_ctx_get_current_return_type(ctx);
             if (_mv_918.has_value) {
                 __auto_type ret_type = _mv_918.value;
                 if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
-                    __auto_type _mv_919 = context_ctx_lookup_var(ctx, code);
-                    if (_mv_919.has_value) {
-                        __auto_type var_entry = _mv_919.value;
+                    final_code = context_ctx_str3(ctx, SLOP_STR("("), ret_type, SLOP_STR("){.has_value = false}"));
+                }
+            } else if (!_mv_918.has_value) {
+            }
+        } else {
+            __auto_type _mv_919 = context_ctx_get_current_return_type(ctx);
+            if (_mv_919.has_value) {
+                __auto_type ret_type = _mv_919.value;
+                if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
+                    __auto_type _mv_920 = context_ctx_lookup_var(ctx, code);
+                    if (_mv_920.has_value) {
+                        __auto_type var_entry = _mv_920.value;
                         {
                             __auto_type var_type = var_entry.c_type;
                             if (string_eq(var_type, SLOP_STR("_slop_option_generic")) || string_eq(var_type, SLOP_STR("auto"))) {
@@ -2033,10 +2034,10 @@ void stmt_emit_return_with_typed_none(context_TranspileContext* ctx, slop_string
                                 }
                             }
                         }
-                    } else if (!_mv_919.has_value) {
+                    } else if (!_mv_920.has_value) {
                     }
                 }
-            } else if (!_mv_918.has_value) {
+            } else if (!_mv_919.has_value) {
             }
         }
         if (context_ctx_is_capture_retval(ctx)) {

--- a/bootstrap/compiler/slop_transpiler.c
+++ b/bootstrap/compiler/slop_transpiler.c
@@ -212,48 +212,48 @@ transpiler_GenericInfo transpiler_extract_generic_info(slop_arena* arena, slop_l
         __auto_type result_is_generic = 0;
         __auto_type result_type_params = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
         while (i < len) {
-            __auto_type _mv_1254 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1254.has_value) {
-                __auto_type item = _mv_1254.value;
-                __auto_type _mv_1255 = (*item);
-                switch (_mv_1255.tag) {
+            __auto_type _mv_1255 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1255.has_value) {
+                __auto_type item = _mv_1255.value;
+                __auto_type _mv_1256 = (*item);
+                switch (_mv_1256.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type lst = _mv_1255.data.lst;
+                        __auto_type lst = _mv_1256.data.lst;
                         {
                             __auto_type sub_items = lst.items;
                             if (((int64_t)((sub_items).len)) >= 1) {
-                                __auto_type _mv_1256 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1256.has_value) {
-                                    __auto_type head = _mv_1256.value;
-                                    __auto_type _mv_1257 = (*head);
-                                    switch (_mv_1257.tag) {
+                                __auto_type _mv_1257 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1257.has_value) {
+                                    __auto_type head = _mv_1257.value;
+                                    __auto_type _mv_1258 = (*head);
+                                    switch (_mv_1258.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_1257.data.sym;
+                                            __auto_type sym = _mv_1258.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("@generic"))) {
                                                 if (((int64_t)((sub_items).len)) >= 2) {
-                                                    __auto_type _mv_1258 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1258.has_value) {
-                                                        __auto_type params_expr = _mv_1258.value;
-                                                        __auto_type _mv_1259 = (*params_expr);
-                                                        switch (_mv_1259.tag) {
+                                                    __auto_type _mv_1259 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1259.has_value) {
+                                                        __auto_type params_expr = _mv_1259.value;
+                                                        __auto_type _mv_1260 = (*params_expr);
+                                                        switch (_mv_1260.tag) {
                                                             case types_SExpr_lst:
                                                             {
-                                                                __auto_type params_lst = _mv_1259.data.lst;
+                                                                __auto_type params_lst = _mv_1260.data.lst;
                                                                 {
                                                                     __auto_type param_items = params_lst.items;
                                                                     __auto_type param_len = ((int64_t)((param_items).len));
                                                                     __auto_type j = 0;
                                                                     while (j < param_len) {
-                                                                        __auto_type _mv_1260 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                        if (_mv_1260.has_value) {
-                                                                            __auto_type param = _mv_1260.value;
-                                                                            __auto_type _mv_1261 = (*param);
-                                                                            switch (_mv_1261.tag) {
+                                                                        __auto_type _mv_1261 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                        if (_mv_1261.has_value) {
+                                                                            __auto_type param = _mv_1261.value;
+                                                                            __auto_type _mv_1262 = (*param);
+                                                                            switch (_mv_1262.tag) {
                                                                                 case types_SExpr_sym:
                                                                                 {
-                                                                                    __auto_type param_sym = _mv_1261.data.sym;
+                                                                                    __auto_type param_sym = _mv_1262.data.sym;
                                                                                     ({ __auto_type _lst_p = &(result_type_params); __auto_type _item = (param_sym.name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                                                     break;
                                                                                 }
@@ -261,7 +261,7 @@ transpiler_GenericInfo transpiler_extract_generic_info(slop_arena* arena, slop_l
                                                                                     break;
                                                                                 }
                                                                             }
-                                                                        } else if (!_mv_1260.has_value) {
+                                                                        } else if (!_mv_1261.has_value) {
                                                                         }
                                                                         j = (j + 1);
                                                                     }
@@ -270,7 +270,7 @@ transpiler_GenericInfo transpiler_extract_generic_info(slop_arena* arena, slop_l
                                                             }
                                                             case types_SExpr_sym:
                                                             {
-                                                                __auto_type single_sym = _mv_1259.data.sym;
+                                                                __auto_type single_sym = _mv_1260.data.sym;
                                                                 ({ __auto_type _lst_p = &(result_type_params); __auto_type _item = (single_sym.name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                                 break;
                                                             }
@@ -278,7 +278,7 @@ transpiler_GenericInfo transpiler_extract_generic_info(slop_arena* arena, slop_l
                                                                 break;
                                                             }
                                                         }
-                                                    } else if (!_mv_1258.has_value) {
+                                                    } else if (!_mv_1259.has_value) {
                                                     }
                                                 }
                                             }
@@ -288,7 +288,7 @@ transpiler_GenericInfo transpiler_extract_generic_info(slop_arena* arena, slop_l
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1256.has_value) {
+                                } else if (!_mv_1257.has_value) {
                                 }
                             }
                         }
@@ -298,7 +298,7 @@ transpiler_GenericInfo transpiler_extract_generic_info(slop_arena* arena, slop_l
                         break;
                     }
                 }
-            } else if (!_mv_1254.has_value) {
+            } else if (!_mv_1255.has_value) {
             }
             i = (i + 1);
         }
@@ -312,11 +312,11 @@ void transpiler_prescan_module(context_TranspileContext* ctx, slop_list_types_SE
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1262 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1262.has_value) {
-                __auto_type item = _mv_1262.value;
+            __auto_type _mv_1263 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1263.has_value) {
+                __auto_type item = _mv_1263.value;
                 transpiler_prescan_top_level(ctx, item);
-            } else if (!_mv_1262.has_value) {
+            } else if (!_mv_1263.has_value) {
             }
             i = (i + 1);
         }
@@ -326,22 +326,22 @@ void transpiler_prescan_module(context_TranspileContext* ctx, slop_list_types_SE
 void transpiler_prescan_top_level(context_TranspileContext* ctx, types_SExpr* item) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1263 = (*item);
-    switch (_mv_1263.tag) {
+    __auto_type _mv_1264 = (*item);
+    switch (_mv_1264.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1263.data.lst;
+            __auto_type lst = _mv_1264.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) >= 1) {
-                    __auto_type _mv_1264 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1264.has_value) {
-                        __auto_type head = _mv_1264.value;
-                        __auto_type _mv_1265 = (*head);
-                        switch (_mv_1265.tag) {
+                    __auto_type _mv_1265 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1265.has_value) {
+                        __auto_type head = _mv_1265.value;
+                        __auto_type _mv_1266 = (*head);
+                        switch (_mv_1266.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1265.data.sym;
+                                __auto_type sym = _mv_1266.data.sym;
                                 {
                                     __auto_type name = sym.name;
                                     if (string_eq(name, SLOP_STR("type"))) {
@@ -365,7 +365,7 @@ void transpiler_prescan_top_level(context_TranspileContext* ctx, types_SExpr* it
                                 break;
                             }
                         }
-                    } else if (!_mv_1264.has_value) {
+                    } else if (!_mv_1265.has_value) {
                     }
                 }
             }
@@ -382,14 +382,14 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
     {
         __auto_type arena = (*ctx).arena;
         if (((int64_t)((items).len)) >= 2) {
-            __auto_type _mv_1266 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1266.has_value) {
-                __auto_type name_expr = _mv_1266.value;
-                __auto_type _mv_1267 = (*name_expr);
-                switch (_mv_1267.tag) {
+            __auto_type _mv_1267 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1267.has_value) {
+                __auto_type name_expr = _mv_1267.value;
+                __auto_type _mv_1268 = (*name_expr);
+                switch (_mv_1268.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_1267.data.sym;
+                        __auto_type sym = _mv_1268.data.sym;
                         {
                             __auto_type type_name = sym.name;
                             __auto_type base_c_name = ctype_to_c_name(arena, type_name);
@@ -408,14 +408,14 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
                                 }
                                 if (is_record || is_union) {
                                     if (((int64_t)((items).len)) >= 3) {
-                                        __auto_type _mv_1268 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1268.has_value) {
-                                            __auto_type def_expr = _mv_1268.value;
-                                            __auto_type _mv_1269 = (*def_expr);
-                                            switch (_mv_1269.tag) {
+                                        __auto_type _mv_1269 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1269.has_value) {
+                                            __auto_type def_expr = _mv_1269.value;
+                                            __auto_type _mv_1270 = (*def_expr);
+                                            switch (_mv_1270.tag) {
                                                 case types_SExpr_lst:
                                                 {
-                                                    __auto_type def_lst = _mv_1269.data.lst;
+                                                    __auto_type def_lst = _mv_1270.data.lst;
                                                     transpiler_scan_record_fields_for_generics(ctx, def_lst.items);
                                                     break;
                                                 }
@@ -423,7 +423,7 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
                                                     break;
                                                 }
                                             }
-                                        } else if (!_mv_1268.has_value) {
+                                        } else if (!_mv_1269.has_value) {
                                         }
                                     }
                                     {
@@ -433,9 +433,9 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
                                     }
                                 }
                                 if (((int64_t)((items).len)) >= 3) {
-                                    __auto_type _mv_1270 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_1270.has_value) {
-                                        __auto_type body_expr = _mv_1270.value;
+                                    __auto_type _mv_1271 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_1271.has_value) {
+                                        __auto_type body_expr = _mv_1271.value;
                                         transpiler_check_and_register_result_alias(ctx, type_name, body_expr);
                                         {
                                             __auto_type slop_type_str = parser_pretty_print(arena, body_expr);
@@ -446,7 +446,7 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
                                                 transpiler_scan_type_for_generics(ctx, body_expr);
                                             }
                                         }
-                                    } else if (!_mv_1270.has_value) {
+                                    } else if (!_mv_1271.has_value) {
                                     }
                                 }
                             }
@@ -457,7 +457,7 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
                         break;
                     }
                 }
-            } else if (!_mv_1266.has_value) {
+            } else if (!_mv_1267.has_value) {
             }
         }
     }
@@ -466,42 +466,42 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
 void transpiler_register_enum_variants(context_TranspileContext* ctx, slop_string enum_name, slop_list_types_SExpr_ptr items) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     if (((int64_t)((items).len)) >= 3) {
-        __auto_type _mv_1271 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1271.has_value) {
-            __auto_type def_expr = _mv_1271.value;
-            __auto_type _mv_1272 = (*def_expr);
-            switch (_mv_1272.tag) {
+        __auto_type _mv_1272 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1272.has_value) {
+            __auto_type def_expr = _mv_1272.value;
+            __auto_type _mv_1273 = (*def_expr);
+            switch (_mv_1273.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type def_lst = _mv_1272.data.lst;
+                    __auto_type def_lst = _mv_1273.data.lst;
                     {
                         __auto_type def_items = def_lst.items;
                         __auto_type len = ((int64_t)((def_items).len));
                         __auto_type i = 1;
                         while (i < len) {
-                            __auto_type _mv_1273 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1273.has_value) {
-                                __auto_type variant_expr = _mv_1273.value;
-                                __auto_type _mv_1274 = (*variant_expr);
-                                switch (_mv_1274.tag) {
+                            __auto_type _mv_1274 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1274.has_value) {
+                                __auto_type variant_expr = _mv_1274.value;
+                                __auto_type _mv_1275 = (*variant_expr);
+                                switch (_mv_1275.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1274.data.sym;
+                                        __auto_type sym = _mv_1275.data.sym;
                                         context_ctx_register_enum_variant(ctx, sym.name, enum_name);
                                         break;
                                     }
                                     case types_SExpr_lst:
                                     {
-                                        __auto_type variant_lst = _mv_1274.data.lst;
+                                        __auto_type variant_lst = _mv_1275.data.lst;
                                         if (((int64_t)((variant_lst.items).len)) > 0) {
-                                            __auto_type _mv_1275 = ({ __auto_type _lst = variant_lst.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1275.has_value) {
-                                                __auto_type name_expr = _mv_1275.value;
-                                                __auto_type _mv_1276 = (*name_expr);
-                                                switch (_mv_1276.tag) {
+                                            __auto_type _mv_1276 = ({ __auto_type _lst = variant_lst.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1276.has_value) {
+                                                __auto_type name_expr = _mv_1276.value;
+                                                __auto_type _mv_1277 = (*name_expr);
+                                                switch (_mv_1277.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type name_sym = _mv_1276.data.sym;
+                                                        __auto_type name_sym = _mv_1277.data.sym;
                                                         context_ctx_register_enum_variant(ctx, name_sym.name, enum_name);
                                                         break;
                                                     }
@@ -509,7 +509,7 @@ void transpiler_register_enum_variants(context_TranspileContext* ctx, slop_strin
                                                         break;
                                                     }
                                                 }
-                                            } else if (!_mv_1275.has_value) {
+                                            } else if (!_mv_1276.has_value) {
                                             }
                                         }
                                         break;
@@ -518,7 +518,7 @@ void transpiler_register_enum_variants(context_TranspileContext* ctx, slop_strin
                                         break;
                                     }
                                 }
-                            } else if (!_mv_1273.has_value) {
+                            } else if (!_mv_1274.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -529,7 +529,7 @@ void transpiler_register_enum_variants(context_TranspileContext* ctx, slop_strin
                     break;
                 }
             }
-        } else if (!_mv_1271.has_value) {
+        } else if (!_mv_1272.has_value) {
         }
     }
 }
@@ -539,27 +539,27 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
     {
         __auto_type arena = (*ctx).arena;
         if (((int64_t)((items).len)) >= 3) {
-            __auto_type _mv_1277 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1277.has_value) {
-                __auto_type def_expr = _mv_1277.value;
-                __auto_type _mv_1278 = (*def_expr);
-                switch (_mv_1278.tag) {
+            __auto_type _mv_1278 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1278.has_value) {
+                __auto_type def_expr = _mv_1278.value;
+                __auto_type _mv_1279 = (*def_expr);
+                switch (_mv_1279.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type def_lst = _mv_1278.data.lst;
+                        __auto_type def_lst = _mv_1279.data.lst;
                         {
                             __auto_type def_items = def_lst.items;
                             __auto_type len = ((int64_t)((def_items).len));
                             __auto_type i = 1;
                             while (i < len) {
-                                __auto_type _mv_1279 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1279.has_value) {
-                                    __auto_type variant_expr = _mv_1279.value;
-                                    __auto_type _mv_1280 = (*variant_expr);
-                                    switch (_mv_1280.tag) {
+                                __auto_type _mv_1280 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1280.has_value) {
+                                    __auto_type variant_expr = _mv_1280.value;
+                                    __auto_type _mv_1281 = (*variant_expr);
+                                    switch (_mv_1281.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_1280.data.sym;
+                                            __auto_type sym = _mv_1281.data.sym;
                                             {
                                                 __auto_type variant_name = sym.name;
                                                 context_ctx_register_enum_variant(ctx, variant_name, union_name);
@@ -569,26 +569,26 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                         }
                                         case types_SExpr_lst:
                                         {
-                                            __auto_type variant_lst = _mv_1280.data.lst;
+                                            __auto_type variant_lst = _mv_1281.data.lst;
                                             {
                                                 __auto_type vl_items = variant_lst.items;
                                                 __auto_type vl_len = ((int64_t)((vl_items).len));
                                                 if (vl_len >= 2) {
-                                                    __auto_type _mv_1281 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1281.has_value) {
-                                                        __auto_type name_expr = _mv_1281.value;
-                                                        __auto_type _mv_1282 = (*name_expr);
-                                                        switch (_mv_1282.tag) {
+                                                    __auto_type _mv_1282 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1282.has_value) {
+                                                        __auto_type name_expr = _mv_1282.value;
+                                                        __auto_type _mv_1283 = (*name_expr);
+                                                        switch (_mv_1283.tag) {
                                                             case types_SExpr_sym:
                                                             {
-                                                                __auto_type name_sym = _mv_1282.data.sym;
+                                                                __auto_type name_sym = _mv_1283.data.sym;
                                                                 {
                                                                     __auto_type variant_name = name_sym.name;
                                                                     __auto_type c_variant_name = ctype_to_c_name(arena, variant_name);
                                                                     context_ctx_register_enum_variant(ctx, variant_name, union_name);
-                                                                    __auto_type _mv_1283 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                    if (_mv_1283.has_value) {
-                                                                        __auto_type type_expr = _mv_1283.value;
+                                                                    __auto_type _mv_1284 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                    if (_mv_1284.has_value) {
+                                                                        __auto_type type_expr = _mv_1284.value;
                                                                         {
                                                                             __auto_type slop_type = parser_pretty_print(arena, type_expr);
                                                                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
@@ -596,7 +596,7 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                                                             context_ctx_register_union_variant(ctx, variant_name, union_name, c_variant_name, slop_type, c_type);
                                                                             context_ctx_register_field_type(ctx, union_name, variant_name, c_type, slop_type, is_ptr);
                                                                         }
-                                                                    } else if (!_mv_1283.has_value) {
+                                                                    } else if (!_mv_1284.has_value) {
                                                                         context_ctx_register_union_variant(ctx, variant_name, union_name, c_variant_name, SLOP_STR(""), SLOP_STR(""));
                                                                     }
                                                                     if (vl_len >= 3) {
@@ -606,9 +606,9 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                                                             context_ctx_register_field_type(ctx, union_name, count_key, count_str, SLOP_STR(""), 0);
                                                                         }
                                                                         for (int64_t fi = 1; fi < vl_len; fi++) {
-                                                                            __auto_type _mv_1284 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                            if (_mv_1284.has_value) {
-                                                                                __auto_type type_expr = _mv_1284.value;
+                                                                            __auto_type _mv_1285 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                            if (_mv_1285.has_value) {
+                                                                                __auto_type type_expr = _mv_1285.value;
                                                                                 {
                                                                                     __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                                                     __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
@@ -616,7 +616,7 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                                                                     __auto_type field_key = context_ctx_str3(ctx, variant_name, SLOP_STR("__"), int_to_string(arena, (fi - 1)));
                                                                                     context_ctx_register_field_type(ctx, union_name, field_key, c_type, slop_type_str, is_ptr);
                                                                                 }
-                                                                            } else if (!_mv_1284.has_value) {
+                                                                            } else if (!_mv_1285.has_value) {
                                                                             }
                                                                         }
                                                                     }
@@ -627,18 +627,18 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                                                 break;
                                                             }
                                                         }
-                                                    } else if (!_mv_1281.has_value) {
+                                                    } else if (!_mv_1282.has_value) {
                                                     }
                                                 } else {
                                                     if (((int64_t)((vl_items).len)) == 1) {
-                                                        __auto_type _mv_1285 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                        if (_mv_1285.has_value) {
-                                                            __auto_type name_expr = _mv_1285.value;
-                                                            __auto_type _mv_1286 = (*name_expr);
-                                                            switch (_mv_1286.tag) {
+                                                        __auto_type _mv_1286 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                        if (_mv_1286.has_value) {
+                                                            __auto_type name_expr = _mv_1286.value;
+                                                            __auto_type _mv_1287 = (*name_expr);
+                                                            switch (_mv_1287.tag) {
                                                                 case types_SExpr_sym:
                                                                 {
-                                                                    __auto_type name_sym = _mv_1286.data.sym;
+                                                                    __auto_type name_sym = _mv_1287.data.sym;
                                                                     {
                                                                         __auto_type variant_name = name_sym.name;
                                                                         context_ctx_register_enum_variant(ctx, variant_name, union_name);
@@ -650,7 +650,7 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                                                     break;
                                                                 }
                                                             }
-                                                        } else if (!_mv_1285.has_value) {
+                                                        } else if (!_mv_1286.has_value) {
                                                         }
                                                     }
                                                 }
@@ -661,7 +661,7 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1279.has_value) {
+                                } else if (!_mv_1280.has_value) {
                                 }
                                 i = (i + 1);
                             }
@@ -672,7 +672,7 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                         break;
                     }
                 }
-            } else if (!_mv_1277.has_value) {
+            } else if (!_mv_1278.has_value) {
             }
         }
     }
@@ -683,14 +683,14 @@ void transpiler_prescan_fn(context_TranspileContext* ctx, slop_list_types_SExpr_
     {
         __auto_type arena = (*ctx).arena;
         if (((int64_t)((items).len)) >= 2) {
-            __auto_type _mv_1287 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1287.has_value) {
-                __auto_type name_expr = _mv_1287.value;
-                __auto_type _mv_1288 = (*name_expr);
-                switch (_mv_1288.tag) {
+            __auto_type _mv_1288 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1288.has_value) {
+                __auto_type name_expr = _mv_1288.value;
+                __auto_type _mv_1289 = (*name_expr);
+                switch (_mv_1289.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_1288.data.sym;
+                        __auto_type sym = _mv_1289.data.sym;
                         {
                             __auto_type fn_name = sym.name;
                             __auto_type base_name = ctype_to_c_name(arena, fn_name);
@@ -720,7 +720,7 @@ void transpiler_prescan_fn(context_TranspileContext* ctx, slop_list_types_SExpr_
                         break;
                     }
                 }
-            } else if (!_mv_1287.has_value) {
+            } else if (!_mv_1288.has_value) {
             }
         }
     }
@@ -732,46 +732,46 @@ uint8_t transpiler_fn_returns_string(slop_list_types_SExpr_ptr items) {
         int64_t i = 3;
         uint8_t result = 0;
         while ((i < len) && !(result)) {
-            __auto_type _mv_1289 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1289.has_value) {
-                __auto_type item = _mv_1289.value;
-                __auto_type _mv_1290 = (*item);
-                switch (_mv_1290.tag) {
+            __auto_type _mv_1290 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1290.has_value) {
+                __auto_type item = _mv_1290.value;
+                __auto_type _mv_1291 = (*item);
+                switch (_mv_1291.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type lst = _mv_1290.data.lst;
+                        __auto_type lst = _mv_1291.data.lst;
                         {
                             __auto_type sub_items = lst.items;
                             if (((int64_t)((sub_items).len)) >= 2) {
-                                __auto_type _mv_1291 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1291.has_value) {
-                                    __auto_type head = _mv_1291.value;
-                                    __auto_type _mv_1292 = (*head);
-                                    switch (_mv_1292.tag) {
+                                __auto_type _mv_1292 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1292.has_value) {
+                                    __auto_type head = _mv_1292.value;
+                                    __auto_type _mv_1293 = (*head);
+                                    switch (_mv_1293.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_1292.data.sym;
+                                            __auto_type sym = _mv_1293.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("@spec"))) {
-                                                __auto_type _mv_1293 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1293.has_value) {
-                                                    __auto_type spec_body = _mv_1293.value;
-                                                    __auto_type _mv_1294 = (*spec_body);
-                                                    switch (_mv_1294.tag) {
+                                                __auto_type _mv_1294 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1294.has_value) {
+                                                    __auto_type spec_body = _mv_1294.value;
+                                                    __auto_type _mv_1295 = (*spec_body);
+                                                    switch (_mv_1295.tag) {
                                                         case types_SExpr_lst:
                                                         {
-                                                            __auto_type body_lst = _mv_1294.data.lst;
+                                                            __auto_type body_lst = _mv_1295.data.lst;
                                                             {
                                                                 __auto_type body_items = body_lst.items;
                                                                 __auto_type body_len = ((int64_t)((body_items).len));
                                                                 if (body_len >= 1) {
-                                                                    __auto_type _mv_1295 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                    if (_mv_1295.has_value) {
-                                                                        __auto_type ret_type = _mv_1295.value;
-                                                                        __auto_type _mv_1296 = (*ret_type);
-                                                                        switch (_mv_1296.tag) {
+                                                                    __auto_type _mv_1296 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                    if (_mv_1296.has_value) {
+                                                                        __auto_type ret_type = _mv_1296.value;
+                                                                        __auto_type _mv_1297 = (*ret_type);
+                                                                        switch (_mv_1297.tag) {
                                                                             case types_SExpr_sym:
                                                                             {
-                                                                                __auto_type ret_sym = _mv_1296.data.sym;
+                                                                                __auto_type ret_sym = _mv_1297.data.sym;
                                                                                 result = string_eq(ret_sym.name, SLOP_STR("String"));
                                                                                 break;
                                                                             }
@@ -779,7 +779,7 @@ uint8_t transpiler_fn_returns_string(slop_list_types_SExpr_ptr items) {
                                                                                 break;
                                                                             }
                                                                         }
-                                                                    } else if (!_mv_1295.has_value) {
+                                                                    } else if (!_mv_1296.has_value) {
                                                                     }
                                                                 }
                                                             }
@@ -789,7 +789,7 @@ uint8_t transpiler_fn_returns_string(slop_list_types_SExpr_ptr items) {
                                                             break;
                                                         }
                                                     }
-                                                } else if (!_mv_1293.has_value) {
+                                                } else if (!_mv_1294.has_value) {
                                                 }
                                             }
                                             break;
@@ -798,7 +798,7 @@ uint8_t transpiler_fn_returns_string(slop_list_types_SExpr_ptr items) {
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1291.has_value) {
+                                } else if (!_mv_1292.has_value) {
                                 }
                             }
                         }
@@ -808,7 +808,7 @@ uint8_t transpiler_fn_returns_string(slop_list_types_SExpr_ptr items) {
                         break;
                     }
                 }
-            } else if (!_mv_1289.has_value) {
+            } else if (!_mv_1290.has_value) {
             }
             i = (i + 1);
         }
@@ -823,43 +823,43 @@ slop_string transpiler_fn_return_type(context_TranspileContext* ctx, slop_list_t
         int64_t i = 3;
         __auto_type result = SLOP_STR("");
         while ((i < len) && string_eq(result, SLOP_STR(""))) {
-            __auto_type _mv_1297 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1297.has_value) {
-                __auto_type item = _mv_1297.value;
-                __auto_type _mv_1298 = (*item);
-                switch (_mv_1298.tag) {
+            __auto_type _mv_1298 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1298.has_value) {
+                __auto_type item = _mv_1298.value;
+                __auto_type _mv_1299 = (*item);
+                switch (_mv_1299.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type lst = _mv_1298.data.lst;
+                        __auto_type lst = _mv_1299.data.lst;
                         {
                             __auto_type sub_items = lst.items;
                             if (((int64_t)((sub_items).len)) >= 2) {
-                                __auto_type _mv_1299 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1299.has_value) {
-                                    __auto_type head = _mv_1299.value;
-                                    __auto_type _mv_1300 = (*head);
-                                    switch (_mv_1300.tag) {
+                                __auto_type _mv_1300 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1300.has_value) {
+                                    __auto_type head = _mv_1300.value;
+                                    __auto_type _mv_1301 = (*head);
+                                    switch (_mv_1301.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_1300.data.sym;
+                                            __auto_type sym = _mv_1301.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("@spec"))) {
-                                                __auto_type _mv_1301 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1301.has_value) {
-                                                    __auto_type spec_body = _mv_1301.value;
-                                                    __auto_type _mv_1302 = (*spec_body);
-                                                    switch (_mv_1302.tag) {
+                                                __auto_type _mv_1302 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1302.has_value) {
+                                                    __auto_type spec_body = _mv_1302.value;
+                                                    __auto_type _mv_1303 = (*spec_body);
+                                                    switch (_mv_1303.tag) {
                                                         case types_SExpr_lst:
                                                         {
-                                                            __auto_type body_lst = _mv_1302.data.lst;
+                                                            __auto_type body_lst = _mv_1303.data.lst;
                                                             {
                                                                 __auto_type body_items = body_lst.items;
                                                                 __auto_type body_len = ((int64_t)((body_items).len));
                                                                 if (body_len >= 1) {
-                                                                    __auto_type _mv_1303 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                    if (_mv_1303.has_value) {
-                                                                        __auto_type ret_type = _mv_1303.value;
+                                                                    __auto_type _mv_1304 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                    if (_mv_1304.has_value) {
+                                                                        __auto_type ret_type = _mv_1304.value;
                                                                         result = context_to_c_type_prefixed(ctx, ret_type);
-                                                                    } else if (!_mv_1303.has_value) {
+                                                                    } else if (!_mv_1304.has_value) {
                                                                     }
                                                                 }
                                                             }
@@ -869,7 +869,7 @@ slop_string transpiler_fn_return_type(context_TranspileContext* ctx, slop_list_t
                                                             break;
                                                         }
                                                     }
-                                                } else if (!_mv_1301.has_value) {
+                                                } else if (!_mv_1302.has_value) {
                                                 }
                                             }
                                             break;
@@ -878,7 +878,7 @@ slop_string transpiler_fn_return_type(context_TranspileContext* ctx, slop_list_t
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1299.has_value) {
+                                } else if (!_mv_1300.has_value) {
                                 }
                             }
                         }
@@ -888,7 +888,7 @@ slop_string transpiler_fn_return_type(context_TranspileContext* ctx, slop_list_t
                         break;
                     }
                 }
-            } else if (!_mv_1297.has_value) {
+            } else if (!_mv_1298.has_value) {
             }
             i = (i + 1);
         }
@@ -899,35 +899,35 @@ slop_string transpiler_fn_return_type(context_TranspileContext* ctx, slop_list_t
 void transpiler_prescan_fn_params(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     if (((int64_t)((items).len)) >= 3) {
-        __auto_type _mv_1304 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1304.has_value) {
-            __auto_type params_expr = _mv_1304.value;
-            __auto_type _mv_1305 = (*params_expr);
-            switch (_mv_1305.tag) {
+        __auto_type _mv_1305 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1305.has_value) {
+            __auto_type params_expr = _mv_1305.value;
+            __auto_type _mv_1306 = (*params_expr);
+            switch (_mv_1306.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type params_lst = _mv_1305.data.lst;
+                    __auto_type params_lst = _mv_1306.data.lst;
                     {
                         __auto_type params = params_lst.items;
                         __auto_type param_count = ((int64_t)((params).len));
                         __auto_type i = 0;
                         while (i < param_count) {
-                            __auto_type _mv_1306 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1306.has_value) {
-                                __auto_type param_expr = _mv_1306.value;
-                                __auto_type _mv_1307 = (*param_expr);
-                                switch (_mv_1307.tag) {
+                            __auto_type _mv_1307 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1307.has_value) {
+                                __auto_type param_expr = _mv_1307.value;
+                                __auto_type _mv_1308 = (*param_expr);
+                                switch (_mv_1308.tag) {
                                     case types_SExpr_lst:
                                     {
-                                        __auto_type param_lst = _mv_1307.data.lst;
+                                        __auto_type param_lst = _mv_1308.data.lst;
                                         {
                                             __auto_type param_items = param_lst.items;
                                             if (((int64_t)((param_items).len)) >= 2) {
-                                                __auto_type _mv_1308 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1308.has_value) {
-                                                    __auto_type type_expr = _mv_1308.value;
+                                                __auto_type _mv_1309 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1309.has_value) {
+                                                    __auto_type type_expr = _mv_1309.value;
                                                     transpiler_scan_type_for_generics(ctx, type_expr);
-                                                } else if (!_mv_1308.has_value) {
+                                                } else if (!_mv_1309.has_value) {
                                                 }
                                             }
                                         }
@@ -937,7 +937,7 @@ void transpiler_prescan_fn_params(context_TranspileContext* ctx, slop_list_types
                                         break;
                                     }
                                 }
-                            } else if (!_mv_1306.has_value) {
+                            } else if (!_mv_1307.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -948,7 +948,7 @@ void transpiler_prescan_fn_params(context_TranspileContext* ctx, slop_list_types
                     break;
                 }
             }
-        } else if (!_mv_1304.has_value) {
+        } else if (!_mv_1305.has_value) {
         }
     }
 }
@@ -959,29 +959,29 @@ slop_list_context_FuncParamType_ptr transpiler_prescan_collect_param_types(conte
         __auto_type arena = (*ctx).arena;
         __auto_type result = ((slop_list_context_FuncParamType_ptr){ .data = (context_FuncParamType**)slop_arena_alloc(arena, 16 * sizeof(context_FuncParamType*)), .len = 0, .cap = 16 });
         if (((int64_t)((items).len)) >= 3) {
-            __auto_type _mv_1309 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1309.has_value) {
-                __auto_type params_expr = _mv_1309.value;
-                __auto_type _mv_1310 = (*params_expr);
-                switch (_mv_1310.tag) {
+            __auto_type _mv_1310 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1310.has_value) {
+                __auto_type params_expr = _mv_1310.value;
+                __auto_type _mv_1311 = (*params_expr);
+                switch (_mv_1311.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type params_lst = _mv_1310.data.lst;
+                        __auto_type params_lst = _mv_1311.data.lst;
                         {
                             __auto_type params = params_lst.items;
                             __auto_type param_count = ((int64_t)((params).len));
                             __auto_type i = 0;
                             while (i < param_count) {
-                                __auto_type _mv_1311 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1311.has_value) {
-                                    __auto_type param_expr = _mv_1311.value;
+                                __auto_type _mv_1312 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1312.has_value) {
+                                    __auto_type param_expr = _mv_1312.value;
                                     {
                                         __auto_type c_type = transpiler_prescan_get_param_c_type(ctx, param_expr);
                                         __auto_type param_info = ((context_FuncParamType*)(({ __auto_type _alloc = (context_FuncParamType*)slop_arena_alloc(arena, sizeof(context_FuncParamType)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                                         (*param_info).c_type = c_type;
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (param_info); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
-                                } else if (!_mv_1311.has_value) {
+                                } else if (!_mv_1312.has_value) {
                                 }
                                 i = (i + 1);
                             }
@@ -992,7 +992,7 @@ slop_list_context_FuncParamType_ptr transpiler_prescan_collect_param_types(conte
                         break;
                     }
                 }
-            } else if (!_mv_1309.has_value) {
+            } else if (!_mv_1310.has_value) {
             }
         }
         return result;
@@ -1004,11 +1004,11 @@ slop_string transpiler_prescan_get_param_c_type(context_TranspileContext* ctx, t
     SLOP_PRE(((param != NULL)), "(!= param nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1312 = (*param);
-        switch (_mv_1312.tag) {
+        __auto_type _mv_1313 = (*param);
+        switch (_mv_1313.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1312.data.lst;
+                __auto_type lst = _mv_1313.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -1018,11 +1018,11 @@ slop_string transpiler_prescan_get_param_c_type(context_TranspileContext* ctx, t
                         {
                             __auto_type has_mode = ((len >= 3) && transpiler_prescan_is_param_mode(items));
                             __auto_type type_idx = ((has_mode) ? 2 : 1);
-                            __auto_type _mv_1313 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1313.has_value) {
-                                __auto_type type_expr = _mv_1313.value;
+                            __auto_type _mv_1314 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1314.has_value) {
+                                __auto_type type_expr = _mv_1314.value;
                                 return context_to_c_type_prefixed(ctx, type_expr);
-                            } else if (!_mv_1313.has_value) {
+                            } else if (!_mv_1314.has_value) {
                                 return SLOP_STR("void*");
                             }
                             SLOP_UNREACHABLE();
@@ -1041,14 +1041,14 @@ uint8_t transpiler_prescan_is_param_mode(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_1314 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1314.has_value) {
-            __auto_type first = _mv_1314.value;
-            __auto_type _mv_1315 = (*first);
-            switch (_mv_1315.tag) {
+        __auto_type _mv_1315 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1315.has_value) {
+            __auto_type first = _mv_1315.value;
+            __auto_type _mv_1316 = (*first);
+            switch (_mv_1316.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_1315.data.sym;
+                    __auto_type sym = _mv_1316.data.sym;
                     {
                         __auto_type name = sym.name;
                         if (string_eq(name, SLOP_STR("in"))) {
@@ -1068,7 +1068,7 @@ uint8_t transpiler_prescan_is_param_mode(slop_list_types_SExpr_ptr items) {
                     return 0;
                 }
             }
-        } else if (!_mv_1314.has_value) {
+        } else if (!_mv_1315.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -1082,13 +1082,13 @@ void transpiler_prescan_fn_result_type(context_TranspileContext* ctx, slop_list_
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 3;
         while (i < len) {
-            __auto_type _mv_1316 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1316.has_value) {
-                __auto_type item = _mv_1316.value;
+            __auto_type _mv_1317 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1317.has_value) {
+                __auto_type item = _mv_1317.value;
                 if (transpiler_is_spec_annotation(item)) {
                     transpiler_extract_result_type(ctx, item);
                 }
-            } else if (!_mv_1316.has_value) {
+            } else if (!_mv_1317.has_value) {
             }
             i = (i + 1);
         }
@@ -1097,31 +1097,31 @@ void transpiler_prescan_fn_result_type(context_TranspileContext* ctx, slop_list_
 
 uint8_t transpiler_is_spec_annotation(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1317 = (*expr);
-    switch (_mv_1317.tag) {
+    __auto_type _mv_1318 = (*expr);
+    switch (_mv_1318.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1317.data.lst;
+            __auto_type lst = _mv_1318.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1318 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1318.has_value) {
-                        __auto_type head = _mv_1318.value;
-                        __auto_type _mv_1319 = (*head);
-                        switch (_mv_1319.tag) {
+                    __auto_type _mv_1319 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1319.has_value) {
+                        __auto_type head = _mv_1319.value;
+                        __auto_type _mv_1320 = (*head);
+                        switch (_mv_1320.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1319.data.sym;
+                                __auto_type sym = _mv_1320.data.sym;
                                 return string_eq(sym.name, SLOP_STR("@spec"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1318.has_value) {
+                    } else if (!_mv_1319.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1139,32 +1139,32 @@ void transpiler_extract_result_type(context_TranspileContext* ctx, types_SExpr* 
     SLOP_PRE(((spec_expr != NULL)), "(!= spec-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1320 = (*spec_expr);
-        switch (_mv_1320.tag) {
+        __auto_type _mv_1321 = (*spec_expr);
+        switch (_mv_1321.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1320.data.lst;
+                __auto_type lst = _mv_1321.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_1321 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1321.has_value) {
-                            __auto_type spec_body = _mv_1321.value;
-                            __auto_type _mv_1322 = (*spec_body);
-                            switch (_mv_1322.tag) {
+                        __auto_type _mv_1322 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1322.has_value) {
+                            __auto_type spec_body = _mv_1322.value;
+                            __auto_type _mv_1323 = (*spec_body);
+                            switch (_mv_1323.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type body_lst = _mv_1322.data.lst;
+                                    __auto_type body_lst = _mv_1323.data.lst;
                                     {
                                         __auto_type body_items = body_lst.items;
                                         __auto_type body_len = ((int64_t)((body_items).len));
                                         if (body_len >= 1) {
-                                            __auto_type _mv_1323 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1323.has_value) {
-                                                __auto_type ret_type = _mv_1323.value;
+                                            __auto_type _mv_1324 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1324.has_value) {
+                                                __auto_type ret_type = _mv_1324.value;
                                                 transpiler_scan_type_for_generics(ctx, ret_type);
                                                 transpiler_check_and_register_result_type(ctx, ret_type);
-                                            } else if (!_mv_1323.has_value) {
+                                            } else if (!_mv_1324.has_value) {
                                             }
                                         }
                                     }
@@ -1174,7 +1174,7 @@ void transpiler_extract_result_type(context_TranspileContext* ctx, types_SExpr* 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1321.has_value) {
+                        } else if (!_mv_1322.has_value) {
                         }
                     }
                 }
@@ -1192,38 +1192,38 @@ void transpiler_check_and_register_result_type(context_TranspileContext* ctx, ty
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1324 = (*type_expr);
-        switch (_mv_1324.tag) {
+        __auto_type _mv_1325 = (*type_expr);
+        switch (_mv_1325.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1324.data.lst;
+                __auto_type lst = _mv_1325.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_1325 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1325.has_value) {
-                            __auto_type head = _mv_1325.value;
-                            __auto_type _mv_1326 = (*head);
-                            switch (_mv_1326.tag) {
+                        __auto_type _mv_1326 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1326.has_value) {
+                            __auto_type head = _mv_1326.value;
+                            __auto_type _mv_1327 = (*head);
+                            switch (_mv_1327.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1326.data.sym;
+                                    __auto_type sym = _mv_1327.data.sym;
                                     if (string_eq(sym.name, SLOP_STR("Result"))) {
-                                        __auto_type _mv_1327 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1327.has_value) {
-                                            __auto_type ok_type_expr = _mv_1327.value;
-                                            __auto_type _mv_1328 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1328.has_value) {
-                                                __auto_type err_type_expr = _mv_1328.value;
+                                        __auto_type _mv_1328 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1328.has_value) {
+                                            __auto_type ok_type_expr = _mv_1328.value;
+                                            __auto_type _mv_1329 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1329.has_value) {
+                                                __auto_type err_type_expr = _mv_1329.value;
                                                 {
                                                     __auto_type ok_c_type = context_to_c_type_prefixed(ctx, ok_type_expr);
                                                     __auto_type err_c_type = context_to_c_type_prefixed(ctx, err_type_expr);
                                                     __auto_type result_name = transpiler_build_result_type_name(ctx, ok_c_type, err_c_type);
                                                     context_ctx_register_result_type(ctx, ok_c_type, err_c_type, result_name);
                                                 }
-                                            } else if (!_mv_1328.has_value) {
+                                            } else if (!_mv_1329.has_value) {
                                             }
-                                        } else if (!_mv_1327.has_value) {
+                                        } else if (!_mv_1328.has_value) {
                                         }
                                     }
                                     break;
@@ -1232,7 +1232,7 @@ void transpiler_check_and_register_result_type(context_TranspileContext* ctx, ty
                                     break;
                                 }
                             }
-                        } else if (!_mv_1325.has_value) {
+                        } else if (!_mv_1326.has_value) {
                         }
                     }
                 }
@@ -1261,11 +1261,11 @@ void transpiler_prescan_fn_for_struct_keys(context_TranspileContext* ctx, slop_l
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 3;
         while (i < len) {
-            __auto_type _mv_1329 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1329.has_value) {
-                __auto_type item = _mv_1329.value;
+            __auto_type _mv_1330 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1330.has_value) {
+                __auto_type item = _mv_1330.value;
                 transpiler_prescan_expr_for_struct_keys(ctx, item);
-            } else if (!_mv_1329.has_value) {
+            } else if (!_mv_1330.has_value) {
             }
             i = (i + 1);
         }
@@ -1275,59 +1275,45 @@ void transpiler_prescan_fn_for_struct_keys(context_TranspileContext* ctx, slop_l
 void transpiler_prescan_expr_for_struct_keys(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1330 = (*expr);
-    switch (_mv_1330.tag) {
+    __auto_type _mv_1331 = (*expr);
+    switch (_mv_1331.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1330.data.lst;
+            __auto_type lst = _mv_1331.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 if (len >= 1) {
-                    __auto_type _mv_1331 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1331.has_value) {
-                        __auto_type head = _mv_1331.value;
-                        __auto_type _mv_1332 = (*head);
-                        switch (_mv_1332.tag) {
+                    __auto_type _mv_1332 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1332.has_value) {
+                        __auto_type head = _mv_1332.value;
+                        __auto_type _mv_1333 = (*head);
+                        switch (_mv_1333.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1332.data.sym;
+                                __auto_type sym = _mv_1333.data.sym;
                                 {
                                     __auto_type name = sym.name;
                                     if (string_eq(name, SLOP_STR("map-new"))) {
                                         if (len >= 3) {
-                                            __auto_type _mv_1333 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1333.has_value) {
-                                                __auto_type key_type_expr = _mv_1333.value;
+                                            __auto_type _mv_1334 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1334.has_value) {
+                                                __auto_type key_type_expr = _mv_1334.value;
                                                 transpiler_prescan_register_struct_key_type(ctx, key_type_expr);
-                                            } else if (!_mv_1333.has_value) {
+                                            } else if (!_mv_1334.has_value) {
                                             }
                                         }
                                     } else if (string_eq(name, SLOP_STR("set-new"))) {
                                         if (len >= 3) {
-                                            __auto_type _mv_1334 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1334.has_value) {
-                                                __auto_type elem_type_expr = _mv_1334.value;
+                                            __auto_type _mv_1335 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1335.has_value) {
+                                                __auto_type elem_type_expr = _mv_1335.value;
                                                 transpiler_prescan_register_struct_key_type(ctx, elem_type_expr);
-                                            } else if (!_mv_1334.has_value) {
+                                            } else if (!_mv_1335.has_value) {
                                             }
                                         }
                                     } else if (string_eq(name, SLOP_STR("chan-buffered"))) {
                                         if (len >= 4) {
-                                            __auto_type _mv_1335 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1335.has_value) {
-                                                __auto_type type_expr = _mv_1335.value;
-                                                {
-                                                    __auto_type elem_c = context_to_c_type_prefixed(ctx, type_expr);
-                                                    __auto_type elem_id = ctype_type_to_identifier((*ctx).arena, elem_c);
-                                                    __auto_type c_name = context_ctx_str(ctx, SLOP_STR("slop_chan_"), elem_id);
-                                                    context_ctx_register_chan_type(ctx, elem_c, c_name);
-                                                }
-                                            } else if (!_mv_1335.has_value) {
-                                            }
-                                        }
-                                    } else if (string_eq(name, SLOP_STR("chan"))) {
-                                        if (len >= 3) {
                                             __auto_type _mv_1336 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                             if (_mv_1336.has_value) {
                                                 __auto_type type_expr = _mv_1336.value;
@@ -1340,15 +1326,29 @@ void transpiler_prescan_expr_for_struct_keys(context_TranspileContext* ctx, type
                                             } else if (!_mv_1336.has_value) {
                                             }
                                         }
+                                    } else if (string_eq(name, SLOP_STR("chan"))) {
+                                        if (len >= 3) {
+                                            __auto_type _mv_1337 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1337.has_value) {
+                                                __auto_type type_expr = _mv_1337.value;
+                                                {
+                                                    __auto_type elem_c = context_to_c_type_prefixed(ctx, type_expr);
+                                                    __auto_type elem_id = ctype_type_to_identifier((*ctx).arena, elem_c);
+                                                    __auto_type c_name = context_ctx_str(ctx, SLOP_STR("slop_chan_"), elem_id);
+                                                    context_ctx_register_chan_type(ctx, elem_c, c_name);
+                                                }
+                                            } else if (!_mv_1337.has_value) {
+                                            }
+                                        }
                                     } else {
                                         {
                                             __auto_type i = 0;
                                             while (i < len) {
-                                                __auto_type _mv_1337 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1337.has_value) {
-                                                    __auto_type child = _mv_1337.value;
+                                                __auto_type _mv_1338 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1338.has_value) {
+                                                    __auto_type child = _mv_1338.value;
                                                     transpiler_prescan_expr_for_struct_keys(ctx, child);
-                                                } else if (!_mv_1337.has_value) {
+                                                } else if (!_mv_1338.has_value) {
                                                 }
                                                 i = (i + 1);
                                             }
@@ -1361,11 +1361,11 @@ void transpiler_prescan_expr_for_struct_keys(context_TranspileContext* ctx, type
                                 {
                                     __auto_type i = 0;
                                     while (i < len) {
-                                        __auto_type _mv_1338 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1338.has_value) {
-                                            __auto_type child = _mv_1338.value;
+                                        __auto_type _mv_1339 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1339.has_value) {
+                                            __auto_type child = _mv_1339.value;
                                             transpiler_prescan_expr_for_struct_keys(ctx, child);
-                                        } else if (!_mv_1338.has_value) {
+                                        } else if (!_mv_1339.has_value) {
                                         }
                                         i = (i + 1);
                                     }
@@ -1373,7 +1373,7 @@ void transpiler_prescan_expr_for_struct_keys(context_TranspileContext* ctx, type
                                 break;
                             }
                         }
-                    } else if (!_mv_1331.has_value) {
+                    } else if (!_mv_1332.has_value) {
                     }
                 }
             }
@@ -1390,33 +1390,33 @@ void transpiler_prescan_register_struct_key_type(context_TranspileContext* ctx, 
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1339 = (*type_expr);
-        switch (_mv_1339.tag) {
+        __auto_type _mv_1340 = (*type_expr);
+        switch (_mv_1340.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1339.data.sym;
+                __auto_type sym = _mv_1340.data.sym;
                 {
                     __auto_type name = sym.name;
                     if (!(transpiler_is_builtin_map_key_type(name))) {
-                        __auto_type _mv_1340 = context_ctx_lookup_type(ctx, name);
-                        if (_mv_1340.has_value) {
-                            __auto_type type_entry = _mv_1340.value;
+                        __auto_type _mv_1341 = context_ctx_lookup_type(ctx, name);
+                        if (_mv_1341.has_value) {
+                            __auto_type type_entry = _mv_1341.value;
                             context_ctx_register_struct_key_type(ctx, type_entry.c_name);
-                        } else if (!_mv_1340.has_value) {
-                            __auto_type _mv_1341 = context_ctx_get_module(ctx);
-                            if (_mv_1341.has_value) {
-                                __auto_type mod = _mv_1341.value;
+                        } else if (!_mv_1341.has_value) {
+                            __auto_type _mv_1342 = context_ctx_get_module(ctx);
+                            if (_mv_1342.has_value) {
+                                __auto_type mod = _mv_1342.value;
                                 {
                                     __auto_type prefixed = context_ctx_str3(ctx, mod, SLOP_STR("_"), name);
-                                    __auto_type _mv_1342 = context_ctx_lookup_type(ctx, prefixed);
-                                    if (_mv_1342.has_value) {
-                                        __auto_type type_entry = _mv_1342.value;
+                                    __auto_type _mv_1343 = context_ctx_lookup_type(ctx, prefixed);
+                                    if (_mv_1343.has_value) {
+                                        __auto_type type_entry = _mv_1343.value;
                                         context_ctx_register_struct_key_type(ctx, type_entry.c_name);
-                                    } else if (!_mv_1342.has_value) {
+                                    } else if (!_mv_1343.has_value) {
                                         context_ctx_register_struct_key_type(ctx, ctype_to_c_name(arena, name));
                                     }
                                 }
-                            } else if (!_mv_1341.has_value) {
+                            } else if (!_mv_1342.has_value) {
                                 context_ctx_register_struct_key_type(ctx, ctype_to_c_name(arena, name));
                             }
                         }
@@ -1440,29 +1440,29 @@ void transpiler_check_and_register_result_alias(context_TranspileContext* ctx, s
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1343 = (*body_expr);
-        switch (_mv_1343.tag) {
+        __auto_type _mv_1344 = (*body_expr);
+        switch (_mv_1344.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1343.data.lst;
+                __auto_type lst = _mv_1344.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_1344 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1344.has_value) {
-                            __auto_type head = _mv_1344.value;
-                            __auto_type _mv_1345 = (*head);
-                            switch (_mv_1345.tag) {
+                        __auto_type _mv_1345 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1345.has_value) {
+                            __auto_type head = _mv_1345.value;
+                            __auto_type _mv_1346 = (*head);
+                            switch (_mv_1346.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1345.data.sym;
+                                    __auto_type sym = _mv_1346.data.sym;
                                     if (string_eq(sym.name, SLOP_STR("Result"))) {
-                                        __auto_type _mv_1346 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1346.has_value) {
-                                            __auto_type ok_type_expr = _mv_1346.value;
-                                            __auto_type _mv_1347 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1347.has_value) {
-                                                __auto_type err_type_expr = _mv_1347.value;
+                                        __auto_type _mv_1347 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1347.has_value) {
+                                            __auto_type ok_type_expr = _mv_1347.value;
+                                            __auto_type _mv_1348 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1348.has_value) {
+                                                __auto_type err_type_expr = _mv_1348.value;
                                                 {
                                                     __auto_type ok_c_type = context_to_c_type_prefixed(ctx, ok_type_expr);
                                                     __auto_type err_c_type = context_to_c_type_prefixed(ctx, err_type_expr);
@@ -1470,9 +1470,9 @@ void transpiler_check_and_register_result_alias(context_TranspileContext* ctx, s
                                                     context_ctx_register_result_type_alias(ctx, alias_name, result_name);
                                                     context_ctx_register_result_type(ctx, ok_c_type, err_c_type, result_name);
                                                 }
-                                            } else if (!_mv_1347.has_value) {
+                                            } else if (!_mv_1348.has_value) {
                                             }
-                                        } else if (!_mv_1346.has_value) {
+                                        } else if (!_mv_1347.has_value) {
                                         }
                                     }
                                     break;
@@ -1481,7 +1481,7 @@ void transpiler_check_and_register_result_alias(context_TranspileContext* ctx, s
                                     break;
                                 }
                             }
-                        } else if (!_mv_1344.has_value) {
+                        } else if (!_mv_1345.has_value) {
                         }
                     }
                 }
@@ -1500,14 +1500,14 @@ void transpiler_prescan_ffi(context_TranspileContext* ctx, slop_list_types_SExpr
         __auto_type arena = (*ctx).arena;
         __auto_type len = ((int64_t)((items).len));
         if (len >= 2) {
-            __auto_type _mv_1348 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1348.has_value) {
-                __auto_type header_expr = _mv_1348.value;
-                __auto_type _mv_1349 = (*header_expr);
-                switch (_mv_1349.tag) {
+            __auto_type _mv_1349 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1349.has_value) {
+                __auto_type header_expr = _mv_1349.value;
+                __auto_type _mv_1350 = (*header_expr);
+                switch (_mv_1350.tag) {
                     case types_SExpr_str:
                     {
-                        __auto_type str = _mv_1349.data.str;
+                        __auto_type str = _mv_1350.data.str;
                         context_ctx_add_include(ctx, str.value);
                         break;
                     }
@@ -1515,16 +1515,16 @@ void transpiler_prescan_ffi(context_TranspileContext* ctx, slop_list_types_SExpr
                         break;
                     }
                 }
-            } else if (!_mv_1348.has_value) {
+            } else if (!_mv_1349.has_value) {
             }
             {
                 int64_t i = 2;
                 while (i < len) {
-                    __auto_type _mv_1350 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1350.has_value) {
-                        __auto_type func_decl = _mv_1350.value;
+                    __auto_type _mv_1351 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1351.has_value) {
+                        __auto_type func_decl = _mv_1351.value;
                         transpiler_register_ffi_function(ctx, func_decl);
-                    } else if (!_mv_1350.has_value) {
+                    } else if (!_mv_1351.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -1547,14 +1547,14 @@ uint8_t transpiler_is_type_name(slop_string name) {
 void transpiler_prescan_import(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     if (((int64_t)((items).len)) >= 3) {
-        __auto_type _mv_1351 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1351.has_value) {
-            __auto_type mod_expr = _mv_1351.value;
-            __auto_type _mv_1352 = (*mod_expr);
-            switch (_mv_1352.tag) {
+        __auto_type _mv_1352 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1352.has_value) {
+            __auto_type mod_expr = _mv_1352.value;
+            __auto_type _mv_1353 = (*mod_expr);
+            switch (_mv_1353.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type mod_sym = _mv_1352.data.sym;
+                    __auto_type mod_sym = _mv_1353.data.sym;
                     {
                         __auto_type mod_name = mod_sym.name;
                         __auto_type arena = (*ctx).arena;
@@ -1565,27 +1565,27 @@ void transpiler_prescan_import(context_TranspileContext* ctx, slop_list_types_SE
                         if (string_eq(mod_name, SLOP_STR("file"))) {
                             transpiler_register_file_module_variants(ctx);
                         }
-                        __auto_type _mv_1353 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1353.has_value) {
-                            __auto_type symbols_expr = _mv_1353.value;
-                            __auto_type _mv_1354 = (*symbols_expr);
-                            switch (_mv_1354.tag) {
+                        __auto_type _mv_1354 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1354.has_value) {
+                            __auto_type symbols_expr = _mv_1354.value;
+                            __auto_type _mv_1355 = (*symbols_expr);
+                            switch (_mv_1355.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type symbols_lst = _mv_1354.data.lst;
+                                    __auto_type symbols_lst = _mv_1355.data.lst;
                                     {
                                         __auto_type syms = symbols_lst.items;
                                         __auto_type sym_len = ((int64_t)((syms).len));
                                         __auto_type j = 0;
                                         while (j < sym_len) {
-                                            __auto_type _mv_1355 = ({ __auto_type _lst = syms; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1355.has_value) {
-                                                __auto_type sym_item = _mv_1355.value;
-                                                __auto_type _mv_1356 = (*sym_item);
-                                                switch (_mv_1356.tag) {
+                                            __auto_type _mv_1356 = ({ __auto_type _lst = syms; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1356.has_value) {
+                                                __auto_type sym_item = _mv_1356.value;
+                                                __auto_type _mv_1357 = (*sym_item);
+                                                switch (_mv_1357.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type s = _mv_1356.data.sym;
+                                                        __auto_type s = _mv_1357.data.sym;
                                                         {
                                                             __auto_type sym_name = s.name;
                                                             __auto_type c_mod_name = ctype_to_c_name(arena, mod_name);
@@ -1619,7 +1619,7 @@ void transpiler_prescan_import(context_TranspileContext* ctx, slop_list_types_SE
                                                         break;
                                                     }
                                                 }
-                                            } else if (!_mv_1355.has_value) {
+                                            } else if (!_mv_1356.has_value) {
                                             }
                                             j = (j + 1);
                                         }
@@ -1630,7 +1630,7 @@ void transpiler_prescan_import(context_TranspileContext* ctx, slop_list_types_SE
                                     break;
                                 }
                             }
-                        } else if (!_mv_1353.has_value) {
+                        } else if (!_mv_1354.has_value) {
                         }
                     }
                     break;
@@ -1639,7 +1639,7 @@ void transpiler_prescan_import(context_TranspileContext* ctx, slop_list_types_SE
                     break;
                 }
             }
-        } else if (!_mv_1351.has_value) {
+        } else if (!_mv_1352.has_value) {
         }
     }
 }
@@ -1685,14 +1685,14 @@ void transpiler_prescan_const(context_TranspileContext* ctx, slop_list_types_SEx
     {
         __auto_type arena = (*ctx).arena;
         if (((int64_t)((items).len)) >= 3) {
-            __auto_type _mv_1357 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1357.has_value) {
-                __auto_type name_expr = _mv_1357.value;
-                __auto_type _mv_1358 = (*name_expr);
-                switch (_mv_1358.tag) {
+            __auto_type _mv_1358 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1358.has_value) {
+                __auto_type name_expr = _mv_1358.value;
+                __auto_type _mv_1359 = (*name_expr);
+                switch (_mv_1359.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_1358.data.sym;
+                        __auto_type sym = _mv_1359.data.sym;
                         {
                             __auto_type const_name = sym.name;
                             __auto_type base_name = ctype_to_c_name(arena, const_name);
@@ -1705,7 +1705,7 @@ void transpiler_prescan_const(context_TranspileContext* ctx, slop_list_types_SEx
                         break;
                     }
                 }
-            } else if (!_mv_1357.has_value) {
+            } else if (!_mv_1358.has_value) {
             }
         }
     }
@@ -1716,23 +1716,23 @@ void transpiler_register_ffi_function(context_TranspileContext* ctx, types_SExpr
     SLOP_PRE(((func_decl != NULL)), "(!= func-decl nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1359 = (*func_decl);
-        switch (_mv_1359.tag) {
+        __auto_type _mv_1360 = (*func_decl);
+        switch (_mv_1360.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1359.data.lst;
+                __auto_type lst = _mv_1360.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 1) {
-                        __auto_type _mv_1360 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1360.has_value) {
-                            __auto_type name_expr = _mv_1360.value;
-                            __auto_type _mv_1361 = (*name_expr);
-                            switch (_mv_1361.tag) {
+                        __auto_type _mv_1361 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1361.has_value) {
+                            __auto_type name_expr = _mv_1361.value;
+                            __auto_type _mv_1362 = (*name_expr);
+                            switch (_mv_1362.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1361.data.sym;
+                                    __auto_type sym = _mv_1362.data.sym;
                                     {
                                         __auto_type fn_name = sym.name;
                                         __auto_type c_name = transpiler_extract_ffi_c_name(ctx, items, fn_name);
@@ -1749,7 +1749,7 @@ void transpiler_register_ffi_function(context_TranspileContext* ctx, types_SExpr
                                     break;
                                 }
                             }
-                        } else if (!_mv_1360.has_value) {
+                        } else if (!_mv_1361.has_value) {
                         }
                     }
                 }
@@ -1768,29 +1768,29 @@ slop_list_context_FuncParamType_ptr transpiler_extract_ffi_param_types(context_T
         __auto_type arena = (*ctx).arena;
         __auto_type result = ((slop_list_context_FuncParamType_ptr){ .data = (context_FuncParamType**)slop_arena_alloc(arena, 16 * sizeof(context_FuncParamType*)), .len = 0, .cap = 16 });
         if (((int64_t)((items).len)) >= 2) {
-            __auto_type _mv_1362 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1362.has_value) {
-                __auto_type params_expr = _mv_1362.value;
-                __auto_type _mv_1363 = (*params_expr);
-                switch (_mv_1363.tag) {
+            __auto_type _mv_1363 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1363.has_value) {
+                __auto_type params_expr = _mv_1363.value;
+                __auto_type _mv_1364 = (*params_expr);
+                switch (_mv_1364.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type params_lst = _mv_1363.data.lst;
+                        __auto_type params_lst = _mv_1364.data.lst;
                         {
                             __auto_type params = params_lst.items;
                             __auto_type param_count = ((int64_t)((params).len));
                             __auto_type i = 0;
                             while (i < param_count) {
-                                __auto_type _mv_1364 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1364.has_value) {
-                                    __auto_type param_expr = _mv_1364.value;
+                                __auto_type _mv_1365 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1365.has_value) {
+                                    __auto_type param_expr = _mv_1365.value;
                                     {
                                         __auto_type c_type = transpiler_prescan_get_param_c_type(ctx, param_expr);
                                         __auto_type param_info = ((context_FuncParamType*)(({ __auto_type _alloc = (context_FuncParamType*)slop_arena_alloc(arena, sizeof(context_FuncParamType)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                                         (*param_info).c_type = c_type;
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (param_info); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
-                                } else if (!_mv_1364.has_value) {
+                                } else if (!_mv_1365.has_value) {
                                 }
                                 i = (i + 1);
                             }
@@ -1801,7 +1801,7 @@ slop_list_context_FuncParamType_ptr transpiler_extract_ffi_param_types(context_T
                         break;
                     }
                 }
-            } else if (!_mv_1362.has_value) {
+            } else if (!_mv_1363.has_value) {
             }
         }
         return result;
@@ -1817,23 +1817,23 @@ slop_string transpiler_extract_ffi_c_name(context_TranspileContext* ctx, slop_li
         uint8_t found_c_name = 0;
         __auto_type c_name = SLOP_STR("");
         while (i < len) {
-            __auto_type _mv_1365 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1365.has_value) {
-                __auto_type item_expr = _mv_1365.value;
-                __auto_type _mv_1366 = (*item_expr);
-                switch (_mv_1366.tag) {
+            __auto_type _mv_1366 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1366.has_value) {
+                __auto_type item_expr = _mv_1366.value;
+                __auto_type _mv_1367 = (*item_expr);
+                switch (_mv_1367.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_1366.data.sym;
+                        __auto_type sym = _mv_1367.data.sym;
                         if (string_eq(sym.name, SLOP_STR(":c-name"))) {
-                            __auto_type _mv_1367 = ({ __auto_type _lst = items; size_t _idx = (size_t)(i + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1367.has_value) {
-                                __auto_type c_name_expr = _mv_1367.value;
-                                __auto_type _mv_1368 = (*c_name_expr);
-                                switch (_mv_1368.tag) {
+                            __auto_type _mv_1368 = ({ __auto_type _lst = items; size_t _idx = (size_t)(i + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1368.has_value) {
+                                __auto_type c_name_expr = _mv_1368.value;
+                                __auto_type _mv_1369 = (*c_name_expr);
+                                switch (_mv_1369.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type c_sym = _mv_1368.data.sym;
+                                        __auto_type c_sym = _mv_1369.data.sym;
                                         c_name = c_sym.name;
                                         found_c_name = 1;
                                         break;
@@ -1842,7 +1842,7 @@ slop_string transpiler_extract_ffi_c_name(context_TranspileContext* ctx, slop_li
                                         break;
                                     }
                                 }
-                            } else if (!_mv_1367.has_value) {
+                            } else if (!_mv_1368.has_value) {
                             }
                         }
                         break;
@@ -1851,7 +1851,7 @@ slop_string transpiler_extract_ffi_c_name(context_TranspileContext* ctx, slop_li
                         break;
                     }
                 }
-            } else if (!_mv_1365.has_value) {
+            } else if (!_mv_1366.has_value) {
             }
             i = (i + 1);
         }
@@ -1873,14 +1873,14 @@ void transpiler_prescan_ffi_struct(context_TranspileContext* ctx, slop_list_type
                 __auto_type has_header = ((len >= 2) && transpiler_is_ffi_string_item(items, 1));
                 __auto_type name_idx = ((((len >= 2) && transpiler_is_ffi_string_item(items, 1))) ? 2 : 1);
                 if (has_header) {
-                    __auto_type _mv_1369 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1369.has_value) {
-                        __auto_type header_expr = _mv_1369.value;
-                        __auto_type _mv_1370 = (*header_expr);
-                        switch (_mv_1370.tag) {
+                    __auto_type _mv_1370 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1370.has_value) {
+                        __auto_type header_expr = _mv_1370.value;
+                        __auto_type _mv_1371 = (*header_expr);
+                        switch (_mv_1371.tag) {
                             case types_SExpr_str:
                             {
-                                __auto_type str = _mv_1370.data.str;
+                                __auto_type str = _mv_1371.data.str;
                                 context_ctx_add_include(ctx, str.value);
                                 break;
                             }
@@ -1888,18 +1888,18 @@ void transpiler_prescan_ffi_struct(context_TranspileContext* ctx, slop_list_type
                                 break;
                             }
                         }
-                    } else if (!_mv_1369.has_value) {
+                    } else if (!_mv_1370.has_value) {
                     }
                 }
                 if (len >= (name_idx + 1)) {
-                    __auto_type _mv_1371 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1371.has_value) {
-                        __auto_type name_expr = _mv_1371.value;
-                        __auto_type _mv_1372 = (*name_expr);
-                        switch (_mv_1372.tag) {
+                    __auto_type _mv_1372 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1372.has_value) {
+                        __auto_type name_expr = _mv_1372.value;
+                        __auto_type _mv_1373 = (*name_expr);
+                        switch (_mv_1373.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1372.data.sym;
+                                __auto_type sym = _mv_1373.data.sym;
                                 {
                                     __auto_type type_name = sym.name;
                                     __auto_type c_name = transpiler_get_ffi_struct_c_name(arena, items, name_idx, type_name);
@@ -1911,7 +1911,7 @@ void transpiler_prescan_ffi_struct(context_TranspileContext* ctx, slop_list_type
                                 break;
                             }
                         }
-                    } else if (!_mv_1371.has_value) {
+                    } else if (!_mv_1372.has_value) {
                     }
                 }
             }
@@ -1924,30 +1924,30 @@ slop_string transpiler_get_ffi_struct_c_name(slop_arena* arena, slop_list_types_
         __auto_type len = ((int64_t)((items).len));
         __auto_type modifier_idx = (name_idx + 1);
         if (len >= (modifier_idx + 2)) {
-            __auto_type _mv_1373 = ({ __auto_type _lst = items; size_t _idx = (size_t)modifier_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1373.has_value) {
-                __auto_type mod_expr = _mv_1373.value;
-                __auto_type _mv_1374 = (*mod_expr);
-                switch (_mv_1374.tag) {
+            __auto_type _mv_1374 = ({ __auto_type _lst = items; size_t _idx = (size_t)modifier_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1374.has_value) {
+                __auto_type mod_expr = _mv_1374.value;
+                __auto_type _mv_1375 = (*mod_expr);
+                switch (_mv_1375.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_1374.data.sym;
+                        __auto_type sym = _mv_1375.data.sym;
                         if (string_eq(sym.name, SLOP_STR(":c-name"))) {
-                            __auto_type _mv_1375 = ({ __auto_type _lst = items; size_t _idx = (size_t)(modifier_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1375.has_value) {
-                                __auto_type cname_expr = _mv_1375.value;
-                                __auto_type _mv_1376 = (*cname_expr);
-                                switch (_mv_1376.tag) {
+                            __auto_type _mv_1376 = ({ __auto_type _lst = items; size_t _idx = (size_t)(modifier_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1376.has_value) {
+                                __auto_type cname_expr = _mv_1376.value;
+                                __auto_type _mv_1377 = (*cname_expr);
+                                switch (_mv_1377.tag) {
                                     case types_SExpr_str:
                                     {
-                                        __auto_type str = _mv_1376.data.str;
+                                        __auto_type str = _mv_1377.data.str;
                                         return transpiler_apply_struct_prefix_heuristic(arena, str.value);
                                     }
                                     default: {
                                         return transpiler_apply_struct_prefix_heuristic(arena, default_name);
                                     }
                                 }
-                            } else if (!_mv_1375.has_value) {
+                            } else if (!_mv_1376.has_value) {
                                 return transpiler_apply_struct_prefix_heuristic(arena, default_name);
                             }
                             SLOP_UNREACHABLE();
@@ -1959,7 +1959,7 @@ slop_string transpiler_get_ffi_struct_c_name(slop_arena* arena, slop_list_types_
                         return transpiler_apply_struct_prefix_heuristic(arena, default_name);
                     }
                 }
-            } else if (!_mv_1373.has_value) {
+            } else if (!_mv_1374.has_value) {
                 return transpiler_apply_struct_prefix_heuristic(arena, default_name);
             }
             SLOP_UNREACHABLE();
@@ -2005,21 +2005,21 @@ uint8_t transpiler_string_ends_with(slop_string s, slop_string suffix) {
 }
 
 uint8_t transpiler_is_ffi_string_item(slop_list_types_SExpr_ptr items, int64_t idx) {
-    __auto_type _mv_1377 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-    if (_mv_1377.has_value) {
-        __auto_type item = _mv_1377.value;
-        __auto_type _mv_1378 = (*item);
-        switch (_mv_1378.tag) {
+    __auto_type _mv_1378 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+    if (_mv_1378.has_value) {
+        __auto_type item = _mv_1378.value;
+        __auto_type _mv_1379 = (*item);
+        switch (_mv_1379.tag) {
             case types_SExpr_str:
             {
-                __auto_type _ = _mv_1378.data.str;
+                __auto_type _ = _mv_1379.data.str;
                 return 1;
             }
             default: {
                 return 0;
             }
         }
-    } else if (!_mv_1377.has_value) {
+    } else if (!_mv_1378.has_value) {
         return 0;
     }
     SLOP_UNREACHABLE();
@@ -2029,34 +2029,34 @@ uint8_t transpiler_is_enum_def(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 3) {
         return 0;
     } else {
-        __auto_type _mv_1379 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1379.has_value) {
-            __auto_type def_expr = _mv_1379.value;
-            __auto_type _mv_1380 = (*def_expr);
-            switch (_mv_1380.tag) {
+        __auto_type _mv_1380 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1380.has_value) {
+            __auto_type def_expr = _mv_1380.value;
+            __auto_type _mv_1381 = (*def_expr);
+            switch (_mv_1381.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type def_lst = _mv_1380.data.lst;
+                    __auto_type def_lst = _mv_1381.data.lst;
                     {
                         __auto_type def_items = def_lst.items;
                         if (((int64_t)((def_items).len)) < 1) {
                             return 0;
                         } else {
-                            __auto_type _mv_1381 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1381.has_value) {
-                                __auto_type head = _mv_1381.value;
-                                __auto_type _mv_1382 = (*head);
-                                switch (_mv_1382.tag) {
+                            __auto_type _mv_1382 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1382.has_value) {
+                                __auto_type head = _mv_1382.value;
+                                __auto_type _mv_1383 = (*head);
+                                switch (_mv_1383.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1382.data.sym;
+                                        __auto_type sym = _mv_1383.data.sym;
                                         return string_eq(sym.name, SLOP_STR("enum"));
                                     }
                                     default: {
                                         return 0;
                                     }
                                 }
-                            } else if (!_mv_1381.has_value) {
+                            } else if (!_mv_1382.has_value) {
                                 return 0;
                             }
                             SLOP_UNREACHABLE();
@@ -2067,7 +2067,7 @@ uint8_t transpiler_is_enum_def(slop_list_types_SExpr_ptr items) {
                     return 0;
                 }
             }
-        } else if (!_mv_1379.has_value) {
+        } else if (!_mv_1380.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -2078,34 +2078,34 @@ uint8_t transpiler_is_record_def(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 3) {
         return 0;
     } else {
-        __auto_type _mv_1383 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1383.has_value) {
-            __auto_type def_expr = _mv_1383.value;
-            __auto_type _mv_1384 = (*def_expr);
-            switch (_mv_1384.tag) {
+        __auto_type _mv_1384 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1384.has_value) {
+            __auto_type def_expr = _mv_1384.value;
+            __auto_type _mv_1385 = (*def_expr);
+            switch (_mv_1385.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type def_lst = _mv_1384.data.lst;
+                    __auto_type def_lst = _mv_1385.data.lst;
                     {
                         __auto_type def_items = def_lst.items;
                         if (((int64_t)((def_items).len)) < 1) {
                             return 0;
                         } else {
-                            __auto_type _mv_1385 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1385.has_value) {
-                                __auto_type head = _mv_1385.value;
-                                __auto_type _mv_1386 = (*head);
-                                switch (_mv_1386.tag) {
+                            __auto_type _mv_1386 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1386.has_value) {
+                                __auto_type head = _mv_1386.value;
+                                __auto_type _mv_1387 = (*head);
+                                switch (_mv_1387.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1386.data.sym;
+                                        __auto_type sym = _mv_1387.data.sym;
                                         return string_eq(sym.name, SLOP_STR("record"));
                                     }
                                     default: {
                                         return 0;
                                     }
                                 }
-                            } else if (!_mv_1385.has_value) {
+                            } else if (!_mv_1386.has_value) {
                                 return 0;
                             }
                             SLOP_UNREACHABLE();
@@ -2116,7 +2116,7 @@ uint8_t transpiler_is_record_def(slop_list_types_SExpr_ptr items) {
                     return 0;
                 }
             }
-        } else if (!_mv_1383.has_value) {
+        } else if (!_mv_1384.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -2127,34 +2127,34 @@ uint8_t transpiler_is_union_def(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 3) {
         return 0;
     } else {
-        __auto_type _mv_1387 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1387.has_value) {
-            __auto_type def_expr = _mv_1387.value;
-            __auto_type _mv_1388 = (*def_expr);
-            switch (_mv_1388.tag) {
+        __auto_type _mv_1388 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1388.has_value) {
+            __auto_type def_expr = _mv_1388.value;
+            __auto_type _mv_1389 = (*def_expr);
+            switch (_mv_1389.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type def_lst = _mv_1388.data.lst;
+                    __auto_type def_lst = _mv_1389.data.lst;
                     {
                         __auto_type def_items = def_lst.items;
                         if (((int64_t)((def_items).len)) < 1) {
                             return 0;
                         } else {
-                            __auto_type _mv_1389 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1389.has_value) {
-                                __auto_type head = _mv_1389.value;
-                                __auto_type _mv_1390 = (*head);
-                                switch (_mv_1390.tag) {
+                            __auto_type _mv_1390 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1390.has_value) {
+                                __auto_type head = _mv_1390.value;
+                                __auto_type _mv_1391 = (*head);
+                                switch (_mv_1391.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1390.data.sym;
+                                        __auto_type sym = _mv_1391.data.sym;
                                         return string_eq(sym.name, SLOP_STR("union"));
                                     }
                                     default: {
                                         return 0;
                                     }
                                 }
-                            } else if (!_mv_1389.has_value) {
+                            } else if (!_mv_1390.has_value) {
                                 return 0;
                             }
                             SLOP_UNREACHABLE();
@@ -2165,7 +2165,7 @@ uint8_t transpiler_is_union_def(slop_list_types_SExpr_ptr items) {
                     return 0;
                 }
             }
-        } else if (!_mv_1387.has_value) {
+        } else if (!_mv_1388.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -2177,36 +2177,36 @@ slop_string transpiler_get_array_c_type(context_TranspileContext* ctx, slop_list
     if (((int64_t)((items).len)) < 3) {
         return default_c_type;
     } else {
-        __auto_type _mv_1391 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1391.has_value) {
-            __auto_type body_expr = _mv_1391.value;
-            __auto_type _mv_1392 = (*body_expr);
-            switch (_mv_1392.tag) {
+        __auto_type _mv_1392 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1392.has_value) {
+            __auto_type body_expr = _mv_1392.value;
+            __auto_type _mv_1393 = (*body_expr);
+            switch (_mv_1393.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type body_lst = _mv_1392.data.lst;
+                    __auto_type body_lst = _mv_1393.data.lst;
                     {
                         __auto_type body_items = body_lst.items;
                         if (((int64_t)((body_items).len)) < 2) {
                             return default_c_type;
                         } else {
-                            __auto_type _mv_1393 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1393.has_value) {
-                                __auto_type head = _mv_1393.value;
-                                __auto_type _mv_1394 = (*head);
-                                switch (_mv_1394.tag) {
+                            __auto_type _mv_1394 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1394.has_value) {
+                                __auto_type head = _mv_1394.value;
+                                __auto_type _mv_1395 = (*head);
+                                switch (_mv_1395.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1394.data.sym;
+                                        __auto_type sym = _mv_1395.data.sym;
                                         if (string_eq(sym.name, SLOP_STR("Array"))) {
-                                            __auto_type _mv_1395 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1395.has_value) {
-                                                __auto_type elem_expr = _mv_1395.value;
+                                            __auto_type _mv_1396 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1396.has_value) {
+                                                __auto_type elem_expr = _mv_1396.value;
                                                 {
                                                     __auto_type elem_c = context_to_c_type_prefixed(ctx, elem_expr);
                                                     return context_ctx_str(ctx, elem_c, SLOP_STR("*"));
                                                 }
-                                            } else if (!_mv_1395.has_value) {
+                                            } else if (!_mv_1396.has_value) {
                                                 return default_c_type;
                                             }
                                             SLOP_UNREACHABLE();
@@ -2218,7 +2218,7 @@ slop_string transpiler_get_array_c_type(context_TranspileContext* ctx, slop_list
                                         return default_c_type;
                                     }
                                 }
-                            } else if (!_mv_1393.has_value) {
+                            } else if (!_mv_1394.has_value) {
                                 return default_c_type;
                             }
                             SLOP_UNREACHABLE();
@@ -2229,7 +2229,7 @@ slop_string transpiler_get_array_c_type(context_TranspileContext* ctx, slop_list
                     return default_c_type;
                 }
             }
-        } else if (!_mv_1391.has_value) {
+        } else if (!_mv_1392.has_value) {
             return default_c_type;
         }
         SLOP_UNREACHABLE();
@@ -2250,13 +2250,13 @@ void transpiler_emit_all_types(context_TranspileContext* ctx, slop_list_types_SE
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1396 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1396.has_value) {
-                __auto_type item = _mv_1396.value;
+            __auto_type _mv_1397 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1397.has_value) {
+                __auto_type item = _mv_1397.value;
                 if (transpiler_is_type_def(item) && !(transpiler_is_union_type_def(item))) {
                     defn_transpile_type(ctx, item);
                 }
-            } else if (!_mv_1396.has_value) {
+            } else if (!_mv_1397.has_value) {
             }
             i = (i + 1);
         }
@@ -2265,13 +2265,13 @@ void transpiler_emit_all_types(context_TranspileContext* ctx, slop_list_types_SE
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1397 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1397.has_value) {
-                __auto_type item = _mv_1397.value;
+            __auto_type _mv_1398 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1398.has_value) {
+                __auto_type item = _mv_1398.value;
                 if (transpiler_is_type_def(item) && transpiler_is_union_type_def(item)) {
                     defn_transpile_type(ctx, item);
                 }
-            } else if (!_mv_1397.has_value) {
+            } else if (!_mv_1398.has_value) {
             }
             i = (i + 1);
         }
@@ -2280,44 +2280,44 @@ void transpiler_emit_all_types(context_TranspileContext* ctx, slop_list_types_SE
 
 uint8_t transpiler_is_union_type_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1398 = (*item);
-    switch (_mv_1398.tag) {
+    __auto_type _mv_1399 = (*item);
+    switch (_mv_1399.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1398.data.lst;
+            __auto_type lst = _mv_1399.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 3) {
                     return 0;
                 } else {
-                    __auto_type _mv_1399 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1399.has_value) {
-                        __auto_type def_expr = _mv_1399.value;
-                        __auto_type _mv_1400 = (*def_expr);
-                        switch (_mv_1400.tag) {
+                    __auto_type _mv_1400 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1400.has_value) {
+                        __auto_type def_expr = _mv_1400.value;
+                        __auto_type _mv_1401 = (*def_expr);
+                        switch (_mv_1401.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type def_lst = _mv_1400.data.lst;
+                                __auto_type def_lst = _mv_1401.data.lst;
                                 {
                                     __auto_type def_items = def_lst.items;
                                     if (((int64_t)((def_items).len)) < 1) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1401 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1401.has_value) {
-                                            __auto_type head = _mv_1401.value;
-                                            __auto_type _mv_1402 = (*head);
-                                            switch (_mv_1402.tag) {
+                                        __auto_type _mv_1402 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1402.has_value) {
+                                            __auto_type head = _mv_1402.value;
+                                            __auto_type _mv_1403 = (*head);
+                                            switch (_mv_1403.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_1402.data.sym;
+                                                    __auto_type sym = _mv_1403.data.sym;
                                                     return string_eq(sym.name, SLOP_STR("union"));
                                                 }
                                                 default: {
                                                     return 0;
                                                 }
                                             }
-                                        } else if (!_mv_1401.has_value) {
+                                        } else if (!_mv_1402.has_value) {
                                             return 0;
                                         }
                                         SLOP_UNREACHABLE();
@@ -2328,7 +2328,7 @@ uint8_t transpiler_is_union_type_def(types_SExpr* item) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1399.has_value) {
+                    } else if (!_mv_1400.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2343,31 +2343,31 @@ uint8_t transpiler_is_union_type_def(types_SExpr* item) {
 
 uint8_t transpiler_is_type_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1403 = (*item);
-    switch (_mv_1403.tag) {
+    __auto_type _mv_1404 = (*item);
+    switch (_mv_1404.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1403.data.lst;
+            __auto_type lst = _mv_1404.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1404 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1404.has_value) {
-                        __auto_type head = _mv_1404.value;
-                        __auto_type _mv_1405 = (*head);
-                        switch (_mv_1405.tag) {
+                    __auto_type _mv_1405 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1405.has_value) {
+                        __auto_type head = _mv_1405.value;
+                        __auto_type _mv_1406 = (*head);
+                        switch (_mv_1406.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1405.data.sym;
+                                __auto_type sym = _mv_1406.data.sym;
                                 return string_eq(sym.name, SLOP_STR("type"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1404.has_value) {
+                    } else if (!_mv_1405.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2386,13 +2386,13 @@ void transpiler_emit_all_functions(context_TranspileContext* ctx, slop_list_type
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1406 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1406.has_value) {
-                __auto_type item = _mv_1406.value;
+            __auto_type _mv_1407 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1407.has_value) {
+                __auto_type item = _mv_1407.value;
                 if (transpiler_is_fn_def(item)) {
                     defn_transpile_function(ctx, item);
                 }
-            } else if (!_mv_1406.has_value) {
+            } else if (!_mv_1407.has_value) {
             }
             i = (i + 1);
         }
@@ -2401,31 +2401,31 @@ void transpiler_emit_all_functions(context_TranspileContext* ctx, slop_list_type
 
 uint8_t transpiler_is_fn_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1407 = (*item);
-    switch (_mv_1407.tag) {
+    __auto_type _mv_1408 = (*item);
+    switch (_mv_1408.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1407.data.lst;
+            __auto_type lst = _mv_1408.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1408 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1408.has_value) {
-                        __auto_type head = _mv_1408.value;
-                        __auto_type _mv_1409 = (*head);
-                        switch (_mv_1409.tag) {
+                    __auto_type _mv_1409 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1409.has_value) {
+                        __auto_type head = _mv_1409.value;
+                        __auto_type _mv_1410 = (*head);
+                        switch (_mv_1410.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1409.data.sym;
+                                __auto_type sym = _mv_1410.data.sym;
                                 return string_eq(sym.name, SLOP_STR("fn"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1408.has_value) {
+                    } else if (!_mv_1409.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2443,23 +2443,23 @@ void transpiler_transpile_module(context_TranspileContext* ctx, types_SExpr* mod
     SLOP_PRE(((module_expr != NULL)), "(!= module-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1410 = (*module_expr);
-        switch (_mv_1410.tag) {
+        __auto_type _mv_1411 = (*module_expr);
+        switch (_mv_1411.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1410.data.lst;
+                __auto_type lst = _mv_1411.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 2) {
-                        __auto_type _mv_1411 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1411.has_value) {
-                            __auto_type name_expr = _mv_1411.value;
-                            __auto_type _mv_1412 = (*name_expr);
-                            switch (_mv_1412.tag) {
+                        __auto_type _mv_1412 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1412.has_value) {
+                            __auto_type name_expr = _mv_1412.value;
+                            __auto_type _mv_1413 = (*name_expr);
+                            switch (_mv_1413.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1412.data.sym;
+                                    __auto_type sym = _mv_1413.data.sym;
                                     context_ctx_set_module(ctx, (slop_option_string){.has_value = 1, .value = sym.name});
                                     break;
                                 }
@@ -2467,7 +2467,7 @@ void transpiler_transpile_module(context_TranspileContext* ctx, types_SExpr* mod
                                     break;
                                 }
                             }
-                        } else if (!_mv_1411.has_value) {
+                        } else if (!_mv_1412.has_value) {
                         }
                         {
                             __auto_type body_start = transpiler_get_body_start(items);
@@ -2524,27 +2524,27 @@ int64_t transpiler_get_body_start(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 3) {
         return 2;
     } else {
-        __auto_type _mv_1413 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1413.has_value) {
-            __auto_type third = _mv_1413.value;
-            __auto_type _mv_1414 = (*third);
-            switch (_mv_1414.tag) {
+        __auto_type _mv_1414 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1414.has_value) {
+            __auto_type third = _mv_1414.value;
+            __auto_type _mv_1415 = (*third);
+            switch (_mv_1415.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type lst = _mv_1414.data.lst;
+                    __auto_type lst = _mv_1415.data.lst;
                     {
                         __auto_type sub_items = lst.items;
                         if (((int64_t)((sub_items).len)) < 1) {
                             return 2;
                         } else {
-                            __auto_type _mv_1415 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1415.has_value) {
-                                __auto_type head = _mv_1415.value;
-                                __auto_type _mv_1416 = (*head);
-                                switch (_mv_1416.tag) {
+                            __auto_type _mv_1416 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1416.has_value) {
+                                __auto_type head = _mv_1416.value;
+                                __auto_type _mv_1417 = (*head);
+                                switch (_mv_1417.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1416.data.sym;
+                                        __auto_type sym = _mv_1417.data.sym;
                                         if (string_eq(sym.name, SLOP_STR("export"))) {
                                             return 3;
                                         } else {
@@ -2555,7 +2555,7 @@ int64_t transpiler_get_body_start(slop_list_types_SExpr_ptr items) {
                                         return 2;
                                     }
                                 }
-                            } else if (!_mv_1415.has_value) {
+                            } else if (!_mv_1416.has_value) {
                                 return 2;
                             }
                             SLOP_UNREACHABLE();
@@ -2566,7 +2566,7 @@ int64_t transpiler_get_body_start(slop_list_types_SExpr_ptr items) {
                     return 2;
                 }
             }
-        } else if (!_mv_1413.has_value) {
+        } else if (!_mv_1414.has_value) {
             return 2;
         }
         SLOP_UNREACHABLE();
@@ -2579,38 +2579,38 @@ slop_list_string transpiler_get_export_names(slop_arena* arena, slop_list_types_
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 2;
         while (i < len) {
-            __auto_type _mv_1417 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1417.has_value) {
-                __auto_type item = _mv_1417.value;
-                __auto_type _mv_1418 = (*item);
-                switch (_mv_1418.tag) {
+            __auto_type _mv_1418 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1418.has_value) {
+                __auto_type item = _mv_1418.value;
+                __auto_type _mv_1419 = (*item);
+                switch (_mv_1419.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type lst = _mv_1418.data.lst;
+                        __auto_type lst = _mv_1419.data.lst;
                         {
                             __auto_type sub_items = lst.items;
                             if (((int64_t)((sub_items).len)) >= 1) {
-                                __auto_type _mv_1419 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1419.has_value) {
-                                    __auto_type head = _mv_1419.value;
-                                    __auto_type _mv_1420 = (*head);
-                                    switch (_mv_1420.tag) {
+                                __auto_type _mv_1420 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1420.has_value) {
+                                    __auto_type head = _mv_1420.value;
+                                    __auto_type _mv_1421 = (*head);
+                                    switch (_mv_1421.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_1420.data.sym;
+                                            __auto_type sym = _mv_1421.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("export"))) {
                                                 {
                                                     __auto_type export_len = ((int64_t)((sub_items).len));
                                                     __auto_type j = 1;
                                                     while (j < export_len) {
-                                                        __auto_type _mv_1421 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                        if (_mv_1421.has_value) {
-                                                            __auto_type name_expr = _mv_1421.value;
-                                                            __auto_type _mv_1422 = (*name_expr);
-                                                            switch (_mv_1422.tag) {
+                                                        __auto_type _mv_1422 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                        if (_mv_1422.has_value) {
+                                                            __auto_type name_expr = _mv_1422.value;
+                                                            __auto_type _mv_1423 = (*name_expr);
+                                                            switch (_mv_1423.tag) {
                                                                 case types_SExpr_sym:
                                                                 {
-                                                                    __auto_type name_sym = _mv_1422.data.sym;
+                                                                    __auto_type name_sym = _mv_1423.data.sym;
                                                                     ({ __auto_type _lst_p = &(result); __auto_type _item = (name_sym.name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                                     break;
                                                                 }
@@ -2618,7 +2618,7 @@ slop_list_string transpiler_get_export_names(slop_arena* arena, slop_list_types_
                                                                     break;
                                                                 }
                                                             }
-                                                        } else if (!_mv_1421.has_value) {
+                                                        } else if (!_mv_1422.has_value) {
                                                         }
                                                         j = (j + 1);
                                                     }
@@ -2630,7 +2630,7 @@ slop_list_string transpiler_get_export_names(slop_arena* arena, slop_list_types_
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1419.has_value) {
+                                } else if (!_mv_1420.has_value) {
                                 }
                             }
                         }
@@ -2640,7 +2640,7 @@ slop_list_string transpiler_get_export_names(slop_arena* arena, slop_list_types_
                         break;
                     }
                 }
-            } else if (!_mv_1417.has_value) {
+            } else if (!_mv_1418.has_value) {
             }
             i = (i + 1);
         }
@@ -2654,13 +2654,13 @@ uint8_t transpiler_list_contains_str(slop_list_string lst, slop_string needle) {
         int64_t i = 0;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1423 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1423.has_value) {
-                __auto_type s = _mv_1423.value;
+            __auto_type _mv_1424 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1424.has_value) {
+                __auto_type s = _mv_1424.value;
                 if (string_eq(s, needle)) {
                     found = 1;
                 }
-            } else if (!_mv_1423.has_value) {
+            } else if (!_mv_1424.has_value) {
             }
             i = (i + 1);
         }
@@ -2674,11 +2674,11 @@ void transpiler_prescan_module_body(context_TranspileContext* ctx, slop_list_typ
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1424 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1424.has_value) {
-                __auto_type item = _mv_1424.value;
+            __auto_type _mv_1425 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1425.has_value) {
+                __auto_type item = _mv_1425.value;
                 transpiler_prescan_top_level(ctx, item);
-            } else if (!_mv_1424.has_value) {
+            } else if (!_mv_1425.has_value) {
             }
             i = (i + 1);
         }
@@ -2690,30 +2690,30 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1425 = (*type_expr);
-        switch (_mv_1425.tag) {
+        __auto_type _mv_1426 = (*type_expr);
+        switch (_mv_1426.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1425.data.lst;
+                __auto_type lst = _mv_1426.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 1) {
-                        __auto_type _mv_1426 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1426.has_value) {
-                            __auto_type head = _mv_1426.value;
-                            __auto_type _mv_1427 = (*head);
-                            switch (_mv_1427.tag) {
+                        __auto_type _mv_1427 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1427.has_value) {
+                            __auto_type head = _mv_1427.value;
+                            __auto_type _mv_1428 = (*head);
+                            switch (_mv_1428.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1427.data.sym;
+                                    __auto_type sym = _mv_1428.data.sym;
                                     {
                                         __auto_type op = sym.name;
                                         if (string_eq(op, SLOP_STR("Option"))) {
                                             if (len >= 2) {
-                                                __auto_type _mv_1428 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1428.has_value) {
-                                                    __auto_type inner = _mv_1428.value;
+                                                __auto_type _mv_1429 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1429.has_value) {
+                                                    __auto_type inner = _mv_1429.value;
                                                     {
                                                         __auto_type inner_c = context_to_c_type_prefixed(ctx, inner);
                                                         __auto_type inner_id = ctype_type_to_identifier(arena, inner_c);
@@ -2721,14 +2721,14 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                         context_ctx_register_option_type(ctx, inner_c, c_name);
                                                         transpiler_scan_type_for_generics(ctx, inner);
                                                     }
-                                                } else if (!_mv_1428.has_value) {
+                                                } else if (!_mv_1429.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("List"))) {
                                             if (len >= 2) {
-                                                __auto_type _mv_1429 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1429.has_value) {
-                                                    __auto_type elem = _mv_1429.value;
+                                                __auto_type _mv_1430 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1430.has_value) {
+                                                    __auto_type elem = _mv_1430.value;
                                                     {
                                                         __auto_type elem_c = context_to_c_type_prefixed(ctx, elem);
                                                         __auto_type elem_id = ctype_type_to_identifier(arena, elem_c);
@@ -2738,26 +2738,26 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                         context_ctx_register_option_type(ctx, elem_c, option_c_name);
                                                         transpiler_scan_type_for_generics(ctx, elem);
                                                     }
-                                                } else if (!_mv_1429.has_value) {
+                                                } else if (!_mv_1430.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("Ptr"))) {
                                             if (len >= 2) {
-                                                __auto_type _mv_1430 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1430.has_value) {
-                                                    __auto_type inner = _mv_1430.value;
+                                                __auto_type _mv_1431 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1431.has_value) {
+                                                    __auto_type inner = _mv_1431.value;
                                                     transpiler_scan_type_for_generics(ctx, inner);
-                                                } else if (!_mv_1430.has_value) {
+                                                } else if (!_mv_1431.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("Result"))) {
                                             if (len >= 3) {
-                                                __auto_type _mv_1431 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1431.has_value) {
-                                                    __auto_type ok_type = _mv_1431.value;
-                                                    __auto_type _mv_1432 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1432.has_value) {
-                                                        __auto_type err_type = _mv_1432.value;
+                                                __auto_type _mv_1432 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1432.has_value) {
+                                                    __auto_type ok_type = _mv_1432.value;
+                                                    __auto_type _mv_1433 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1433.has_value) {
+                                                        __auto_type err_type = _mv_1433.value;
                                                         {
                                                             __auto_type ok_c = context_to_c_type_prefixed(ctx, ok_type);
                                                             __auto_type err_c = context_to_c_type_prefixed(ctx, err_type);
@@ -2768,16 +2768,16 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                             transpiler_scan_type_for_generics(ctx, ok_type);
                                                             transpiler_scan_type_for_generics(ctx, err_type);
                                                         }
-                                                    } else if (!_mv_1432.has_value) {
+                                                    } else if (!_mv_1433.has_value) {
                                                     }
-                                                } else if (!_mv_1431.has_value) {
+                                                } else if (!_mv_1432.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("Chan"))) {
                                             if (len >= 2) {
-                                                __auto_type _mv_1433 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1433.has_value) {
-                                                    __auto_type elem = _mv_1433.value;
+                                                __auto_type _mv_1434 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1434.has_value) {
+                                                    __auto_type elem = _mv_1434.value;
                                                     {
                                                         __auto_type elem_c = context_to_c_type_prefixed(ctx, elem);
                                                         __auto_type elem_id = ctype_type_to_identifier(arena, elem_c);
@@ -2785,14 +2785,14 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                         context_ctx_register_chan_type(ctx, elem_c, c_name);
                                                         transpiler_scan_type_for_generics(ctx, elem);
                                                     }
-                                                } else if (!_mv_1433.has_value) {
+                                                } else if (!_mv_1434.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("Thread"))) {
                                             if (len >= 2) {
-                                                __auto_type _mv_1434 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1434.has_value) {
-                                                    __auto_type result = _mv_1434.value;
+                                                __auto_type _mv_1435 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1435.has_value) {
+                                                    __auto_type result = _mv_1435.value;
                                                     {
                                                         __auto_type result_c = context_to_c_type_prefixed(ctx, result);
                                                         {
@@ -2803,14 +2803,14 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                             transpiler_scan_type_for_generics(ctx, result);
                                                         }
                                                     }
-                                                } else if (!_mv_1434.has_value) {
+                                                } else if (!_mv_1435.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("Map"))) {
                                             if (len >= 3) {
-                                                __auto_type _mv_1435 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1435.has_value) {
-                                                    __auto_type key_type = _mv_1435.value;
+                                                __auto_type _mv_1436 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1436.has_value) {
+                                                    __auto_type key_type = _mv_1436.value;
                                                     {
                                                         __auto_type key_c = context_to_c_type_prefixed(ctx, key_type);
                                                         __auto_type key_id = ctype_type_to_identifier(arena, key_c);
@@ -2819,9 +2819,9 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                         context_ctx_register_list_type(ctx, key_c, list_c_name);
                                                         context_ctx_register_option_type(ctx, key_c, option_c_name);
                                                         transpiler_scan_type_for_generics(ctx, key_type);
-                                                        __auto_type _mv_1436 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                        if (_mv_1436.has_value) {
-                                                            __auto_type val_type = _mv_1436.value;
+                                                        __auto_type _mv_1437 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                        if (_mv_1437.has_value) {
+                                                            __auto_type val_type = _mv_1437.value;
                                                             {
                                                                 __auto_type val_c = context_to_c_type_prefixed(ctx, val_type);
                                                                 __auto_type val_id = ctype_type_to_identifier(arena, val_c);
@@ -2829,17 +2829,17 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                                 context_ctx_register_option_type(ctx, val_c, val_option_c_name);
                                                                 transpiler_scan_type_for_generics(ctx, val_type);
                                                             }
-                                                        } else if (!_mv_1436.has_value) {
+                                                        } else if (!_mv_1437.has_value) {
                                                         }
                                                     }
-                                                } else if (!_mv_1435.has_value) {
+                                                } else if (!_mv_1436.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("Set"))) {
                                             if (len >= 2) {
-                                                __auto_type _mv_1437 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1437.has_value) {
-                                                    __auto_type elem_type = _mv_1437.value;
+                                                __auto_type _mv_1438 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1438.has_value) {
+                                                    __auto_type elem_type = _mv_1438.value;
                                                     {
                                                         __auto_type elem_c = context_to_c_type_prefixed(ctx, elem_type);
                                                         __auto_type elem_id = ctype_type_to_identifier(arena, elem_c);
@@ -2849,7 +2849,7 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                         context_ctx_register_option_type(ctx, elem_c, option_c_name);
                                                         transpiler_scan_type_for_generics(ctx, elem_type);
                                                     }
-                                                } else if (!_mv_1437.has_value) {
+                                                } else if (!_mv_1438.has_value) {
                                                 }
                                             }
                                         } else {
@@ -2861,7 +2861,7 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                     break;
                                 }
                             }
-                        } else if (!_mv_1426.has_value) {
+                        } else if (!_mv_1427.has_value) {
                         }
                     }
                 }
@@ -2880,22 +2880,22 @@ void transpiler_scan_record_fields_for_generics(context_TranspileContext* ctx, s
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1438 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1438.has_value) {
-                __auto_type field_expr = _mv_1438.value;
-                __auto_type _mv_1439 = (*field_expr);
-                switch (_mv_1439.tag) {
+            __auto_type _mv_1439 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1439.has_value) {
+                __auto_type field_expr = _mv_1439.value;
+                __auto_type _mv_1440 = (*field_expr);
+                switch (_mv_1440.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type field_lst = _mv_1439.data.lst;
+                        __auto_type field_lst = _mv_1440.data.lst;
                         {
                             __auto_type field_items = field_lst.items;
                             if (((int64_t)((field_items).len)) >= 2) {
-                                __auto_type _mv_1440 = ({ __auto_type _lst = field_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1440.has_value) {
-                                    __auto_type type_expr = _mv_1440.value;
+                                __auto_type _mv_1441 = ({ __auto_type _lst = field_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1441.has_value) {
+                                    __auto_type type_expr = _mv_1441.value;
                                     transpiler_scan_type_for_generics(ctx, type_expr);
-                                } else if (!_mv_1440.has_value) {
+                                } else if (!_mv_1441.has_value) {
                                 }
                             }
                         }
@@ -2905,7 +2905,7 @@ void transpiler_scan_record_fields_for_generics(context_TranspileContext* ctx, s
                         break;
                     }
                 }
-            } else if (!_mv_1438.has_value) {
+            } else if (!_mv_1439.has_value) {
             }
             i = (i + 1);
         }
@@ -2919,11 +2919,11 @@ void transpiler_emit_ffi_includes(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((includes).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1441 = ({ __auto_type _lst = includes; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1441.has_value) {
-                __auto_type header = _mv_1441.value;
+            __auto_type _mv_1442 = ({ __auto_type _lst = includes; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1442.has_value) {
+                __auto_type header = _mv_1442.value;
                 emit_emit_include(ctx, header, 1);
-            } else if (!_mv_1441.has_value) {
+            } else if (!_mv_1442.has_value) {
             }
             i = (i + 1);
         }
@@ -2937,11 +2937,11 @@ void transpiler_emit_ffi_includes_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((includes).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1442 = ({ __auto_type _lst = includes; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1442.has_value) {
-                __auto_type header = _mv_1442.value;
+            __auto_type _mv_1443 = ({ __auto_type _lst = includes; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1443.has_value) {
+                __auto_type header = _mv_1443.value;
                 context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("#include <"), header, SLOP_STR(">")));
-            } else if (!_mv_1442.has_value) {
+            } else if (!_mv_1443.has_value) {
             }
             i = (i + 1);
         }
@@ -2952,9 +2952,9 @@ void transpiler_emit_header_guard_open(context_TranspileContext* ctx) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1443 = context_ctx_get_module(ctx);
-        if (_mv_1443.has_value) {
-            __auto_type mod_name = _mv_1443.value;
+        __auto_type _mv_1444 = context_ctx_get_module(ctx);
+        if (_mv_1444.has_value) {
+            __auto_type mod_name = _mv_1444.value;
             {
                 __auto_type c_name = ctype_to_c_name(arena, mod_name);
                 __auto_type guard = context_ctx_str3(ctx, SLOP_STR("SLOP_"), c_name, SLOP_STR("_H"));
@@ -2962,7 +2962,7 @@ void transpiler_emit_header_guard_open(context_TranspileContext* ctx) {
                 context_ctx_emit_header(ctx, context_ctx_str(ctx, SLOP_STR("#define "), guard));
                 context_ctx_emit_header(ctx, SLOP_STR(""));
             }
-        } else if (!_mv_1443.has_value) {
+        } else if (!_mv_1444.has_value) {
         }
     }
 }
@@ -2988,14 +2988,14 @@ void transpiler_emit_header_dependency_includes(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((imports).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1444 = ({ __auto_type _lst = imports; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1444.has_value) {
-                __auto_type mod_name = _mv_1444.value;
+            __auto_type _mv_1445 = ({ __auto_type _lst = imports; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1445.has_value) {
+                __auto_type mod_name = _mv_1445.value;
                 {
                     __auto_type c_name = ctype_to_c_name(arena, mod_name);
                     context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("#include \"slop_"), c_name, SLOP_STR(".h\"")));
                 }
-            } else if (!_mv_1444.has_value) {
+            } else if (!_mv_1445.has_value) {
             }
             i = (i + 1);
         }
@@ -3010,22 +3010,22 @@ void transpiler_emit_forward_decls(context_TranspileContext* ctx, slop_list_type
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1445 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1445.has_value) {
-                __auto_type item = _mv_1445.value;
+            __auto_type _mv_1446 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1446.has_value) {
+                __auto_type item = _mv_1446.value;
                 if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
-                    __auto_type _mv_1446 = transpiler_get_type_name(item);
-                    if (_mv_1446.has_value) {
-                        __auto_type type_name = _mv_1446.value;
+                    __auto_type _mv_1447 = transpiler_get_type_name(item);
+                    if (_mv_1447.has_value) {
+                        __auto_type type_name = _mv_1447.value;
                         {
                             __auto_type c_name = ctype_to_c_name(arena, type_name);
                             context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("typedef struct "), c_name, context_ctx_str(ctx, SLOP_STR(" "), context_ctx_str(ctx, c_name, SLOP_STR(";")))));
                             emitted_any = 1;
                         }
-                    } else if (!_mv_1446.has_value) {
+                    } else if (!_mv_1447.has_value) {
                     }
                 }
-            } else if (!_mv_1445.has_value) {
+            } else if (!_mv_1446.has_value) {
             }
             i = (i + 1);
         }
@@ -3037,37 +3037,37 @@ void transpiler_emit_forward_decls(context_TranspileContext* ctx, slop_list_type
 
 uint8_t transpiler_is_struct_type_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1447 = (*item);
-    switch (_mv_1447.tag) {
+    __auto_type _mv_1448 = (*item);
+    switch (_mv_1448.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1447.data.lst;
+            __auto_type lst = _mv_1448.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 3) {
                     return 0;
                 } else {
-                    __auto_type _mv_1448 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1448.has_value) {
-                        __auto_type def_expr = _mv_1448.value;
-                        __auto_type _mv_1449 = (*def_expr);
-                        switch (_mv_1449.tag) {
+                    __auto_type _mv_1449 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1449.has_value) {
+                        __auto_type def_expr = _mv_1449.value;
+                        __auto_type _mv_1450 = (*def_expr);
+                        switch (_mv_1450.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type def_lst = _mv_1449.data.lst;
+                                __auto_type def_lst = _mv_1450.data.lst;
                                 {
                                     __auto_type def_items = def_lst.items;
                                     if (((int64_t)((def_items).len)) < 1) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1450 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1450.has_value) {
-                                            __auto_type head = _mv_1450.value;
-                                            __auto_type _mv_1451 = (*head);
-                                            switch (_mv_1451.tag) {
+                                        __auto_type _mv_1451 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1451.has_value) {
+                                            __auto_type head = _mv_1451.value;
+                                            __auto_type _mv_1452 = (*head);
+                                            switch (_mv_1452.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_1451.data.sym;
+                                                    __auto_type sym = _mv_1452.data.sym;
                                                     {
                                                         __auto_type kind = sym.name;
                                                         return ((string_eq(kind, SLOP_STR("record"))) || (string_eq(kind, SLOP_STR("union"))) || ((string_eq(kind, SLOP_STR("enum")) && transpiler_has_enum_payload_variants(def_items))));
@@ -3077,7 +3077,7 @@ uint8_t transpiler_is_struct_type_def(types_SExpr* item) {
                                                     return 0;
                                                 }
                                             }
-                                        } else if (!_mv_1450.has_value) {
+                                        } else if (!_mv_1451.has_value) {
                                             return 0;
                                         }
                                         SLOP_UNREACHABLE();
@@ -3088,7 +3088,7 @@ uint8_t transpiler_is_struct_type_def(types_SExpr* item) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1448.has_value) {
+                    } else if (!_mv_1449.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -3107,14 +3107,14 @@ uint8_t transpiler_has_enum_payload_variants(slop_list_types_SExpr_ptr items) {
         int64_t i = 1;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1452 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1452.has_value) {
-                __auto_type item = _mv_1452.value;
-                __auto_type _mv_1453 = (*item);
-                switch (_mv_1453.tag) {
+            __auto_type _mv_1453 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1453.has_value) {
+                __auto_type item = _mv_1453.value;
+                __auto_type _mv_1454 = (*item);
+                switch (_mv_1454.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type _ = _mv_1453.data.lst;
+                        __auto_type _ = _mv_1454.data.lst;
                         found = 1;
                         break;
                     }
@@ -3122,7 +3122,7 @@ uint8_t transpiler_has_enum_payload_variants(slop_list_types_SExpr_ptr items) {
                         break;
                     }
                 }
-            } else if (!_mv_1452.has_value) {
+            } else if (!_mv_1453.has_value) {
             }
             i = (i + 1);
         }
@@ -3132,42 +3132,42 @@ uint8_t transpiler_has_enum_payload_variants(slop_list_types_SExpr_ptr items) {
 
 uint8_t transpiler_is_type_alias_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1454 = (*item);
-    switch (_mv_1454.tag) {
+    __auto_type _mv_1455 = (*item);
+    switch (_mv_1455.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1454.data.lst;
+            __auto_type lst = _mv_1455.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 3) {
                     return 0;
                 } else {
-                    __auto_type _mv_1455 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1455.has_value) {
-                        __auto_type def_expr = _mv_1455.value;
-                        __auto_type _mv_1456 = (*def_expr);
-                        switch (_mv_1456.tag) {
+                    __auto_type _mv_1456 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1456.has_value) {
+                        __auto_type def_expr = _mv_1456.value;
+                        __auto_type _mv_1457 = (*def_expr);
+                        switch (_mv_1457.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type _ = _mv_1456.data.sym;
+                                __auto_type _ = _mv_1457.data.sym;
                                 return 1;
                             }
                             case types_SExpr_lst:
                             {
-                                __auto_type def_lst = _mv_1456.data.lst;
+                                __auto_type def_lst = _mv_1457.data.lst;
                                 {
                                     __auto_type def_items = def_lst.items;
                                     if (((int64_t)((def_items).len)) < 1) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1457 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1457.has_value) {
-                                            __auto_type head = _mv_1457.value;
-                                            __auto_type _mv_1458 = (*head);
-                                            switch (_mv_1458.tag) {
+                                        __auto_type _mv_1458 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1458.has_value) {
+                                            __auto_type head = _mv_1458.value;
+                                            __auto_type _mv_1459 = (*head);
+                                            switch (_mv_1459.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_1458.data.sym;
+                                                    __auto_type sym = _mv_1459.data.sym;
                                                     {
                                                         __auto_type kind = sym.name;
                                                         return ((!(string_eq(kind, SLOP_STR("record")))) && (!(string_eq(kind, SLOP_STR("enum")))) && (!(string_eq(kind, SLOP_STR("union")))));
@@ -3177,7 +3177,7 @@ uint8_t transpiler_is_type_alias_def(types_SExpr* item) {
                                                     return 0;
                                                 }
                                             }
-                                        } else if (!_mv_1457.has_value) {
+                                        } else if (!_mv_1458.has_value) {
                                             return 0;
                                         }
                                         SLOP_UNREACHABLE();
@@ -3188,7 +3188,7 @@ uint8_t transpiler_is_type_alias_def(types_SExpr* item) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1455.has_value) {
+                    } else if (!_mv_1456.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -3203,44 +3203,44 @@ uint8_t transpiler_is_type_alias_def(types_SExpr* item) {
 
 uint8_t transpiler_is_result_type_alias_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1459 = (*item);
-    switch (_mv_1459.tag) {
+    __auto_type _mv_1460 = (*item);
+    switch (_mv_1460.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1459.data.lst;
+            __auto_type lst = _mv_1460.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 3) {
                     return 0;
                 } else {
-                    __auto_type _mv_1460 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1460.has_value) {
-                        __auto_type def_expr = _mv_1460.value;
-                        __auto_type _mv_1461 = (*def_expr);
-                        switch (_mv_1461.tag) {
+                    __auto_type _mv_1461 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1461.has_value) {
+                        __auto_type def_expr = _mv_1461.value;
+                        __auto_type _mv_1462 = (*def_expr);
+                        switch (_mv_1462.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type def_lst = _mv_1461.data.lst;
+                                __auto_type def_lst = _mv_1462.data.lst;
                                 {
                                     __auto_type def_items = def_lst.items;
                                     if (((int64_t)((def_items).len)) < 1) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1462 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1462.has_value) {
-                                            __auto_type head = _mv_1462.value;
-                                            __auto_type _mv_1463 = (*head);
-                                            switch (_mv_1463.tag) {
+                                        __auto_type _mv_1463 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1463.has_value) {
+                                            __auto_type head = _mv_1463.value;
+                                            __auto_type _mv_1464 = (*head);
+                                            switch (_mv_1464.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_1463.data.sym;
+                                                    __auto_type sym = _mv_1464.data.sym;
                                                     return string_eq(sym.name, SLOP_STR("Result"));
                                                 }
                                                 default: {
                                                     return 0;
                                                 }
                                             }
-                                        } else if (!_mv_1462.has_value) {
+                                        } else if (!_mv_1463.has_value) {
                                             return 0;
                                         }
                                         SLOP_UNREACHABLE();
@@ -3251,7 +3251,7 @@ uint8_t transpiler_is_result_type_alias_def(types_SExpr* item) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1460.has_value) {
+                    } else if (!_mv_1461.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -3269,29 +3269,29 @@ void transpiler_emit_type_alias_to_header(context_TranspileContext* ctx, types_S
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1464 = (*type_def);
-        switch (_mv_1464.tag) {
+        __auto_type _mv_1465 = (*type_def);
+        switch (_mv_1465.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1464.data.lst;
+                __auto_type lst = _mv_1465.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_1465 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1465.has_value) {
-                            __auto_type name_expr = _mv_1465.value;
-                            __auto_type _mv_1466 = (*name_expr);
-                            switch (_mv_1466.tag) {
+                        __auto_type _mv_1466 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1466.has_value) {
+                            __auto_type name_expr = _mv_1466.value;
+                            __auto_type _mv_1467 = (*name_expr);
+                            switch (_mv_1467.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1466.data.sym;
+                                    __auto_type name_sym = _mv_1467.data.sym;
                                     {
                                         __auto_type type_name = name_sym.name;
                                         __auto_type base_c_name = ctype_to_c_name(arena, type_name);
                                         __auto_type c_name = context_ctx_prefix_type(ctx, base_c_name);
-                                        __auto_type _mv_1467 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1467.has_value) {
-                                            __auto_type body_expr = _mv_1467.value;
+                                        __auto_type _mv_1468 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1468.has_value) {
+                                            __auto_type body_expr = _mv_1468.value;
                                             if (transpiler_is_array_type_body(body_expr)) {
                                                 transpiler_emit_array_typedef_to_header(ctx, c_name, body_expr);
                                             } else if (transpiler_is_range_type_body(body_expr)) {
@@ -3304,7 +3304,7 @@ void transpiler_emit_type_alias_to_header(context_TranspileContext* ctx, types_S
                                                     context_ctx_mark_type_emitted(ctx, c_name);
                                                 }
                                             }
-                                        } else if (!_mv_1467.has_value) {
+                                        } else if (!_mv_1468.has_value) {
                                         }
                                     }
                                     break;
@@ -3313,7 +3313,7 @@ void transpiler_emit_type_alias_to_header(context_TranspileContext* ctx, types_S
                                     break;
                                 }
                             }
-                        } else if (!_mv_1465.has_value) {
+                        } else if (!_mv_1466.has_value) {
                         }
                     }
                 }
@@ -3328,31 +3328,31 @@ void transpiler_emit_type_alias_to_header(context_TranspileContext* ctx, types_S
 
 uint8_t transpiler_is_array_type_body(types_SExpr* body_expr) {
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
-    __auto_type _mv_1468 = (*body_expr);
-    switch (_mv_1468.tag) {
+    __auto_type _mv_1469 = (*body_expr);
+    switch (_mv_1469.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1468.data.lst;
+            __auto_type lst = _mv_1469.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1469 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1469.has_value) {
-                        __auto_type head = _mv_1469.value;
-                        __auto_type _mv_1470 = (*head);
-                        switch (_mv_1470.tag) {
+                    __auto_type _mv_1470 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1470.has_value) {
+                        __auto_type head = _mv_1470.value;
+                        __auto_type _mv_1471 = (*head);
+                        switch (_mv_1471.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1470.data.sym;
+                                __auto_type sym = _mv_1471.data.sym;
                                 return string_eq(sym.name, SLOP_STR("Array"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1469.has_value) {
+                    } else if (!_mv_1470.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -3370,33 +3370,33 @@ void transpiler_emit_array_typedef_to_header(context_TranspileContext* ctx, slop
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1471 = (*body_expr);
-        switch (_mv_1471.tag) {
+        __auto_type _mv_1472 = (*body_expr);
+        switch (_mv_1472.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1471.data.lst;
+                __auto_type lst = _mv_1472.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 3) {
                         context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("typedef void* "), c_name, SLOP_STR(";")));
                     } else {
-                        __auto_type _mv_1472 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1472.has_value) {
-                            __auto_type elem_type_expr = _mv_1472.value;
-                            __auto_type _mv_1473 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1473.has_value) {
-                                __auto_type size_expr = _mv_1473.value;
+                        __auto_type _mv_1473 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1473.has_value) {
+                            __auto_type elem_type_expr = _mv_1473.value;
+                            __auto_type _mv_1474 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1474.has_value) {
+                                __auto_type size_expr = _mv_1474.value;
                                 {
                                     __auto_type elem_c_type = context_to_c_type_prefixed(ctx, elem_type_expr);
                                     __auto_type size_str = transpiler_get_array_size_string(size_expr);
                                     context_ctx_emit_header(ctx, context_ctx_str5(ctx, SLOP_STR("typedef "), elem_c_type, SLOP_STR(" "), c_name, context_ctx_str3(ctx, SLOP_STR("["), size_str, SLOP_STR("];"))));
                                     context_ctx_emit_header(ctx, SLOP_STR(""));
                                 }
-                            } else if (!_mv_1473.has_value) {
+                            } else if (!_mv_1474.has_value) {
                                 context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("typedef void* "), c_name, SLOP_STR(";")));
                             }
-                        } else if (!_mv_1472.has_value) {
+                        } else if (!_mv_1473.has_value) {
                             context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("typedef void* "), c_name, SLOP_STR(";")));
                         }
                     }
@@ -3413,11 +3413,11 @@ void transpiler_emit_array_typedef_to_header(context_TranspileContext* ctx, slop
 
 slop_string transpiler_get_array_size_string(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1474 = (*expr);
-    switch (_mv_1474.tag) {
+    __auto_type _mv_1475 = (*expr);
+    switch (_mv_1475.tag) {
         case types_SExpr_num:
         {
-            __auto_type num = _mv_1474.data.num;
+            __auto_type num = _mv_1475.data.num;
             return num.raw;
         }
         default: {
@@ -3428,25 +3428,25 @@ slop_string transpiler_get_array_size_string(types_SExpr* expr) {
 
 uint8_t transpiler_is_range_type_body(types_SExpr* body_expr) {
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
-    __auto_type _mv_1475 = (*body_expr);
-    switch (_mv_1475.tag) {
+    __auto_type _mv_1476 = (*body_expr);
+    switch (_mv_1476.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1475.data.lst;
+            __auto_type lst = _mv_1476.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type found_dots = 0;
                 __auto_type i = 0;
                 while ((i < len) && !(found_dots)) {
-                    __auto_type _mv_1476 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1476.has_value) {
-                        __auto_type item = _mv_1476.value;
-                        __auto_type _mv_1477 = (*item);
-                        switch (_mv_1477.tag) {
+                    __auto_type _mv_1477 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1477.has_value) {
+                        __auto_type item = _mv_1477.value;
+                        __auto_type _mv_1478 = (*item);
+                        switch (_mv_1478.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1477.data.sym;
+                                __auto_type sym = _mv_1478.data.sym;
                                 if (string_eq(sym.name, SLOP_STR(".."))) {
                                     found_dots = 1;
                                 }
@@ -3456,7 +3456,7 @@ uint8_t transpiler_is_range_type_body(types_SExpr* body_expr) {
                                 break;
                             }
                         }
-                    } else if (!_mv_1476.has_value) {
+                    } else if (!_mv_1477.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -3477,24 +3477,24 @@ transpiler_RangeBoundsHeader transpiler_parse_range_bounds_header(types_SExpr* b
         uint8_t has_min = 0;
         uint8_t has_max = 0;
         uint8_t found_dots = 0;
-        __auto_type _mv_1478 = (*body_expr);
-        switch (_mv_1478.tag) {
+        __auto_type _mv_1479 = (*body_expr);
+        switch (_mv_1479.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1478.data.lst;
+                __auto_type lst = _mv_1479.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type i = 1;
                     while (i < len) {
-                        __auto_type _mv_1479 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1479.has_value) {
-                            __auto_type item = _mv_1479.value;
-                            __auto_type _mv_1480 = (*item);
-                            switch (_mv_1480.tag) {
+                        __auto_type _mv_1480 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1480.has_value) {
+                            __auto_type item = _mv_1480.value;
+                            __auto_type _mv_1481 = (*item);
+                            switch (_mv_1481.tag) {
                                 case types_SExpr_num:
                                 {
-                                    __auto_type num = _mv_1480.data.num;
+                                    __auto_type num = _mv_1481.data.num;
                                     if (!(found_dots)) {
                                         min_val = transpiler_string_to_int_header(num.raw);
                                         has_min = 1;
@@ -3506,7 +3506,7 @@ transpiler_RangeBoundsHeader transpiler_parse_range_bounds_header(types_SExpr* b
                                 }
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1480.data.sym;
+                                    __auto_type sym = _mv_1481.data.sym;
                                     if (string_eq(sym.name, SLOP_STR(".."))) {
                                         found_dots = 1;
                                     }
@@ -3516,7 +3516,7 @@ transpiler_RangeBoundsHeader transpiler_parse_range_bounds_header(types_SExpr* b
                                     break;
                                 }
                             }
-                        } else if (!_mv_1479.has_value) {
+                        } else if (!_mv_1480.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -3626,23 +3626,23 @@ void transpiler_emit_forward_decls_header(context_TranspileContext* ctx, slop_li
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1481 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1481.has_value) {
-                __auto_type item = _mv_1481.value;
+            __auto_type _mv_1482 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1482.has_value) {
+                __auto_type item = _mv_1482.value;
                 if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
-                    __auto_type _mv_1482 = transpiler_get_type_name(item);
-                    if (_mv_1482.has_value) {
-                        __auto_type type_name = _mv_1482.value;
+                    __auto_type _mv_1483 = transpiler_get_type_name(item);
+                    if (_mv_1483.has_value) {
+                        __auto_type type_name = _mv_1483.value;
                         {
                             __auto_type base_name = ctype_to_c_name(arena, type_name);
                             __auto_type c_name = ((context_ctx_prefixing_enabled(ctx)) ? ({ __auto_type _mv = context_ctx_get_module(ctx); _mv.has_value ? ({ __auto_type mod_name = _mv.value; context_ctx_str(ctx, ctype_to_c_name(arena, mod_name), context_ctx_str(ctx, SLOP_STR("_"), base_name)); }) : (base_name); }) : base_name);
                             context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("typedef struct "), c_name, context_ctx_str(ctx, SLOP_STR(" "), context_ctx_str(ctx, c_name, SLOP_STR(";")))));
                             emitted_any = 1;
                         }
-                    } else if (!_mv_1482.has_value) {
+                    } else if (!_mv_1483.has_value) {
                     }
                 }
-            } else if (!_mv_1481.has_value) {
+            } else if (!_mv_1482.has_value) {
             }
             i = (i + 1);
         }
@@ -3659,14 +3659,14 @@ void transpiler_emit_fn_forward_decls(context_TranspileContext* ctx, slop_list_t
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1483 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1483.has_value) {
-                __auto_type item = _mv_1483.value;
+            __auto_type _mv_1484 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1484.has_value) {
+                __auto_type item = _mv_1484.value;
                 if (transpiler_is_fn_def(item)) {
                     defn_emit_forward_declaration(ctx, item);
                     emitted_any = 1;
                 }
-            } else if (!_mv_1483.has_value) {
+            } else if (!_mv_1484.has_value) {
             }
             i = (i + 1);
         }
@@ -3683,14 +3683,14 @@ void transpiler_emit_fn_forward_decls_header(context_TranspileContext* ctx, slop
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1484 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1484.has_value) {
-                __auto_type item = _mv_1484.value;
+            __auto_type _mv_1485 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1485.has_value) {
+                __auto_type item = _mv_1485.value;
                 if (transpiler_is_fn_def(item)) {
                     transpiler_emit_fn_forward_decl_header(ctx, item);
                     emitted_any = 1;
                 }
-            } else if (!_mv_1484.has_value) {
+            } else if (!_mv_1485.has_value) {
             }
             i = (i + 1);
         }
@@ -3709,11 +3709,11 @@ void transpiler_emit_c_name_aliases(context_TranspileContext* ctx) {
         if (len > 0) {
             context_ctx_emit_header(ctx, SLOP_STR("/* Function name aliases for C interop */"));
             while (i < len) {
-                __auto_type _mv_1485 = ({ __auto_type _lst = aliases; size_t _idx = (size_t)i; slop_option_context_FuncCNameAlias _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1485.has_value) {
-                    __auto_type alias = _mv_1485.value;
+                __auto_type _mv_1486 = ({ __auto_type _lst = aliases; size_t _idx = (size_t)i; slop_option_context_FuncCNameAlias _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1486.has_value) {
+                    __auto_type alias = _mv_1486.value;
                     context_ctx_emit_header(ctx, context_ctx_str(ctx, SLOP_STR("#define "), context_ctx_str(ctx, alias.mangled_name, context_ctx_str(ctx, SLOP_STR(" "), alias.clean_name))));
-                } else if (!_mv_1485.has_value) {
+                } else if (!_mv_1486.has_value) {
                 }
                 i = (i + 1);
             }
@@ -3727,31 +3727,31 @@ void transpiler_emit_fn_forward_decl_header(context_TranspileContext* ctx, types
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1486 = (*expr);
-        switch (_mv_1486.tag) {
+        __auto_type _mv_1487 = (*expr);
+        switch (_mv_1487.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1486.data.lst;
+                __auto_type lst = _mv_1487.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 3) {
-                        __auto_type _mv_1487 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1487.has_value) {
-                            __auto_type name_expr = _mv_1487.value;
-                            __auto_type _mv_1488 = (*name_expr);
-                            switch (_mv_1488.tag) {
+                        __auto_type _mv_1488 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1488.has_value) {
+                            __auto_type name_expr = _mv_1488.value;
+                            __auto_type _mv_1489 = (*name_expr);
+                            switch (_mv_1489.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1488.data.sym;
+                                    __auto_type name_sym = _mv_1489.data.sym;
                                     {
                                         __auto_type raw_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, raw_name);
                                         __auto_type mangled_name = ((string_eq(base_name, SLOP_STR("main"))) ? base_name : context_ctx_prefix_type(ctx, base_name));
                                         __auto_type fn_name = context_extract_fn_c_name(arena, items, mangled_name);
-                                        __auto_type _mv_1489 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1489.has_value) {
-                                            __auto_type params_expr = _mv_1489.value;
+                                        __auto_type _mv_1490 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1490.has_value) {
+                                            __auto_type params_expr = _mv_1490.value;
                                             {
                                                 __auto_type result_type_opt = defn_get_result_type_name(ctx, items);
                                                 __auto_type raw_return = defn_get_return_type(ctx, items);
@@ -3762,7 +3762,7 @@ void transpiler_emit_fn_forward_decl_header(context_TranspileContext* ctx, types
                                                     context_ctx_emit_header(ctx, context_ctx_str5(ctx, actual_return, SLOP_STR(" "), fn_name, SLOP_STR("("), context_ctx_str(ctx, ((string_eq(param_str, SLOP_STR(""))) ? SLOP_STR("void") : param_str), SLOP_STR(");"))));
                                                 }
                                             }
-                                        } else if (!_mv_1489.has_value) {
+                                        } else if (!_mv_1490.has_value) {
                                         }
                                     }
                                     break;
@@ -3771,7 +3771,7 @@ void transpiler_emit_fn_forward_decl_header(context_TranspileContext* ctx, types
                                     break;
                                 }
                             }
-                        } else if (!_mv_1487.has_value) {
+                        } else if (!_mv_1488.has_value) {
                         }
                     }
                 }
@@ -3786,31 +3786,31 @@ void transpiler_emit_fn_forward_decl_header(context_TranspileContext* ctx, types
 
 slop_option_string transpiler_get_type_name(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1490 = (*item);
-    switch (_mv_1490.tag) {
+    __auto_type _mv_1491 = (*item);
+    switch (_mv_1491.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1490.data.lst;
+            __auto_type lst = _mv_1491.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return (slop_option_string){.has_value = false};
                 } else {
-                    __auto_type _mv_1491 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1491.has_value) {
-                        __auto_type name_expr = _mv_1491.value;
-                        __auto_type _mv_1492 = (*name_expr);
-                        switch (_mv_1492.tag) {
+                    __auto_type _mv_1492 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1492.has_value) {
+                        __auto_type name_expr = _mv_1492.value;
+                        __auto_type _mv_1493 = (*name_expr);
+                        switch (_mv_1493.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1492.data.sym;
+                                __auto_type sym = _mv_1493.data.sym;
                                 return (slop_option_string){.has_value = 1, .value = sym.name};
                             }
                             default: {
                                 return (slop_option_string){.has_value = false};
                             }
                         }
-                    } else if (!_mv_1491.has_value) {
+                    } else if (!_mv_1492.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
                     SLOP_UNREACHABLE();
@@ -3829,14 +3829,14 @@ void transpiler_emit_module_types(context_TranspileContext* ctx, slop_list_types
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1493 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1493.has_value) {
-                __auto_type item = _mv_1493.value;
+            __auto_type _mv_1494 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1494.has_value) {
+                __auto_type item = _mv_1494.value;
                 if (transpiler_is_type_def(item)) {
                     defn_transpile_type(ctx, item);
                     context_ctx_emit(ctx, SLOP_STR(""));
                 }
-            } else if (!_mv_1493.has_value) {
+            } else if (!_mv_1494.has_value) {
             }
             i = (i + 1);
         }
@@ -3850,14 +3850,14 @@ void transpiler_emit_type_aliases(context_TranspileContext* ctx, slop_list_types
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1494 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1494.has_value) {
-                __auto_type item = _mv_1494.value;
+            __auto_type _mv_1495 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1495.has_value) {
+                __auto_type item = _mv_1495.value;
                 if (transpiler_is_type_def(item) && transpiler_is_type_alias_def(item)) {
                     defn_transpile_type(ctx, item);
                     emitted_any = 1;
                 }
-            } else if (!_mv_1494.has_value) {
+            } else if (!_mv_1495.has_value) {
             }
             i = (i + 1);
         }
@@ -3874,14 +3874,14 @@ void transpiler_emit_enum_types(context_TranspileContext* ctx, slop_list_types_S
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1495 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1495.has_value) {
-                __auto_type item = _mv_1495.value;
+            __auto_type _mv_1496 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1496.has_value) {
+                __auto_type item = _mv_1496.value;
                 if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
                     defn_transpile_type(ctx, item);
                     emitted_any = 1;
                 }
-            } else if (!_mv_1495.has_value) {
+            } else if (!_mv_1496.has_value) {
             }
             i = (i + 1);
         }
@@ -3897,14 +3897,14 @@ void transpiler_emit_struct_types(context_TranspileContext* ctx, slop_list_types
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1496 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1496.has_value) {
-                __auto_type item = _mv_1496.value;
+            __auto_type _mv_1497 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1497.has_value) {
+                __auto_type item = _mv_1497.value;
                 if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                     defn_transpile_type(ctx, item);
                     context_ctx_emit(ctx, SLOP_STR(""));
                 }
-            } else if (!_mv_1496.has_value) {
+            } else if (!_mv_1497.has_value) {
             }
             i = (i + 1);
         }
@@ -3918,11 +3918,11 @@ void transpiler_emit_result_types(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((result_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1497 = ({ __auto_type _lst = result_types; size_t _idx = (size_t)i; slop_option_context_ResultType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1497.has_value) {
-                __auto_type rt = _mv_1497.value;
+            __auto_type _mv_1498 = ({ __auto_type _lst = result_types; size_t _idx = (size_t)i; slop_option_context_ResultType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1498.has_value) {
+                __auto_type rt = _mv_1498.value;
                 transpiler_emit_single_result_type(ctx, rt);
-            } else if (!_mv_1497.has_value) {
+            } else if (!_mv_1498.has_value) {
             }
             i = (i + 1);
         }
@@ -3957,11 +3957,11 @@ void transpiler_emit_result_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((result_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1498 = ({ __auto_type _lst = result_types; size_t _idx = (size_t)i; slop_option_context_ResultType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1498.has_value) {
-                __auto_type rt = _mv_1498.value;
+            __auto_type _mv_1499 = ({ __auto_type _lst = result_types; size_t _idx = (size_t)i; slop_option_context_ResultType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1499.has_value) {
+                __auto_type rt = _mv_1499.value;
                 transpiler_emit_single_result_type_header(ctx, rt);
-            } else if (!_mv_1498.has_value) {
+            } else if (!_mv_1499.has_value) {
             }
             i = (i + 1);
         }
@@ -3996,9 +3996,9 @@ void transpiler_emit_inline_records_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((inline_records).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1499 = ({ __auto_type _lst = inline_records; size_t _idx = (size_t)i; slop_option_context_InlineRecord _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1499.has_value) {
-                __auto_type ir = _mv_1499.value;
+            __auto_type _mv_1500 = ({ __auto_type _lst = inline_records; size_t _idx = (size_t)i; slop_option_context_InlineRecord _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1500.has_value) {
+                __auto_type ir = _mv_1500.value;
                 {
                     __auto_type type_name = ir.type_name;
                     __auto_type field_body = ir.field_body;
@@ -4009,7 +4009,7 @@ void transpiler_emit_inline_records_header(context_TranspileContext* ctx) {
                     context_ctx_emit_header(ctx, SLOP_STR("#endif"));
                     context_ctx_emit_header(ctx, SLOP_STR(""));
                 }
-            } else if (!_mv_1499.has_value) {
+            } else if (!_mv_1500.has_value) {
             }
             i = (i + 1);
         }
@@ -4023,13 +4023,13 @@ void transpiler_emit_option_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1500 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1500.has_value) {
-                __auto_type ot = _mv_1500.value;
+            __auto_type _mv_1501 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1501.has_value) {
+                __auto_type ot = _mv_1501.value;
                 if (transpiler_is_pointer_elem_type(ot.inner_type)) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1500.has_value) {
+            } else if (!_mv_1501.has_value) {
             }
             i = (i + 1);
         }
@@ -4043,13 +4043,13 @@ void transpiler_emit_value_option_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1501 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1501.has_value) {
-                __auto_type ot = _mv_1501.value;
+            __auto_type _mv_1502 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1502.has_value) {
+                __auto_type ot = _mv_1502.value;
                 if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_is_type_emitted_or_primitive(ctx, ot.inner_type)) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1501.has_value) {
+            } else if (!_mv_1502.has_value) {
             }
             i = (i + 1);
         }
@@ -4063,13 +4063,13 @@ void transpiler_emit_complex_value_option_types_header(context_TranspileContext*
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1502 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1502.has_value) {
-                __auto_type ot = _mv_1502.value;
+            __auto_type _mv_1503 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1503.has_value) {
+                __auto_type ot = _mv_1503.value;
                 if (!(transpiler_is_pointer_elem_type(ot.inner_type))) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1502.has_value) {
+            } else if (!_mv_1503.has_value) {
             }
             i = (i + 1);
         }
@@ -4111,14 +4111,14 @@ void transpiler_emit_list_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1503 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1503.has_value) {
-                __auto_type lt = _mv_1503.value;
+            __auto_type _mv_1504 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1504.has_value) {
+                __auto_type lt = _mv_1504.value;
                 if (transpiler_is_pointer_elem_type(lt.elem_type)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                     transpiler_emit_option_for_inner_type(ctx, lt.c_name);
                 }
-            } else if (!_mv_1503.has_value) {
+            } else if (!_mv_1504.has_value) {
             }
             i = (i + 1);
         }
@@ -4132,14 +4132,14 @@ void transpiler_emit_primitive_list_types_header(context_TranspileContext* ctx) 
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1504 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1504.has_value) {
-                __auto_type lt = _mv_1504.value;
+            __auto_type _mv_1505 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1505.has_value) {
+                __auto_type lt = _mv_1505.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_is_primitive_or_runtime_type(lt.elem_type)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                     transpiler_emit_option_for_inner_type(ctx, lt.c_name);
                 }
-            } else if (!_mv_1504.has_value) {
+            } else if (!_mv_1505.has_value) {
             }
             i = (i + 1);
         }
@@ -4153,13 +4153,13 @@ void transpiler_emit_primitive_option_types_header(context_TranspileContext* ctx
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1505 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1505.has_value) {
-                __auto_type ot = _mv_1505.value;
+            __auto_type _mv_1506 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1506.has_value) {
+                __auto_type ot = _mv_1506.value;
                 if ((!(transpiler_is_pointer_elem_type(ot.inner_type))) && (transpiler_is_primitive_or_runtime_type(ot.inner_type)) && (!(strlib_starts_with(ot.inner_type, SLOP_STR("slop_list_"))))) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1505.has_value) {
+            } else if (!_mv_1506.has_value) {
             }
             i = (i + 1);
         }
@@ -4177,14 +4177,14 @@ void transpiler_emit_imported_list_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1506 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1506.has_value) {
-                __auto_type lt = _mv_1506.value;
+            __auto_type _mv_1507 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1507.has_value) {
+                __auto_type lt = _mv_1507.value;
                 if ((!(transpiler_is_pointer_elem_type(lt.elem_type))) && (!(transpiler_is_primitive_or_runtime_type(lt.elem_type))) && (transpiler_is_imported_type(ctx, lt.elem_type))) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                     transpiler_emit_option_for_inner_type(ctx, lt.c_name);
                 }
-            } else if (!_mv_1506.has_value) {
+            } else if (!_mv_1507.has_value) {
             }
             i = (i + 1);
         }
@@ -4198,13 +4198,13 @@ void transpiler_emit_imported_option_types_header(context_TranspileContext* ctx)
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1507 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1507.has_value) {
-                __auto_type ot = _mv_1507.value;
+            __auto_type _mv_1508 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1508.has_value) {
+                __auto_type ot = _mv_1508.value;
                 if ((!(transpiler_is_pointer_elem_type(ot.inner_type))) && (!(transpiler_is_primitive_or_runtime_type(ot.inner_type))) && (!(strlib_starts_with(ot.inner_type, SLOP_STR("slop_list_")))) && (transpiler_is_imported_type(ctx, ot.inner_type))) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1507.has_value) {
+            } else if (!_mv_1508.has_value) {
             }
             i = (i + 1);
         }
@@ -4218,11 +4218,11 @@ void transpiler_emit_late_registered_list_types_header(context_TranspileContext*
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1508 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1508.has_value) {
-                __auto_type lt = _mv_1508.value;
+            __auto_type _mv_1509 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1509.has_value) {
+                __auto_type lt = _mv_1509.value;
                 transpiler_emit_single_list_type_header(ctx, lt);
-            } else if (!_mv_1508.has_value) {
+            } else if (!_mv_1509.has_value) {
             }
             i = (i + 1);
         }
@@ -4236,11 +4236,11 @@ void transpiler_emit_late_registered_option_types_header(context_TranspileContex
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1509 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1509.has_value) {
-                __auto_type ot = _mv_1509.value;
+            __auto_type _mv_1510 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1510.has_value) {
+                __auto_type ot = _mv_1510.value;
                 transpiler_emit_single_option_type_header(ctx, ot);
-            } else if (!_mv_1509.has_value) {
+            } else if (!_mv_1510.has_value) {
             }
             i = (i + 1);
         }
@@ -4254,13 +4254,13 @@ void transpiler_emit_value_list_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1510 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1510.has_value) {
-                __auto_type lt = _mv_1510.value;
+            __auto_type _mv_1511 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1511.has_value) {
+                __auto_type lt = _mv_1511.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_is_type_emitted_or_primitive(ctx, lt.elem_type)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1510.has_value) {
+            } else if (!_mv_1511.has_value) {
             }
             i = (i + 1);
         }
@@ -4274,13 +4274,13 @@ void transpiler_emit_complex_value_list_types_header(context_TranspileContext* c
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1511 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1511.has_value) {
-                __auto_type lt = _mv_1511.value;
+            __auto_type _mv_1512 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1512.has_value) {
+                __auto_type lt = _mv_1512.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && !(context_ctx_is_type_emitted(ctx, lt.c_name))) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1511.has_value) {
+            } else if (!_mv_1512.has_value) {
             }
             i = (i + 1);
         }
@@ -4316,9 +4316,9 @@ void transpiler_emit_union_payload_hash_eq(context_TranspileContext* ctx, slop_l
         __auto_type len = ((int64_t)((variants).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1512 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1512.has_value) {
-                __auto_type variant = _mv_1512.value;
+            __auto_type _mv_1513 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1513.has_value) {
+                __auto_type variant = _mv_1513.value;
                 {
                     __auto_type slop_type = variant.slop_type;
                     __auto_type c_payload_type = variant.c_type;
@@ -4338,7 +4338,7 @@ void transpiler_emit_union_payload_hash_eq(context_TranspileContext* ctx, slop_l
                         }
                     }
                 }
-            } else if (!_mv_1512.has_value) {
+            } else if (!_mv_1513.has_value) {
             }
             i = (i + 1);
         }
@@ -4351,9 +4351,9 @@ void transpiler_emit_record_field_dependencies(context_TranspileContext* ctx, sl
         __auto_type len = ((int64_t)((fields).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1513 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1513.has_value) {
-                __auto_type field = _mv_1513.value;
+            __auto_type _mv_1514 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1514.has_value) {
+                __auto_type field = _mv_1514.value;
                 {
                     __auto_type slop_type = field.slop_type;
                     __auto_type c_type = field.c_type;
@@ -4389,7 +4389,7 @@ void transpiler_emit_record_field_dependencies(context_TranspileContext* ctx, sl
                         }
                     }
                 }
-            } else if (!_mv_1513.has_value) {
+            } else if (!_mv_1514.has_value) {
             }
             i = (i + 1);
         }
@@ -4446,9 +4446,9 @@ uint8_t transpiler_is_primitive_slop_type(slop_string slop_type) {
 
 uint8_t transpiler_is_range_type_alias(context_TranspileContext* ctx, slop_string slop_type) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
-    __auto_type _mv_1514 = context_ctx_lookup_type_alias(ctx, slop_type);
-    if (_mv_1514.has_value) {
-        __auto_type underlying = _mv_1514.value;
+    __auto_type _mv_1515 = context_ctx_lookup_type_alias(ctx, slop_type);
+    if (_mv_1515.has_value) {
+        __auto_type underlying = _mv_1515.value;
         if (strlib_starts_with(underlying, SLOP_STR("(Int"))) {
             return 1;
         } else if (strlib_starts_with(underlying, SLOP_STR("(I64"))) {
@@ -4470,7 +4470,7 @@ uint8_t transpiler_is_range_type_alias(context_TranspileContext* ctx, slop_strin
         } else {
             return 0;
         }
-    } else if (!_mv_1514.has_value) {
+    } else if (!_mv_1515.has_value) {
         return 0;
     }
     SLOP_UNREACHABLE();
@@ -4487,11 +4487,11 @@ uint8_t transpiler_is_narrow_signed_payload_type(slop_string slop_type) {
 slop_string transpiler_resolve_payload_slop_type(context_TranspileContext* ctx, slop_string slop_type) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     if (transpiler_is_range_type_alias(ctx, slop_type)) {
-        __auto_type _mv_1515 = context_ctx_lookup_type_alias(ctx, slop_type);
-        if (_mv_1515.has_value) {
-            __auto_type underlying = _mv_1515.value;
+        __auto_type _mv_1516 = context_ctx_lookup_type_alias(ctx, slop_type);
+        if (_mv_1516.has_value) {
+            __auto_type underlying = _mv_1516.value;
             return underlying;
-        } else if (!_mv_1515.has_value) {
+        } else if (!_mv_1516.has_value) {
             return slop_type;
         }
         SLOP_UNREACHABLE();
@@ -4559,30 +4559,30 @@ slop_list_transpiler_PayloadSlot transpiler_union_variant_payloads(context_Trans
         __auto_type arena = (*ctx).arena;
         __auto_type slots = ((slop_list_transpiler_PayloadSlot){ .data = (transpiler_PayloadSlot*)slop_arena_alloc(arena, 16 * sizeof(transpiler_PayloadSlot)), .len = 0, .cap = 16 });
         __auto_type count_key = context_ctx_str(ctx, variant_name, SLOP_STR("__count"));
-        __auto_type _mv_1516 = context_ctx_lookup_field_type(ctx, union_name, count_key);
-        if (_mv_1516.has_value) {
-            __auto_type _ = _mv_1516.value;
+        __auto_type _mv_1517 = context_ctx_lookup_field_type(ctx, union_name, count_key);
+        if (_mv_1517.has_value) {
+            __auto_type _ = _mv_1517.value;
             {
                 __auto_type i = 0;
                 __auto_type more = 1;
                 while (more) {
                     {
                         __auto_type key = context_ctx_str3(ctx, variant_name, SLOP_STR("__"), int_to_string(arena, i));
-                        __auto_type _mv_1517 = context_ctx_lookup_field_type(ctx, union_name, key);
-                        if (_mv_1517.has_value) {
-                            __auto_type slot_c_type = _mv_1517.value;
+                        __auto_type _mv_1518 = context_ctx_lookup_field_type(ctx, union_name, key);
+                        if (_mv_1518.has_value) {
+                            __auto_type slot_c_type = _mv_1518.value;
                             {
                                 __auto_type slot_slop_type = ({ __auto_type _mv = context_ctx_lookup_field_slop_type(ctx, union_name, key); _mv.has_value ? ({ __auto_type st = _mv.value; st; }) : (SLOP_STR("")); });
                                 ({ __auto_type _lst_p = &(slots); __auto_type _item = ((transpiler_PayloadSlot){slot_slop_type, slot_c_type}); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                 i = (i + 1);
                             }
-                        } else if (!_mv_1517.has_value) {
+                        } else if (!_mv_1518.has_value) {
                             more = 0;
                         }
                     }
                 }
             }
-        } else if (!_mv_1516.has_value) {
+        } else if (!_mv_1517.has_value) {
         }
         return slots;
     }
@@ -4597,11 +4597,11 @@ void transpiler_emit_union_hash_fn(context_TranspileContext* ctx, slop_string c_
         __auto_type len = ((int64_t)((variants).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1518 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1518.has_value) {
-                __auto_type variant = _mv_1518.value;
+            __auto_type _mv_1519 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1519.has_value) {
+                __auto_type variant = _mv_1519.value;
                 transpiler_emit_union_variant_hash(ctx, c_type, variant);
-            } else if (!_mv_1518.has_value) {
+            } else if (!_mv_1519.has_value) {
             }
             i = (i + 1);
         }
@@ -4639,14 +4639,14 @@ void transpiler_emit_multi_payload_hash(context_TranspileContext* ctx, slop_stri
         context_ctx_emit_header(ctx, SLOP_STR("            {"));
         context_ctx_emit_header(ctx, SLOP_STR("                uint64_t hash = 14695981039346656037ULL;"));
         while (i < len) {
-            __auto_type _mv_1519 = ({ __auto_type _lst = payloads; size_t _idx = (size_t)i; slop_option_transpiler_PayloadSlot _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1519.has_value) {
-                __auto_type slot = _mv_1519.value;
+            __auto_type _mv_1520 = ({ __auto_type _lst = payloads; size_t _idx = (size_t)i; slop_option_transpiler_PayloadSlot _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1520.has_value) {
+                __auto_type slot = _mv_1520.value;
                 {
                     __auto_type access = context_ctx_str4(ctx, SLOP_STR("_k->data."), c_variant_name, SLOP_STR(".f"), int_to_string(arena, i));
                     context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("                hash ^= "), transpiler_payload_hash_expr(ctx, slot.slop_type, slot.c_type, access), SLOP_STR("; hash *= 1099511628211ULL;")));
                 }
-            } else if (!_mv_1519.has_value) {
+            } else if (!_mv_1520.has_value) {
             }
             i = (i + 1);
         }
@@ -4666,11 +4666,11 @@ void transpiler_emit_union_eq_fn(context_TranspileContext* ctx, slop_string c_ty
         __auto_type len = ((int64_t)((variants).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1520 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1520.has_value) {
-                __auto_type variant = _mv_1520.value;
+            __auto_type _mv_1521 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1521.has_value) {
+                __auto_type variant = _mv_1521.value;
                 transpiler_emit_union_variant_eq(ctx, c_type, variant);
-            } else if (!_mv_1520.has_value) {
+            } else if (!_mv_1521.has_value) {
             }
             i = (i + 1);
         }
@@ -4707,15 +4707,15 @@ void transpiler_emit_multi_payload_eq(context_TranspileContext* ctx, slop_string
         int64_t i = 0;
         context_ctx_emit_header(ctx, SLOP_STR("            return true"));
         while (i < len) {
-            __auto_type _mv_1521 = ({ __auto_type _lst = payloads; size_t _idx = (size_t)i; slop_option_transpiler_PayloadSlot _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1521.has_value) {
-                __auto_type slot = _mv_1521.value;
+            __auto_type _mv_1522 = ({ __auto_type _lst = payloads; size_t _idx = (size_t)i; slop_option_transpiler_PayloadSlot _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1522.has_value) {
+                __auto_type slot = _mv_1522.value;
                 {
                     __auto_type a_access = context_ctx_str4(ctx, SLOP_STR("_a->data."), c_variant_name, SLOP_STR(".f"), int_to_string(arena, i));
                     __auto_type b_access = context_ctx_str4(ctx, SLOP_STR("_b->data."), c_variant_name, SLOP_STR(".f"), int_to_string(arena, i));
                     context_ctx_emit_header(ctx, context_ctx_str(ctx, SLOP_STR("                && "), transpiler_payload_eq_expr(ctx, slot.slop_type, slot.c_type, a_access, b_access)));
                 }
-            } else if (!_mv_1521.has_value) {
+            } else if (!_mv_1522.has_value) {
             }
             i = (i + 1);
         }
@@ -4732,11 +4732,11 @@ void transpiler_emit_struct_hash_fn(context_TranspileContext* ctx, slop_string c
         __auto_type len = ((int64_t)((fields).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1522 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1522.has_value) {
-                __auto_type field = _mv_1522.value;
+            __auto_type _mv_1523 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1523.has_value) {
+                __auto_type field = _mv_1523.value;
                 transpiler_emit_field_hash(ctx, field);
-            } else if (!_mv_1522.has_value) {
+            } else if (!_mv_1523.has_value) {
             }
             i = (i + 1);
         }
@@ -4803,11 +4803,11 @@ void transpiler_emit_struct_eq_fn(context_TranspileContext* ctx, slop_string c_t
             {
                 int64_t i = 0;
                 while (i < len) {
-                    __auto_type _mv_1523 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1523.has_value) {
-                        __auto_type field = _mv_1523.value;
+                    __auto_type _mv_1524 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1524.has_value) {
+                        __auto_type field = _mv_1524.value;
                         transpiler_emit_field_eq(ctx, field);
-                    } else if (!_mv_1523.has_value) {
+                    } else if (!_mv_1524.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -4865,9 +4865,9 @@ void transpiler_emit_struct_key_types_header(context_TranspileContext* ctx) {
         uint8_t banner = 0;
         int64_t i = 0;
         while (i < ((int64_t)((struct_key_types).len))) {
-            __auto_type _mv_1524 = ({ __auto_type _lst = struct_key_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1524.has_value) {
-                __auto_type c_type = _mv_1524.value;
+            __auto_type _mv_1525 = ({ __auto_type _lst = struct_key_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1525.has_value) {
+                __auto_type c_type = _mv_1525.value;
                 {
                     __auto_type emitted_marker = context_ctx_str(ctx, SLOP_STR("hasheq:"), c_type);
                     if (!(context_ctx_is_type_emitted(ctx, emitted_marker))) {
@@ -4892,7 +4892,7 @@ void transpiler_emit_struct_key_types_header(context_TranspileContext* ctx) {
                         }
                     }
                 }
-            } else if (!_mv_1524.has_value) {
+            } else if (!_mv_1525.has_value) {
             }
             i = (i + 1);
         }
@@ -4993,9 +4993,9 @@ void transpiler_emit_chan_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((chan_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1525 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1525.has_value) {
-                __auto_type ct = _mv_1525.value;
+            __auto_type _mv_1526 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1526.has_value) {
+                __auto_type ct = _mv_1526.value;
                 {
                     __auto_type elem_type = ct.elem_type;
                     __auto_type c_name = ct.c_name;
@@ -5020,7 +5020,7 @@ void transpiler_emit_chan_types_header(context_TranspileContext* ctx) {
                         }
                     }
                 }
-            } else if (!_mv_1525.has_value) {
+            } else if (!_mv_1526.has_value) {
             }
             i = (i + 1);
         }
@@ -5034,9 +5034,9 @@ void transpiler_emit_chan_funcs_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((chan_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1526 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1526.has_value) {
-                __auto_type ct = _mv_1526.value;
+            __auto_type _mv_1527 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1527.has_value) {
+                __auto_type ct = _mv_1527.value;
                 {
                     __auto_type elem_type = ct.elem_type;
                     __auto_type c_name = ct.c_name;
@@ -5044,7 +5044,7 @@ void transpiler_emit_chan_funcs_header(context_TranspileContext* ctx) {
                         transpiler_emit_chan_send_recv_funcs(ctx, c_name, elem_type);
                     }
                 }
-            } else if (!_mv_1526.has_value) {
+            } else if (!_mv_1527.has_value) {
             }
             i = (i + 1);
         }
@@ -5180,9 +5180,9 @@ void transpiler_emit_thread_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((thread_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1527 = ({ __auto_type _lst = thread_types; size_t _idx = (size_t)i; slop_option_context_ThreadType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1527.has_value) {
-                __auto_type tt = _mv_1527.value;
+            __auto_type _mv_1528 = ({ __auto_type _lst = thread_types; size_t _idx = (size_t)i; slop_option_context_ThreadType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1528.has_value) {
+                __auto_type tt = _mv_1528.value;
                 {
                     __auto_type result_type = tt.result_type;
                     __auto_type c_name = tt.c_name;
@@ -5214,7 +5214,7 @@ void transpiler_emit_thread_types_header(context_TranspileContext* ctx) {
                         }
                     }
                 }
-            } else if (!_mv_1527.has_value) {
+            } else if (!_mv_1528.has_value) {
             }
             i = (i + 1);
         }
@@ -5259,44 +5259,44 @@ slop_string transpiler_uppercase_name(context_TranspileContext* ctx, slop_string
 
 uint8_t transpiler_is_simple_enum_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1528 = (*item);
-    switch (_mv_1528.tag) {
+    __auto_type _mv_1529 = (*item);
+    switch (_mv_1529.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1528.data.lst;
+            __auto_type lst = _mv_1529.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 3) {
                     return 0;
                 } else {
-                    __auto_type _mv_1529 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1529.has_value) {
-                        __auto_type def_expr = _mv_1529.value;
-                        __auto_type _mv_1530 = (*def_expr);
-                        switch (_mv_1530.tag) {
+                    __auto_type _mv_1530 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1530.has_value) {
+                        __auto_type def_expr = _mv_1530.value;
+                        __auto_type _mv_1531 = (*def_expr);
+                        switch (_mv_1531.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type def_lst = _mv_1530.data.lst;
+                                __auto_type def_lst = _mv_1531.data.lst;
                                 {
                                     __auto_type def_items = def_lst.items;
                                     if (((int64_t)((def_items).len)) < 1) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1531 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1531.has_value) {
-                                            __auto_type head = _mv_1531.value;
-                                            __auto_type _mv_1532 = (*head);
-                                            switch (_mv_1532.tag) {
+                                        __auto_type _mv_1532 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1532.has_value) {
+                                            __auto_type head = _mv_1532.value;
+                                            __auto_type _mv_1533 = (*head);
+                                            switch (_mv_1533.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_1532.data.sym;
+                                                    __auto_type sym = _mv_1533.data.sym;
                                                     return (string_eq(sym.name, SLOP_STR("enum")) && !(transpiler_has_enum_payload_variants(def_items)));
                                                 }
                                                 default: {
                                                     return 0;
                                                 }
                                             }
-                                        } else if (!_mv_1531.has_value) {
+                                        } else if (!_mv_1532.has_value) {
                                             return 0;
                                         }
                                         SLOP_UNREACHABLE();
@@ -5307,7 +5307,7 @@ uint8_t transpiler_is_simple_enum_def(types_SExpr* item) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1529.has_value) {
+                    } else if (!_mv_1530.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -5327,23 +5327,11 @@ void transpiler_emit_module_types_header(context_TranspileContext* ctx, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1533 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1533.has_value) {
-                __auto_type item = _mv_1533.value;
-                if (transpiler_is_type_def(item) && transpiler_is_type_alias_def(item)) {
-                    transpiler_emit_type_alias_to_header(ctx, item);
-                }
-            } else if (!_mv_1533.has_value) {
-            }
-            i = (i + 1);
-        }
-        i = start;
-        while (i < len) {
             __auto_type _mv_1534 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_1534.has_value) {
                 __auto_type item = _mv_1534.value;
-                if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
-                    transpiler_emit_type_to_header(ctx, item);
+                if (transpiler_is_type_def(item) && transpiler_is_type_alias_def(item)) {
+                    transpiler_emit_type_alias_to_header(ctx, item);
                 }
             } else if (!_mv_1534.has_value) {
             }
@@ -5354,10 +5342,22 @@ void transpiler_emit_module_types_header(context_TranspileContext* ctx, slop_lis
             __auto_type _mv_1535 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_1535.has_value) {
                 __auto_type item = _mv_1535.value;
-                if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
+                if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
                     transpiler_emit_type_to_header(ctx, item);
                 }
             } else if (!_mv_1535.has_value) {
+            }
+            i = (i + 1);
+        }
+        i = start;
+        while (i < len) {
+            __auto_type _mv_1536 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1536.has_value) {
+                __auto_type item = _mv_1536.value;
+                if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
+                    transpiler_emit_type_to_header(ctx, item);
+                }
+            } else if (!_mv_1536.has_value) {
             }
             i = (i + 1);
         }
@@ -5370,13 +5370,13 @@ void transpiler_emit_simple_type_aliases_header(context_TranspileContext* ctx, s
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1536 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1536.has_value) {
-                __auto_type item = _mv_1536.value;
+            __auto_type _mv_1537 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1537.has_value) {
+                __auto_type item = _mv_1537.value;
                 if ((transpiler_is_type_def(item)) && (transpiler_is_type_alias_def(item)) && (!(transpiler_is_result_type_alias_def(item)))) {
                     transpiler_emit_type_alias_to_header(ctx, item);
                 }
-            } else if (!_mv_1536.has_value) {
+            } else if (!_mv_1537.has_value) {
             }
             i = (i + 1);
         }
@@ -5389,13 +5389,13 @@ void transpiler_emit_type_aliases_header(context_TranspileContext* ctx, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1537 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1537.has_value) {
-                __auto_type item = _mv_1537.value;
+            __auto_type _mv_1538 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1538.has_value) {
+                __auto_type item = _mv_1538.value;
                 if ((transpiler_is_type_def(item)) && (transpiler_is_type_alias_def(item)) && (transpiler_is_result_type_alias_def(item))) {
                     transpiler_emit_type_alias_to_header(ctx, item);
                 }
-            } else if (!_mv_1537.has_value) {
+            } else if (!_mv_1538.has_value) {
             }
             i = (i + 1);
         }
@@ -5408,13 +5408,13 @@ void transpiler_emit_simple_enums_header(context_TranspileContext* ctx, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1538 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1538.has_value) {
-                __auto_type item = _mv_1538.value;
+            __auto_type _mv_1539 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1539.has_value) {
+                __auto_type item = _mv_1539.value;
                 if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
                     transpiler_emit_type_to_header(ctx, item);
                 }
-            } else if (!_mv_1538.has_value) {
+            } else if (!_mv_1539.has_value) {
             }
             i = (i + 1);
         }
@@ -5429,9 +5429,9 @@ void transpiler_emit_pending_container_deps(context_TranspileContext* ctx, types
         __auto_type len = ((int64_t)((field_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1539 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1539.has_value) {
-                __auto_type field_type = _mv_1539.value;
+            __auto_type _mv_1540 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1540.has_value) {
+                __auto_type field_type = _mv_1540.value;
                 if (!(context_ctx_is_type_emitted(ctx, field_type)) && transpiler_is_emittable_container_type(ctx, field_type)) {
                     if (strlib_starts_with(field_type, SLOP_STR("slop_option_"))) {
                         transpiler_emit_option_by_c_name(ctx, field_type);
@@ -5440,7 +5440,7 @@ void transpiler_emit_pending_container_deps(context_TranspileContext* ctx, types
                         transpiler_emit_list_by_c_name(ctx, field_type);
                     }
                 }
-            } else if (!_mv_1539.has_value) {
+            } else if (!_mv_1540.has_value) {
             }
             i = (i + 1);
         }
@@ -5454,13 +5454,13 @@ void transpiler_emit_option_by_c_name(context_TranspileContext* ctx, slop_string
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1540 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1540.has_value) {
-                __auto_type ot = _mv_1540.value;
+            __auto_type _mv_1541 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1541.has_value) {
+                __auto_type ot = _mv_1541.value;
                 if (string_eq(ot.c_name, c_name)) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1540.has_value) {
+            } else if (!_mv_1541.has_value) {
             }
             i = (i + 1);
         }
@@ -5474,13 +5474,13 @@ void transpiler_emit_list_by_c_name(context_TranspileContext* ctx, slop_string c
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1541 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1541.has_value) {
-                __auto_type lt = _mv_1541.value;
+            __auto_type _mv_1542 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1542.has_value) {
+                __auto_type lt = _mv_1542.value;
                 if (string_eq(lt.c_name, c_name)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1541.has_value) {
+            } else if (!_mv_1542.has_value) {
             }
             i = (i + 1);
         }
@@ -5501,9 +5501,9 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                 int64_t i = start;
                 while (i < len) {
                     if (!(transpiler_index_in_list(emitted, i))) {
-                        __auto_type _mv_1542 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1542.has_value) {
-                            __auto_type item = _mv_1542.value;
+                        __auto_type _mv_1543 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1543.has_value) {
+                            __auto_type item = _mv_1543.value;
                             if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                                 if (transpiler_type_deps_satisfied(ctx, item)) {
                                     transpiler_emit_pending_container_deps(ctx, item);
@@ -5513,7 +5513,7 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                                     transpiler_emit_option_list_for_type(ctx, item);
                                 }
                             }
-                        } else if (!_mv_1542.has_value) {
+                        } else if (!_mv_1543.has_value) {
                         }
                     }
                     i = (i + 1);
@@ -5530,9 +5530,9 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                     int64_t i = start;
                     while (i < len) {
                         if (!(transpiler_index_in_list(emitted, i))) {
-                            __auto_type _mv_1543 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1543.has_value) {
-                                __auto_type item = _mv_1543.value;
+                            __auto_type _mv_1544 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1544.has_value) {
+                                __auto_type item = _mv_1544.value;
                                 if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                                     if (transpiler_type_deps_satisfied(ctx, item)) {
                                         transpiler_emit_pending_container_deps(ctx, item);
@@ -5542,7 +5542,7 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                                         transpiler_emit_option_list_for_type(ctx, item);
                                     }
                                 }
-                            } else if (!_mv_1543.has_value) {
+                            } else if (!_mv_1544.has_value) {
                             }
                         }
                         i = (i + 1);
@@ -5559,13 +5559,13 @@ uint8_t transpiler_has_unemitted_struct_types(slop_list_types_SExpr_ptr items, i
         uint8_t found = 0;
         while ((i < len) && !(found)) {
             if (!(transpiler_index_in_list(emitted, i))) {
-                __auto_type _mv_1544 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1544.has_value) {
-                    __auto_type item = _mv_1544.value;
+                __auto_type _mv_1545 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1545.has_value) {
+                    __auto_type item = _mv_1545.value;
                     if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                         found = 1;
                     }
-                } else if (!_mv_1544.has_value) {
+                } else if (!_mv_1545.has_value) {
                 }
             }
             i = (i + 1);
@@ -5580,26 +5580,26 @@ void transpiler_break_list_cycles(context_TranspileContext* ctx, slop_list_types
         int64_t i = start;
         while (i < len) {
             if (!(transpiler_index_in_list(emitted, i))) {
-                __auto_type _mv_1545 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1545.has_value) {
-                    __auto_type item = _mv_1545.value;
+                __auto_type _mv_1546 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1546.has_value) {
+                    __auto_type item = _mv_1546.value;
                     if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                         {
                             __auto_type blocking_deps = transpiler_find_blocking_list_deps(ctx, item);
                             __auto_type dep_len = ((int64_t)((blocking_deps).len));
                             __auto_type j = 0;
                             while (j < dep_len) {
-                                __auto_type _mv_1546 = ({ __auto_type _lst = blocking_deps; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1546.has_value) {
-                                    __auto_type dep_name = _mv_1546.value;
+                                __auto_type _mv_1547 = ({ __auto_type _lst = blocking_deps; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1547.has_value) {
+                                    __auto_type dep_name = _mv_1547.value;
                                     transpiler_emit_list_declare_by_c_name(ctx, dep_name);
-                                } else if (!_mv_1546.has_value) {
+                                } else if (!_mv_1547.has_value) {
                                 }
                                 j = (j + 1);
                             }
                         }
                     }
-                } else if (!_mv_1545.has_value) {
+                } else if (!_mv_1546.has_value) {
                 }
             }
             i = (i + 1);
@@ -5617,13 +5617,13 @@ slop_list_string transpiler_find_blocking_list_deps(context_TranspileContext* ct
         __auto_type result = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1547 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1547.has_value) {
-                __auto_type field_type = _mv_1547.value;
+            __auto_type _mv_1548 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1548.has_value) {
+                __auto_type field_type = _mv_1548.value;
                 if ((strlib_starts_with(field_type, SLOP_STR("slop_list_"))) && (!(context_ctx_is_type_emitted(ctx, field_type))) && (!(transpiler_is_runtime_list_type(field_type)))) {
                     ({ __auto_type _lst_p = &(result); __auto_type _item = (field_type); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                 }
-            } else if (!_mv_1547.has_value) {
+            } else if (!_mv_1548.has_value) {
             }
             i = (i + 1);
         }
@@ -5638,13 +5638,13 @@ void transpiler_emit_list_declare_by_c_name(context_TranspileContext* ctx, slop_
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1548 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1548.has_value) {
-                __auto_type lt = _mv_1548.value;
+            __auto_type _mv_1549 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1549.has_value) {
+                __auto_type lt = _mv_1549.value;
                 if (string_eq(lt.c_name, c_name)) {
                     transpiler_emit_list_type_declare_only(ctx, lt);
                 }
-            } else if (!_mv_1548.has_value) {
+            } else if (!_mv_1549.has_value) {
             }
             i = (i + 1);
         }
@@ -5657,13 +5657,13 @@ uint8_t transpiler_index_in_list(slop_list_int lst, int64_t idx) {
         int64_t i = 0;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1549 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_int _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1549.has_value) {
-                __auto_type v = _mv_1549.value;
+            __auto_type _mv_1550 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_int _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1550.has_value) {
+                __auto_type v = _mv_1550.value;
                 if (v == idx) {
                     found = 1;
                 }
-            } else if (!_mv_1549.has_value) {
+            } else if (!_mv_1550.has_value) {
             }
             i = (i + 1);
         }
@@ -5680,13 +5680,13 @@ uint8_t transpiler_type_deps_satisfied(context_TranspileContext* ctx, types_SExp
         int64_t i = 0;
         uint8_t all_satisfied = 1;
         while ((i < len) && all_satisfied) {
-            __auto_type _mv_1550 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1550.has_value) {
-                __auto_type field_type = _mv_1550.value;
+            __auto_type _mv_1551 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1551.has_value) {
+                __auto_type field_type = _mv_1551.value;
                 if (!(transpiler_type_is_available(ctx, field_type))) {
                     all_satisfied = 0;
                 }
-            } else if (!_mv_1550.has_value) {
+            } else if (!_mv_1551.has_value) {
             }
             i = (i + 1);
         }
@@ -5733,34 +5733,34 @@ slop_list_string transpiler_get_type_field_types(context_TranspileContext* ctx, 
     {
         __auto_type arena = (*ctx).arena;
         __auto_type result = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
-        __auto_type _mv_1551 = (*type_def);
-        switch (_mv_1551.tag) {
+        __auto_type _mv_1552 = (*type_def);
+        switch (_mv_1552.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1551.data.lst;
+                __auto_type lst = _mv_1552.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_1552 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1552.has_value) {
-                            __auto_type def_expr = _mv_1552.value;
-                            __auto_type _mv_1553 = (*def_expr);
-                            switch (_mv_1553.tag) {
+                        __auto_type _mv_1553 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1553.has_value) {
+                            __auto_type def_expr = _mv_1553.value;
+                            __auto_type _mv_1554 = (*def_expr);
+                            switch (_mv_1554.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type def_lst = _mv_1553.data.lst;
+                                    __auto_type def_lst = _mv_1554.data.lst;
                                     {
                                         __auto_type def_items = def_lst.items;
                                         __auto_type def_len = ((int64_t)((def_items).len));
                                         if (def_len > 0) {
-                                            __auto_type _mv_1554 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1554.has_value) {
-                                                __auto_type head = _mv_1554.value;
-                                                __auto_type _mv_1555 = (*head);
-                                                switch (_mv_1555.tag) {
+                                            __auto_type _mv_1555 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1555.has_value) {
+                                                __auto_type head = _mv_1555.value;
+                                                __auto_type _mv_1556 = (*head);
+                                                switch (_mv_1556.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type sym = _mv_1555.data.sym;
+                                                        __auto_type sym = _mv_1556.data.sym;
                                                         {
                                                             __auto_type kind = sym.name;
                                                             if (string_eq(kind, SLOP_STR("record"))) {
@@ -5776,7 +5776,7 @@ slop_list_string transpiler_get_type_field_types(context_TranspileContext* ctx, 
                                                         break;
                                                     }
                                                 }
-                                            } else if (!_mv_1554.has_value) {
+                                            } else if (!_mv_1555.has_value) {
                                             }
                                         }
                                     }
@@ -5786,7 +5786,7 @@ slop_list_string transpiler_get_type_field_types(context_TranspileContext* ctx, 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1552.has_value) {
+                        } else if (!_mv_1553.has_value) {
                         }
                     }
                 }
@@ -5808,25 +5808,25 @@ slop_list_string transpiler_extract_record_field_types(context_TranspileContext*
         __auto_type len = ((int64_t)((def_items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1556 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1556.has_value) {
-                __auto_type field_expr = _mv_1556.value;
-                __auto_type _mv_1557 = (*field_expr);
-                switch (_mv_1557.tag) {
+            __auto_type _mv_1557 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1557.has_value) {
+                __auto_type field_expr = _mv_1557.value;
+                __auto_type _mv_1558 = (*field_expr);
+                switch (_mv_1558.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type field_lst = _mv_1557.data.lst;
+                        __auto_type field_lst = _mv_1558.data.lst;
                         if (((int64_t)((field_lst.items).len)) >= 2) {
-                            __auto_type _mv_1558 = ({ __auto_type _lst = field_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1558.has_value) {
-                                __auto_type type_expr = _mv_1558.value;
+                            __auto_type _mv_1559 = ({ __auto_type _lst = field_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1559.has_value) {
+                                __auto_type type_expr = _mv_1559.value;
                                 {
                                     __auto_type type_str = transpiler_get_field_type_string(ctx, type_expr);
                                     if (!(string_eq(type_str, SLOP_STR("")))) {
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (type_str); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
                                 }
-                            } else if (!_mv_1558.has_value) {
+                            } else if (!_mv_1559.has_value) {
                             }
                         }
                         break;
@@ -5835,7 +5835,7 @@ slop_list_string transpiler_extract_record_field_types(context_TranspileContext*
                         break;
                     }
                 }
-            } else if (!_mv_1556.has_value) {
+            } else if (!_mv_1557.has_value) {
             }
             i = (i + 1);
         }
@@ -5851,25 +5851,25 @@ slop_list_string transpiler_extract_union_variant_types(context_TranspileContext
         __auto_type len = ((int64_t)((def_items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1559 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1559.has_value) {
-                __auto_type variant_expr = _mv_1559.value;
-                __auto_type _mv_1560 = (*variant_expr);
-                switch (_mv_1560.tag) {
+            __auto_type _mv_1560 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1560.has_value) {
+                __auto_type variant_expr = _mv_1560.value;
+                __auto_type _mv_1561 = (*variant_expr);
+                switch (_mv_1561.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type variant_lst = _mv_1560.data.lst;
+                        __auto_type variant_lst = _mv_1561.data.lst;
                         if (((int64_t)((variant_lst.items).len)) >= 2) {
-                            __auto_type _mv_1561 = ({ __auto_type _lst = variant_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1561.has_value) {
-                                __auto_type type_expr = _mv_1561.value;
+                            __auto_type _mv_1562 = ({ __auto_type _lst = variant_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1562.has_value) {
+                                __auto_type type_expr = _mv_1562.value;
                                 {
                                     __auto_type type_str = transpiler_get_field_type_string(ctx, type_expr);
                                     if (!(string_eq(type_str, SLOP_STR("")))) {
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (type_str); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
                                 }
-                            } else if (!_mv_1561.has_value) {
+                            } else if (!_mv_1562.has_value) {
                             }
                         }
                         break;
@@ -5878,7 +5878,7 @@ slop_list_string transpiler_extract_union_variant_types(context_TranspileContext
                         break;
                     }
                 }
-            } else if (!_mv_1559.has_value) {
+            } else if (!_mv_1560.has_value) {
             }
             i = (i + 1);
         }
@@ -5891,18 +5891,18 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1562 = (*type_expr);
-        switch (_mv_1562.tag) {
+        __auto_type _mv_1563 = (*type_expr);
+        switch (_mv_1563.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1562.data.sym;
+                __auto_type sym = _mv_1563.data.sym;
                 {
                     __auto_type name = sym.name;
-                    __auto_type _mv_1563 = context_ctx_lookup_type(ctx, name);
-                    if (_mv_1563.has_value) {
-                        __auto_type entry = _mv_1563.value;
+                    __auto_type _mv_1564 = context_ctx_lookup_type(ctx, name);
+                    if (_mv_1564.has_value) {
+                        __auto_type entry = _mv_1564.value;
                         return entry.c_name;
-                    } else if (!_mv_1563.has_value) {
+                    } else if (!_mv_1564.has_value) {
                         return ctype_to_c_type(arena, type_expr);
                     }
                     SLOP_UNREACHABLE();
@@ -5910,45 +5910,25 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1562.data.lst;
+                __auto_type lst = _mv_1563.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 1) {
                         return SLOP_STR("");
                     } else {
-                        __auto_type _mv_1564 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1564.has_value) {
-                            __auto_type head = _mv_1564.value;
-                            __auto_type _mv_1565 = (*head);
-                            switch (_mv_1565.tag) {
+                        __auto_type _mv_1565 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1565.has_value) {
+                            __auto_type head = _mv_1565.value;
+                            __auto_type _mv_1566 = (*head);
+                            switch (_mv_1566.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1565.data.sym;
+                                    __auto_type sym = _mv_1566.data.sym;
                                     {
                                         __auto_type kind = sym.name;
                                         if (string_eq(kind, SLOP_STR("Ptr"))) {
                                             return SLOP_STR("");
                                         } else if (string_eq(kind, SLOP_STR("Option"))) {
-                                            if (((int64_t)((items).len)) >= 2) {
-                                                __auto_type _mv_1566 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1566.has_value) {
-                                                    __auto_type inner = _mv_1566.value;
-                                                    {
-                                                        __auto_type inner_str = transpiler_get_field_type_string(ctx, inner);
-                                                        if (string_eq(inner_str, SLOP_STR(""))) {
-                                                            return SLOP_STR("");
-                                                        } else {
-                                                            return context_ctx_str(ctx, SLOP_STR("slop_option_"), ctype_type_to_identifier(arena, inner_str));
-                                                        }
-                                                    }
-                                                } else if (!_mv_1566.has_value) {
-                                                    return SLOP_STR("");
-                                                }
-                                                SLOP_UNREACHABLE();
-                                            } else {
-                                                return SLOP_STR("");
-                                            }
-                                        } else if (string_eq(kind, SLOP_STR("List"))) {
                                             if (((int64_t)((items).len)) >= 2) {
                                                 __auto_type _mv_1567 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                                 if (_mv_1567.has_value) {
@@ -5958,10 +5938,30 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                                                         if (string_eq(inner_str, SLOP_STR(""))) {
                                                             return SLOP_STR("");
                                                         } else {
-                                                            return context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, inner_str));
+                                                            return context_ctx_str(ctx, SLOP_STR("slop_option_"), ctype_type_to_identifier(arena, inner_str));
                                                         }
                                                     }
                                                 } else if (!_mv_1567.has_value) {
+                                                    return SLOP_STR("");
+                                                }
+                                                SLOP_UNREACHABLE();
+                                            } else {
+                                                return SLOP_STR("");
+                                            }
+                                        } else if (string_eq(kind, SLOP_STR("List"))) {
+                                            if (((int64_t)((items).len)) >= 2) {
+                                                __auto_type _mv_1568 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1568.has_value) {
+                                                    __auto_type inner = _mv_1568.value;
+                                                    {
+                                                        __auto_type inner_str = transpiler_get_field_type_string(ctx, inner);
+                                                        if (string_eq(inner_str, SLOP_STR(""))) {
+                                                            return SLOP_STR("");
+                                                        } else {
+                                                            return context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, inner_str));
+                                                        }
+                                                    }
+                                                } else if (!_mv_1568.has_value) {
                                                     return SLOP_STR("");
                                                 }
                                                 SLOP_UNREACHABLE();
@@ -5977,7 +5977,7 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                                     return SLOP_STR("");
                                 }
                             }
-                        } else if (!_mv_1564.has_value) {
+                        } else if (!_mv_1565.has_value) {
                             return SLOP_STR("");
                         }
                         SLOP_UNREACHABLE();
@@ -6006,31 +6006,31 @@ void transpiler_emit_option_list_for_type(context_TranspileContext* ctx, types_S
 slop_string transpiler_get_type_c_name(context_TranspileContext* ctx, types_SExpr* type_def) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
-    __auto_type _mv_1568 = (*type_def);
-    switch (_mv_1568.tag) {
+    __auto_type _mv_1569 = (*type_def);
+    switch (_mv_1569.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1568.data.lst;
+            __auto_type lst = _mv_1569.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return SLOP_STR("");
                 } else {
-                    __auto_type _mv_1569 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1569.has_value) {
-                        __auto_type name_expr = _mv_1569.value;
-                        __auto_type _mv_1570 = (*name_expr);
-                        switch (_mv_1570.tag) {
+                    __auto_type _mv_1570 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1570.has_value) {
+                        __auto_type name_expr = _mv_1570.value;
+                        __auto_type _mv_1571 = (*name_expr);
+                        switch (_mv_1571.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1570.data.sym;
+                                __auto_type sym = _mv_1571.data.sym;
                                 {
                                     __auto_type name = sym.name;
-                                    __auto_type _mv_1571 = context_ctx_lookup_type(ctx, name);
-                                    if (_mv_1571.has_value) {
-                                        __auto_type entry = _mv_1571.value;
+                                    __auto_type _mv_1572 = context_ctx_lookup_type(ctx, name);
+                                    if (_mv_1572.has_value) {
+                                        __auto_type entry = _mv_1572.value;
                                         return entry.c_name;
-                                    } else if (!_mv_1571.has_value) {
+                                    } else if (!_mv_1572.has_value) {
                                         return SLOP_STR("");
                                     }
                                     SLOP_UNREACHABLE();
@@ -6040,7 +6040,7 @@ slop_string transpiler_get_type_c_name(context_TranspileContext* ctx, types_SExp
                                 return SLOP_STR("");
                             }
                         }
-                    } else if (!_mv_1569.has_value) {
+                    } else if (!_mv_1570.has_value) {
                         return SLOP_STR("");
                     }
                     SLOP_UNREACHABLE();
@@ -6060,13 +6060,13 @@ void transpiler_emit_option_for_inner_type(context_TranspileContext* ctx, slop_s
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1572 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1572.has_value) {
-                __auto_type ot = _mv_1572.value;
+            __auto_type _mv_1573 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1573.has_value) {
+                __auto_type ot = _mv_1573.value;
                 if (string_eq(ot.inner_type, inner_c_name) && !(transpiler_is_pointer_elem_type(ot.inner_type))) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1572.has_value) {
+            } else if (!_mv_1573.has_value) {
             }
             i = (i + 1);
         }
@@ -6080,14 +6080,14 @@ void transpiler_emit_list_for_elem_type(context_TranspileContext* ctx, slop_stri
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1573 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1573.has_value) {
-                __auto_type lt = _mv_1573.value;
+            __auto_type _mv_1574 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1574.has_value) {
+                __auto_type lt = _mv_1574.value;
                 if (string_eq(lt.elem_type, elem_c_name) && !(transpiler_is_pointer_elem_type(lt.elem_type))) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                     transpiler_emit_option_for_inner_type(ctx, lt.c_name);
                 }
-            } else if (!_mv_1573.has_value) {
+            } else if (!_mv_1574.has_value) {
             }
             i = (i + 1);
         }
@@ -6105,13 +6105,13 @@ uint8_t transpiler_struct_uses_value_list_or_option(context_TranspileContext* ct
             __auto_type len = ((int64_t)((list_types).len));
             int64_t i = 0;
             while ((i < len) && !(found)) {
-                __auto_type _mv_1574 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1574.has_value) {
-                    __auto_type lt = _mv_1574.value;
+                __auto_type _mv_1575 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1575.has_value) {
+                    __auto_type lt = _mv_1575.value;
                     if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_struct_uses_list_type(ctx, type_def, lt.c_name)) {
                         found = 1;
                     }
-                } else if (!_mv_1574.has_value) {
+                } else if (!_mv_1575.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6121,13 +6121,13 @@ uint8_t transpiler_struct_uses_value_list_or_option(context_TranspileContext* ct
                 __auto_type len2 = ((int64_t)((option_types).len));
                 int64_t j = 0;
                 while ((j < len2) && !(found)) {
-                    __auto_type _mv_1575 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)j; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1575.has_value) {
-                        __auto_type ot = _mv_1575.value;
+                    __auto_type _mv_1576 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)j; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1576.has_value) {
+                        __auto_type ot = _mv_1576.value;
                         if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_struct_uses_option_type(ctx, type_def, ot.c_name)) {
                             found = 1;
                         }
-                    } else if (!_mv_1575.has_value) {
+                    } else if (!_mv_1576.has_value) {
                     }
                     j = (j + 1);
                 }
@@ -6145,13 +6145,13 @@ void transpiler_emit_struct_dependent_list_types(context_TranspileContext* ctx, 
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1576 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1576.has_value) {
-                __auto_type lt = _mv_1576.value;
+            __auto_type _mv_1577 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1577.has_value) {
+                __auto_type lt = _mv_1577.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_struct_uses_list_type(ctx, type_def, lt.c_name)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1576.has_value) {
+            } else if (!_mv_1577.has_value) {
             }
             i = (i + 1);
         }
@@ -6166,14 +6166,14 @@ void transpiler_emit_struct_dependent_option_types(context_TranspileContext* ctx
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1577 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1577.has_value) {
-                __auto_type ot = _mv_1577.value;
+            __auto_type _mv_1578 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1578.has_value) {
+                __auto_type ot = _mv_1578.value;
                 if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_struct_uses_option_type(ctx, type_def, ot.c_name)) {
                     transpiler_emit_list_type_if_needed(ctx, ot.inner_type);
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1577.has_value) {
+            } else if (!_mv_1578.has_value) {
             }
             i = (i + 1);
         }
@@ -6188,15 +6188,15 @@ void transpiler_emit_struct_dependent_list_types_safe(context_TranspileContext* 
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1578 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1578.has_value) {
-                __auto_type lt = _mv_1578.value;
+            __auto_type _mv_1579 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1579.has_value) {
+                __auto_type lt = _mv_1579.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_struct_uses_list_type(ctx, type_def, lt.c_name)) {
                     if (transpiler_is_type_emitted_or_primitive(ctx, lt.elem_type)) {
                         transpiler_emit_single_list_type_header(ctx, lt);
                     }
                 }
-            } else if (!_mv_1578.has_value) {
+            } else if (!_mv_1579.has_value) {
             }
             i = (i + 1);
         }
@@ -6211,16 +6211,16 @@ void transpiler_emit_struct_dependent_option_types_safe(context_TranspileContext
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1579 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1579.has_value) {
-                __auto_type ot = _mv_1579.value;
+            __auto_type _mv_1580 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1580.has_value) {
+                __auto_type ot = _mv_1580.value;
                 if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_struct_uses_option_type(ctx, type_def, ot.c_name)) {
                     if (transpiler_is_type_emitted_or_primitive(ctx, ot.inner_type)) {
                         transpiler_emit_list_type_if_needed_safe(ctx, ot.inner_type);
                         transpiler_emit_single_option_type_header(ctx, ot);
                     }
                 }
-            } else if (!_mv_1579.has_value) {
+            } else if (!_mv_1580.has_value) {
             }
             i = (i + 1);
         }
@@ -6245,9 +6245,9 @@ uint8_t transpiler_is_imported_type(context_TranspileContext* ctx, slop_string t
     if (strlib_starts_with(type_name, SLOP_STR("slop_list_")) || strlib_starts_with(type_name, SLOP_STR("slop_option_"))) {
         return 0;
     } else {
-        __auto_type _mv_1580 = context_ctx_get_module(ctx);
-        if (_mv_1580.has_value) {
-            __auto_type current_mod = _mv_1580.value;
+        __auto_type _mv_1581 = context_ctx_get_module(ctx);
+        if (_mv_1581.has_value) {
+            __auto_type current_mod = _mv_1581.value;
             {
                 __auto_type arena = (*ctx).arena;
                 __auto_type c_mod = ctype_to_c_name(arena, current_mod);
@@ -6261,7 +6261,7 @@ uint8_t transpiler_is_imported_type(context_TranspileContext* ctx, slop_string t
                     }
                 }
             }
-        } else if (!_mv_1580.has_value) {
+        } else if (!_mv_1581.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -6293,13 +6293,13 @@ void transpiler_emit_list_type_if_needed_safe(context_TranspileContext* ctx, slo
             __auto_type len = ((int64_t)((list_types).len));
             int64_t i = 0;
             while (i < len) {
-                __auto_type _mv_1581 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1581.has_value) {
-                    __auto_type lt = _mv_1581.value;
+                __auto_type _mv_1582 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1582.has_value) {
+                    __auto_type lt = _mv_1582.value;
                     if (string_eq(lt.c_name, inner_type) && transpiler_is_type_emitted_or_primitive(ctx, lt.elem_type)) {
                         transpiler_emit_single_list_type_header(ctx, lt);
                     }
-                } else if (!_mv_1581.has_value) {
+                } else if (!_mv_1582.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6315,13 +6315,13 @@ void transpiler_emit_list_type_if_needed(context_TranspileContext* ctx, slop_str
             __auto_type len = ((int64_t)((list_types).len));
             int64_t i = 0;
             while (i < len) {
-                __auto_type _mv_1582 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1582.has_value) {
-                    __auto_type lt = _mv_1582.value;
+                __auto_type _mv_1583 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1583.has_value) {
+                    __auto_type lt = _mv_1583.value;
                     if (string_eq(lt.c_name, inner_type)) {
                         transpiler_emit_single_list_type_header(ctx, lt);
                     }
-                } else if (!_mv_1582.has_value) {
+                } else if (!_mv_1583.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6334,21 +6334,21 @@ uint8_t transpiler_struct_uses_list_type(context_TranspileContext* ctx, types_SE
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1583 = (*type_def);
-        switch (_mv_1583.tag) {
+        __auto_type _mv_1584 = (*type_def);
+        switch (_mv_1584.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1583.data.lst;
+                __auto_type lst = _mv_1584.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 3) {
                         return 0;
                     } else {
-                        __auto_type _mv_1584 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1584.has_value) {
-                            __auto_type body_expr = _mv_1584.value;
+                        __auto_type _mv_1585 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1585.has_value) {
+                            __auto_type body_expr = _mv_1585.value;
                             return transpiler_type_body_uses_typename(ctx, body_expr, list_type_name);
-                        } else if (!_mv_1584.has_value) {
+                        } else if (!_mv_1585.has_value) {
                             return 0;
                         }
                         SLOP_UNREACHABLE();
@@ -6373,24 +6373,24 @@ uint8_t transpiler_type_body_uses_typename(context_TranspileContext* ctx, types_
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1585 = (*body_expr);
-        switch (_mv_1585.tag) {
+        __auto_type _mv_1586 = (*body_expr);
+        switch (_mv_1586.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1585.data.lst;
+                __auto_type lst = _mv_1586.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type found = 0;
                     __auto_type i = 1;
                     while ((i < len) && !(found)) {
-                        __auto_type _mv_1586 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1586.has_value) {
-                            __auto_type field_expr = _mv_1586.value;
+                        __auto_type _mv_1587 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1587.has_value) {
+                            __auto_type field_expr = _mv_1587.value;
                             if (transpiler_field_uses_typename(ctx, field_expr, typename)) {
                                 found = 1;
                             }
-                        } else if (!_mv_1586.has_value) {
+                        } else if (!_mv_1587.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -6407,24 +6407,24 @@ uint8_t transpiler_type_body_uses_typename(context_TranspileContext* ctx, types_
 uint8_t transpiler_field_uses_typename(context_TranspileContext* ctx, types_SExpr* field_expr, slop_string typename) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((field_expr != NULL)), "(!= field-expr nil)");
-    __auto_type _mv_1587 = (*field_expr);
-    switch (_mv_1587.tag) {
+    __auto_type _mv_1588 = (*field_expr);
+    switch (_mv_1588.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1587.data.lst;
+            __auto_type lst = _mv_1588.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return 0;
                 } else {
-                    __auto_type _mv_1588 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1588.has_value) {
-                        __auto_type type_expr = _mv_1588.value;
+                    __auto_type _mv_1589 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1589.has_value) {
+                        __auto_type type_expr = _mv_1589.value;
                         {
                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                             return string_eq(c_type, typename);
                         }
-                    } else if (!_mv_1588.has_value) {
+                    } else if (!_mv_1589.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -6442,33 +6442,33 @@ void transpiler_emit_type_to_header(context_TranspileContext* ctx, types_SExpr* 
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1589 = (*type_def);
-        switch (_mv_1589.tag) {
+        __auto_type _mv_1590 = (*type_def);
+        switch (_mv_1590.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1589.data.lst;
+                __auto_type lst = _mv_1590.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 3) {
-                        __auto_type _mv_1590 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1590.has_value) {
-                            __auto_type name_expr = _mv_1590.value;
-                            __auto_type _mv_1591 = (*name_expr);
-                            switch (_mv_1591.tag) {
+                        __auto_type _mv_1591 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1591.has_value) {
+                            __auto_type name_expr = _mv_1591.value;
+                            __auto_type _mv_1592 = (*name_expr);
+                            switch (_mv_1592.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1591.data.sym;
+                                    __auto_type name_sym = _mv_1592.data.sym;
                                     {
                                         __auto_type type_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, type_name);
                                         __auto_type c_name = ((context_ctx_prefixing_enabled(ctx)) ? ({ __auto_type _mv = context_ctx_get_module(ctx); _mv.has_value ? ({ __auto_type mod_name = _mv.value; context_ctx_str(ctx, ctype_to_c_name(arena, mod_name), context_ctx_str(ctx, SLOP_STR("_"), base_name)); }) : (base_name); }) : base_name);
-                                        __auto_type _mv_1592 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1592.has_value) {
-                                            __auto_type body_expr = _mv_1592.value;
+                                        __auto_type _mv_1593 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1593.has_value) {
+                                            __auto_type body_expr = _mv_1593.value;
                                             transpiler_emit_type_body_to_header(ctx, type_name, c_name, body_expr);
                                             context_ctx_mark_type_emitted(ctx, c_name);
-                                        } else if (!_mv_1592.has_value) {
+                                        } else if (!_mv_1593.has_value) {
                                         }
                                     }
                                     break;
@@ -6477,7 +6477,7 @@ void transpiler_emit_type_to_header(context_TranspileContext* ctx, types_SExpr* 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1590.has_value) {
+                        } else if (!_mv_1591.has_value) {
                         }
                     }
                 }
@@ -6495,23 +6495,23 @@ void transpiler_emit_type_body_to_header(context_TranspileContext* ctx, slop_str
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1593 = (*body_expr);
-        switch (_mv_1593.tag) {
+        __auto_type _mv_1594 = (*body_expr);
+        switch (_mv_1594.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1593.data.lst;
+                __auto_type lst = _mv_1594.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 1) {
                     } else {
-                        __auto_type _mv_1594 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1594.has_value) {
-                            __auto_type kind_expr = _mv_1594.value;
-                            __auto_type _mv_1595 = (*kind_expr);
-                            switch (_mv_1595.tag) {
+                        __auto_type _mv_1595 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1595.has_value) {
+                            __auto_type kind_expr = _mv_1595.value;
+                            __auto_type _mv_1596 = (*kind_expr);
+                            switch (_mv_1596.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type kind_sym = _mv_1595.data.sym;
+                                    __auto_type kind_sym = _mv_1596.data.sym;
                                     {
                                         __auto_type kind = kind_sym.name;
                                         if (string_eq(kind, SLOP_STR("enum"))) {
@@ -6529,7 +6529,7 @@ void transpiler_emit_type_body_to_header(context_TranspileContext* ctx, slop_str
                                     break;
                                 }
                             }
-                        } else if (!_mv_1594.has_value) {
+                        } else if (!_mv_1595.has_value) {
                         }
                     }
                 }
@@ -6550,14 +6550,14 @@ void transpiler_emit_enum_to_header(context_TranspileContext* ctx, slop_string c
         int64_t i = 1;
         context_ctx_emit_header(ctx, SLOP_STR("typedef enum {"));
         while (i < len) {
-            __auto_type _mv_1596 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1596.has_value) {
-                __auto_type variant_expr = _mv_1596.value;
-                __auto_type _mv_1597 = (*variant_expr);
-                switch (_mv_1597.tag) {
+            __auto_type _mv_1597 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1597.has_value) {
+                __auto_type variant_expr = _mv_1597.value;
+                __auto_type _mv_1598 = (*variant_expr);
+                switch (_mv_1598.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type variant_sym = _mv_1597.data.sym;
+                        __auto_type variant_sym = _mv_1598.data.sym;
                         {
                             __auto_type variant_name = variant_sym.name;
                             __auto_type c_variant = context_ctx_str3(ctx, c_name, SLOP_STR("_"), ctype_to_c_name(arena, variant_name));
@@ -6574,7 +6574,7 @@ void transpiler_emit_enum_to_header(context_TranspileContext* ctx, slop_string c
                         break;
                     }
                 }
-            } else if (!_mv_1596.has_value) {
+            } else if (!_mv_1597.has_value) {
             }
             i = (i + 1);
         }
@@ -6592,11 +6592,11 @@ void transpiler_emit_struct_to_header(context_TranspileContext* ctx, slop_string
         int64_t i = 1;
         context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("struct "), c_name, SLOP_STR(" {")));
         while (i < len) {
-            __auto_type _mv_1598 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1598.has_value) {
-                __auto_type field_expr = _mv_1598.value;
+            __auto_type _mv_1599 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1599.has_value) {
+                __auto_type field_expr = _mv_1599.value;
                 transpiler_emit_field_to_header(ctx, raw_type_name, c_name, field_expr);
-            } else if (!_mv_1598.has_value) {
+            } else if (!_mv_1599.has_value) {
             }
             i = (i + 1);
         }
@@ -6611,28 +6611,28 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
     SLOP_PRE(((field_expr != NULL)), "(!= field-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1599 = (*field_expr);
-        switch (_mv_1599.tag) {
+        __auto_type _mv_1600 = (*field_expr);
+        switch (_mv_1600.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1599.data.lst;
+                __auto_type lst = _mv_1600.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_1600 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1600.has_value) {
-                            __auto_type name_expr = _mv_1600.value;
-                            __auto_type _mv_1601 = (*name_expr);
-                            switch (_mv_1601.tag) {
+                        __auto_type _mv_1601 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1601.has_value) {
+                            __auto_type name_expr = _mv_1601.value;
+                            __auto_type _mv_1602 = (*name_expr);
+                            switch (_mv_1602.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1601.data.sym;
+                                    __auto_type name_sym = _mv_1602.data.sym;
                                     {
                                         __auto_type field_name = name_sym.name;
                                         __auto_type c_field_name = ctype_to_c_name(arena, field_name);
-                                        __auto_type _mv_1602 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1602.has_value) {
-                                            __auto_type type_expr = _mv_1602.value;
+                                        __auto_type _mv_1603 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1603.has_value) {
+                                            __auto_type type_expr = _mv_1603.value;
                                             {
                                                 __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                 __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
@@ -6641,7 +6641,7 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
                                                 context_ctx_register_field_type(ctx, raw_type_name, field_name, c_type, slop_type_str, is_ptr);
                                                 context_ctx_register_field_type(ctx, c_type_name, field_name, c_type, slop_type_str, is_ptr);
                                             }
-                                        } else if (!_mv_1602.has_value) {
+                                        } else if (!_mv_1603.has_value) {
                                         }
                                     }
                                     break;
@@ -6650,7 +6650,7 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1600.has_value) {
+                        } else if (!_mv_1601.has_value) {
                         }
                     }
                 }
@@ -6665,31 +6665,31 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
 
 uint8_t transpiler_is_pointer_type_expr_header(types_SExpr* type_expr) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_1603 = (*type_expr);
-    switch (_mv_1603.tag) {
+    __auto_type _mv_1604 = (*type_expr);
+    switch (_mv_1604.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1603.data.lst;
+            __auto_type lst = _mv_1604.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1604 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1604.has_value) {
-                        __auto_type head = _mv_1604.value;
-                        __auto_type _mv_1605 = (*head);
-                        switch (_mv_1605.tag) {
+                    __auto_type _mv_1605 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1605.has_value) {
+                        __auto_type head = _mv_1605.value;
+                        __auto_type _mv_1606 = (*head);
+                        switch (_mv_1606.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1605.data.sym;
+                                __auto_type sym = _mv_1606.data.sym;
                                 return string_eq(sym.name, SLOP_STR("Ptr"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1604.has_value) {
+                    } else if (!_mv_1605.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -6712,9 +6712,9 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
         {
             int64_t i = 1;
             while (i < len) {
-                __auto_type _mv_1606 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1606.has_value) {
-                    __auto_type variant_expr = _mv_1606.value;
+                __auto_type _mv_1607 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1607.has_value) {
+                    __auto_type variant_expr = _mv_1607.value;
                     {
                         __auto_type variant_name = transpiler_get_variant_name(variant_expr);
                         __auto_type c_variant = context_ctx_str3(ctx, c_name, SLOP_STR("_"), ctype_to_c_name(arena, variant_name));
@@ -6725,7 +6725,7 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
                             context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("    "), c_variant, SLOP_STR(",")));
                         }
                     }
-                } else if (!_mv_1606.has_value) {
+                } else if (!_mv_1607.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6738,11 +6738,11 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
         {
             int64_t i = 1;
             while (i < len) {
-                __auto_type _mv_1607 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1607.has_value) {
-                    __auto_type variant_expr = _mv_1607.value;
+                __auto_type _mv_1608 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1608.has_value) {
+                    __auto_type variant_expr = _mv_1608.value;
                     transpiler_emit_union_variant_to_header(ctx, variant_expr);
-                } else if (!_mv_1607.has_value) {
+                } else if (!_mv_1608.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6756,36 +6756,36 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
 
 slop_string transpiler_get_variant_name(types_SExpr* variant_expr) {
     SLOP_PRE(((variant_expr != NULL)), "(!= variant-expr nil)");
-    __auto_type _mv_1608 = (*variant_expr);
-    switch (_mv_1608.tag) {
+    __auto_type _mv_1609 = (*variant_expr);
+    switch (_mv_1609.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1608.data.sym;
+            __auto_type sym = _mv_1609.data.sym;
             return sym.name;
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1608.data.lst;
+            __auto_type lst = _mv_1609.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return SLOP_STR("unknown");
                 } else {
-                    __auto_type _mv_1609 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1609.has_value) {
-                        __auto_type name_expr = _mv_1609.value;
-                        __auto_type _mv_1610 = (*name_expr);
-                        switch (_mv_1610.tag) {
+                    __auto_type _mv_1610 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1610.has_value) {
+                        __auto_type name_expr = _mv_1610.value;
+                        __auto_type _mv_1611 = (*name_expr);
+                        switch (_mv_1611.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type name_sym = _mv_1610.data.sym;
+                                __auto_type name_sym = _mv_1611.data.sym;
                                 return name_sym.name;
                             }
                             default: {
                                 return SLOP_STR("unknown");
                             }
                         }
-                    } else if (!_mv_1609.has_value) {
+                    } else if (!_mv_1610.has_value) {
                         return SLOP_STR("unknown");
                     }
                     SLOP_UNREACHABLE();
@@ -6803,35 +6803,35 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
     SLOP_PRE(((variant_expr != NULL)), "(!= variant-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1611 = (*variant_expr);
-        switch (_mv_1611.tag) {
+        __auto_type _mv_1612 = (*variant_expr);
+        switch (_mv_1612.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1611.data.sym;
+                __auto_type sym = _mv_1612.data.sym;
                 break;
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1611.data.lst;
+                __auto_type lst = _mv_1612.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type num_items = ((int64_t)((items).len));
                     if (num_items >= 2) {
-                        __auto_type _mv_1612 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1612.has_value) {
-                            __auto_type name_expr = _mv_1612.value;
-                            __auto_type _mv_1613 = (*name_expr);
-                            switch (_mv_1613.tag) {
+                        __auto_type _mv_1613 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1613.has_value) {
+                            __auto_type name_expr = _mv_1613.value;
+                            __auto_type _mv_1614 = (*name_expr);
+                            switch (_mv_1614.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1613.data.sym;
+                                    __auto_type name_sym = _mv_1614.data.sym;
                                     {
                                         __auto_type variant_name = name_sym.name;
                                         __auto_type c_field = ctype_to_c_name(arena, variant_name);
                                         if (num_items == 2) {
-                                            __auto_type _mv_1614 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1614.has_value) {
-                                                __auto_type type_expr = _mv_1614.value;
+                                            __auto_type _mv_1615 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1615.has_value) {
+                                                __auto_type type_expr = _mv_1615.value;
                                                 {
                                                     __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                     {
@@ -6839,14 +6839,14 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
                                                         context_ctx_emit_header(ctx, context_ctx_str4(ctx, SLOP_STR("        "), actual_type, SLOP_STR(" "), context_ctx_str(ctx, c_field, SLOP_STR(";"))));
                                                     }
                                                 }
-                                            } else if (!_mv_1614.has_value) {
+                                            } else if (!_mv_1615.has_value) {
                                             }
                                         } else if (num_items >= 3) {
                                             context_ctx_emit_header(ctx, SLOP_STR("        struct {"));
                                             for (int64_t fi = 1; fi < num_items; fi++) {
-                                                __auto_type _mv_1615 = ({ __auto_type _lst = items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1615.has_value) {
-                                                    __auto_type type_expr = _mv_1615.value;
+                                                __auto_type _mv_1616 = ({ __auto_type _lst = items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1616.has_value) {
+                                                    __auto_type type_expr = _mv_1616.value;
                                                     {
                                                         __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                         {
@@ -6855,7 +6855,7 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
                                                             context_ctx_emit_header(ctx, context_ctx_str5(ctx, SLOP_STR("            "), actual_type, SLOP_STR(" "), field_name, SLOP_STR(";")));
                                                         }
                                                     }
-                                                } else if (!_mv_1615.has_value) {
+                                                } else if (!_mv_1616.has_value) {
                                                 }
                                             }
                                             context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("        } "), c_field, SLOP_STR(";")));
@@ -6868,7 +6868,7 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
                                     break;
                                 }
                             }
-                        } else if (!_mv_1612.has_value) {
+                        } else if (!_mv_1613.has_value) {
                         }
                     }
                 }
@@ -6888,9 +6888,9 @@ void transpiler_emit_module_consts(context_TranspileContext* ctx, slop_list_type
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1616 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1616.has_value) {
-                __auto_type item = _mv_1616.value;
+            __auto_type _mv_1617 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1617.has_value) {
+                __auto_type item = _mv_1617.value;
                 if (transpiler_is_const_def(item)) {
                     {
                         __auto_type const_name = transpiler_get_const_name(item);
@@ -6899,7 +6899,7 @@ void transpiler_emit_module_consts(context_TranspileContext* ctx, slop_list_type
                     }
                     emitted_any = 1;
                 }
-            } else if (!_mv_1616.has_value) {
+            } else if (!_mv_1617.has_value) {
             }
             i = (i + 1);
         }
@@ -6911,31 +6911,31 @@ void transpiler_emit_module_consts(context_TranspileContext* ctx, slop_list_type
 
 slop_string transpiler_get_const_name(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1617 = (*item);
-    switch (_mv_1617.tag) {
+    __auto_type _mv_1618 = (*item);
+    switch (_mv_1618.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1617.data.lst;
+            __auto_type lst = _mv_1618.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return SLOP_STR("");
                 } else {
-                    __auto_type _mv_1618 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1618.has_value) {
-                        __auto_type name_expr = _mv_1618.value;
-                        __auto_type _mv_1619 = (*name_expr);
-                        switch (_mv_1619.tag) {
+                    __auto_type _mv_1619 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1619.has_value) {
+                        __auto_type name_expr = _mv_1619.value;
+                        __auto_type _mv_1620 = (*name_expr);
+                        switch (_mv_1620.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1619.data.sym;
+                                __auto_type sym = _mv_1620.data.sym;
                                 return sym.name;
                             }
                             default: {
                                 return SLOP_STR("");
                             }
                         }
-                    } else if (!_mv_1618.has_value) {
+                    } else if (!_mv_1619.has_value) {
                         return SLOP_STR("");
                     }
                     SLOP_UNREACHABLE();
@@ -6955,15 +6955,15 @@ void transpiler_emit_module_consts_header(context_TranspileContext* ctx, slop_li
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1620 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1620.has_value) {
-                __auto_type item = _mv_1620.value;
+            __auto_type _mv_1621 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1621.has_value) {
+                __auto_type item = _mv_1621.value;
                 if (transpiler_is_const_def(item)) {
                     if (transpiler_emit_const_header_if_exported(ctx, item, exports)) {
                         emitted_any = 1;
                     }
                 }
-            } else if (!_mv_1620.has_value) {
+            } else if (!_mv_1621.has_value) {
             }
             i = (i + 1);
         }
@@ -6976,35 +6976,35 @@ void transpiler_emit_module_consts_header(context_TranspileContext* ctx, slop_li
 uint8_t transpiler_emit_const_header_if_exported(context_TranspileContext* ctx, types_SExpr* item, slop_list_string exports) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1621 = (*item);
-    switch (_mv_1621.tag) {
+    __auto_type _mv_1622 = (*item);
+    switch (_mv_1622.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1621.data.lst;
+            __auto_type lst = _mv_1622.data.lst;
             {
                 __auto_type const_items = lst.items;
                 if (((int64_t)((const_items).len)) < 4) {
                     return 0;
                 } else {
-                    __auto_type _mv_1622 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1622.has_value) {
-                        __auto_type name_expr = _mv_1622.value;
-                        __auto_type _mv_1623 = (*name_expr);
-                        switch (_mv_1623.tag) {
+                    __auto_type _mv_1623 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1623.has_value) {
+                        __auto_type name_expr = _mv_1623.value;
+                        __auto_type _mv_1624 = (*name_expr);
+                        switch (_mv_1624.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type name_sym = _mv_1623.data.sym;
+                                __auto_type name_sym = _mv_1624.data.sym;
                                 {
                                     __auto_type raw_name = name_sym.name;
                                     if (!(transpiler_list_contains_str(exports, raw_name))) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1624 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1624.has_value) {
-                                            __auto_type type_expr = _mv_1624.value;
+                                        __auto_type _mv_1625 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1625.has_value) {
+                                            __auto_type type_expr = _mv_1625.value;
                                             transpiler_emit_const_header_decl(ctx, raw_name, type_expr, ({ __auto_type _mv = ({ __auto_type _lst = const_items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type v = _mv.value; v; }) : (NULL); }));
                                             return 1;
-                                        } else if (!_mv_1624.has_value) {
+                                        } else if (!_mv_1625.has_value) {
                                             return 0;
                                         }
                                         SLOP_UNREACHABLE();
@@ -7015,7 +7015,7 @@ uint8_t transpiler_emit_const_header_if_exported(context_TranspileContext* ctx, 
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1622.has_value) {
+                    } else if (!_mv_1623.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -7066,13 +7066,13 @@ void transpiler_emit_module_functions(context_TranspileContext* ctx, slop_list_t
         int64_t i = start;
         context_ctx_start_function_buffer(ctx);
         while (i < len) {
-            __auto_type _mv_1625 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1625.has_value) {
-                __auto_type item = _mv_1625.value;
+            __auto_type _mv_1626 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1626.has_value) {
+                __auto_type item = _mv_1626.value;
                 if (transpiler_is_fn_def(item)) {
                     defn_transpile_function(ctx, item);
                 }
-            } else if (!_mv_1625.has_value) {
+            } else if (!_mv_1626.has_value) {
             }
             i = (i + 1);
         }
@@ -7090,12 +7090,12 @@ void transpiler_emit_all_lambdas(context_TranspileContext* ctx) {
         int64_t i = 0;
         if (count > 0) {
             while (i < count) {
-                __auto_type _mv_1626 = ({ __auto_type _lst = lambdas; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1626.has_value) {
-                    __auto_type lambda_code = _mv_1626.value;
+                __auto_type _mv_1627 = ({ __auto_type _lst = lambdas; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1627.has_value) {
+                    __auto_type lambda_code = _mv_1627.value;
                     context_ctx_emit(ctx, lambda_code);
                     context_ctx_emit(ctx, SLOP_STR(""));
-                } else if (!_mv_1626.has_value) {
+                } else if (!_mv_1627.has_value) {
                 }
                 i = (i + 1);
             }
@@ -7113,11 +7113,11 @@ slop_string transpiler_generate_c_output(context_TranspileContext* ctx) {
         __auto_type result = SLOP_STR("");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1627 = ({ __auto_type _lst = output_lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1627.has_value) {
-                __auto_type line = _mv_1627.value;
+            __auto_type _mv_1628 = ({ __auto_type _lst = output_lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1628.has_value) {
+                __auto_type line = _mv_1628.value;
                 result = context_ctx_str3(ctx, result, line, SLOP_STR("\n"));
-            } else if (!_mv_1627.has_value) {
+            } else if (!_mv_1628.has_value) {
             }
             i = (i + 1);
         }
@@ -7131,11 +7131,11 @@ void transpiler_transpile_file(context_TranspileContext* ctx, slop_list_types_SE
         __auto_type len = ((int64_t)((exprs).len));
         int64_t i = 0;
         if ((len > 0) && transpiler_is_module_expr(exprs)) {
-            __auto_type _mv_1628 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1628.has_value) {
-                __auto_type module_expr = _mv_1628.value;
+            __auto_type _mv_1629 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1629.has_value) {
+                __auto_type module_expr = _mv_1629.value;
                 transpiler_transpile_module(ctx, module_expr);
-            } else if (!_mv_1628.has_value) {
+            } else if (!_mv_1629.has_value) {
             }
         } else {
             emit_emit_standard_includes(ctx);
@@ -7151,34 +7151,34 @@ uint8_t transpiler_is_module_expr(slop_list_types_SExpr_ptr exprs) {
     if (((int64_t)((exprs).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_1629 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1629.has_value) {
-            __auto_type first = _mv_1629.value;
-            __auto_type _mv_1630 = (*first);
-            switch (_mv_1630.tag) {
+        __auto_type _mv_1630 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1630.has_value) {
+            __auto_type first = _mv_1630.value;
+            __auto_type _mv_1631 = (*first);
+            switch (_mv_1631.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type lst = _mv_1630.data.lst;
+                    __auto_type lst = _mv_1631.data.lst;
                     {
                         __auto_type items = lst.items;
                         if (((int64_t)((items).len)) < 1) {
                             return 0;
                         } else {
-                            __auto_type _mv_1631 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1631.has_value) {
-                                __auto_type head = _mv_1631.value;
-                                __auto_type _mv_1632 = (*head);
-                                switch (_mv_1632.tag) {
+                            __auto_type _mv_1632 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1632.has_value) {
+                                __auto_type head = _mv_1632.value;
+                                __auto_type _mv_1633 = (*head);
+                                switch (_mv_1633.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1632.data.sym;
+                                        __auto_type sym = _mv_1633.data.sym;
                                         return string_eq(sym.name, SLOP_STR("module"));
                                     }
                                     default: {
                                         return 0;
                                     }
                                 }
-                            } else if (!_mv_1631.has_value) {
+                            } else if (!_mv_1632.has_value) {
                                 return 0;
                             }
                             SLOP_UNREACHABLE();
@@ -7189,7 +7189,7 @@ uint8_t transpiler_is_module_expr(slop_list_types_SExpr_ptr exprs) {
                     return 0;
                 }
             }
-        } else if (!_mv_1629.has_value) {
+        } else if (!_mv_1630.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();

--- a/bootstrap/tester/slop_defn.c
+++ b/bootstrap/tester/slop_defn.c
@@ -86,31 +86,31 @@ slop_string defn_escape_for_c_string(slop_arena* arena, slop_string s);
 
 uint8_t defn_is_type_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_920 = (*expr);
-    switch (_mv_920.tag) {
+    __auto_type _mv_921 = (*expr);
+    switch (_mv_921.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_920.data.lst;
+            __auto_type lst = _mv_921.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_921 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_921.has_value) {
-                        __auto_type head = _mv_921.value;
-                        __auto_type _mv_922 = (*head);
-                        switch (_mv_922.tag) {
+                    __auto_type _mv_922 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_922.has_value) {
+                        __auto_type head = _mv_922.value;
+                        __auto_type _mv_923 = (*head);
+                        switch (_mv_923.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_922.data.sym;
+                                __auto_type sym = _mv_923.data.sym;
                                 return string_eq(sym.name, SLOP_STR("type"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_921.has_value) {
+                    } else if (!_mv_922.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -125,31 +125,31 @@ uint8_t defn_is_type_form(types_SExpr* expr) {
 
 uint8_t defn_is_function_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_923 = (*expr);
-    switch (_mv_923.tag) {
+    __auto_type _mv_924 = (*expr);
+    switch (_mv_924.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_923.data.lst;
+            __auto_type lst = _mv_924.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_924 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_924.has_value) {
-                        __auto_type head = _mv_924.value;
-                        __auto_type _mv_925 = (*head);
-                        switch (_mv_925.tag) {
+                    __auto_type _mv_925 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_925.has_value) {
+                        __auto_type head = _mv_925.value;
+                        __auto_type _mv_926 = (*head);
+                        switch (_mv_926.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_925.data.sym;
+                                __auto_type sym = _mv_926.data.sym;
                                 return string_eq(sym.name, SLOP_STR("fn"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_924.has_value) {
+                    } else if (!_mv_925.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -164,31 +164,31 @@ uint8_t defn_is_function_form(types_SExpr* expr) {
 
 uint8_t defn_is_const_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_926 = (*expr);
-    switch (_mv_926.tag) {
+    __auto_type _mv_927 = (*expr);
+    switch (_mv_927.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_926.data.lst;
+            __auto_type lst = _mv_927.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_927 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_927.has_value) {
-                        __auto_type head = _mv_927.value;
-                        __auto_type _mv_928 = (*head);
-                        switch (_mv_928.tag) {
+                    __auto_type _mv_928 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_928.has_value) {
+                        __auto_type head = _mv_928.value;
+                        __auto_type _mv_929 = (*head);
+                        switch (_mv_929.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_928.data.sym;
+                                __auto_type sym = _mv_929.data.sym;
                                 return string_eq(sym.name, SLOP_STR("const"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_927.has_value) {
+                    } else if (!_mv_928.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -203,31 +203,31 @@ uint8_t defn_is_const_form(types_SExpr* expr) {
 
 uint8_t defn_is_ffi_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_929 = (*expr);
-    switch (_mv_929.tag) {
+    __auto_type _mv_930 = (*expr);
+    switch (_mv_930.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_929.data.lst;
+            __auto_type lst = _mv_930.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_930 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_930.has_value) {
-                        __auto_type head = _mv_930.value;
-                        __auto_type _mv_931 = (*head);
-                        switch (_mv_931.tag) {
+                    __auto_type _mv_931 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_931.has_value) {
+                        __auto_type head = _mv_931.value;
+                        __auto_type _mv_932 = (*head);
+                        switch (_mv_932.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_931.data.sym;
+                                __auto_type sym = _mv_932.data.sym;
                                 return string_eq(sym.name, SLOP_STR("ffi"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_930.has_value) {
+                    } else if (!_mv_931.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -242,31 +242,31 @@ uint8_t defn_is_ffi_form(types_SExpr* expr) {
 
 uint8_t defn_is_ffi_struct_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_932 = (*expr);
-    switch (_mv_932.tag) {
+    __auto_type _mv_933 = (*expr);
+    switch (_mv_933.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_932.data.lst;
+            __auto_type lst = _mv_933.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_933 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_933.has_value) {
-                        __auto_type head = _mv_933.value;
-                        __auto_type _mv_934 = (*head);
-                        switch (_mv_934.tag) {
+                    __auto_type _mv_934 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_934.has_value) {
+                        __auto_type head = _mv_934.value;
+                        __auto_type _mv_935 = (*head);
+                        switch (_mv_935.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_934.data.sym;
+                                __auto_type sym = _mv_935.data.sym;
                                 return string_eq(sym.name, SLOP_STR("ffi-struct"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_933.has_value) {
+                    } else if (!_mv_934.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -285,25 +285,25 @@ uint8_t defn_has_generic_annotation(slop_list_types_SExpr_ptr items) {
         __auto_type i = 0;
         __auto_type found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_935 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_935.has_value) {
-                __auto_type item = _mv_935.value;
-                __auto_type _mv_936 = (*item);
-                switch (_mv_936.tag) {
+            __auto_type _mv_936 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_936.has_value) {
+                __auto_type item = _mv_936.value;
+                __auto_type _mv_937 = (*item);
+                switch (_mv_937.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type lst = _mv_936.data.lst;
+                        __auto_type lst = _mv_937.data.lst;
                         {
                             __auto_type sub_items = lst.items;
                             if (((int64_t)((sub_items).len)) > 0) {
-                                __auto_type _mv_937 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_937.has_value) {
-                                    __auto_type head = _mv_937.value;
-                                    __auto_type _mv_938 = (*head);
-                                    switch (_mv_938.tag) {
+                                __auto_type _mv_938 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_938.has_value) {
+                                    __auto_type head = _mv_938.value;
+                                    __auto_type _mv_939 = (*head);
+                                    switch (_mv_939.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_938.data.sym;
+                                            __auto_type sym = _mv_939.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("@generic"))) {
                                                 found = 1;
                                             } else {
@@ -314,7 +314,7 @@ uint8_t defn_has_generic_annotation(slop_list_types_SExpr_ptr items) {
                                             break;
                                         }
                                     }
-                                } else if (!_mv_937.has_value) {
+                                } else if (!_mv_938.has_value) {
                                 }
                             } else {
                             }
@@ -325,7 +325,7 @@ uint8_t defn_has_generic_annotation(slop_list_types_SExpr_ptr items) {
                         break;
                     }
                 }
-            } else if (!_mv_935.has_value) {
+            } else if (!_mv_936.has_value) {
             }
             i = (i + 1);
         }
@@ -334,31 +334,31 @@ uint8_t defn_has_generic_annotation(slop_list_types_SExpr_ptr items) {
 }
 
 uint8_t defn_is_pointer_type_expr(types_SExpr* type_expr) {
-    __auto_type _mv_939 = (*type_expr);
-    switch (_mv_939.tag) {
+    __auto_type _mv_940 = (*type_expr);
+    switch (_mv_940.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_939.data.lst;
+            __auto_type lst = _mv_940.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_940 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_940.has_value) {
-                        __auto_type head = _mv_940.value;
-                        __auto_type _mv_941 = (*head);
-                        switch (_mv_941.tag) {
+                    __auto_type _mv_941 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_941.has_value) {
+                        __auto_type head = _mv_941.value;
+                        __auto_type _mv_942 = (*head);
+                        switch (_mv_942.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_941.data.sym;
+                                __auto_type sym = _mv_942.data.sym;
                                 return (string_eq(sym.name, SLOP_STR("Ptr")) || string_eq(sym.name, SLOP_STR("ScopedPtr")));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_940.has_value) {
+                    } else if (!_mv_941.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -376,44 +376,44 @@ void defn_transpile_const(context_TranspileContext* ctx, types_SExpr* expr, uint
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_942 = (*expr);
-        switch (_mv_942.tag) {
+        __auto_type _mv_943 = (*expr);
+        switch (_mv_943.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_942.data.lst;
+                __auto_type lst = _mv_943.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 4) {
                         context_ctx_fail(ctx, SLOP_STR("invalid const: need name, type, value"));
                     } else {
-                        __auto_type _mv_943 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_943.has_value) {
-                            __auto_type name_expr = _mv_943.value;
-                            __auto_type _mv_944 = (*name_expr);
-                            switch (_mv_944.tag) {
+                        __auto_type _mv_944 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_944.has_value) {
+                            __auto_type name_expr = _mv_944.value;
+                            __auto_type _mv_945 = (*name_expr);
+                            switch (_mv_945.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_944.data.sym;
+                                    __auto_type name_sym = _mv_945.data.sym;
                                     {
                                         __auto_type raw_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, raw_name);
                                         __auto_type c_name = context_ctx_prefix_type(ctx, base_name);
-                                        __auto_type _mv_945 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_945.has_value) {
-                                            __auto_type type_expr = _mv_945.value;
+                                        __auto_type _mv_946 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_946.has_value) {
+                                            __auto_type type_expr = _mv_946.value;
                                             {
                                                 __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
                                                 context_ctx_bind_var(ctx, (context_VarEntry){raw_name, c_name, SLOP_STR("auto"), slop_type_str, 0, 0, 0, SLOP_STR(""), SLOP_STR("")});
-                                                __auto_type _mv_946 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_946.has_value) {
-                                                    __auto_type value_expr = _mv_946.value;
+                                                __auto_type _mv_947 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_947.has_value) {
+                                                    __auto_type value_expr = _mv_947.value;
                                                     defn_emit_const_def(ctx, c_name, type_expr, value_expr, is_exported);
-                                                } else if (!_mv_946.has_value) {
+                                                } else if (!_mv_947.has_value) {
                                                     context_ctx_fail(ctx, SLOP_STR("missing const value"));
                                                 }
                                             }
-                                        } else if (!_mv_945.has_value) {
+                                        } else if (!_mv_946.has_value) {
                                             context_ctx_fail(ctx, SLOP_STR("missing const type"));
                                         }
                                     }
@@ -424,7 +424,7 @@ void defn_transpile_const(context_TranspileContext* ctx, types_SExpr* expr, uint
                                     break;
                                 }
                             }
-                        } else if (!_mv_943.has_value) {
+                        } else if (!_mv_944.has_value) {
                             context_ctx_fail(ctx, SLOP_STR("missing const name"));
                         }
                     }
@@ -458,11 +458,11 @@ void defn_emit_const_def(context_TranspileContext* ctx, slop_string c_name, type
             {
                 __auto_type storage = ((is_exported) ? SLOP_STR("const ") : SLOP_STR("static const "));
                 if (string_eq(type_name, SLOP_STR("String"))) {
-                    __auto_type _mv_947 = (*value_expr);
-                    switch (_mv_947.tag) {
+                    __auto_type _mv_948 = (*value_expr);
+                    switch (_mv_948.tag) {
                         case types_SExpr_str:
                         {
-                            __auto_type str = _mv_947.data.str;
+                            __auto_type str = _mv_948.data.str;
                             context_ctx_emit(ctx, context_ctx_str5(ctx, storage, c_type, SLOP_STR(" "), c_name, context_ctx_str3(ctx, SLOP_STR(" = SLOP_STR(\""), str.value, SLOP_STR("\");"))));
                             break;
                         }
@@ -487,11 +487,11 @@ void defn_emit_const_def(context_TranspileContext* ctx, slop_string c_name, type
 
 slop_string defn_get_type_name_str(types_SExpr* type_expr) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_948 = (*type_expr);
-    switch (_mv_948.tag) {
+    __auto_type _mv_949 = (*type_expr);
+    switch (_mv_949.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_948.data.sym;
+            __auto_type sym = _mv_949.data.sym;
             return sym.name;
         }
         default: {
@@ -505,26 +505,26 @@ slop_string defn_eval_const_value(context_TranspileContext* ctx, types_SExpr* ex
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_949 = (*expr);
-        switch (_mv_949.tag) {
+        __auto_type _mv_950 = (*expr);
+        switch (_mv_950.tag) {
             case types_SExpr_num:
             {
-                __auto_type num = _mv_949.data.num;
+                __auto_type num = _mv_950.data.num;
                 return num.raw;
             }
             case types_SExpr_str:
             {
-                __auto_type str = _mv_949.data.str;
+                __auto_type str = _mv_950.data.str;
                 return context_ctx_str3(ctx, SLOP_STR("\""), str.value, SLOP_STR("\""));
             }
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_949.data.sym;
+                __auto_type sym = _mv_950.data.sym;
                 return ctype_to_c_name(arena, sym.name);
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_949.data.lst;
+                __auto_type lst = _mv_950.data.lst;
                 return expr_transpile_expr(ctx, expr);
             }
         }
@@ -542,25 +542,25 @@ void defn_transpile_ffi_struct(context_TranspileContext* ctx, types_SExpr* expr)
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_950 = (*expr);
-        switch (_mv_950.tag) {
+        __auto_type _mv_951 = (*expr);
+        switch (_mv_951.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_950.data.lst;
+                __auto_type lst = _mv_951.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     {
                         __auto_type name_idx = ((((len >= 2) && defn_is_string_expr(items, 1))) ? 2 : 1);
                         if (len >= (name_idx + 1)) {
-                            __auto_type _mv_951 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_951.has_value) {
-                                __auto_type name_expr = _mv_951.value;
-                                __auto_type _mv_952 = (*name_expr);
-                                switch (_mv_952.tag) {
+                            __auto_type _mv_952 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_952.has_value) {
+                                __auto_type name_expr = _mv_952.value;
+                                __auto_type _mv_953 = (*name_expr);
+                                switch (_mv_953.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_952.data.sym;
+                                        __auto_type sym = _mv_953.data.sym;
                                         {
                                             __auto_type type_name = sym.name;
                                             __auto_type c_name = ctype_to_c_name(arena, type_name);
@@ -575,7 +575,7 @@ void defn_transpile_ffi_struct(context_TranspileContext* ctx, types_SExpr* expr)
                                         break;
                                     }
                                 }
-                            } else if (!_mv_951.has_value) {
+                            } else if (!_mv_952.has_value) {
                             }
                         }
                     }
@@ -590,21 +590,21 @@ void defn_transpile_ffi_struct(context_TranspileContext* ctx, types_SExpr* expr)
 }
 
 uint8_t defn_is_string_expr(slop_list_types_SExpr_ptr items, int64_t idx) {
-    __auto_type _mv_953 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-    if (_mv_953.has_value) {
-        __auto_type item = _mv_953.value;
-        __auto_type _mv_954 = (*item);
-        switch (_mv_954.tag) {
+    __auto_type _mv_954 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+    if (_mv_954.has_value) {
+        __auto_type item = _mv_954.value;
+        __auto_type _mv_955 = (*item);
+        switch (_mv_955.tag) {
             case types_SExpr_str:
             {
-                __auto_type _ = _mv_954.data.str;
+                __auto_type _ = _mv_955.data.str;
                 return 1;
             }
             default: {
                 return 0;
             }
         }
-    } else if (!_mv_953.has_value) {
+    } else if (!_mv_954.has_value) {
         return 0;
     }
     SLOP_UNREACHABLE();
@@ -619,34 +619,34 @@ void defn_transpile_type(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_955 = (*expr);
-        switch (_mv_955.tag) {
+        __auto_type _mv_956 = (*expr);
+        switch (_mv_956.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_955.data.lst;
+                __auto_type lst = _mv_956.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 3) {
                         context_ctx_add_error_at(ctx, SLOP_STR("invalid type: need name and definition"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     } else {
-                        __auto_type _mv_956 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_956.has_value) {
-                            __auto_type name_expr = _mv_956.value;
-                            __auto_type _mv_957 = (*name_expr);
-                            switch (_mv_957.tag) {
+                        __auto_type _mv_957 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_957.has_value) {
+                            __auto_type name_expr = _mv_957.value;
+                            __auto_type _mv_958 = (*name_expr);
+                            switch (_mv_958.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_957.data.sym;
+                                    __auto_type name_sym = _mv_958.data.sym;
                                     {
                                         __auto_type raw_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, raw_name);
                                         __auto_type qualified_name = ((context_ctx_prefixing_enabled(ctx)) ? ({ __auto_type _mv = context_ctx_get_module(ctx); _mv.has_value ? ({ __auto_type mod_name = _mv.value; context_ctx_str(ctx, ctype_to_c_name(arena, mod_name), context_ctx_str(ctx, SLOP_STR("_"), base_name)); }) : (base_name); }) : base_name);
-                                        __auto_type _mv_958 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_958.has_value) {
-                                            __auto_type type_def = _mv_958.value;
+                                        __auto_type _mv_959 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_959.has_value) {
+                                            __auto_type type_def = _mv_959.value;
                                             defn_dispatch_type_def(ctx, raw_name, qualified_name, type_def);
-                                        } else if (!_mv_958.has_value) {
+                                        } else if (!_mv_959.has_value) {
                                             context_ctx_add_error_at(ctx, SLOP_STR("missing type definition"), context_ctx_sexpr_line(name_expr), context_ctx_sexpr_col(name_expr));
                                         }
                                     }
@@ -657,7 +657,7 @@ void defn_transpile_type(context_TranspileContext* ctx, types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_956.has_value) {
+                        } else if (!_mv_957.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing type name"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                     }
@@ -675,24 +675,24 @@ void defn_transpile_type(context_TranspileContext* ctx, types_SExpr* expr) {
 void defn_dispatch_type_def(context_TranspileContext* ctx, slop_string raw_name, slop_string qualified_name, types_SExpr* type_def) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
-    __auto_type _mv_959 = (*type_def);
-    switch (_mv_959.tag) {
+    __auto_type _mv_960 = (*type_def);
+    switch (_mv_960.tag) {
         case types_SExpr_lst:
         {
-            __auto_type def_lst = _mv_959.data.lst;
+            __auto_type def_lst = _mv_960.data.lst;
             {
                 __auto_type items = def_lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     context_ctx_add_error_at(ctx, SLOP_STR("empty type definition"), context_ctx_sexpr_line(type_def), context_ctx_sexpr_col(type_def));
                 } else {
-                    __auto_type _mv_960 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_960.has_value) {
-                        __auto_type head = _mv_960.value;
-                        __auto_type _mv_961 = (*head);
-                        switch (_mv_961.tag) {
+                    __auto_type _mv_961 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_961.has_value) {
+                        __auto_type head = _mv_961.value;
+                        __auto_type _mv_962 = (*head);
+                        switch (_mv_962.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_961.data.sym;
+                                __auto_type sym = _mv_962.data.sym;
                                 {
                                     __auto_type kind = sym.name;
                                     if (string_eq(kind, SLOP_STR("record"))) {
@@ -716,7 +716,7 @@ void defn_dispatch_type_def(context_TranspileContext* ctx, slop_string raw_name,
                                 break;
                             }
                         }
-                    } else if (!_mv_960.has_value) {
+                    } else if (!_mv_961.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("empty type definition"), context_ctx_sexpr_line(type_def), context_ctx_sexpr_col(type_def));
                     }
                 }
@@ -725,7 +725,7 @@ void defn_dispatch_type_def(context_TranspileContext* ctx, slop_string raw_name,
         }
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_959.data.sym;
+            __auto_type sym = _mv_960.data.sym;
             defn_transpile_type_alias(ctx, raw_name, qualified_name, type_def);
             break;
         }
@@ -742,14 +742,14 @@ uint8_t defn_has_payload_variants(slop_list_types_SExpr_ptr items) {
         int64_t i = 1;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_962 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_962.has_value) {
-                __auto_type item = _mv_962.value;
-                __auto_type _mv_963 = (*item);
-                switch (_mv_963.tag) {
+            __auto_type _mv_963 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_963.has_value) {
+                __auto_type item = _mv_963.value;
+                __auto_type _mv_964 = (*item);
+                switch (_mv_964.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type _ = _mv_963.data.lst;
+                        __auto_type _ = _mv_964.data.lst;
                         found = 1;
                         break;
                     }
@@ -757,7 +757,7 @@ uint8_t defn_has_payload_variants(slop_list_types_SExpr_ptr items) {
                         break;
                     }
                 }
-            } else if (!_mv_962.has_value) {
+            } else if (!_mv_963.has_value) {
             }
             i = (i + 1);
         }
@@ -770,11 +770,11 @@ void defn_transpile_record(context_TranspileContext* ctx, slop_string raw_name, 
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_964 = (*expr);
-        switch (_mv_964.tag) {
+        __auto_type _mv_965 = (*expr);
+        switch (_mv_965.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_964.data.lst;
+                __auto_type lst = _mv_965.data.lst;
                 {
                     __auto_type items = lst.items;
                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("struct "), qualified_name, SLOP_STR(" {")));
@@ -801,11 +801,11 @@ void defn_emit_record_fields(context_TranspileContext* ctx, slop_string raw_type
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start_idx;
         while (i < len) {
-            __auto_type _mv_965 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_965.has_value) {
-                __auto_type field_expr = _mv_965.value;
+            __auto_type _mv_966 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_966.has_value) {
+                __auto_type field_expr = _mv_966.value;
                 defn_emit_record_field(ctx, raw_type_name, qualified_type_name, field_expr);
-            } else if (!_mv_965.has_value) {
+            } else if (!_mv_966.has_value) {
             }
             i = (i + 1);
         }
@@ -817,28 +817,28 @@ void defn_emit_record_field(context_TranspileContext* ctx, slop_string raw_type_
     SLOP_PRE(((field != NULL)), "(!= field nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_966 = (*field);
-        switch (_mv_966.tag) {
+        __auto_type _mv_967 = (*field);
+        switch (_mv_967.tag) {
             case types_SExpr_lst:
             {
-                __auto_type field_lst = _mv_966.data.lst;
+                __auto_type field_lst = _mv_967.data.lst;
                 {
                     __auto_type items = field_lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 2) {
                         context_ctx_emit(ctx, SLOP_STR("    /* invalid field */"));
                     } else {
-                        __auto_type _mv_967 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_967.has_value) {
-                            __auto_type name_expr = _mv_967.value;
-                            __auto_type _mv_968 = (*name_expr);
-                            switch (_mv_968.tag) {
+                        __auto_type _mv_968 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_968.has_value) {
+                            __auto_type name_expr = _mv_968.value;
+                            __auto_type _mv_969 = (*name_expr);
+                            switch (_mv_969.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_968.data.sym;
-                                    __auto_type _mv_969 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_969.has_value) {
-                                        __auto_type type_expr = _mv_969.value;
+                                    __auto_type name_sym = _mv_969.data.sym;
+                                    __auto_type _mv_970 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_970.has_value) {
+                                        __auto_type type_expr = _mv_970.value;
                                         {
                                             __auto_type raw_field_name = name_sym.name;
                                             __auto_type field_name = ctype_to_c_name(arena, raw_field_name);
@@ -849,7 +849,7 @@ void defn_emit_record_field(context_TranspileContext* ctx, slop_string raw_type_
                                             context_ctx_register_field_type(ctx, raw_type_name, raw_field_name, field_type, slop_type_str, is_ptr);
                                             context_ctx_register_field_type(ctx, qualified_type_name, raw_field_name, field_type, slop_type_str, is_ptr);
                                         }
-                                    } else if (!_mv_969.has_value) {
+                                    } else if (!_mv_970.has_value) {
                                         context_ctx_emit(ctx, SLOP_STR("    /* missing field type */"));
                                     }
                                     break;
@@ -859,7 +859,7 @@ void defn_emit_record_field(context_TranspileContext* ctx, slop_string raw_type_
                                     break;
                                 }
                             }
-                        } else if (!_mv_967.has_value) {
+                        } else if (!_mv_968.has_value) {
                             context_ctx_emit(ctx, SLOP_STR("    /* missing field name */"));
                         }
                     }
@@ -879,11 +879,11 @@ void defn_transpile_enum(context_TranspileContext* ctx, slop_string raw_name, sl
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_970 = (*expr);
-        switch (_mv_970.tag) {
+        __auto_type _mv_971 = (*expr);
+        switch (_mv_971.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_970.data.lst;
+                __auto_type lst = _mv_971.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -909,14 +909,14 @@ void defn_emit_enum_values(context_TranspileContext* ctx, slop_string type_name,
         __auto_type arena = (*ctx).arena;
         int64_t i = start_idx;
         while (i < len) {
-            __auto_type _mv_971 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_971.has_value) {
-                __auto_type val_expr = _mv_971.value;
-                __auto_type _mv_972 = (*val_expr);
-                switch (_mv_972.tag) {
+            __auto_type _mv_972 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_972.has_value) {
+                __auto_type val_expr = _mv_972.value;
+                __auto_type _mv_973 = (*val_expr);
+                switch (_mv_973.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_972.data.sym;
+                        __auto_type sym = _mv_973.data.sym;
                         {
                             __auto_type val_name = ctype_to_c_name(arena, sym.name);
                             __auto_type full_name = context_ctx_str3(ctx, type_name, SLOP_STR("_"), val_name);
@@ -933,7 +933,7 @@ void defn_emit_enum_values(context_TranspileContext* ctx, slop_string type_name,
                         break;
                     }
                 }
-            } else if (!_mv_971.has_value) {
+            } else if (!_mv_972.has_value) {
             }
             i = (i + 1);
         }
@@ -945,11 +945,11 @@ void defn_transpile_union(context_TranspileContext* ctx, slop_string raw_name, s
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_973 = (*expr);
-        switch (_mv_973.tag) {
+        __auto_type _mv_974 = (*expr);
+        switch (_mv_974.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_973.data.lst;
+                __auto_type lst = _mv_974.data.lst;
                 {
                     __auto_type items = lst.items;
                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("struct "), qualified_name, SLOP_STR(" {")));
@@ -982,33 +982,33 @@ void defn_emit_union_variants(context_TranspileContext* ctx, slop_list_types_SEx
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start_idx;
         while (i < len) {
-            __auto_type _mv_974 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_974.has_value) {
-                __auto_type variant_expr = _mv_974.value;
-                __auto_type _mv_975 = (*variant_expr);
-                switch (_mv_975.tag) {
+            __auto_type _mv_975 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_975.has_value) {
+                __auto_type variant_expr = _mv_975.value;
+                __auto_type _mv_976 = (*variant_expr);
+                switch (_mv_976.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type var_lst = _mv_975.data.lst;
+                        __auto_type var_lst = _mv_976.data.lst;
                         {
                             __auto_type var_items = var_lst.items;
                             __auto_type var_len = ((int64_t)((var_items).len));
                             if (var_len >= 1) {
-                                __auto_type _mv_976 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_976.has_value) {
-                                    __auto_type tag_expr = _mv_976.value;
-                                    __auto_type _mv_977 = (*tag_expr);
-                                    switch (_mv_977.tag) {
+                                __auto_type _mv_977 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_977.has_value) {
+                                    __auto_type tag_expr = _mv_977.value;
+                                    __auto_type _mv_978 = (*tag_expr);
+                                    switch (_mv_978.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type tag_sym = _mv_977.data.sym;
+                                            __auto_type tag_sym = _mv_978.data.sym;
                                             {
                                                 __auto_type tag_name = tag_sym.name;
                                                 __auto_type c_tag = ctype_to_c_name(arena, tag_name);
                                                 if (var_len == 2) {
-                                                    __auto_type _mv_978 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_978.has_value) {
-                                                        __auto_type type_expr = _mv_978.value;
+                                                    __auto_type _mv_979 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_979.has_value) {
+                                                        __auto_type type_expr = _mv_979.value;
                                                         {
                                                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                             {
@@ -1016,14 +1016,14 @@ void defn_emit_union_variants(context_TranspileContext* ctx, slop_list_types_SEx
                                                                 context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("        "), actual_type, SLOP_STR(" "), c_tag, SLOP_STR(";")));
                                                             }
                                                         }
-                                                    } else if (!_mv_978.has_value) {
+                                                    } else if (!_mv_979.has_value) {
                                                     }
                                                 } else if (var_len >= 3) {
                                                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("        struct { "), SLOP_STR(""), SLOP_STR("")));
                                                     for (int64_t fi = 1; fi < var_len; fi++) {
-                                                        __auto_type _mv_979 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                        if (_mv_979.has_value) {
-                                                            __auto_type type_expr = _mv_979.value;
+                                                        __auto_type _mv_980 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                        if (_mv_980.has_value) {
+                                                            __auto_type type_expr = _mv_980.value;
                                                             {
                                                                 __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                                 {
@@ -1032,7 +1032,7 @@ void defn_emit_union_variants(context_TranspileContext* ctx, slop_list_types_SEx
                                                                     context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("            "), actual_type, SLOP_STR(" "), field_name, SLOP_STR(";")));
                                                                 }
                                                             }
-                                                        } else if (!_mv_979.has_value) {
+                                                        } else if (!_mv_980.has_value) {
                                                         }
                                                     }
                                                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("        } "), c_tag, SLOP_STR(";")));
@@ -1045,7 +1045,7 @@ void defn_emit_union_variants(context_TranspileContext* ctx, slop_list_types_SEx
                                             break;
                                         }
                                     }
-                                } else if (!_mv_976.has_value) {
+                                } else if (!_mv_977.has_value) {
                                 }
                             }
                         }
@@ -1055,7 +1055,7 @@ void defn_emit_union_variants(context_TranspileContext* ctx, slop_list_types_SEx
                         break;
                     }
                 }
-            } else if (!_mv_974.has_value) {
+            } else if (!_mv_975.has_value) {
             }
             i = (i + 1);
         }
@@ -1070,25 +1070,25 @@ void defn_emit_tag_constants(context_TranspileContext* ctx, slop_string type_nam
         int64_t i = start_idx;
         int64_t tag_idx = 0;
         while (i < len) {
-            __auto_type _mv_980 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_980.has_value) {
-                __auto_type variant_expr = _mv_980.value;
-                __auto_type _mv_981 = (*variant_expr);
-                switch (_mv_981.tag) {
+            __auto_type _mv_981 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_981.has_value) {
+                __auto_type variant_expr = _mv_981.value;
+                __auto_type _mv_982 = (*variant_expr);
+                switch (_mv_982.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type var_lst = _mv_981.data.lst;
+                        __auto_type var_lst = _mv_982.data.lst;
                         {
                             __auto_type var_items = var_lst.items;
                             if (((int64_t)((var_items).len)) >= 1) {
-                                __auto_type _mv_982 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_982.has_value) {
-                                    __auto_type tag_expr = _mv_982.value;
-                                    __auto_type _mv_983 = (*tag_expr);
-                                    switch (_mv_983.tag) {
+                                __auto_type _mv_983 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_983.has_value) {
+                                    __auto_type tag_expr = _mv_983.value;
+                                    __auto_type _mv_984 = (*tag_expr);
+                                    switch (_mv_984.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type tag_sym = _mv_983.data.sym;
+                                            __auto_type tag_sym = _mv_984.data.sym;
                                             {
                                                 __auto_type tag_name = tag_sym.name;
                                                 __auto_type define_name = context_ctx_str4(ctx, type_name, SLOP_STR("_"), ctype_to_c_name(arena, tag_name), SLOP_STR("_TAG"));
@@ -1100,7 +1100,7 @@ void defn_emit_tag_constants(context_TranspileContext* ctx, slop_string type_nam
                                             break;
                                         }
                                     }
-                                } else if (!_mv_982.has_value) {
+                                } else if (!_mv_983.has_value) {
                                 }
                             }
                             tag_idx = (tag_idx + 1);
@@ -1111,7 +1111,7 @@ void defn_emit_tag_constants(context_TranspileContext* ctx, slop_string type_nam
                         break;
                     }
                 }
-            } else if (!_mv_980.has_value) {
+            } else if (!_mv_981.has_value) {
             }
             i = (i + 1);
         }
@@ -1125,32 +1125,32 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start_idx;
         while (i < len) {
-            __auto_type _mv_984 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_984.has_value) {
-                __auto_type variant_expr = _mv_984.value;
-                __auto_type _mv_985 = (*variant_expr);
-                switch (_mv_985.tag) {
+            __auto_type _mv_985 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_985.has_value) {
+                __auto_type variant_expr = _mv_985.value;
+                __auto_type _mv_986 = (*variant_expr);
+                switch (_mv_986.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type var_lst = _mv_985.data.lst;
+                        __auto_type var_lst = _mv_986.data.lst;
                         {
                             __auto_type var_items = var_lst.items;
                             __auto_type var_len = ((int64_t)((var_items).len));
                             if (var_len >= 2) {
-                                __auto_type _mv_986 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_986.has_value) {
-                                    __auto_type tag_expr = _mv_986.value;
-                                    __auto_type _mv_987 = (*tag_expr);
-                                    switch (_mv_987.tag) {
+                                __auto_type _mv_987 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_987.has_value) {
+                                    __auto_type tag_expr = _mv_987.value;
+                                    __auto_type _mv_988 = (*tag_expr);
+                                    switch (_mv_988.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type tag_sym = _mv_987.data.sym;
+                                            __auto_type tag_sym = _mv_988.data.sym;
                                             {
                                                 __auto_type tag_name = tag_sym.name;
                                                 if (var_len == 2) {
-                                                    __auto_type _mv_988 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_988.has_value) {
-                                                        __auto_type type_expr = _mv_988.value;
+                                                    __auto_type _mv_989 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_989.has_value) {
+                                                        __auto_type type_expr = _mv_989.value;
                                                         {
                                                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                             __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
@@ -1158,7 +1158,7 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
                                                             context_ctx_register_field_type(ctx, raw_name, tag_name, c_type, slop_type_str, is_ptr);
                                                             context_ctx_register_field_type(ctx, qualified_name, tag_name, c_type, slop_type_str, is_ptr);
                                                         }
-                                                    } else if (!_mv_988.has_value) {
+                                                    } else if (!_mv_989.has_value) {
                                                     }
                                                 } else if (var_len >= 3) {
                                                     {
@@ -1168,9 +1168,9 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
                                                         context_ctx_register_field_type(ctx, qualified_name, count_key, count_str, SLOP_STR(""), 0);
                                                     }
                                                     for (int64_t fi = 1; fi < var_len; fi++) {
-                                                        __auto_type _mv_989 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                        if (_mv_989.has_value) {
-                                                            __auto_type type_expr = _mv_989.value;
+                                                        __auto_type _mv_990 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                        if (_mv_990.has_value) {
+                                                            __auto_type type_expr = _mv_990.value;
                                                             {
                                                                 __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                                 __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
@@ -1179,12 +1179,12 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
                                                                 context_ctx_register_field_type(ctx, raw_name, field_key, c_type, slop_type_str, is_ptr);
                                                                 context_ctx_register_field_type(ctx, qualified_name, field_key, c_type, slop_type_str, is_ptr);
                                                             }
-                                                        } else if (!_mv_989.has_value) {
+                                                        } else if (!_mv_990.has_value) {
                                                         }
                                                     }
-                                                    __auto_type _mv_990 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_990.has_value) {
-                                                        __auto_type type_expr = _mv_990.value;
+                                                    __auto_type _mv_991 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_991.has_value) {
+                                                        __auto_type type_expr = _mv_991.value;
                                                         {
                                                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                             __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
@@ -1192,7 +1192,7 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
                                                             context_ctx_register_field_type(ctx, raw_name, tag_name, c_type, slop_type_str, is_ptr);
                                                             context_ctx_register_field_type(ctx, qualified_name, tag_name, c_type, slop_type_str, is_ptr);
                                                         }
-                                                    } else if (!_mv_990.has_value) {
+                                                    } else if (!_mv_991.has_value) {
                                                     }
                                                 } else {
                                                 }
@@ -1203,7 +1203,7 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
                                             break;
                                         }
                                     }
-                                } else if (!_mv_986.has_value) {
+                                } else if (!_mv_987.has_value) {
                                 }
                             }
                         }
@@ -1213,7 +1213,7 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
                         break;
                     }
                 }
-            } else if (!_mv_984.has_value) {
+            } else if (!_mv_985.has_value) {
             }
             i = (i + 1);
         }
@@ -1250,31 +1250,31 @@ uint8_t defn_is_generic_type_alias(slop_string s) {
 
 uint8_t defn_is_array_type(types_SExpr* type_expr) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_991 = (*type_expr);
-    switch (_mv_991.tag) {
+    __auto_type _mv_992 = (*type_expr);
+    switch (_mv_992.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_991.data.lst;
+            __auto_type lst = _mv_992.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_992 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_992.has_value) {
-                        __auto_type head = _mv_992.value;
-                        __auto_type _mv_993 = (*head);
-                        switch (_mv_993.tag) {
+                    __auto_type _mv_993 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_993.has_value) {
+                        __auto_type head = _mv_993.value;
+                        __auto_type _mv_994 = (*head);
+                        switch (_mv_994.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_993.data.sym;
+                                __auto_type sym = _mv_994.data.sym;
                                 return string_eq(sym.name, SLOP_STR("Array"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_992.has_value) {
+                    } else if (!_mv_993.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1292,23 +1292,23 @@ void defn_emit_array_typedef(context_TranspileContext* ctx, slop_string qualifie
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_994 = (*type_expr);
-        switch (_mv_994.tag) {
+        __auto_type _mv_995 = (*type_expr);
+        switch (_mv_995.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_994.data.lst;
+                __auto_type lst = _mv_995.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 3) {
                         context_ctx_emit(ctx, context_ctx_str(ctx, SLOP_STR("typedef void* "), context_ctx_str(ctx, qualified_name, SLOP_STR(";"))));
                     } else {
-                        __auto_type _mv_995 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_995.has_value) {
-                            __auto_type elem_type_expr = _mv_995.value;
-                            __auto_type _mv_996 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_996.has_value) {
-                                __auto_type size_expr = _mv_996.value;
+                        __auto_type _mv_996 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_996.has_value) {
+                            __auto_type elem_type_expr = _mv_996.value;
+                            __auto_type _mv_997 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_997.has_value) {
+                                __auto_type size_expr = _mv_997.value;
                                 {
                                     __auto_type elem_c_type = context_to_c_type_prefixed(ctx, elem_type_expr);
                                     __auto_type size_str = defn_get_number_as_string(size_expr);
@@ -1319,10 +1319,10 @@ void defn_emit_array_typedef(context_TranspileContext* ctx, slop_string qualifie
                                         context_ctx_register_type(ctx, (context_TypeEntry){qualified_name, qualified_name, ptr_type, 0, 0, 0});
                                     }
                                 }
-                            } else if (!_mv_996.has_value) {
+                            } else if (!_mv_997.has_value) {
                                 context_ctx_emit(ctx, context_ctx_str(ctx, SLOP_STR("typedef void* "), context_ctx_str(ctx, qualified_name, SLOP_STR(";"))));
                             }
-                        } else if (!_mv_995.has_value) {
+                        } else if (!_mv_996.has_value) {
                             context_ctx_emit(ctx, context_ctx_str(ctx, SLOP_STR("typedef void* "), context_ctx_str(ctx, qualified_name, SLOP_STR(";"))));
                         }
                     }
@@ -1339,11 +1339,11 @@ void defn_emit_array_typedef(context_TranspileContext* ctx, slop_string qualifie
 
 slop_string defn_get_number_as_string(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_997 = (*expr);
-    switch (_mv_997.tag) {
+    __auto_type _mv_998 = (*expr);
+    switch (_mv_998.tag) {
         case types_SExpr_num:
         {
-            __auto_type num = _mv_997.data.num;
+            __auto_type num = _mv_998.data.num;
             return num.raw;
         }
         default: {
@@ -1354,25 +1354,25 @@ slop_string defn_get_number_as_string(types_SExpr* expr) {
 
 uint8_t defn_is_range_type(types_SExpr* type_expr) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_998 = (*type_expr);
-    switch (_mv_998.tag) {
+    __auto_type _mv_999 = (*type_expr);
+    switch (_mv_999.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_998.data.lst;
+            __auto_type lst = _mv_999.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type found_dots = 0;
                 __auto_type i = 0;
                 while ((i < len) && !(found_dots)) {
-                    __auto_type _mv_999 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_999.has_value) {
-                        __auto_type item = _mv_999.value;
-                        __auto_type _mv_1000 = (*item);
-                        switch (_mv_1000.tag) {
+                    __auto_type _mv_1000 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1000.has_value) {
+                        __auto_type item = _mv_1000.value;
+                        __auto_type _mv_1001 = (*item);
+                        switch (_mv_1001.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1000.data.sym;
+                                __auto_type sym = _mv_1001.data.sym;
                                 if (string_eq(sym.name, SLOP_STR(".."))) {
                                     found_dots = 1;
                                 }
@@ -1382,7 +1382,7 @@ uint8_t defn_is_range_type(types_SExpr* type_expr) {
                                 break;
                             }
                         }
-                    } else if (!_mv_999.has_value) {
+                    } else if (!_mv_1000.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -1403,24 +1403,24 @@ types_RangeBounds defn_parse_range_bounds(types_SExpr* type_expr) {
         uint8_t has_min = 0;
         uint8_t has_max = 0;
         uint8_t found_dots = 0;
-        __auto_type _mv_1001 = (*type_expr);
-        switch (_mv_1001.tag) {
+        __auto_type _mv_1002 = (*type_expr);
+        switch (_mv_1002.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1001.data.lst;
+                __auto_type lst = _mv_1002.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type i = 1;
                     while (i < len) {
-                        __auto_type _mv_1002 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1002.has_value) {
-                            __auto_type item = _mv_1002.value;
-                            __auto_type _mv_1003 = (*item);
-                            switch (_mv_1003.tag) {
+                        __auto_type _mv_1003 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1003.has_value) {
+                            __auto_type item = _mv_1003.value;
+                            __auto_type _mv_1004 = (*item);
+                            switch (_mv_1004.tag) {
                                 case types_SExpr_num:
                                 {
-                                    __auto_type num = _mv_1003.data.num;
+                                    __auto_type num = _mv_1004.data.num;
                                     if (!(found_dots)) {
                                         min_val = defn_string_to_int(num.raw);
                                         has_min = 1;
@@ -1432,7 +1432,7 @@ types_RangeBounds defn_parse_range_bounds(types_SExpr* type_expr) {
                                 }
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1003.data.sym;
+                                    __auto_type sym = _mv_1004.data.sym;
                                     if (string_eq(sym.name, SLOP_STR(".."))) {
                                         found_dots = 1;
                                     }
@@ -1442,7 +1442,7 @@ types_RangeBounds defn_parse_range_bounds(types_SExpr* type_expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_1002.has_value) {
+                        } else if (!_mv_1003.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -1549,25 +1549,25 @@ void defn_transpile_function(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1004 = (*expr);
-        switch (_mv_1004.tag) {
+        __auto_type _mv_1005 = (*expr);
+        switch (_mv_1005.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1004.data.lst;
+                __auto_type lst = _mv_1005.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 3) {
                         context_ctx_add_error_at(ctx, SLOP_STR("invalid fn: need name and params"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     } else {
-                        __auto_type _mv_1005 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1005.has_value) {
-                            __auto_type name_expr = _mv_1005.value;
-                            __auto_type _mv_1006 = (*name_expr);
-                            switch (_mv_1006.tag) {
+                        __auto_type _mv_1006 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1006.has_value) {
+                            __auto_type name_expr = _mv_1006.value;
+                            __auto_type _mv_1007 = (*name_expr);
+                            switch (_mv_1007.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1006.data.sym;
+                                    __auto_type name_sym = _mv_1007.data.sym;
                                     {
                                         __auto_type raw_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, raw_name);
@@ -1575,11 +1575,11 @@ void defn_transpile_function(context_TranspileContext* ctx, types_SExpr* expr) {
                                         __auto_type base_fn_name = context_extract_fn_c_name(arena, items, mangled_name);
                                         __auto_type fn_name = base_fn_name;
                                         __auto_type is_public_api = !(string_eq(base_fn_name, mangled_name));
-                                        __auto_type _mv_1007 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1007.has_value) {
-                                            __auto_type params_expr = _mv_1007.value;
+                                        __auto_type _mv_1008 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1008.has_value) {
+                                            __auto_type params_expr = _mv_1008.value;
                                             defn_emit_function_def(ctx, raw_name, fn_name, params_expr, items, is_public_api);
-                                        } else if (!_mv_1007.has_value) {
+                                        } else if (!_mv_1008.has_value) {
                                             context_ctx_add_error_at(ctx, SLOP_STR("missing params"), context_ctx_sexpr_line(name_expr), context_ctx_sexpr_col(name_expr));
                                         }
                                     }
@@ -1590,7 +1590,7 @@ void defn_transpile_function(context_TranspileContext* ctx, types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_1005.has_value) {
+                        } else if (!_mv_1006.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing function name"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                     }
@@ -1624,18 +1624,18 @@ void defn_emit_function_def(context_TranspileContext* ctx, slop_string raw_name,
             __auto_type has_post = ((((int64_t)((postconditions).len)) > 0) || (((int64_t)((assumptions).len)) > 0));
             __auto_type needs_retval = (has_post && !(string_eq(actual_return, SLOP_STR("void"))));
             context_ctx_set_current_return_type(ctx, actual_return);
-            __auto_type _mv_1008 = result_type_opt;
-            if (_mv_1008.has_value) {
-                __auto_type result_name = _mv_1008.value;
+            __auto_type _mv_1009 = result_type_opt;
+            if (_mv_1009.has_value) {
+                __auto_type result_name = _mv_1009.value;
                 context_ctx_set_current_result_type(ctx, result_name);
-            } else if (!_mv_1008.has_value) {
+            } else if (!_mv_1009.has_value) {
                 context_ctx_clear_current_result_type(ctx);
             }
-            __auto_type _mv_1009 = doc_string;
-            if (_mv_1009.has_value) {
-                __auto_type doc = _mv_1009.value;
+            __auto_type _mv_1010 = doc_string;
+            if (_mv_1010.has_value) {
+                __auto_type doc = _mv_1010.value;
                 context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("/* "), doc, SLOP_STR(" */")));
-            } else if (!_mv_1009.has_value) {
+            } else if (!_mv_1010.has_value) {
             }
             context_ctx_emit(ctx, context_ctx_str5(ctx, actual_return, SLOP_STR(" "), fn_name, SLOP_STR("("), context_ctx_str(ctx, ((string_eq(param_str, SLOP_STR(""))) ? SLOP_STR("void") : param_str), SLOP_STR(") {"))));
             context_ctx_indent(ctx);
@@ -1685,21 +1685,21 @@ void defn_bind_params_to_scope(context_TranspileContext* ctx, types_SExpr* param
     SLOP_PRE(((params_expr != NULL)), "(!= params-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1010 = (*params_expr);
-        switch (_mv_1010.tag) {
+        __auto_type _mv_1011 = (*params_expr);
+        switch (_mv_1011.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1010.data.lst;
+                __auto_type lst = _mv_1011.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type i = 0;
                     while (i < len) {
-                        __auto_type _mv_1011 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1011.has_value) {
-                            __auto_type param = _mv_1011.value;
+                        __auto_type _mv_1012 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1012.has_value) {
+                            __auto_type param = _mv_1012.value;
                             defn_bind_single_param(ctx, param);
-                        } else if (!_mv_1011.has_value) {
+                        } else if (!_mv_1012.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -1718,11 +1718,11 @@ void defn_bind_single_param(context_TranspileContext* ctx, types_SExpr* param) {
     SLOP_PRE(((param != NULL)), "(!= param nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1012 = (*param);
-        switch (_mv_1012.tag) {
+        __auto_type _mv_1013 = (*param);
+        switch (_mv_1013.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1012.data.lst;
+                __auto_type lst = _mv_1013.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -1731,17 +1731,17 @@ void defn_bind_single_param(context_TranspileContext* ctx, types_SExpr* param) {
                             __auto_type has_mode = ((len >= 3) && defn_is_param_mode(items));
                             __auto_type name_idx = ((has_mode) ? 1 : 0);
                             __auto_type type_idx = ((has_mode) ? 2 : 1);
-                            __auto_type _mv_1013 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1013.has_value) {
-                                __auto_type name_expr = _mv_1013.value;
-                                __auto_type _mv_1014 = (*name_expr);
-                                switch (_mv_1014.tag) {
+                            __auto_type _mv_1014 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1014.has_value) {
+                                __auto_type name_expr = _mv_1014.value;
+                                __auto_type _mv_1015 = (*name_expr);
+                                switch (_mv_1015.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type name_sym = _mv_1014.data.sym;
-                                        __auto_type _mv_1015 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1015.has_value) {
-                                            __auto_type type_expr = _mv_1015.value;
+                                        __auto_type name_sym = _mv_1015.data.sym;
+                                        __auto_type _mv_1016 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1016.has_value) {
+                                            __auto_type type_expr = _mv_1016.value;
                                             {
                                                 __auto_type param_name = name_sym.name;
                                                 __auto_type c_name = ctype_to_c_name(arena, param_name);
@@ -1751,7 +1751,7 @@ void defn_bind_single_param(context_TranspileContext* ctx, types_SExpr* param) {
                                                 __auto_type is_closure = defn_is_fn_type(type_expr);
                                                 context_ctx_bind_var(ctx, (context_VarEntry){param_name, c_name, c_type, slop_type_str, is_ptr, 0, is_closure, SLOP_STR(""), SLOP_STR("")});
                                             }
-                                        } else if (!_mv_1015.has_value) {
+                                        } else if (!_mv_1016.has_value) {
                                         }
                                         break;
                                     }
@@ -1759,7 +1759,7 @@ void defn_bind_single_param(context_TranspileContext* ctx, types_SExpr* param) {
                                         break;
                                     }
                                 }
-                            } else if (!_mv_1013.has_value) {
+                            } else if (!_mv_1014.has_value) {
                             }
                         }
                     }
@@ -1775,31 +1775,31 @@ void defn_bind_single_param(context_TranspileContext* ctx, types_SExpr* param) {
 
 uint8_t defn_is_pointer_type(types_SExpr* type_expr) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_1016 = (*type_expr);
-    switch (_mv_1016.tag) {
+    __auto_type _mv_1017 = (*type_expr);
+    switch (_mv_1017.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1016.data.lst;
+            __auto_type lst = _mv_1017.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1017 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1017.has_value) {
-                        __auto_type head = _mv_1017.value;
-                        __auto_type _mv_1018 = (*head);
-                        switch (_mv_1018.tag) {
+                    __auto_type _mv_1018 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1018.has_value) {
+                        __auto_type head = _mv_1018.value;
+                        __auto_type _mv_1019 = (*head);
+                        switch (_mv_1019.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1018.data.sym;
+                                __auto_type sym = _mv_1019.data.sym;
                                 return string_eq(sym.name, SLOP_STR("Ptr"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1017.has_value) {
+                    } else if (!_mv_1018.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1818,26 +1818,26 @@ slop_list_context_FuncParamType_ptr defn_collect_param_types(context_TranspileCo
     {
         __auto_type arena = (*ctx).arena;
         __auto_type result = ((slop_list_context_FuncParamType_ptr){ .data = (context_FuncParamType**)slop_arena_alloc(arena, 16 * sizeof(context_FuncParamType*)), .len = 0, .cap = 16 });
-        __auto_type _mv_1019 = (*params_expr);
-        switch (_mv_1019.tag) {
+        __auto_type _mv_1020 = (*params_expr);
+        switch (_mv_1020.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1019.data.lst;
+                __auto_type lst = _mv_1020.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type i = 0;
                     while (i < len) {
-                        __auto_type _mv_1020 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1020.has_value) {
-                            __auto_type param = _mv_1020.value;
+                        __auto_type _mv_1021 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1021.has_value) {
+                            __auto_type param = _mv_1021.value;
                             {
                                 __auto_type c_type = defn_get_param_c_type(ctx, param);
                                 __auto_type param_info = ((context_FuncParamType*)(({ __auto_type _alloc = (context_FuncParamType*)slop_arena_alloc(arena, sizeof(context_FuncParamType)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                                 (*param_info).c_type = c_type;
                                 ({ __auto_type _lst_p = &(result); __auto_type _item = (param_info); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                             }
-                        } else if (!_mv_1020.has_value) {
+                        } else if (!_mv_1021.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -1857,11 +1857,11 @@ slop_string defn_get_param_c_type(context_TranspileContext* ctx, types_SExpr* pa
     SLOP_PRE(((param != NULL)), "(!= param nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1021 = (*param);
-        switch (_mv_1021.tag) {
+        __auto_type _mv_1022 = (*param);
+        switch (_mv_1022.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1021.data.lst;
+                __auto_type lst = _mv_1022.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -1871,11 +1871,11 @@ slop_string defn_get_param_c_type(context_TranspileContext* ctx, types_SExpr* pa
                         {
                             __auto_type has_mode = ((len >= 3) && defn_is_param_mode(items));
                             __auto_type type_idx = ((has_mode) ? 2 : 1);
-                            __auto_type _mv_1022 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1022.has_value) {
-                                __auto_type type_expr = _mv_1022.value;
+                            __auto_type _mv_1023 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1023.has_value) {
+                                __auto_type type_expr = _mv_1023.value;
                                 return context_to_c_type_prefixed(ctx, type_expr);
-                            } else if (!_mv_1022.has_value) {
+                            } else if (!_mv_1023.has_value) {
                                 return SLOP_STR("void*");
                             }
                             SLOP_UNREACHABLE();
@@ -1895,31 +1895,31 @@ void defn_emit_forward_declaration(context_TranspileContext* ctx, types_SExpr* e
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1023 = (*expr);
-        switch (_mv_1023.tag) {
+        __auto_type _mv_1024 = (*expr);
+        switch (_mv_1024.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1023.data.lst;
+                __auto_type lst = _mv_1024.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 3) {
-                        __auto_type _mv_1024 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1024.has_value) {
-                            __auto_type name_expr = _mv_1024.value;
-                            __auto_type _mv_1025 = (*name_expr);
-                            switch (_mv_1025.tag) {
+                        __auto_type _mv_1025 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1025.has_value) {
+                            __auto_type name_expr = _mv_1025.value;
+                            __auto_type _mv_1026 = (*name_expr);
+                            switch (_mv_1026.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1025.data.sym;
+                                    __auto_type name_sym = _mv_1026.data.sym;
                                     {
                                         __auto_type raw_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, raw_name);
                                         __auto_type mangled_name = context_ctx_prefix_type(ctx, base_name);
                                         __auto_type fn_name = context_extract_fn_c_name(arena, items, mangled_name);
-                                        __auto_type _mv_1026 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1026.has_value) {
-                                            __auto_type params_expr = _mv_1026.value;
+                                        __auto_type _mv_1027 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1027.has_value) {
+                                            __auto_type params_expr = _mv_1027.value;
                                             {
                                                 __auto_type result_type_opt = defn_get_result_type_name(ctx, items);
                                                 __auto_type raw_return = defn_get_return_type(ctx, items);
@@ -1930,7 +1930,7 @@ void defn_emit_forward_declaration(context_TranspileContext* ctx, types_SExpr* e
                                                     context_ctx_emit(ctx, context_ctx_str5(ctx, actual_return, SLOP_STR(" "), fn_name, SLOP_STR("("), context_ctx_str(ctx, ((string_eq(param_str, SLOP_STR(""))) ? SLOP_STR("void") : param_str), SLOP_STR(");"))));
                                                 }
                                             }
-                                        } else if (!_mv_1026.has_value) {
+                                        } else if (!_mv_1027.has_value) {
                                         }
                                     }
                                     break;
@@ -1939,7 +1939,7 @@ void defn_emit_forward_declaration(context_TranspileContext* ctx, types_SExpr* e
                                     break;
                                 }
                             }
-                        } else if (!_mv_1024.has_value) {
+                        } else if (!_mv_1025.has_value) {
                         }
                     }
                 }
@@ -1960,13 +1960,13 @@ slop_string defn_get_return_type(context_TranspileContext* ctx, slop_list_types_
         int64_t i = 3;
         __auto_type result = SLOP_STR("void");
         while (i < len) {
-            __auto_type _mv_1027 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1027.has_value) {
-                __auto_type item = _mv_1027.value;
+            __auto_type _mv_1028 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1028.has_value) {
+                __auto_type item = _mv_1028.value;
                 if (defn_is_spec_form(item)) {
                     result = defn_extract_spec_return_type(ctx, item);
                 }
-            } else if (!_mv_1027.has_value) {
+            } else if (!_mv_1028.has_value) {
             }
             i = (i + 1);
         }
@@ -1976,31 +1976,31 @@ slop_string defn_get_return_type(context_TranspileContext* ctx, slop_list_types_
 
 uint8_t defn_is_spec_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1028 = (*expr);
-    switch (_mv_1028.tag) {
+    __auto_type _mv_1029 = (*expr);
+    switch (_mv_1029.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1028.data.lst;
+            __auto_type lst = _mv_1029.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1029 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1029.has_value) {
-                        __auto_type head = _mv_1029.value;
-                        __auto_type _mv_1030 = (*head);
-                        switch (_mv_1030.tag) {
+                    __auto_type _mv_1030 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1030.has_value) {
+                        __auto_type head = _mv_1030.value;
+                        __auto_type _mv_1031 = (*head);
+                        switch (_mv_1031.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1030.data.sym;
+                                __auto_type sym = _mv_1031.data.sym;
                                 return string_eq(sym.name, SLOP_STR("@spec"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1029.has_value) {
+                    } else if (!_mv_1030.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2018,35 +2018,35 @@ slop_string defn_extract_spec_return_type(context_TranspileContext* ctx, types_S
     SLOP_PRE(((spec_expr != NULL)), "(!= spec-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1031 = (*spec_expr);
-        switch (_mv_1031.tag) {
+        __auto_type _mv_1032 = (*spec_expr);
+        switch (_mv_1032.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1031.data.lst;
+                __auto_type lst = _mv_1032.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 2) {
                         return SLOP_STR("void");
                     } else {
-                        __auto_type _mv_1032 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1032.has_value) {
-                            __auto_type spec_body = _mv_1032.value;
-                            __auto_type _mv_1033 = (*spec_body);
-                            switch (_mv_1033.tag) {
+                        __auto_type _mv_1033 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1033.has_value) {
+                            __auto_type spec_body = _mv_1033.value;
+                            __auto_type _mv_1034 = (*spec_body);
+                            switch (_mv_1034.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type body_lst = _mv_1033.data.lst;
+                                    __auto_type body_lst = _mv_1034.data.lst;
                                     {
                                         __auto_type body_items = body_lst.items;
                                         __auto_type body_len = ((int64_t)((body_items).len));
                                         if (body_len < 1) {
                                             return SLOP_STR("void");
                                         } else {
-                                            __auto_type _mv_1034 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1034.has_value) {
-                                                __auto_type ret_type = _mv_1034.value;
+                                            __auto_type _mv_1035 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1035.has_value) {
+                                                __auto_type ret_type = _mv_1035.value;
                                                 return context_to_c_type_prefixed(ctx, ret_type);
-                                            } else if (!_mv_1034.has_value) {
+                                            } else if (!_mv_1035.has_value) {
                                                 return SLOP_STR("void");
                                             }
                                             SLOP_UNREACHABLE();
@@ -2057,7 +2057,7 @@ slop_string defn_extract_spec_return_type(context_TranspileContext* ctx, types_S
                                     return SLOP_STR("void");
                                 }
                             }
-                        } else if (!_mv_1032.has_value) {
+                        } else if (!_mv_1033.has_value) {
                             return SLOP_STR("void");
                         }
                         SLOP_UNREACHABLE();
@@ -2076,35 +2076,35 @@ slop_string defn_extract_spec_slop_return_type(context_TranspileContext* ctx, ty
     SLOP_PRE(((spec_expr != NULL)), "(!= spec-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1035 = (*spec_expr);
-        switch (_mv_1035.tag) {
+        __auto_type _mv_1036 = (*spec_expr);
+        switch (_mv_1036.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1035.data.lst;
+                __auto_type lst = _mv_1036.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 2) {
                         return SLOP_STR("");
                     } else {
-                        __auto_type _mv_1036 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1036.has_value) {
-                            __auto_type spec_body = _mv_1036.value;
-                            __auto_type _mv_1037 = (*spec_body);
-                            switch (_mv_1037.tag) {
+                        __auto_type _mv_1037 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1037.has_value) {
+                            __auto_type spec_body = _mv_1037.value;
+                            __auto_type _mv_1038 = (*spec_body);
+                            switch (_mv_1038.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type body_lst = _mv_1037.data.lst;
+                                    __auto_type body_lst = _mv_1038.data.lst;
                                     {
                                         __auto_type body_items = body_lst.items;
                                         __auto_type body_len = ((int64_t)((body_items).len));
                                         if (body_len < 1) {
                                             return SLOP_STR("");
                                         } else {
-                                            __auto_type _mv_1038 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1038.has_value) {
-                                                __auto_type ret_type = _mv_1038.value;
+                                            __auto_type _mv_1039 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1039.has_value) {
+                                                __auto_type ret_type = _mv_1039.value;
                                                 return parser_pretty_print(arena, ret_type);
-                                            } else if (!_mv_1038.has_value) {
+                                            } else if (!_mv_1039.has_value) {
                                                 return SLOP_STR("");
                                             }
                                             SLOP_UNREACHABLE();
@@ -2115,7 +2115,7 @@ slop_string defn_extract_spec_slop_return_type(context_TranspileContext* ctx, ty
                                     return SLOP_STR("");
                                 }
                             }
-                        } else if (!_mv_1036.has_value) {
+                        } else if (!_mv_1037.has_value) {
                             return SLOP_STR("");
                         }
                         SLOP_UNREACHABLE();
@@ -2136,13 +2136,13 @@ slop_string defn_get_slop_return_type(context_TranspileContext* ctx, slop_list_t
         int64_t i = 3;
         __auto_type result = SLOP_STR("");
         while (i < len) {
-            __auto_type _mv_1039 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1039.has_value) {
-                __auto_type item = _mv_1039.value;
+            __auto_type _mv_1040 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1040.has_value) {
+                __auto_type item = _mv_1040.value;
                 if (defn_is_spec_form(item)) {
                     result = defn_extract_spec_slop_return_type(ctx, item);
                 }
-            } else if (!_mv_1039.has_value) {
+            } else if (!_mv_1040.has_value) {
             }
             i = (i + 1);
         }
@@ -2158,13 +2158,13 @@ slop_option_string defn_get_result_type_name(context_TranspileContext* ctx, slop
         int64_t i = 3;
         slop_option_string result = (slop_option_string){.has_value = false};
         while ((i < len) && ({ __auto_type _mv = result; _mv.has_value ? ({ __auto_type _ = _mv.value; 0; }) : (1); })) {
-            __auto_type _mv_1040 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1040.has_value) {
-                __auto_type item = _mv_1040.value;
+            __auto_type _mv_1041 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1041.has_value) {
+                __auto_type item = _mv_1041.value;
                 if (defn_is_spec_form(item)) {
                     result = defn_extract_result_type_name(ctx, item);
                 }
-            } else if (!_mv_1040.has_value) {
+            } else if (!_mv_1041.has_value) {
             }
             i = (i + 1);
         }
@@ -2177,35 +2177,35 @@ slop_option_string defn_extract_result_type_name(context_TranspileContext* ctx, 
     SLOP_PRE(((spec_expr != NULL)), "(!= spec-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1041 = (*spec_expr);
-        switch (_mv_1041.tag) {
+        __auto_type _mv_1042 = (*spec_expr);
+        switch (_mv_1042.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1041.data.lst;
+                __auto_type lst = _mv_1042.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 2) {
                         return (slop_option_string){.has_value = false};
                     } else {
-                        __auto_type _mv_1042 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1042.has_value) {
-                            __auto_type spec_body = _mv_1042.value;
-                            __auto_type _mv_1043 = (*spec_body);
-                            switch (_mv_1043.tag) {
+                        __auto_type _mv_1043 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1043.has_value) {
+                            __auto_type spec_body = _mv_1043.value;
+                            __auto_type _mv_1044 = (*spec_body);
+                            switch (_mv_1044.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type body_lst = _mv_1043.data.lst;
+                                    __auto_type body_lst = _mv_1044.data.lst;
                                     {
                                         __auto_type body_items = body_lst.items;
                                         __auto_type body_len = ((int64_t)((body_items).len));
                                         if (body_len < 1) {
                                             return (slop_option_string){.has_value = false};
                                         } else {
-                                            __auto_type _mv_1044 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1044.has_value) {
-                                                __auto_type ret_type = _mv_1044.value;
+                                            __auto_type _mv_1045 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1045.has_value) {
+                                                __auto_type ret_type = _mv_1045.value;
                                                 return defn_check_result_type(ctx, ret_type);
-                                            } else if (!_mv_1044.has_value) {
+                                            } else if (!_mv_1045.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
                                             SLOP_UNREACHABLE();
@@ -2216,7 +2216,7 @@ slop_option_string defn_extract_result_type_name(context_TranspileContext* ctx, 
                                     return (slop_option_string){.has_value = false};
                                 }
                             }
-                        } else if (!_mv_1042.has_value) {
+                        } else if (!_mv_1043.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -2235,23 +2235,23 @@ slop_option_string defn_check_result_type(context_TranspileContext* ctx, types_S
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1045 = (*type_expr);
-        switch (_mv_1045.tag) {
+        __auto_type _mv_1046 = (*type_expr);
+        switch (_mv_1046.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1045.data.sym;
+                __auto_type sym = _mv_1046.data.sym;
                 {
                     __auto_type type_name = sym.name;
-                    __auto_type _mv_1046 = context_ctx_lookup_result_type_alias(ctx, type_name);
-                    if (_mv_1046.has_value) {
-                        __auto_type alias_result = _mv_1046.value;
+                    __auto_type _mv_1047 = context_ctx_lookup_result_type_alias(ctx, type_name);
+                    if (_mv_1047.has_value) {
+                        __auto_type alias_result = _mv_1047.value;
                         return (slop_option_string){.has_value = 1, .value = alias_result};
-                    } else if (!_mv_1046.has_value) {
-                        __auto_type _mv_1047 = context_ctx_lookup_type(ctx, type_name);
-                        if (_mv_1047.has_value) {
-                            __auto_type entry = _mv_1047.value;
+                    } else if (!_mv_1047.has_value) {
+                        __auto_type _mv_1048 = context_ctx_lookup_type(ctx, type_name);
+                        if (_mv_1048.has_value) {
+                            __auto_type entry = _mv_1048.value;
                             return (slop_option_string){.has_value = 1, .value = entry.c_name};
-                        } else if (!_mv_1047.has_value) {
+                        } else if (!_mv_1048.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -2261,38 +2261,38 @@ slop_option_string defn_check_result_type(context_TranspileContext* ctx, types_S
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1045.data.lst;
+                __auto_type lst = _mv_1046.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 3) {
                         return (slop_option_string){.has_value = false};
                     } else {
-                        __auto_type _mv_1048 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1048.has_value) {
-                            __auto_type head = _mv_1048.value;
-                            __auto_type _mv_1049 = (*head);
-                            switch (_mv_1049.tag) {
+                        __auto_type _mv_1049 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1049.has_value) {
+                            __auto_type head = _mv_1049.value;
+                            __auto_type _mv_1050 = (*head);
+                            switch (_mv_1050.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1049.data.sym;
+                                    __auto_type sym = _mv_1050.data.sym;
                                     if (string_eq(sym.name, SLOP_STR("Result"))) {
-                                        __auto_type _mv_1050 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1050.has_value) {
-                                            __auto_type ok_type_expr = _mv_1050.value;
-                                            __auto_type _mv_1051 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1051.has_value) {
-                                                __auto_type err_type_expr = _mv_1051.value;
+                                        __auto_type _mv_1051 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1051.has_value) {
+                                            __auto_type ok_type_expr = _mv_1051.value;
+                                            __auto_type _mv_1052 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1052.has_value) {
+                                                __auto_type err_type_expr = _mv_1052.value;
                                                 {
                                                     __auto_type ok_c_type = context_to_c_type_prefixed(ctx, ok_type_expr);
                                                     __auto_type err_c_type = context_to_c_type_prefixed(ctx, err_type_expr);
                                                     __auto_type result_name = defn_build_result_name(arena, ok_c_type, err_c_type);
                                                     return (slop_option_string){.has_value = 1, .value = result_name};
                                                 }
-                                            } else if (!_mv_1051.has_value) {
+                                            } else if (!_mv_1052.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
                                             SLOP_UNREACHABLE();
-                                        } else if (!_mv_1050.has_value) {
+                                        } else if (!_mv_1051.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
                                         SLOP_UNREACHABLE();
@@ -2304,7 +2304,7 @@ slop_option_string defn_check_result_type(context_TranspileContext* ctx, types_S
                                     return (slop_option_string){.has_value = false};
                                 }
                             }
-                        } else if (!_mv_1048.has_value) {
+                        } else if (!_mv_1049.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -2331,20 +2331,20 @@ slop_string defn_build_param_str(context_TranspileContext* ctx, types_SExpr* par
     SLOP_PRE(((params_expr != NULL)), "(!= params-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1052 = (*params_expr);
-        switch (_mv_1052.tag) {
+        __auto_type _mv_1053 = (*params_expr);
+        switch (_mv_1053.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1052.data.lst;
+                __auto_type lst = _mv_1053.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type result = SLOP_STR("");
                     __auto_type i = 0;
                     while (i < len) {
-                        __auto_type _mv_1053 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1053.has_value) {
-                            __auto_type param = _mv_1053.value;
+                        __auto_type _mv_1054 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1054.has_value) {
+                            __auto_type param = _mv_1054.value;
                             {
                                 __auto_type param_str = defn_build_single_param(ctx, param);
                                 if (string_eq(result, SLOP_STR(""))) {
@@ -2353,7 +2353,7 @@ slop_string defn_build_param_str(context_TranspileContext* ctx, types_SExpr* par
                                     result = context_ctx_str3(ctx, result, SLOP_STR(", "), param_str);
                                 }
                             }
-                        } else if (!_mv_1053.has_value) {
+                        } else if (!_mv_1054.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -2372,11 +2372,11 @@ slop_string defn_build_single_param(context_TranspileContext* ctx, types_SExpr* 
     SLOP_PRE(((param != NULL)), "(!= param nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1054 = (*param);
-        switch (_mv_1054.tag) {
+        __auto_type _mv_1055 = (*param);
+        switch (_mv_1055.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1054.data.lst;
+                __auto_type lst = _mv_1055.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -2387,17 +2387,17 @@ slop_string defn_build_single_param(context_TranspileContext* ctx, types_SExpr* 
                             __auto_type has_mode = ((len >= 3) && defn_is_param_mode(items));
                             __auto_type name_idx = ((((len >= 3) && defn_is_param_mode(items))) ? 1 : 0);
                             __auto_type type_idx = ((((len >= 3) && defn_is_param_mode(items))) ? 2 : 1);
-                            __auto_type _mv_1055 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1055.has_value) {
-                                __auto_type name_expr = _mv_1055.value;
-                                __auto_type _mv_1056 = (*name_expr);
-                                switch (_mv_1056.tag) {
+                            __auto_type _mv_1056 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1056.has_value) {
+                                __auto_type name_expr = _mv_1056.value;
+                                __auto_type _mv_1057 = (*name_expr);
+                                switch (_mv_1057.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type name_sym = _mv_1056.data.sym;
-                                        __auto_type _mv_1057 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1057.has_value) {
-                                            __auto_type type_expr = _mv_1057.value;
+                                        __auto_type name_sym = _mv_1057.data.sym;
+                                        __auto_type _mv_1058 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1058.has_value) {
+                                            __auto_type type_expr = _mv_1058.value;
                                             {
                                                 __auto_type param_name = ctype_to_c_name(arena, name_sym.name);
                                                 {
@@ -2405,7 +2405,7 @@ slop_string defn_build_single_param(context_TranspileContext* ctx, types_SExpr* 
                                                     return context_ctx_str3(ctx, param_type, SLOP_STR(" "), param_name);
                                                 }
                                             }
-                                        } else if (!_mv_1057.has_value) {
+                                        } else if (!_mv_1058.has_value) {
                                             return SLOP_STR("/* missing param type */");
                                         }
                                         SLOP_UNREACHABLE();
@@ -2414,7 +2414,7 @@ slop_string defn_build_single_param(context_TranspileContext* ctx, types_SExpr* 
                                         return SLOP_STR("/* param name must be symbol */");
                                     }
                                 }
-                            } else if (!_mv_1055.has_value) {
+                            } else if (!_mv_1056.has_value) {
                                 return SLOP_STR("/* missing param name */");
                             }
                             SLOP_UNREACHABLE();
@@ -2433,14 +2433,14 @@ uint8_t defn_is_param_mode(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_1058 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1058.has_value) {
-            __auto_type first = _mv_1058.value;
-            __auto_type _mv_1059 = (*first);
-            switch (_mv_1059.tag) {
+        __auto_type _mv_1059 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1059.has_value) {
+            __auto_type first = _mv_1059.value;
+            __auto_type _mv_1060 = (*first);
+            switch (_mv_1060.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_1059.data.sym;
+                    __auto_type sym = _mv_1060.data.sym;
                     {
                         __auto_type name = sym.name;
                         return ((string_eq(name, SLOP_STR("in"))) || (string_eq(name, SLOP_STR("out"))) || (string_eq(name, SLOP_STR("mut"))));
@@ -2450,7 +2450,7 @@ uint8_t defn_is_param_mode(slop_list_types_SExpr_ptr items) {
                     return 0;
                 }
             }
-        } else if (!_mv_1058.has_value) {
+        } else if (!_mv_1059.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -2458,31 +2458,31 @@ uint8_t defn_is_param_mode(slop_list_types_SExpr_ptr items) {
 }
 
 uint8_t defn_is_fn_type(types_SExpr* type_expr) {
-    __auto_type _mv_1060 = (*type_expr);
-    switch (_mv_1060.tag) {
+    __auto_type _mv_1061 = (*type_expr);
+    switch (_mv_1061.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1060.data.lst;
+            __auto_type lst = _mv_1061.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1061 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1061.has_value) {
-                        __auto_type first = _mv_1061.value;
-                        __auto_type _mv_1062 = (*first);
-                        switch (_mv_1062.tag) {
+                    __auto_type _mv_1062 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1062.has_value) {
+                        __auto_type first = _mv_1062.value;
+                        __auto_type _mv_1063 = (*first);
+                        switch (_mv_1063.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1062.data.sym;
+                                __auto_type sym = _mv_1063.data.sym;
                                 return string_eq(sym.name, SLOP_STR("Fn"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1061.has_value) {
+                    } else if (!_mv_1062.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2499,11 +2499,11 @@ slop_string defn_emit_fn_param_type(context_TranspileContext* ctx, types_SExpr* 
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1063 = (*type_expr);
-        switch (_mv_1063.tag) {
+        __auto_type _mv_1064 = (*type_expr);
+        switch (_mv_1064.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1063.data.lst;
+                __auto_type lst = _mv_1064.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -2515,14 +2515,14 @@ slop_string defn_emit_fn_param_type(context_TranspileContext* ctx, types_SExpr* 
                             if (len == 2) {
                                 return context_ctx_str(ctx, context_ctx_str(ctx, ret_type, SLOP_STR("(*")), context_ctx_str(ctx, param_name, SLOP_STR(")(void)")));
                             } else {
-                                __auto_type _mv_1064 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1064.has_value) {
-                                    __auto_type args_expr = _mv_1064.value;
+                                __auto_type _mv_1065 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1065.has_value) {
+                                    __auto_type args_expr = _mv_1065.value;
                                     {
                                         __auto_type args_str = defn_build_fn_args_str_for_param(ctx, args_expr);
                                         return context_ctx_str(ctx, context_ctx_str(ctx, ret_type, SLOP_STR("(*")), context_ctx_str(ctx, param_name, context_ctx_str(ctx, SLOP_STR(")"), args_str)));
                                     }
-                                } else if (!_mv_1064.has_value) {
+                                } else if (!_mv_1065.has_value) {
                                     return context_ctx_str(ctx, context_ctx_str(ctx, ret_type, SLOP_STR("(*")), context_ctx_str(ctx, param_name, SLOP_STR(")(void)")));
                                 }
                                 SLOP_UNREACHABLE();
@@ -2542,11 +2542,11 @@ slop_string defn_build_fn_args_str_for_param(context_TranspileContext* ctx, type
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1065 = (*args_expr);
-        switch (_mv_1065.tag) {
+        __auto_type _mv_1066 = (*args_expr);
+        switch (_mv_1066.tag) {
             case types_SExpr_lst:
             {
-                __auto_type args_list = _mv_1065.data.lst;
+                __auto_type args_list = _mv_1066.data.lst;
                 {
                     __auto_type arg_items = args_list.items;
                     __auto_type arg_count = ((int64_t)((arg_items).len));
@@ -2557,9 +2557,9 @@ slop_string defn_build_fn_args_str_for_param(context_TranspileContext* ctx, type
                             __auto_type result = SLOP_STR("(");
                             __auto_type i = 0;
                             while (i < arg_count) {
-                                __auto_type _mv_1066 = ({ __auto_type _lst = arg_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1066.has_value) {
-                                    __auto_type arg_expr = _mv_1066.value;
+                                __auto_type _mv_1067 = ({ __auto_type _lst = arg_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1067.has_value) {
+                                    __auto_type arg_expr = _mv_1067.value;
                                     {
                                         __auto_type arg_type = context_to_c_type_prefixed(ctx, arg_expr);
                                         if (i > 0) {
@@ -2568,7 +2568,7 @@ slop_string defn_build_fn_args_str_for_param(context_TranspileContext* ctx, type
                                             result = context_ctx_str(ctx, result, arg_type);
                                         }
                                     }
-                                } else if (!_mv_1066.has_value) {
+                                } else if (!_mv_1067.has_value) {
                                     /* empty list */;
                                 }
                                 i = (i + 1);
@@ -2594,9 +2594,9 @@ void defn_emit_function_body(context_TranspileContext* ctx, slop_list_types_SExp
         __auto_type body_start = defn_find_body_start(items);
         i = body_start;
         while (i < len) {
-            __auto_type _mv_1067 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1067.has_value) {
-                __auto_type item = _mv_1067.value;
+            __auto_type _mv_1068 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1068.has_value) {
+                __auto_type item = _mv_1068.value;
                 if (defn_is_c_name_attr(item)) {
                     i = (i + 1);
                 } else {
@@ -2608,7 +2608,7 @@ void defn_emit_function_body(context_TranspileContext* ctx, slop_list_types_SExp
                         }
                     }
                 }
-            } else if (!_mv_1067.has_value) {
+            } else if (!_mv_1068.has_value) {
             }
             i = (i + 1);
         }
@@ -2617,11 +2617,11 @@ void defn_emit_function_body(context_TranspileContext* ctx, slop_list_types_SExp
 
 uint8_t defn_is_c_name_attr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1068 = (*expr);
-    switch (_mv_1068.tag) {
+    __auto_type _mv_1069 = (*expr);
+    switch (_mv_1069.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1068.data.sym;
+            __auto_type sym = _mv_1069.data.sym;
             return string_eq(sym.name, SLOP_STR(":c-name"));
         }
         default: {
@@ -2636,9 +2636,9 @@ uint8_t defn_is_last_body_item(slop_list_types_SExpr_ptr items, int64_t current_
         int64_t i = (current_i + 1);
         uint8_t found_body = 0;
         while ((i < len) && !(found_body)) {
-            __auto_type _mv_1069 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1069.has_value) {
-                __auto_type item = _mv_1069.value;
+            __auto_type _mv_1070 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1070.has_value) {
+                __auto_type item = _mv_1070.value;
                 if (defn_is_annotation(item) || defn_is_c_name_attr(item)) {
                     i = (i + 1);
                 } else {
@@ -2648,7 +2648,7 @@ uint8_t defn_is_last_body_item(slop_list_types_SExpr_ptr items, int64_t current_
                         found_body = 1;
                     }
                 }
-            } else if (!_mv_1069.has_value) {
+            } else if (!_mv_1070.has_value) {
                 i = (i + 1);
             }
         }
@@ -2657,11 +2657,11 @@ uint8_t defn_is_last_body_item(slop_list_types_SExpr_ptr items, int64_t current_
 }
 
 uint8_t defn_is_c_name_attr_at(slop_list_types_SExpr_ptr items, int64_t idx) {
-    __auto_type _mv_1070 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-    if (_mv_1070.has_value) {
-        __auto_type item = _mv_1070.value;
+    __auto_type _mv_1071 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+    if (_mv_1071.has_value) {
+        __auto_type item = _mv_1071.value;
         return defn_is_c_name_attr(item);
-    } else if (!_mv_1070.has_value) {
+    } else if (!_mv_1071.has_value) {
         return 0;
     }
     SLOP_UNREACHABLE();
@@ -2673,15 +2673,15 @@ int64_t defn_find_body_start(slop_list_types_SExpr_ptr items) {
         int64_t i = 3;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1071 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1071.has_value) {
-                __auto_type item = _mv_1071.value;
+            __auto_type _mv_1072 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1072.has_value) {
+                __auto_type item = _mv_1072.value;
                 if (defn_is_annotation(item)) {
                     i = (i + 1);
                 } else {
                     found = 1;
                 }
-            } else if (!_mv_1071.has_value) {
+            } else if (!_mv_1072.has_value) {
                 found = 1;
             }
         }
@@ -2691,24 +2691,24 @@ int64_t defn_find_body_start(slop_list_types_SExpr_ptr items) {
 
 uint8_t defn_is_annotation(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1072 = (*expr);
-    switch (_mv_1072.tag) {
+    __auto_type _mv_1073 = (*expr);
+    switch (_mv_1073.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1072.data.lst;
+            __auto_type lst = _mv_1073.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1073 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1073.has_value) {
-                        __auto_type head = _mv_1073.value;
-                        __auto_type _mv_1074 = (*head);
-                        switch (_mv_1074.tag) {
+                    __auto_type _mv_1074 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1074.has_value) {
+                        __auto_type head = _mv_1074.value;
+                        __auto_type _mv_1075 = (*head);
+                        switch (_mv_1075.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1074.data.sym;
+                                __auto_type sym = _mv_1075.data.sym;
                                 {
                                     __auto_type name = sym.name;
                                     return ((string_eq(name, SLOP_STR("@intent"))) || (string_eq(name, SLOP_STR("@spec"))) || (string_eq(name, SLOP_STR("@pre"))) || (string_eq(name, SLOP_STR("@post"))) || (string_eq(name, SLOP_STR("@assume"))) || (string_eq(name, SLOP_STR("@alloc"))) || (string_eq(name, SLOP_STR("@example"))) || (string_eq(name, SLOP_STR("@pure"))) || (string_eq(name, SLOP_STR("@doc"))) || (string_eq(name, SLOP_STR("@loop-invariant"))) || (string_eq(name, SLOP_STR("@property"))) || (string_eq(name, SLOP_STR("@callback-assume"))) || (string_eq(name, SLOP_STR("@generic"))));
@@ -2718,7 +2718,7 @@ uint8_t defn_is_annotation(types_SExpr* expr) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1073.has_value) {
+                    } else if (!_mv_1074.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2733,31 +2733,31 @@ uint8_t defn_is_annotation(types_SExpr* expr) {
 
 uint8_t defn_is_pre_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1075 = (*expr);
-    switch (_mv_1075.tag) {
+    __auto_type _mv_1076 = (*expr);
+    switch (_mv_1076.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1075.data.lst;
+            __auto_type lst = _mv_1076.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1076 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1076.has_value) {
-                        __auto_type head = _mv_1076.value;
-                        __auto_type _mv_1077 = (*head);
-                        switch (_mv_1077.tag) {
+                    __auto_type _mv_1077 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1077.has_value) {
+                        __auto_type head = _mv_1077.value;
+                        __auto_type _mv_1078 = (*head);
+                        switch (_mv_1078.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1077.data.sym;
+                                __auto_type sym = _mv_1078.data.sym;
                                 return string_eq(sym.name, SLOP_STR("@pre"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1076.has_value) {
+                    } else if (!_mv_1077.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2772,31 +2772,31 @@ uint8_t defn_is_pre_form(types_SExpr* expr) {
 
 uint8_t defn_is_post_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1078 = (*expr);
-    switch (_mv_1078.tag) {
+    __auto_type _mv_1079 = (*expr);
+    switch (_mv_1079.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1078.data.lst;
+            __auto_type lst = _mv_1079.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1079 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1079.has_value) {
-                        __auto_type head = _mv_1079.value;
-                        __auto_type _mv_1080 = (*head);
-                        switch (_mv_1080.tag) {
+                    __auto_type _mv_1080 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1080.has_value) {
+                        __auto_type head = _mv_1080.value;
+                        __auto_type _mv_1081 = (*head);
+                        switch (_mv_1081.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1080.data.sym;
+                                __auto_type sym = _mv_1081.data.sym;
                                 return string_eq(sym.name, SLOP_STR("@post"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1079.has_value) {
+                    } else if (!_mv_1080.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2811,31 +2811,31 @@ uint8_t defn_is_post_form(types_SExpr* expr) {
 
 uint8_t defn_is_assume_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1081 = (*expr);
-    switch (_mv_1081.tag) {
+    __auto_type _mv_1082 = (*expr);
+    switch (_mv_1082.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1081.data.lst;
+            __auto_type lst = _mv_1082.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1082 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1082.has_value) {
-                        __auto_type head = _mv_1082.value;
-                        __auto_type _mv_1083 = (*head);
-                        switch (_mv_1083.tag) {
+                    __auto_type _mv_1083 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1083.has_value) {
+                        __auto_type head = _mv_1083.value;
+                        __auto_type _mv_1084 = (*head);
+                        switch (_mv_1084.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1083.data.sym;
+                                __auto_type sym = _mv_1084.data.sym;
                                 return string_eq(sym.name, SLOP_STR("@assume"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1082.has_value) {
+                    } else if (!_mv_1083.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2850,11 +2850,11 @@ uint8_t defn_is_assume_form(types_SExpr* expr) {
 
 uint8_t defn_is_verification_only_expr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1084 = (*expr);
-    switch (_mv_1084.tag) {
+    __auto_type _mv_1085 = (*expr);
+    switch (_mv_1085.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1084.data.lst;
+            __auto_type lst = _mv_1085.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
@@ -2864,14 +2864,14 @@ uint8_t defn_is_verification_only_expr(types_SExpr* expr) {
                     {
                         __auto_type found = 0;
                         __auto_type i = 0;
-                        __auto_type _mv_1085 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1085.has_value) {
-                            __auto_type head = _mv_1085.value;
-                            __auto_type _mv_1086 = (*head);
-                            switch (_mv_1086.tag) {
+                        __auto_type _mv_1086 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1086.has_value) {
+                            __auto_type head = _mv_1086.value;
+                            __auto_type _mv_1087 = (*head);
+                            switch (_mv_1087.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1086.data.sym;
+                                    __auto_type sym = _mv_1087.data.sym;
                                     {
                                         __auto_type name = sym.name;
                                         if ((string_eq(name, SLOP_STR("forall"))) || (string_eq(name, SLOP_STR("exists"))) || (string_eq(name, SLOP_STR("implies")))) {
@@ -2884,16 +2884,16 @@ uint8_t defn_is_verification_only_expr(types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_1085.has_value) {
+                        } else if (!_mv_1086.has_value) {
                         }
                         while ((i < len) && !(found)) {
-                            __auto_type _mv_1087 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1087.has_value) {
-                                __auto_type item = _mv_1087.value;
+                            __auto_type _mv_1088 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1088.has_value) {
+                                __auto_type item = _mv_1088.value;
                                 if (defn_is_verification_only_expr(item)) {
                                     found = 1;
                                 }
-                            } else if (!_mv_1087.has_value) {
+                            } else if (!_mv_1088.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -2910,31 +2910,31 @@ uint8_t defn_is_verification_only_expr(types_SExpr* expr) {
 
 uint8_t defn_is_doc_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1088 = (*expr);
-    switch (_mv_1088.tag) {
+    __auto_type _mv_1089 = (*expr);
+    switch (_mv_1089.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1088.data.lst;
+            __auto_type lst = _mv_1089.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1089 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1089.has_value) {
-                        __auto_type head = _mv_1089.value;
-                        __auto_type _mv_1090 = (*head);
-                        switch (_mv_1090.tag) {
+                    __auto_type _mv_1090 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1090.has_value) {
+                        __auto_type head = _mv_1090.value;
+                        __auto_type _mv_1091 = (*head);
+                        switch (_mv_1091.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1090.data.sym;
+                                __auto_type sym = _mv_1091.data.sym;
                                 return string_eq(sym.name, SLOP_STR("@doc"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1089.has_value) {
+                    } else if (!_mv_1090.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2951,22 +2951,22 @@ slop_option_string defn_get_doc_string(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         slop_option_string result = (slop_option_string){.has_value = false};
-        __auto_type _mv_1091 = (*expr);
-        switch (_mv_1091.tag) {
+        __auto_type _mv_1092 = (*expr);
+        switch (_mv_1092.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1091.data.lst;
+                __auto_type lst = _mv_1092.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_1092 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1092.has_value) {
-                            __auto_type val = _mv_1092.value;
-                            __auto_type _mv_1093 = (*val);
-                            switch (_mv_1093.tag) {
+                        __auto_type _mv_1093 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1093.has_value) {
+                            __auto_type val = _mv_1093.value;
+                            __auto_type _mv_1094 = (*val);
+                            switch (_mv_1094.tag) {
                                 case types_SExpr_str:
                                 {
-                                    __auto_type str = _mv_1093.data.str;
+                                    __auto_type str = _mv_1094.data.str;
                                     result = (slop_option_string){.has_value = 1, .value = str.value};
                                     break;
                                 }
@@ -2974,7 +2974,7 @@ slop_option_string defn_get_doc_string(types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_1092.has_value) {
+                        } else if (!_mv_1093.has_value) {
                         }
                     }
                 }
@@ -2994,13 +2994,13 @@ slop_option_string defn_collect_doc_string(slop_arena* arena, slop_list_types_SE
         int64_t i = 3;
         slop_option_string result = (slop_option_string){.has_value = false};
         while ((i < len) && ({ __auto_type _mv = result; _mv.has_value ? (0) : (1); })) {
-            __auto_type _mv_1094 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1094.has_value) {
-                __auto_type item = _mv_1094.value;
+            __auto_type _mv_1095 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1095.has_value) {
+                __auto_type item = _mv_1095.value;
                 if (defn_is_doc_form(item)) {
                     result = defn_get_doc_string(item);
                 }
-            } else if (!_mv_1094.has_value) {
+            } else if (!_mv_1095.has_value) {
             }
             i = (i + 1);
         }
@@ -3012,19 +3012,19 @@ slop_option_types_SExpr_ptr defn_get_annotation_condition(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         slop_option_types_SExpr_ptr result = (slop_option_types_SExpr_ptr){.has_value = false};
-        __auto_type _mv_1095 = (*expr);
-        switch (_mv_1095.tag) {
+        __auto_type _mv_1096 = (*expr);
+        switch (_mv_1096.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1095.data.lst;
+                __auto_type lst = _mv_1096.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_1096 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1096.has_value) {
-                            __auto_type val = _mv_1096.value;
+                        __auto_type _mv_1097 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1097.has_value) {
+                            __auto_type val = _mv_1097.value;
                             result = (slop_option_types_SExpr_ptr){.has_value = 1, .value = val};
-                        } else if (!_mv_1096.has_value) {
+                        } else if (!_mv_1097.has_value) {
                         }
                     }
                 }
@@ -3044,18 +3044,18 @@ slop_list_types_SExpr_ptr defn_collect_preconditions(slop_arena* arena, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 3;
         while (i < len) {
-            __auto_type _mv_1097 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1097.has_value) {
-                __auto_type item = _mv_1097.value;
+            __auto_type _mv_1098 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1098.has_value) {
+                __auto_type item = _mv_1098.value;
                 if (defn_is_pre_form(item)) {
-                    __auto_type _mv_1098 = defn_get_annotation_condition(item);
-                    if (_mv_1098.has_value) {
-                        __auto_type cond = _mv_1098.value;
+                    __auto_type _mv_1099 = defn_get_annotation_condition(item);
+                    if (_mv_1099.has_value) {
+                        __auto_type cond = _mv_1099.value;
                         ({ __auto_type _lst_p = &(result); __auto_type _item = (cond); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                    } else if (!_mv_1098.has_value) {
+                    } else if (!_mv_1099.has_value) {
                     }
                 }
-            } else if (!_mv_1097.has_value) {
+            } else if (!_mv_1098.has_value) {
             }
             i = (i + 1);
         }
@@ -3069,18 +3069,18 @@ slop_list_types_SExpr_ptr defn_collect_postconditions(slop_arena* arena, slop_li
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 3;
         while (i < len) {
-            __auto_type _mv_1099 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1099.has_value) {
-                __auto_type item = _mv_1099.value;
+            __auto_type _mv_1100 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1100.has_value) {
+                __auto_type item = _mv_1100.value;
                 if (defn_is_post_form(item)) {
-                    __auto_type _mv_1100 = defn_get_annotation_condition(item);
-                    if (_mv_1100.has_value) {
-                        __auto_type cond = _mv_1100.value;
+                    __auto_type _mv_1101 = defn_get_annotation_condition(item);
+                    if (_mv_1101.has_value) {
+                        __auto_type cond = _mv_1101.value;
                         ({ __auto_type _lst_p = &(result); __auto_type _item = (cond); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                    } else if (!_mv_1100.has_value) {
+                    } else if (!_mv_1101.has_value) {
                     }
                 }
-            } else if (!_mv_1099.has_value) {
+            } else if (!_mv_1100.has_value) {
             }
             i = (i + 1);
         }
@@ -3094,18 +3094,18 @@ slop_list_types_SExpr_ptr defn_collect_assumptions(slop_arena* arena, slop_list_
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 3;
         while (i < len) {
-            __auto_type _mv_1101 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1101.has_value) {
-                __auto_type item = _mv_1101.value;
+            __auto_type _mv_1102 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1102.has_value) {
+                __auto_type item = _mv_1102.value;
                 if (defn_is_assume_form(item)) {
-                    __auto_type _mv_1102 = defn_get_annotation_condition(item);
-                    if (_mv_1102.has_value) {
-                        __auto_type cond = _mv_1102.value;
+                    __auto_type _mv_1103 = defn_get_annotation_condition(item);
+                    if (_mv_1103.has_value) {
+                        __auto_type cond = _mv_1103.value;
                         ({ __auto_type _lst_p = &(result); __auto_type _item = (cond); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                    } else if (!_mv_1102.has_value) {
+                    } else if (!_mv_1103.has_value) {
                     }
                 }
-            } else if (!_mv_1101.has_value) {
+            } else if (!_mv_1102.has_value) {
             }
             i = (i + 1);
         }
@@ -3119,13 +3119,13 @@ uint8_t defn_has_postconditions(slop_list_types_SExpr_ptr items) {
         int64_t i = 3;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1103 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1103.has_value) {
-                __auto_type item = _mv_1103.value;
+            __auto_type _mv_1104 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1104.has_value) {
+                __auto_type item = _mv_1104.value;
                 if (defn_is_post_form(item) || defn_is_assume_form(item)) {
                     found = 1;
                 }
-            } else if (!_mv_1103.has_value) {
+            } else if (!_mv_1104.has_value) {
             }
             i = (i + 1);
         }
@@ -3140,16 +3140,16 @@ void defn_emit_preconditions(context_TranspileContext* ctx, slop_list_types_SExp
         __auto_type len = ((int64_t)((preconditions).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1104 = ({ __auto_type _lst = preconditions; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1104.has_value) {
-                __auto_type cond_expr = _mv_1104.value;
+            __auto_type _mv_1105 = ({ __auto_type _lst = preconditions; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1105.has_value) {
+                __auto_type cond_expr = _mv_1105.value;
                 {
                     __auto_type cond_c = expr_transpile_expr(ctx, cond_expr);
                     __auto_type expr_str = parser_pretty_print(arena, cond_expr);
                     __auto_type escaped_str = defn_escape_for_c_string(arena, expr_str);
                     context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("SLOP_PRE(("), cond_c, SLOP_STR("), \""), escaped_str, SLOP_STR("\");")));
                 }
-            } else if (!_mv_1104.has_value) {
+            } else if (!_mv_1105.has_value) {
             }
             i = (i + 1);
         }
@@ -3163,9 +3163,9 @@ void defn_emit_postconditions(context_TranspileContext* ctx, slop_list_types_SEx
         __auto_type len = ((int64_t)((postconditions).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1105 = ({ __auto_type _lst = postconditions; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1105.has_value) {
-                __auto_type cond_expr = _mv_1105.value;
+            __auto_type _mv_1106 = ({ __auto_type _lst = postconditions; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1106.has_value) {
+                __auto_type cond_expr = _mv_1106.value;
                 if (!(defn_is_verification_only_expr(cond_expr))) {
                     {
                         __auto_type cond_c = expr_transpile_expr(ctx, cond_expr);
@@ -3174,7 +3174,7 @@ void defn_emit_postconditions(context_TranspileContext* ctx, slop_list_types_SEx
                         context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("SLOP_POST(("), cond_c, SLOP_STR("), \""), escaped_str, SLOP_STR("\");")));
                     }
                 }
-            } else if (!_mv_1105.has_value) {
+            } else if (!_mv_1106.has_value) {
             }
             i = (i + 1);
         }
@@ -3188,9 +3188,9 @@ void defn_emit_assumptions(context_TranspileContext* ctx, slop_list_types_SExpr_
         __auto_type len = ((int64_t)((assumptions).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1106 = ({ __auto_type _lst = assumptions; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1106.has_value) {
-                __auto_type cond_expr = _mv_1106.value;
+            __auto_type _mv_1107 = ({ __auto_type _lst = assumptions; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1107.has_value) {
+                __auto_type cond_expr = _mv_1107.value;
                 if (!(defn_is_verification_only_expr(cond_expr))) {
                     {
                         __auto_type cond_c = expr_transpile_expr(ctx, cond_expr);
@@ -3199,7 +3199,7 @@ void defn_emit_assumptions(context_TranspileContext* ctx, slop_list_types_SExpr_
                         context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("SLOP_POST(("), cond_c, SLOP_STR("), \""), escaped_str, SLOP_STR("\");")));
                     }
                 }
-            } else if (!_mv_1106.has_value) {
+            } else if (!_mv_1107.has_value) {
             }
             i = (i + 1);
         }

--- a/bootstrap/tester/slop_expr.c
+++ b/bootstrap/tester/slop_expr.c
@@ -8621,14 +8621,15 @@ slop_string expr_transpile_with_arena_expr(context_TranspileContext* ctx, slop_l
                 __auto_type arena_name = ((is_named) ? ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type name_expr = _mv.value; ({ __auto_type _mv = (*name_expr); slop_string _mr = {0}; switch (_mv.tag) { case types_SExpr_sym: { __auto_type s2 = _mv.data.sym; _mr = s2.name; break; } default: { _mr = SLOP_STR("arena"); break; }  } _mr; }); }) : (SLOP_STR("arena")); }) : SLOP_STR("arena"));
                 __auto_type size_idx = ((is_named) ? 3 : 1);
                 __auto_type body_start = ((is_named) ? 4 : 2);
-                __auto_type c_local = ((is_named) ? string_concat(arena, SLOP_STR("_arena_"), arena_name) : SLOP_STR("_arena"));
+                __auto_type c_arena_name = ctype_to_c_name(arena, arena_name);
+                __auto_type c_local = ((is_named) ? string_concat(arena, SLOP_STR("_arena_"), c_arena_name) : SLOP_STR("_arena"));
                 if (is_named && (len < 5)) {
                     context_ctx_add_error_at(ctx, SLOP_STR("with-arena :as requires name, size and body"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("({ (void)0; })");
                 } else {
                     context_ctx_push_scope(ctx);
                     {
-                        __auto_type result_str = ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type size_expr = _mv.value; ({ __auto_type size_c = expr_transpile_expr(ctx, size_expr); __auto_type result = context_ctx_str5(ctx, SLOP_STR("({ slop_arena "), c_local, SLOP_STR(" = slop_arena_new("), size_c, SLOP_STR("); ")); ({ result = context_ctx_str5(ctx, result, SLOP_STR("slop_arena* "), arena_name, SLOP_STR(" = &"), context_ctx_str(ctx, c_local, SLOP_STR("; "))); (void)0; }); context_ctx_bind_var(ctx, (context_VarEntry){arena_name, arena_name, SLOP_STR("slop_arena*"), SLOP_STR(""), 1, 0, 0, SLOP_STR(""), SLOP_STR("")}); ({ __auto_type i = body_start; ({ while ((i < (len - 1))) { ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); if (_mv.has_value) { __auto_type body_expr = _mv.value; ({ __auto_type body_c = expr_transpile_expr(ctx, body_expr); ({ result = context_ctx_str3(ctx, result, body_c, SLOP_STR("; ")); (void)0; }); }); } else { ({ (void)0; }); } (void)0; }); ({ i = (i + 1); (void)0; }); } (void)0; }); }); ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)(len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); if (_mv.has_value) { __auto_type last_expr = _mv.value; ({ __auto_type last_c = expr_transpile_expr(ctx, last_expr); __auto_type free_part = context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), arena_name, SLOP_STR("); ")); ({ result = context_ctx_str5(ctx, result, SLOP_STR("__auto_type _wa_result = "), last_c, SLOP_STR("; "), free_part); (void)0; }); ({ result = context_ctx_str(ctx, result, SLOP_STR("_wa_result; })")); (void)0; }); }); } else { ({ __auto_type free_part = context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), arena_name, SLOP_STR("); ")); ({ result = context_ctx_str3(ctx, result, free_part, SLOP_STR("0; })")); (void)0; }); }); } (void)0; }); result; }); }) : (({ context_ctx_add_error_at(ctx, SLOP_STR("with-arena: missing size"), context_ctx_list_first_line(items), context_ctx_list_first_col(items)); SLOP_STR("({ (void)0; })"); })); });
+                        __auto_type result_str = ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type size_expr = _mv.value; ({ __auto_type size_c = expr_transpile_expr(ctx, size_expr); __auto_type result = context_ctx_str5(ctx, SLOP_STR("({ slop_arena "), c_local, SLOP_STR(" = slop_arena_new("), size_c, SLOP_STR("); ")); ({ result = context_ctx_str5(ctx, result, SLOP_STR("slop_arena* "), c_arena_name, SLOP_STR(" = &"), context_ctx_str(ctx, c_local, SLOP_STR("; "))); (void)0; }); context_ctx_bind_var(ctx, (context_VarEntry){arena_name, c_arena_name, SLOP_STR("slop_arena*"), SLOP_STR(""), 1, 0, 0, SLOP_STR(""), SLOP_STR("")}); ({ __auto_type i = body_start; ({ while ((i < (len - 1))) { ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); if (_mv.has_value) { __auto_type body_expr = _mv.value; ({ __auto_type body_c = expr_transpile_expr(ctx, body_expr); ({ result = context_ctx_str3(ctx, result, body_c, SLOP_STR("; ")); (void)0; }); }); } else { ({ (void)0; }); } (void)0; }); ({ i = (i + 1); (void)0; }); } (void)0; }); }); ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)(len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); if (_mv.has_value) { __auto_type last_expr = _mv.value; ({ __auto_type last_c = expr_transpile_expr(ctx, last_expr); __auto_type free_part = context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), c_arena_name, SLOP_STR("); ")); ({ result = context_ctx_str5(ctx, result, SLOP_STR("__auto_type _wa_result = "), last_c, SLOP_STR("; "), free_part); (void)0; }); ({ result = context_ctx_str(ctx, result, SLOP_STR("_wa_result; })")); (void)0; }); }); } else { ({ __auto_type free_part = context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), c_arena_name, SLOP_STR("); ")); ({ result = context_ctx_str3(ctx, result, free_part, SLOP_STR("0; })")); (void)0; }); }); } (void)0; }); result; }); }) : (({ context_ctx_add_error_at(ctx, SLOP_STR("with-arena: missing size"), context_ctx_list_first_line(items), context_ctx_list_first_col(items)); SLOP_STR("({ (void)0; })"); })); });
                         context_ctx_pop_scope(ctx);
                         return result_str;
                     }
@@ -8938,7 +8939,14 @@ slop_string expr_find_arena_ptr_expr(context_TranspileContext* ctx) {
             __auto_type entry = _mv_542.value;
             return entry.c_name;
         } else if (!_mv_542.has_value) {
-            return SLOP_STR("");
+            __auto_type _mv_543 = context_ctx_find_arena_var(ctx);
+            if (_mv_543.has_value) {
+                __auto_type entry = _mv_543.value;
+                return entry.c_name;
+            } else if (!_mv_543.has_value) {
+                return SLOP_STR("");
+            }
+            SLOP_UNREACHABLE();
         }
         SLOP_UNREACHABLE();
     }
@@ -8969,9 +8977,9 @@ slop_string expr_build_env_initializer(context_TranspileContext* ctx, slop_list_
         __auto_type result = SLOP_STR("{ ");
         int64_t i = 0;
         while (i < count) {
-            __auto_type _mv_543 = ({ __auto_type _lst = free_vars; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_543.has_value) {
-                __auto_type var_name = _mv_543.value;
+            __auto_type _mv_544 = ({ __auto_type _lst = free_vars; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_544.has_value) {
+                __auto_type var_name = _mv_544.value;
                 {
                     __auto_type c_name = ctype_to_c_name(arena, var_name);
                     __auto_type access_expr = ({ __auto_type _mv = ({ __auto_type _lst = captured_accesses; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type acc = _mv.value; acc; }) : (c_name); });
@@ -8981,7 +8989,7 @@ slop_string expr_build_env_initializer(context_TranspileContext* ctx, slop_list_
                         result = context_ctx_str(ctx, result, context_ctx_str5(ctx, SLOP_STR("."), c_name, SLOP_STR(" = "), access_expr, SLOP_STR("")));
                     }
                 }
-            } else if (!_mv_543.has_value) {
+            } else if (!_mv_544.has_value) {
             }
             i = (i + 1);
         }
@@ -9001,28 +9009,28 @@ slop_string expr_build_lambda_params(context_TranspileContext* ctx, slop_list_ty
                 __auto_type result = SLOP_STR("(");
                 int64_t i = 0;
                 while (i < param_count) {
-                    __auto_type _mv_544 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_544.has_value) {
-                        __auto_type param_expr = _mv_544.value;
-                        __auto_type _mv_545 = (*param_expr);
-                        switch (_mv_545.tag) {
+                    __auto_type _mv_545 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_545.has_value) {
+                        __auto_type param_expr = _mv_545.value;
+                        __auto_type _mv_546 = (*param_expr);
+                        switch (_mv_546.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type param_lst = _mv_545.data.lst;
+                                __auto_type param_lst = _mv_546.data.lst;
                                 {
                                     __auto_type param_items = param_lst.items;
                                     if (((int64_t)((param_items).len)) >= 2) {
-                                        __auto_type _mv_546 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_546.has_value) {
-                                            __auto_type name_expr = _mv_546.value;
-                                            __auto_type _mv_547 = (*name_expr);
-                                            switch (_mv_547.tag) {
+                                        __auto_type _mv_547 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_547.has_value) {
+                                            __auto_type name_expr = _mv_547.value;
+                                            __auto_type _mv_548 = (*name_expr);
+                                            switch (_mv_548.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type name_sym = _mv_547.data.sym;
-                                                    __auto_type _mv_548 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_548.has_value) {
-                                                        __auto_type type_expr = _mv_548.value;
+                                                    __auto_type name_sym = _mv_548.data.sym;
+                                                    __auto_type _mv_549 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_549.has_value) {
+                                                        __auto_type type_expr = _mv_549.value;
                                                         {
                                                             __auto_type param_name = ctype_to_c_name(arena, name_sym.name);
                                                             __auto_type param_type = context_to_c_type_prefixed(ctx, type_expr);
@@ -9032,7 +9040,7 @@ slop_string expr_build_lambda_params(context_TranspileContext* ctx, slop_list_ty
                                                                 result = context_ctx_str(ctx, result, context_ctx_str4(ctx, param_type, SLOP_STR(" "), param_name, SLOP_STR("")));
                                                             }
                                                         }
-                                                    } else if (!_mv_548.has_value) {
+                                                    } else if (!_mv_549.has_value) {
                                                     }
                                                     break;
                                                 }
@@ -9040,7 +9048,7 @@ slop_string expr_build_lambda_params(context_TranspileContext* ctx, slop_list_ty
                                                     break;
                                                 }
                                             }
-                                        } else if (!_mv_546.has_value) {
+                                        } else if (!_mv_547.has_value) {
                                         }
                                     }
                                 }
@@ -9050,7 +9058,7 @@ slop_string expr_build_lambda_params(context_TranspileContext* ctx, slop_list_ty
                                 break;
                             }
                         }
-                    } else if (!_mv_544.has_value) {
+                    } else if (!_mv_545.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -9067,28 +9075,28 @@ void expr_bind_lambda_params(context_TranspileContext* ctx, slop_list_types_SExp
         __auto_type param_count = ((int64_t)((params).len));
         int64_t i = 0;
         while (i < param_count) {
-            __auto_type _mv_549 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_549.has_value) {
-                __auto_type param_expr = _mv_549.value;
-                __auto_type _mv_550 = (*param_expr);
-                switch (_mv_550.tag) {
+            __auto_type _mv_550 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_550.has_value) {
+                __auto_type param_expr = _mv_550.value;
+                __auto_type _mv_551 = (*param_expr);
+                switch (_mv_551.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type param_lst = _mv_550.data.lst;
+                        __auto_type param_lst = _mv_551.data.lst;
                         {
                             __auto_type param_items = param_lst.items;
                             if (((int64_t)((param_items).len)) >= 2) {
-                                __auto_type _mv_551 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_551.has_value) {
-                                    __auto_type name_expr = _mv_551.value;
-                                    __auto_type _mv_552 = (*name_expr);
-                                    switch (_mv_552.tag) {
+                                __auto_type _mv_552 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_552.has_value) {
+                                    __auto_type name_expr = _mv_552.value;
+                                    __auto_type _mv_553 = (*name_expr);
+                                    switch (_mv_553.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type name_sym = _mv_552.data.sym;
-                                            __auto_type _mv_553 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_553.has_value) {
-                                                __auto_type type_expr = _mv_553.value;
+                                            __auto_type name_sym = _mv_553.data.sym;
+                                            __auto_type _mv_554 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_554.has_value) {
+                                                __auto_type type_expr = _mv_554.value;
                                                 {
                                                     __auto_type param_name = name_sym.name;
                                                     __auto_type c_name = ctype_to_c_name(arena, param_name);
@@ -9096,7 +9104,7 @@ void expr_bind_lambda_params(context_TranspileContext* ctx, slop_list_types_SExp
                                                     __auto_type is_ptr = expr_is_pointer_type_sexpr(type_expr);
                                                     context_ctx_bind_var(ctx, (context_VarEntry){param_name, c_name, c_type, SLOP_STR(""), is_ptr, 0, 0, SLOP_STR(""), SLOP_STR("")});
                                                 }
-                                            } else if (!_mv_553.has_value) {
+                                            } else if (!_mv_554.has_value) {
                                             }
                                             break;
                                         }
@@ -9104,7 +9112,7 @@ void expr_bind_lambda_params(context_TranspileContext* ctx, slop_list_types_SExp
                                             break;
                                         }
                                     }
-                                } else if (!_mv_551.has_value) {
+                                } else if (!_mv_552.has_value) {
                                 }
                             }
                         }
@@ -9114,7 +9122,7 @@ void expr_bind_lambda_params(context_TranspileContext* ctx, slop_list_types_SExp
                         break;
                     }
                 }
-            } else if (!_mv_549.has_value) {
+            } else if (!_mv_550.has_value) {
             }
             i = (i + 1);
         }
@@ -9122,31 +9130,31 @@ void expr_bind_lambda_params(context_TranspileContext* ctx, slop_list_types_SExp
 }
 
 uint8_t expr_is_pointer_type_sexpr(types_SExpr* type_expr) {
-    __auto_type _mv_554 = (*type_expr);
-    switch (_mv_554.tag) {
+    __auto_type _mv_555 = (*type_expr);
+    switch (_mv_555.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_554.data.lst;
+            __auto_type lst = _mv_555.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_555 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_555.has_value) {
-                        __auto_type head = _mv_555.value;
-                        __auto_type _mv_556 = (*head);
-                        switch (_mv_556.tag) {
+                    __auto_type _mv_556 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_556.has_value) {
+                        __auto_type head = _mv_556.value;
+                        __auto_type _mv_557 = (*head);
+                        switch (_mv_557.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_556.data.sym;
+                                __auto_type sym = _mv_557.data.sym;
                                 return (string_eq(sym.name, SLOP_STR("Ptr")) || string_eq(sym.name, SLOP_STR("ScopedPtr")));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_555.has_value) {
+                    } else if (!_mv_556.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -9175,9 +9183,9 @@ slop_string expr_transpile_lambda_body(context_TranspileContext* ctx, slop_list_
             }
         } else {
             while (i < len) {
-                __auto_type _mv_557 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_557.has_value) {
-                    __auto_type expr = _mv_557.value;
+                __auto_type _mv_558 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_558.has_value) {
+                    __auto_type expr = _mv_558.value;
                     {
                         __auto_type expr_c = expr_transpile_expr(ctx, expr);
                         __auto_type is_last = (i == (len - 1));
@@ -9191,7 +9199,7 @@ slop_string expr_transpile_lambda_body(context_TranspileContext* ctx, slop_list_
                             result = context_ctx_str(ctx, result, context_ctx_str3(ctx, expr_c, SLOP_STR("; "), SLOP_STR("")));
                         }
                     }
-                } else if (!_mv_557.has_value) {
+                } else if (!_mv_558.has_value) {
                 }
                 i = (i + 1);
             }
@@ -9213,42 +9221,42 @@ slop_string expr_build_lambda_function(context_TranspileContext* ctx, slop_strin
 
 uint8_t expr_is_capturing_lambda(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_558 = (*expr);
-    switch (_mv_558.tag) {
+    __auto_type _mv_559 = (*expr);
+    switch (_mv_559.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_558.data.lst;
+            __auto_type lst = _mv_559.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return 0;
                 } else {
-                    __auto_type _mv_559 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_559.has_value) {
-                        __auto_type head = _mv_559.value;
-                        __auto_type _mv_560 = (*head);
-                        switch (_mv_560.tag) {
+                    __auto_type _mv_560 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_560.has_value) {
+                        __auto_type head = _mv_560.value;
+                        __auto_type _mv_561 = (*head);
+                        switch (_mv_561.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_560.data.sym;
+                                __auto_type sym = _mv_561.data.sym;
                                 if (!(string_eq(sym.name, SLOP_STR("fn")))) {
                                     return 0;
                                 } else {
-                                    __auto_type _mv_561 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_561.has_value) {
-                                        __auto_type second = _mv_561.value;
-                                        __auto_type _mv_562 = (*second);
-                                        switch (_mv_562.tag) {
+                                    __auto_type _mv_562 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_562.has_value) {
+                                        __auto_type second = _mv_562.value;
+                                        __auto_type _mv_563 = (*second);
+                                        switch (_mv_563.tag) {
                                             case types_SExpr_lst:
                                             {
-                                                __auto_type _ = _mv_562.data.lst;
+                                                __auto_type _ = _mv_563.data.lst;
                                                 return 1;
                                             }
                                             default: {
                                                 return 0;
                                             }
                                         }
-                                    } else if (!_mv_561.has_value) {
+                                    } else if (!_mv_562.has_value) {
                                         return 0;
                                     }
                                     SLOP_UNREACHABLE();
@@ -9258,7 +9266,7 @@ uint8_t expr_is_capturing_lambda(types_SExpr* expr) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_559.has_value) {
+                    } else if (!_mv_560.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -9276,9 +9284,9 @@ slop_string expr_transpile_spawn_closure(context_TranspileContext* ctx, slop_lis
     SLOP_PRE(((fn_expr != NULL)), "(!= fn-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_563 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_563.has_value) {
-            __auto_type arena_expr = _mv_563.value;
+        __auto_type _mv_564 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_564.has_value) {
+            __auto_type arena_expr = _mv_564.value;
             {
                 __auto_type arena_c = expr_transpile_expr(ctx, arena_expr);
                 __auto_type has_captures = expr_lambda_has_captures(ctx, fn_expr);
@@ -9291,7 +9299,7 @@ slop_string expr_transpile_spawn_closure(context_TranspileContext* ctx, slop_lis
                     return expr_transpile_regular_fn_call(ctx, SLOP_STR("spawn"), items);
                 }
             }
-        } else if (!_mv_563.has_value) {
+        } else if (!_mv_564.has_value) {
             context_ctx_add_error_at(ctx, SLOP_STR("spawn: missing arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             return SLOP_STR("NULL");
         }
@@ -9302,25 +9310,25 @@ slop_string expr_transpile_spawn_closure(context_TranspileContext* ctx, slop_lis
 uint8_t expr_lambda_has_captures(context_TranspileContext* ctx, types_SExpr* fn_expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((fn_expr != NULL)), "(!= fn-expr nil)");
-    __auto_type _mv_564 = (*fn_expr);
-    switch (_mv_564.tag) {
+    __auto_type _mv_565 = (*fn_expr);
+    switch (_mv_565.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_564.data.lst;
+            __auto_type lst = _mv_565.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type arena = (*ctx).arena;
                 if (((int64_t)((items).len)) < 2) {
                     return 0;
                 } else {
-                    __auto_type _mv_565 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_565.has_value) {
-                        __auto_type params_expr = _mv_565.value;
-                        __auto_type _mv_566 = (*params_expr);
-                        switch (_mv_566.tag) {
+                    __auto_type _mv_566 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_566.has_value) {
+                        __auto_type params_expr = _mv_566.value;
+                        __auto_type _mv_567 = (*params_expr);
+                        switch (_mv_567.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type params_lst = _mv_566.data.lst;
+                                __auto_type params_lst = _mv_567.data.lst;
                                 {
                                     __auto_type params = params_lst.items;
                                     __auto_type param_names = expr_extract_param_names(arena, params);
@@ -9333,7 +9341,7 @@ uint8_t expr_lambda_has_captures(context_TranspileContext* ctx, types_SExpr* fn_
                                 return 0;
                             }
                         }
-                    } else if (!_mv_565.has_value) {
+                    } else if (!_mv_566.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -9356,9 +9364,9 @@ slop_string expr_transpile_regular_fn_call(context_TranspileContext* ctx, slop_s
         int64_t i = 1;
         int64_t param_idx = 0;
         while (i < len) {
-            __auto_type _mv_567 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_567.has_value) {
-                __auto_type arg = _mv_567.value;
+            __auto_type _mv_568 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_568.has_value) {
+                __auto_type arg = _mv_568.value;
                 {
                     __auto_type arg_c = expr_transpile_expr(ctx, arg);
                     __auto_type expected_type = ({ __auto_type _mv = func_opt; _mv.has_value ? ({ __auto_type func_entry = _mv.value; ({ __auto_type _mv = ({ __auto_type _lst = func_entry.param_types; size_t _idx = (size_t)param_idx; slop_option_context_FuncParamType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type p = _mv.value; (*p).c_type; }) : (SLOP_STR("")); }); }) : (SLOP_STR("")); });
@@ -9370,7 +9378,7 @@ slop_string expr_transpile_regular_fn_call(context_TranspileContext* ctx, slop_s
                     }
                     param_idx = (param_idx + 1);
                 }
-            } else if (!_mv_567.has_value) {
+            } else if (!_mv_568.has_value) {
             }
             i = (i + 1);
         }
@@ -9385,9 +9393,9 @@ slop_string expr_infer_generic_type_binding(context_TranspileContext* ctx, slop_
         if (((int64_t)((items).len)) < 2) {
             return SLOP_STR("");
         } else {
-            __auto_type _mv_568 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_568.has_value) {
-                __auto_type first_arg = _mv_568.value;
+            __auto_type _mv_569 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_569.has_value) {
+                __auto_type first_arg = _mv_569.value;
                 {
                     __auto_type slop_type = expr_infer_expr_slop_type(ctx, first_arg);
                     if (string_eq(slop_type, SLOP_STR(""))) {
@@ -9399,7 +9407,7 @@ slop_string expr_infer_generic_type_binding(context_TranspileContext* ctx, slop_
                         return expr_extract_type_binding_from_slop_type(arena, slop_type);
                     }
                 }
-            } else if (!_mv_568.has_value) {
+            } else if (!_mv_569.has_value) {
                 return SLOP_STR("");
             }
             SLOP_UNREACHABLE();
@@ -9538,11 +9546,11 @@ slop_list_string expr_find_free_vars(context_TranspileContext* ctx, slop_list_st
         __auto_type len = ((int64_t)((body_items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_569 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_569.has_value) {
-                __auto_type expr = _mv_569.value;
+            __auto_type _mv_570 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_570.has_value) {
+                __auto_type expr = _mv_570.value;
                 expr_collect_symbols_in_expr(ctx, (&all_symbols), pending, expr);
-            } else if (!_mv_569.has_value) {
+            } else if (!_mv_570.has_value) {
             }
             i = (i + 1);
         }
@@ -9550,15 +9558,15 @@ slop_list_string expr_find_free_vars(context_TranspileContext* ctx, slop_list_st
             __auto_type sym_count = ((int64_t)((all_symbols).len));
             int64_t j = 0;
             while (j < sym_count) {
-                __auto_type _mv_570 = ({ __auto_type _lst = all_symbols; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_570.has_value) {
-                    __auto_type sym_name = _mv_570.value;
+                __auto_type _mv_571 = ({ __auto_type _lst = all_symbols; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_571.has_value) {
+                    __auto_type sym_name = _mv_571.value;
                     if (expr_is_free_var(ctx, param_names, pending, sym_name)) {
                         if (!(expr_list_contains_string(free_vars, sym_name))) {
                             ({ __auto_type _lst_p = &(free_vars); __auto_type _item = (sym_name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                         }
                     }
-                } else if (!_mv_570.has_value) {
+                } else if (!_mv_571.has_value) {
                 }
                 j = (j + 1);
             }
@@ -9570,11 +9578,11 @@ slop_list_string expr_find_free_vars(context_TranspileContext* ctx, slop_list_st
 void expr_collect_symbols_in_expr(context_TranspileContext* ctx, slop_list_string* symbols, slop_list_string pending, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_571 = (*expr);
-    switch (_mv_571.tag) {
+    __auto_type _mv_572 = (*expr);
+    switch (_mv_572.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_571.data.sym;
+            __auto_type sym = _mv_572.data.sym;
             {
                 __auto_type name = sym.name;
                 if (!(expr_is_special_keyword(name)) && !(expr_list_contains_string(pending, name))) {
@@ -9585,19 +9593,19 @@ void expr_collect_symbols_in_expr(context_TranspileContext* ctx, slop_list_strin
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_571.data.lst;
+            __auto_type lst = _mv_572.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 if (len > 0) {
-                    __auto_type _mv_572 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_572.has_value) {
-                        __auto_type head = _mv_572.value;
-                        __auto_type _mv_573 = (*head);
-                        switch (_mv_573.tag) {
+                    __auto_type _mv_573 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_573.has_value) {
+                        __auto_type head = _mv_573.value;
+                        __auto_type _mv_574 = (*head);
+                        switch (_mv_574.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type head_sym = _mv_573.data.sym;
+                                __auto_type head_sym = _mv_574.data.sym;
                                 {
                                     __auto_type op = head_sym.name;
                                     if (string_eq(op, SLOP_STR("let"))) {
@@ -9621,7 +9629,7 @@ void expr_collect_symbols_in_expr(context_TranspileContext* ctx, slop_list_strin
                                 break;
                             }
                         }
-                    } else if (!_mv_572.has_value) {
+                    } else if (!_mv_573.has_value) {
                     }
                 }
             }
@@ -9639,11 +9647,11 @@ void expr_collect_symbols_in_list(context_TranspileContext* ctx, slop_list_strin
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_574 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_574.has_value) {
-                __auto_type item = _mv_574.value;
+            __auto_type _mv_575 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_575.has_value) {
+                __auto_type item = _mv_575.value;
                 expr_collect_symbols_in_expr(ctx, symbols, pending, item);
-            } else if (!_mv_574.has_value) {
+            } else if (!_mv_575.has_value) {
             }
             i = (i + 1);
         }
@@ -9656,40 +9664,40 @@ void expr_collect_symbols_in_let(context_TranspileContext* ctx, slop_list_string
         __auto_type arena = (*ctx).arena;
         __auto_type len = ((int64_t)((items).len));
         if (len >= 2) {
-            __auto_type _mv_575 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_575.has_value) {
-                __auto_type bindings_expr = _mv_575.value;
+            __auto_type _mv_576 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_576.has_value) {
+                __auto_type bindings_expr = _mv_576.value;
                 {
                     __auto_type new_names = expr_extract_let_binding_names(arena, bindings_expr);
                     __auto_type updated_pending = expr_list_concat(arena, pending, new_names);
-                    __auto_type _mv_576 = (*bindings_expr);
-                    switch (_mv_576.tag) {
+                    __auto_type _mv_577 = (*bindings_expr);
+                    switch (_mv_577.tag) {
                         case types_SExpr_lst:
                         {
-                            __auto_type bindings_lst = _mv_576.data.lst;
+                            __auto_type bindings_lst = _mv_577.data.lst;
                             {
                                 __auto_type bindings = bindings_lst.items;
                                 __auto_type binding_count = ((int64_t)((bindings).len));
                                 __auto_type i = 0;
                                 while (i < binding_count) {
-                                    __auto_type _mv_577 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_577.has_value) {
-                                        __auto_type binding = _mv_577.value;
-                                        __auto_type _mv_578 = (*binding);
-                                        switch (_mv_578.tag) {
+                                    __auto_type _mv_578 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_578.has_value) {
+                                        __auto_type binding = _mv_578.value;
+                                        __auto_type _mv_579 = (*binding);
+                                        switch (_mv_579.tag) {
                                             case types_SExpr_lst:
                                             {
-                                                __auto_type bind_lst = _mv_578.data.lst;
+                                                __auto_type bind_lst = _mv_579.data.lst;
                                                 {
                                                     __auto_type bind_items = bind_lst.items;
                                                     if (((int64_t)((bind_items).len)) >= 2) {
                                                         {
                                                             __auto_type val_idx = ((expr_is_mut_binding(bind_items)) ? 2 : 1);
-                                                            __auto_type _mv_579 = ({ __auto_type _lst = bind_items; size_t _idx = (size_t)val_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                            if (_mv_579.has_value) {
-                                                                __auto_type val_expr = _mv_579.value;
+                                                            __auto_type _mv_580 = ({ __auto_type _lst = bind_items; size_t _idx = (size_t)val_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                            if (_mv_580.has_value) {
+                                                                __auto_type val_expr = _mv_580.value;
                                                                 expr_collect_symbols_in_expr(ctx, symbols, pending, val_expr);
-                                                            } else if (!_mv_579.has_value) {
+                                                            } else if (!_mv_580.has_value) {
                                                             }
                                                         }
                                                     }
@@ -9700,7 +9708,7 @@ void expr_collect_symbols_in_let(context_TranspileContext* ctx, slop_list_string
                                                 break;
                                             }
                                         }
-                                    } else if (!_mv_577.has_value) {
+                                    } else if (!_mv_578.has_value) {
                                     }
                                     i = (i + 1);
                                 }
@@ -9713,7 +9721,7 @@ void expr_collect_symbols_in_let(context_TranspileContext* ctx, slop_list_string
                     }
                     expr_collect_symbols_in_list(ctx, symbols, updated_pending, items, 2);
                 }
-            } else if (!_mv_575.has_value) {
+            } else if (!_mv_576.has_value) {
             }
         }
     }
@@ -9723,21 +9731,21 @@ uint8_t expr_is_mut_binding(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_580 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_580.has_value) {
-            __auto_type first = _mv_580.value;
-            __auto_type _mv_581 = (*first);
-            switch (_mv_581.tag) {
+        __auto_type _mv_581 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_581.has_value) {
+            __auto_type first = _mv_581.value;
+            __auto_type _mv_582 = (*first);
+            switch (_mv_582.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_581.data.sym;
+                    __auto_type sym = _mv_582.data.sym;
                     return string_eq(sym.name, SLOP_STR("mut"));
                 }
                 default: {
                     return 0;
                 }
             }
-        } else if (!_mv_580.has_value) {
+        } else if (!_mv_581.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -9748,37 +9756,37 @@ slop_list_string expr_extract_let_binding_names(slop_arena* arena, types_SExpr* 
     SLOP_PRE(((bindings_expr != NULL)), "(!= bindings-expr nil)");
     {
         __auto_type names = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
-        __auto_type _mv_582 = (*bindings_expr);
-        switch (_mv_582.tag) {
+        __auto_type _mv_583 = (*bindings_expr);
+        switch (_mv_583.tag) {
             case types_SExpr_lst:
             {
-                __auto_type bindings_lst = _mv_582.data.lst;
+                __auto_type bindings_lst = _mv_583.data.lst;
                 {
                     __auto_type bindings = bindings_lst.items;
                     __auto_type binding_count = ((int64_t)((bindings).len));
                     __auto_type i = 0;
                     while (i < binding_count) {
-                        __auto_type _mv_583 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_583.has_value) {
-                            __auto_type binding = _mv_583.value;
-                            __auto_type _mv_584 = (*binding);
-                            switch (_mv_584.tag) {
+                        __auto_type _mv_584 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_584.has_value) {
+                            __auto_type binding = _mv_584.value;
+                            __auto_type _mv_585 = (*binding);
+                            switch (_mv_585.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type bind_lst = _mv_584.data.lst;
+                                    __auto_type bind_lst = _mv_585.data.lst;
                                     {
                                         __auto_type bind_items = bind_lst.items;
                                         if (((int64_t)((bind_items).len)) >= 1) {
                                             {
                                                 __auto_type name_idx = ((expr_is_mut_binding(bind_items)) ? 1 : 0);
-                                                __auto_type _mv_585 = ({ __auto_type _lst = bind_items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_585.has_value) {
-                                                    __auto_type name_expr = _mv_585.value;
-                                                    __auto_type _mv_586 = (*name_expr);
-                                                    switch (_mv_586.tag) {
+                                                __auto_type _mv_586 = ({ __auto_type _lst = bind_items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_586.has_value) {
+                                                    __auto_type name_expr = _mv_586.value;
+                                                    __auto_type _mv_587 = (*name_expr);
+                                                    switch (_mv_587.tag) {
                                                         case types_SExpr_sym:
                                                         {
-                                                            __auto_type sym = _mv_586.data.sym;
+                                                            __auto_type sym = _mv_587.data.sym;
                                                             ({ __auto_type _lst_p = &(names); __auto_type _item = (sym.name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                             break;
                                                         }
@@ -9786,7 +9794,7 @@ slop_list_string expr_extract_let_binding_names(slop_arena* arena, types_SExpr* 
                                                             break;
                                                         }
                                                     }
-                                                } else if (!_mv_585.has_value) {
+                                                } else if (!_mv_586.has_value) {
                                                 }
                                             }
                                         }
@@ -9797,7 +9805,7 @@ slop_list_string expr_extract_let_binding_names(slop_arena* arena, types_SExpr* 
                                     break;
                                 }
                             }
-                        } else if (!_mv_583.has_value) {
+                        } else if (!_mv_584.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -9817,23 +9825,23 @@ void expr_collect_symbols_in_match(context_TranspileContext* ctx, slop_list_stri
     {
         __auto_type len = ((int64_t)((items).len));
         if (len >= 2) {
-            __auto_type _mv_587 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_587.has_value) {
-                __auto_type scrutinee = _mv_587.value;
+            __auto_type _mv_588 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_588.has_value) {
+                __auto_type scrutinee = _mv_588.value;
                 expr_collect_symbols_in_expr(ctx, symbols, pending, scrutinee);
-            } else if (!_mv_587.has_value) {
+            } else if (!_mv_588.has_value) {
             }
             {
                 int64_t i = 2;
                 while (i < len) {
-                    __auto_type _mv_588 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_588.has_value) {
-                        __auto_type clause = _mv_588.value;
-                        __auto_type _mv_589 = (*clause);
-                        switch (_mv_589.tag) {
+                    __auto_type _mv_589 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_589.has_value) {
+                        __auto_type clause = _mv_589.value;
+                        __auto_type _mv_590 = (*clause);
+                        switch (_mv_590.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type clause_lst = _mv_589.data.lst;
+                                __auto_type clause_lst = _mv_590.data.lst;
                                 {
                                     __auto_type clause_items = clause_lst.items;
                                     expr_collect_symbols_in_list(ctx, symbols, pending, clause_items, 1);
@@ -9844,7 +9852,7 @@ void expr_collect_symbols_in_match(context_TranspileContext* ctx, slop_list_stri
                                 break;
                             }
                         }
-                    } else if (!_mv_588.has_value) {
+                    } else if (!_mv_589.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -9859,14 +9867,14 @@ void expr_collect_symbols_in_for(context_TranspileContext* ctx, slop_list_string
         __auto_type arena = (*ctx).arena;
         __auto_type len = ((int64_t)((items).len));
         if (len >= 2) {
-            __auto_type _mv_590 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_590.has_value) {
-                __auto_type binding = _mv_590.value;
-                __auto_type _mv_591 = (*binding);
-                switch (_mv_591.tag) {
+            __auto_type _mv_591 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_591.has_value) {
+                __auto_type binding = _mv_591.value;
+                __auto_type _mv_592 = (*binding);
+                switch (_mv_592.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type bind_lst = _mv_591.data.lst;
+                        __auto_type bind_lst = _mv_592.data.lst;
                         {
                             __auto_type bind_items = bind_lst.items;
                             expr_collect_symbols_in_list(ctx, symbols, pending, bind_items, 1);
@@ -9881,7 +9889,7 @@ void expr_collect_symbols_in_for(context_TranspileContext* ctx, slop_list_string
                         break;
                     }
                 }
-            } else if (!_mv_590.has_value) {
+            } else if (!_mv_591.has_value) {
             }
         }
     }
@@ -9891,25 +9899,25 @@ slop_list_string expr_extract_for_loop_var_pending(slop_arena* arena, slop_list_
     if (((int64_t)((bind_items).len)) < 1) {
         return pending;
     } else {
-        __auto_type _mv_592 = ({ __auto_type _lst = bind_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_592.has_value) {
-            __auto_type var_expr = _mv_592.value;
-            __auto_type _mv_593 = (*var_expr);
-            switch (_mv_593.tag) {
+        __auto_type _mv_593 = ({ __auto_type _lst = bind_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_593.has_value) {
+            __auto_type var_expr = _mv_593.value;
+            __auto_type _mv_594 = (*var_expr);
+            switch (_mv_594.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type var_sym = _mv_593.data.sym;
+                    __auto_type var_sym = _mv_594.data.sym;
                     {
                         __auto_type result = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
                         __auto_type var_name = var_sym.name;
                         __auto_type plen = ((int64_t)((pending).len));
                         __auto_type i = 0;
                         while (i < plen) {
-                            __auto_type _mv_594 = ({ __auto_type _lst = pending; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_594.has_value) {
-                                __auto_type s = _mv_594.value;
+                            __auto_type _mv_595 = ({ __auto_type _lst = pending; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_595.has_value) {
+                                __auto_type s = _mv_595.value;
                                 ({ __auto_type _lst_p = &(result); __auto_type _item = (s); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                            } else if (!_mv_594.has_value) {
+                            } else if (!_mv_595.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -9921,7 +9929,7 @@ slop_list_string expr_extract_for_loop_var_pending(slop_arena* arena, slop_list_
                     return pending;
                 }
             }
-        } else if (!_mv_592.has_value) {
+        } else if (!_mv_593.has_value) {
             return pending;
         }
         SLOP_UNREACHABLE();
@@ -9939,11 +9947,11 @@ void expr_collect_symbols_in_with_arena(context_TranspileContext* ctx, slop_list
                 __auto_type arena_name = ((is_named) ? ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type name_expr = _mv.value; ({ __auto_type _mv = (*name_expr); slop_string _mr = {0}; switch (_mv.tag) { case types_SExpr_sym: { __auto_type s2 = _mv.data.sym; _mr = s2.name; break; } default: { _mr = SLOP_STR("arena"); break; }  } _mr; }); }) : (SLOP_STR("arena")); }) : SLOP_STR("arena"));
                 __auto_type size_idx = ((is_named) ? 3 : 1);
                 __auto_type body_start = ((is_named) ? 4 : 2);
-                __auto_type _mv_595 = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_595.has_value) {
-                    __auto_type size_expr = _mv_595.value;
+                __auto_type _mv_596 = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_596.has_value) {
+                    __auto_type size_expr = _mv_596.value;
                     expr_collect_symbols_in_expr(ctx, symbols, pending, size_expr);
-                } else if (!_mv_595.has_value) {
+                } else if (!_mv_596.has_value) {
                 }
                 {
                     __auto_type updated_pending = expr_list_concat(arena, pending, ({ __auto_type tmp = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 }); ({ __auto_type _lst_p = &(tmp); __auto_type _item = (arena_name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; }); tmp; }));
@@ -9960,14 +9968,14 @@ void expr_collect_nested_lambda_free_vars(context_TranspileContext* ctx, slop_li
         __auto_type arena = (*ctx).arena;
         __auto_type len = ((int64_t)((items).len));
         if (len >= 2) {
-            __auto_type _mv_596 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_596.has_value) {
-                __auto_type params_expr = _mv_596.value;
-                __auto_type _mv_597 = (*params_expr);
-                switch (_mv_597.tag) {
+            __auto_type _mv_597 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_597.has_value) {
+                __auto_type params_expr = _mv_597.value;
+                __auto_type _mv_598 = (*params_expr);
+                switch (_mv_598.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type params_lst = _mv_597.data.lst;
+                        __auto_type params_lst = _mv_598.data.lst;
                         {
                             __auto_type params = params_lst.items;
                             __auto_type param_names = expr_extract_param_names(arena, params);
@@ -9980,7 +9988,7 @@ void expr_collect_nested_lambda_free_vars(context_TranspileContext* ctx, slop_li
                         break;
                     }
                 }
-            } else if (!_mv_596.has_value) {
+            } else if (!_mv_597.has_value) {
             }
         }
     }
@@ -10001,21 +10009,21 @@ uint8_t expr_is_free_var(context_TranspileContext* ctx, slop_list_string param_n
             if (expr_is_builtin_op(sym_name)) {
                 return 0;
             } else {
-                __auto_type _mv_598 = context_ctx_lookup_func(ctx, sym_name);
-                if (_mv_598.has_value) {
-                    __auto_type _ = _mv_598.value;
+                __auto_type _mv_599 = context_ctx_lookup_func(ctx, sym_name);
+                if (_mv_599.has_value) {
+                    __auto_type _ = _mv_599.value;
                     return 0;
-                } else if (!_mv_598.has_value) {
-                    __auto_type _mv_599 = context_ctx_lookup_type(ctx, sym_name);
-                    if (_mv_599.has_value) {
-                        __auto_type _ = _mv_599.value;
+                } else if (!_mv_599.has_value) {
+                    __auto_type _mv_600 = context_ctx_lookup_type(ctx, sym_name);
+                    if (_mv_600.has_value) {
+                        __auto_type _ = _mv_600.value;
                         return 0;
-                    } else if (!_mv_599.has_value) {
-                        __auto_type _mv_600 = context_ctx_lookup_var(ctx, sym_name);
-                        if (_mv_600.has_value) {
-                            __auto_type _ = _mv_600.value;
+                    } else if (!_mv_600.has_value) {
+                        __auto_type _mv_601 = context_ctx_lookup_var(ctx, sym_name);
+                        if (_mv_601.has_value) {
+                            __auto_type _ = _mv_601.value;
                             return 1;
-                        } else if (!_mv_600.has_value) {
+                        } else if (!_mv_601.has_value) {
                             return 0;
                         }
                         SLOP_UNREACHABLE();
@@ -10038,13 +10046,13 @@ uint8_t expr_list_contains_string(slop_list_string lst, slop_string needle) {
         int64_t i = 0;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_601 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_601.has_value) {
-                __auto_type s = _mv_601.value;
+            __auto_type _mv_602 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_602.has_value) {
+                __auto_type s = _mv_602.value;
                 if (string_eq(s, needle)) {
                     found = 1;
                 }
-            } else if (!_mv_601.has_value) {
+            } else if (!_mv_602.has_value) {
             }
             i = (i + 1);
         }
@@ -10059,21 +10067,21 @@ slop_list_string expr_list_concat(slop_arena* arena, slop_list_string a, slop_li
         __auto_type len_b = ((int64_t)((b).len));
         int64_t i = 0;
         while (i < len_a) {
-            __auto_type _mv_602 = ({ __auto_type _lst = a; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_602.has_value) {
-                __auto_type s = _mv_602.value;
+            __auto_type _mv_603 = ({ __auto_type _lst = a; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_603.has_value) {
+                __auto_type s = _mv_603.value;
                 ({ __auto_type _lst_p = &(result); __auto_type _item = (s); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-            } else if (!_mv_602.has_value) {
+            } else if (!_mv_603.has_value) {
             }
             i = (i + 1);
         }
         i = 0;
         while (i < len_b) {
-            __auto_type _mv_603 = ({ __auto_type _lst = b; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_603.has_value) {
-                __auto_type s = _mv_603.value;
+            __auto_type _mv_604 = ({ __auto_type _lst = b; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_604.has_value) {
+                __auto_type s = _mv_604.value;
                 ({ __auto_type _lst_p = &(result); __auto_type _item = (s); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-            } else if (!_mv_603.has_value) {
+            } else if (!_mv_604.has_value) {
             }
             i = (i + 1);
         }
@@ -10166,33 +10174,33 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
     SLOP_PRE(((coll_expr != NULL)), "(!= coll-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_604 = (*coll_expr);
-        switch (_mv_604.tag) {
+        __auto_type _mv_605 = (*coll_expr);
+        switch (_mv_605.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_604.data.lst;
+                __auto_type lst = _mv_605.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 1) {
                         return SLOP_STR("");
                     } else {
-                        __auto_type _mv_605 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_605.has_value) {
-                            __auto_type head = _mv_605.value;
-                            __auto_type _mv_606 = (*head);
-                            switch (_mv_606.tag) {
+                        __auto_type _mv_606 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_606.has_value) {
+                            __auto_type head = _mv_606.value;
+                            __auto_type _mv_607 = (*head);
+                            switch (_mv_607.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_606.data.sym;
+                                    __auto_type sym = _mv_607.data.sym;
                                     {
                                         __auto_type op = sym.name;
                                         if (string_eq(op, SLOP_STR("map-keys"))) {
                                             if (((int64_t)((items).len)) < 2) {
                                                 return SLOP_STR("");
                                             } else {
-                                                __auto_type _mv_607 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_607.has_value) {
-                                                    __auto_type map_expr = _mv_607.value;
+                                                __auto_type _mv_608 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_608.has_value) {
+                                                    __auto_type map_expr = _mv_608.value;
                                                     {
                                                         __auto_type map_slop_type = expr_infer_expr_slop_type(ctx, map_expr);
                                                         if (string_len(map_slop_type) > 0) {
@@ -10204,7 +10212,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                                             return SLOP_STR("");
                                                         }
                                                     }
-                                                } else if (!_mv_607.has_value) {
+                                                } else if (!_mv_608.has_value) {
                                                     return SLOP_STR("");
                                                 }
                                                 SLOP_UNREACHABLE();
@@ -10213,9 +10221,9 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                             if (((int64_t)((items).len)) < 2) {
                                                 return SLOP_STR("");
                                             } else {
-                                                __auto_type _mv_608 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_608.has_value) {
-                                                    __auto_type set_expr = _mv_608.value;
+                                                __auto_type _mv_609 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_609.has_value) {
+                                                    __auto_type set_expr = _mv_609.value;
                                                     {
                                                         __auto_type set_slop_type = expr_infer_expr_slop_type(ctx, set_expr);
                                                         if (string_len(set_slop_type) > 0) {
@@ -10227,7 +10235,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                                             return SLOP_STR("");
                                                         }
                                                     }
-                                                } else if (!_mv_608.has_value) {
+                                                } else if (!_mv_609.has_value) {
                                                     return SLOP_STR("");
                                                 }
                                                 SLOP_UNREACHABLE();
@@ -10236,9 +10244,9 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                             if (((int64_t)((items).len)) < 2) {
                                                 return SLOP_STR("");
                                             } else {
-                                                __auto_type _mv_609 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_609.has_value) {
-                                                    __auto_type map_expr = _mv_609.value;
+                                                __auto_type _mv_610 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_610.has_value) {
+                                                    __auto_type map_expr = _mv_610.value;
                                                     {
                                                         __auto_type map_slop_type = expr_infer_expr_slop_type(ctx, map_expr);
                                                         if (string_len(map_slop_type) > 0) {
@@ -10250,7 +10258,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                                             return SLOP_STR("");
                                                         }
                                                     }
-                                                } else if (!_mv_609.has_value) {
+                                                } else if (!_mv_610.has_value) {
                                                     return SLOP_STR("");
                                                 }
                                                 SLOP_UNREACHABLE();
@@ -10264,7 +10272,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                     return expr_infer_elem_from_type(ctx, coll_expr);
                                 }
                             }
-                        } else if (!_mv_605.has_value) {
+                        } else if (!_mv_606.has_value) {
                             return SLOP_STR("");
                         }
                         SLOP_UNREACHABLE();

--- a/bootstrap/tester/slop_extract.c
+++ b/bootstrap/tester/slop_extract.c
@@ -27,28 +27,6 @@ int64_t extract_find_arrow_separator(slop_list_types_SExpr_ptr items) {
         int64_t i = 0;
         int64_t found = -1;
         while ((i < len) && (found == -1)) {
-            __auto_type _mv_1509 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1509.has_value) {
-                __auto_type item = _mv_1509.value;
-                if (parser_sexpr_is_symbol(item)) {
-                    if (string_eq(parser_sexpr_get_symbol_name(item), SLOP_STR("->"))) {
-                        found = i;
-                    }
-                }
-            } else if (!_mv_1509.has_value) {
-            }
-            i = (i + 1);
-        }
-        return found;
-    }
-}
-
-int64_t extract_find_arrow_separator_from(slop_list_types_SExpr_ptr items, int64_t start) {
-    {
-        __auto_type len = ((int64_t)((items).len));
-        int64_t i = start;
-        int64_t found = -1;
-        while ((i < len) && (found == -1)) {
             __auto_type _mv_1510 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_1510.has_value) {
                 __auto_type item = _mv_1510.value;
@@ -65,6 +43,28 @@ int64_t extract_find_arrow_separator_from(slop_list_types_SExpr_ptr items, int64
     }
 }
 
+int64_t extract_find_arrow_separator_from(slop_list_types_SExpr_ptr items, int64_t start) {
+    {
+        __auto_type len = ((int64_t)((items).len));
+        int64_t i = start;
+        int64_t found = -1;
+        while ((i < len) && (found == -1)) {
+            __auto_type _mv_1511 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1511.has_value) {
+                __auto_type item = _mv_1511.value;
+                if (parser_sexpr_is_symbol(item)) {
+                    if (string_eq(parser_sexpr_get_symbol_name(item), SLOP_STR("->"))) {
+                        found = i;
+                    }
+                }
+            } else if (!_mv_1511.has_value) {
+            }
+            i = (i + 1);
+        }
+        return found;
+    }
+}
+
 int64_t extract_detect_arena_param(types_SExpr* params) {
     if (!(parser_sexpr_is_symbol(params))) {
         {
@@ -72,38 +72,38 @@ int64_t extract_detect_arena_param(types_SExpr* params) {
             int64_t i = 0;
             int64_t found = -1;
             while ((i < len) && (found == -1)) {
-                __auto_type _mv_1511 = parser_sexpr_list_get(params, i);
-                if (_mv_1511.has_value) {
-                    __auto_type param = _mv_1511.value;
+                __auto_type _mv_1512 = parser_sexpr_list_get(params, i);
+                if (_mv_1512.has_value) {
+                    __auto_type param = _mv_1512.value;
                     {
                         __auto_type plen = parser_sexpr_list_len(param);
                         if (plen >= 2) {
                             {
                                 __auto_type type_pos = (((plen == 2)) ? 1 : 2);
                                 __auto_type name_pos = (((plen == 2)) ? 0 : 1);
-                                __auto_type _mv_1512 = parser_sexpr_list_get(param, name_pos);
-                                if (_mv_1512.has_value) {
-                                    __auto_type name_expr = _mv_1512.value;
+                                __auto_type _mv_1513 = parser_sexpr_list_get(param, name_pos);
+                                if (_mv_1513.has_value) {
+                                    __auto_type name_expr = _mv_1513.value;
                                     if (parser_sexpr_is_symbol(name_expr)) {
                                         if (string_eq(parser_sexpr_get_symbol_name(name_expr), SLOP_STR("arena"))) {
-                                            __auto_type _mv_1513 = parser_sexpr_list_get(param, type_pos);
-                                            if (_mv_1513.has_value) {
-                                                __auto_type type_expr = _mv_1513.value;
+                                            __auto_type _mv_1514 = parser_sexpr_list_get(param, type_pos);
+                                            if (_mv_1514.has_value) {
+                                                __auto_type type_expr = _mv_1514.value;
                                                 if (parser_sexpr_is_symbol(type_expr)) {
                                                     if (string_eq(parser_sexpr_get_symbol_name(type_expr), SLOP_STR("Arena"))) {
                                                         found = i;
                                                     }
                                                 }
-                                            } else if (!_mv_1513.has_value) {
+                                            } else if (!_mv_1514.has_value) {
                                             }
                                         }
                                     }
-                                } else if (!_mv_1512.has_value) {
+                                } else if (!_mv_1513.has_value) {
                                 }
                             }
                         }
                     }
-                } else if (!_mv_1511.has_value) {
+                } else if (!_mv_1512.has_value) {
                 }
                 i = (i + 1);
             }
@@ -118,25 +118,25 @@ slop_option_string extract_extract_return_type(slop_arena* arena, types_SExpr* s
     if (parser_sexpr_list_len(spec_form) < 2) {
         return (slop_option_string){.has_value = false};
     } else {
-        __auto_type _mv_1514 = parser_sexpr_list_get(spec_form, 1);
-        if (_mv_1514.has_value) {
-            __auto_type sig = _mv_1514.value;
+        __auto_type _mv_1515 = parser_sexpr_list_get(spec_form, 1);
+        if (_mv_1515.has_value) {
+            __auto_type sig = _mv_1515.value;
             {
                 __auto_type sig_len = parser_sexpr_list_len(sig);
                 if (sig_len < 3) {
                     return (slop_option_string){.has_value = false};
                 } else {
-                    __auto_type _mv_1515 = parser_sexpr_list_get(sig, (sig_len - 1));
-                    if (_mv_1515.has_value) {
-                        __auto_type ret_type = _mv_1515.value;
+                    __auto_type _mv_1516 = parser_sexpr_list_get(sig, (sig_len - 1));
+                    if (_mv_1516.has_value) {
+                        __auto_type ret_type = _mv_1516.value;
                         return (slop_option_string){.has_value = 1, .value = parser_pretty_print(arena, ret_type)};
-                    } else if (!_mv_1515.has_value) {
+                    } else if (!_mv_1516.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
                     SLOP_UNREACHABLE();
                 }
             }
-        } else if (!_mv_1514.has_value) {
+        } else if (!_mv_1515.has_value) {
             return (slop_option_string){.has_value = false};
         }
         SLOP_UNREACHABLE();
@@ -150,20 +150,20 @@ slop_list_types_SExpr_ptr extract_collect_preconditions(slop_arena* arena, types
         __auto_type form_len = parser_sexpr_list_len(fn_form);
         int64_t i = 3;
         while (i < form_len) {
-            __auto_type _mv_1516 = parser_sexpr_list_get(fn_form, i);
-            if (_mv_1516.has_value) {
-                __auto_type item = _mv_1516.value;
+            __auto_type _mv_1517 = parser_sexpr_list_get(fn_form, i);
+            if (_mv_1517.has_value) {
+                __auto_type item = _mv_1517.value;
                 if (parser_is_form(item, SLOP_STR("@pre"))) {
                     if (parser_sexpr_list_len(item) >= 2) {
-                        __auto_type _mv_1517 = parser_sexpr_list_get(item, 1);
-                        if (_mv_1517.has_value) {
-                            __auto_type cond_expr = _mv_1517.value;
+                        __auto_type _mv_1518 = parser_sexpr_list_get(item, 1);
+                        if (_mv_1518.has_value) {
+                            __auto_type cond_expr = _mv_1518.value;
                             ({ __auto_type _lst_p = &(result); __auto_type _item = (cond_expr); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                        } else if (!_mv_1517.has_value) {
+                        } else if (!_mv_1518.has_value) {
                         }
                     }
                 }
-            } else if (!_mv_1516.has_value) {
+            } else if (!_mv_1517.has_value) {
             }
             i = (i + 1);
         }
@@ -179,11 +179,11 @@ slop_list_extract_TestCase_ptr extract_extract_fn_examples(slop_arena* arena, ty
         } else {
             {
                 __auto_type fn_name_opt = parser_sexpr_list_get(fn_form, 1);
-                __auto_type _mv_1518 = fn_name_opt;
-                if (!_mv_1518.has_value) {
+                __auto_type _mv_1519 = fn_name_opt;
+                if (!_mv_1519.has_value) {
                     return result;
-                } else if (_mv_1518.has_value) {
-                    __auto_type fn_name_expr = _mv_1518.value;
+                } else if (_mv_1519.has_value) {
+                    __auto_type fn_name_expr = _mv_1519.value;
                     if (!(parser_sexpr_is_symbol(fn_name_expr))) {
                         return result;
                     } else {
@@ -191,11 +191,11 @@ slop_list_extract_TestCase_ptr extract_extract_fn_examples(slop_arena* arena, ty
                             __auto_type fn_name = parser_sexpr_get_symbol_name(fn_name_expr);
                             {
                                 __auto_type params_opt = parser_sexpr_list_get(fn_form, 2);
-                                __auto_type _mv_1519 = params_opt;
-                                if (!_mv_1519.has_value) {
+                                __auto_type _mv_1520 = params_opt;
+                                if (!_mv_1520.has_value) {
                                     return result;
-                                } else if (_mv_1519.has_value) {
-                                    __auto_type params = _mv_1519.value;
+                                } else if (_mv_1520.has_value) {
+                                    __auto_type params = _mv_1520.value;
                                     {
                                         __auto_type arena_pos = extract_detect_arena_param(params);
                                         __auto_type needs_arena = (arena_pos >= 0);
@@ -205,24 +205,24 @@ slop_list_extract_TestCase_ptr extract_extract_fn_examples(slop_arena* arena, ty
                                             __auto_type form_len = parser_sexpr_list_len(fn_form);
                                             __auto_type i = 3;
                                             while (i < form_len) {
-                                                __auto_type _mv_1520 = parser_sexpr_list_get(fn_form, i);
-                                                if (_mv_1520.has_value) {
-                                                    __auto_type item = _mv_1520.value;
+                                                __auto_type _mv_1521 = parser_sexpr_list_get(fn_form, i);
+                                                if (_mv_1521.has_value) {
+                                                    __auto_type item = _mv_1521.value;
                                                     if (parser_is_form(item, SLOP_STR("@spec"))) {
                                                         return_type = extract_extract_return_type(arena, item);
                                                     }
                                                     if (parser_is_form(item, SLOP_STR("@example"))) {
                                                         {
                                                             __auto_type example_tc = extract_parse_example(arena, item, fn_name, module_name, return_type, needs_arena, arena_pos, params, preconditions);
-                                                            __auto_type _mv_1521 = example_tc;
-                                                            if (_mv_1521.has_value) {
-                                                                __auto_type tc = _mv_1521.value;
+                                                            __auto_type _mv_1522 = example_tc;
+                                                            if (_mv_1522.has_value) {
+                                                                __auto_type tc = _mv_1522.value;
                                                                 ({ __auto_type _lst_p = &(result); __auto_type _item = (tc); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                                                            } else if (!_mv_1521.has_value) {
+                                                            } else if (!_mv_1522.has_value) {
                                                             }
                                                         }
                                                     }
-                                                } else if (!_mv_1520.has_value) {
+                                                } else if (!_mv_1521.has_value) {
                                                 }
                                                 i = (i + 1);
                                             }
@@ -251,11 +251,11 @@ slop_option_extract_TestCase_ptr extract_parse_example(slop_arena* arena, types_
                 __auto_type items = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
                 int64_t i = 1;
                 while (i < example_len) {
-                    __auto_type _mv_1522 = parser_sexpr_list_get(example_form, i);
-                    if (_mv_1522.has_value) {
-                        __auto_type item = _mv_1522.value;
+                    __auto_type _mv_1523 = parser_sexpr_list_get(example_form, i);
+                    if (_mv_1523.has_value) {
+                        __auto_type item = _mv_1523.value;
                         ({ __auto_type _lst_p = &(items); __auto_type _item = (item); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                    } else if (!_mv_1522.has_value) {
+                    } else if (!_mv_1523.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -263,23 +263,23 @@ slop_option_extract_TestCase_ptr extract_parse_example(slop_arena* arena, types_
                     slop_option_string eq_fn = (slop_option_string){.has_value = false};
                     int64_t args_start = 0;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_1523 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1523.has_value) {
-                            __auto_type first_item = _mv_1523.value;
+                        __auto_type _mv_1524 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1524.has_value) {
+                            __auto_type first_item = _mv_1524.value;
                             if (parser_sexpr_is_symbol(first_item)) {
                                 if (string_eq(parser_sexpr_get_symbol_name(first_item), SLOP_STR(":eq"))) {
-                                    __auto_type _mv_1524 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_1524.has_value) {
-                                        __auto_type eq_name_expr = _mv_1524.value;
+                                    __auto_type _mv_1525 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_1525.has_value) {
+                                        __auto_type eq_name_expr = _mv_1525.value;
                                         if (parser_sexpr_is_symbol(eq_name_expr)) {
                                             eq_fn = (slop_option_string){.has_value = 1, .value = parser_sexpr_get_symbol_name(eq_name_expr)};
                                             args_start = 2;
                                         }
-                                    } else if (!_mv_1524.has_value) {
+                                    } else if (!_mv_1525.has_value) {
                                     }
                                 }
                             }
-                        } else if (!_mv_1523.has_value) {
+                        } else if (!_mv_1524.has_value) {
                         }
                     }
                     {
@@ -294,21 +294,21 @@ slop_option_extract_TestCase_ptr extract_parse_example(slop_arena* arena, types_
                                     __auto_type args = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
                                     int64_t j = args_start;
                                     while (j < arrow_idx) {
-                                        __auto_type _mv_1525 = ({ __auto_type _lst = items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1525.has_value) {
-                                            __auto_type arg = _mv_1525.value;
+                                        __auto_type _mv_1526 = ({ __auto_type _lst = items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1526.has_value) {
+                                            __auto_type arg = _mv_1526.value;
                                             ({ __auto_type _lst_p = &(args); __auto_type _item = (arg); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                                        } else if (!_mv_1525.has_value) {
+                                        } else if (!_mv_1526.has_value) {
                                         }
                                         j = (j + 1);
                                     }
                                     {
                                         __auto_type final_args = extract_unpack_grouped_args(arena, args);
-                                        __auto_type _mv_1526 = ({ __auto_type _lst = items; size_t _idx = (size_t)(arrow_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1526.has_value) {
-                                            __auto_type expected = _mv_1526.value;
+                                        __auto_type _mv_1527 = ({ __auto_type _lst = items; size_t _idx = (size_t)(arrow_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1527.has_value) {
+                                            __auto_type expected = _mv_1527.value;
                                             return (slop_option_extract_TestCase_ptr){.has_value = 1, .value = extract_test_case_new(arena, fn_name, module_name, final_args, expected, return_type, needs_arena, arena_pos, eq_fn, params, preconditions)};
-                                        } else if (!_mv_1526.has_value) {
+                                        } else if (!_mv_1527.has_value) {
                                             return (slop_option_extract_TestCase_ptr){.has_value = false};
                                         }
                                         SLOP_UNREACHABLE();
@@ -327,28 +327,28 @@ slop_list_types_SExpr_ptr extract_unpack_grouped_args(slop_arena* arena, slop_li
     {
         slop_list_types_SExpr_ptr result = args;
         if (((int64_t)((args).len)) == 1) {
-            __auto_type _mv_1527 = ({ __auto_type _lst = args; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1527.has_value) {
-                __auto_type first_arg = _mv_1527.value;
+            __auto_type _mv_1528 = ({ __auto_type _lst = args; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1528.has_value) {
+                __auto_type first_arg = _mv_1528.value;
                 if (!(parser_sexpr_is_symbol(first_arg))) {
                     {
                         __auto_type inner_len = parser_sexpr_list_len(first_arg);
                         if (inner_len == 0) {
                             result = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
                         } else {
-                            __auto_type _mv_1528 = parser_sexpr_list_get(first_arg, 0);
-                            if (_mv_1528.has_value) {
-                                __auto_type first_inner = _mv_1528.value;
+                            __auto_type _mv_1529 = parser_sexpr_list_get(first_arg, 0);
+                            if (_mv_1529.has_value) {
+                                __auto_type first_inner = _mv_1529.value;
                                 if (parser_sexpr_is_symbol(first_inner) && string_eq(parser_sexpr_get_symbol_name(first_inner), SLOP_STR("arena"))) {
                                     {
                                         __auto_type unpacked = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
                                         __auto_type i = 1;
                                         while (i < inner_len) {
-                                            __auto_type _mv_1529 = parser_sexpr_list_get(first_arg, i);
-                                            if (_mv_1529.has_value) {
-                                                __auto_type item = _mv_1529.value;
+                                            __auto_type _mv_1530 = parser_sexpr_list_get(first_arg, i);
+                                            if (_mv_1530.has_value) {
+                                                __auto_type item = _mv_1530.value;
                                                 ({ __auto_type _lst_p = &(unpacked); __auto_type _item = (item); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                                            } else if (!_mv_1529.has_value) {
+                                            } else if (!_mv_1530.has_value) {
                                             }
                                             i = (i + 1);
                                         }
@@ -360,11 +360,11 @@ slop_list_types_SExpr_ptr extract_unpack_grouped_args(slop_arena* arena, slop_li
                                             __auto_type unpacked = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
                                             __auto_type i = 0;
                                             while (i < inner_len) {
-                                                __auto_type _mv_1530 = parser_sexpr_list_get(first_arg, i);
-                                                if (_mv_1530.has_value) {
-                                                    __auto_type item = _mv_1530.value;
+                                                __auto_type _mv_1531 = parser_sexpr_list_get(first_arg, i);
+                                                if (_mv_1531.has_value) {
+                                                    __auto_type item = _mv_1531.value;
                                                     ({ __auto_type _lst_p = &(unpacked); __auto_type _item = (item); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                                                } else if (!_mv_1530.has_value) {
+                                                } else if (!_mv_1531.has_value) {
                                                 }
                                                 i = (i + 1);
                                             }
@@ -372,12 +372,12 @@ slop_list_types_SExpr_ptr extract_unpack_grouped_args(slop_arena* arena, slop_li
                                         }
                                     }
                                 }
-                            } else if (!_mv_1528.has_value) {
+                            } else if (!_mv_1529.has_value) {
                             }
                         }
                     }
                 }
-            } else if (!_mv_1527.has_value) {
+            } else if (!_mv_1528.has_value) {
             }
         }
         return result;
@@ -392,11 +392,11 @@ slop_list_extract_TestCase_ptr extract_extract_examples_from_module(slop_arena* 
         } else {
             {
                 __auto_type mod_name_opt = parser_sexpr_list_get(module_form, 1);
-                __auto_type _mv_1531 = mod_name_opt;
-                if (!_mv_1531.has_value) {
+                __auto_type _mv_1532 = mod_name_opt;
+                if (!_mv_1532.has_value) {
                     return result;
-                } else if (_mv_1531.has_value) {
-                    __auto_type mod_name_expr = _mv_1531.value;
+                } else if (_mv_1532.has_value) {
+                    __auto_type mod_name_expr = _mv_1532.value;
                     {
                         slop_option_string mod_name = (slop_option_string){.has_value = false};
                         if (parser_sexpr_is_symbol(mod_name_expr)) {
@@ -406,26 +406,26 @@ slop_list_extract_TestCase_ptr extract_extract_examples_from_module(slop_arena* 
                             __auto_type form_len = parser_sexpr_list_len(module_form);
                             __auto_type i = 2;
                             while (i < form_len) {
-                                __auto_type _mv_1532 = parser_sexpr_list_get(module_form, i);
-                                if (_mv_1532.has_value) {
-                                    __auto_type item = _mv_1532.value;
+                                __auto_type _mv_1533 = parser_sexpr_list_get(module_form, i);
+                                if (_mv_1533.has_value) {
+                                    __auto_type item = _mv_1533.value;
                                     if (parser_is_form(item, SLOP_STR("fn"))) {
                                         {
                                             __auto_type fn_tests = extract_extract_fn_examples(arena, item, mod_name);
                                             __auto_type fn_tests_len = ((int64_t)((fn_tests).len));
                                             __auto_type j = 0;
                                             while (j < fn_tests_len) {
-                                                __auto_type _mv_1533 = ({ __auto_type _lst = fn_tests; size_t _idx = (size_t)j; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1533.has_value) {
-                                                    __auto_type tc = _mv_1533.value;
+                                                __auto_type _mv_1534 = ({ __auto_type _lst = fn_tests; size_t _idx = (size_t)j; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1534.has_value) {
+                                                    __auto_type tc = _mv_1534.value;
                                                     ({ __auto_type _lst_p = &(result); __auto_type _item = (tc); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                                                } else if (!_mv_1533.has_value) {
+                                                } else if (!_mv_1534.has_value) {
                                                 }
                                                 j = (j + 1);
                                             }
                                         }
                                     }
-                                } else if (!_mv_1532.has_value) {
+                                } else if (!_mv_1533.has_value) {
                                 }
                                 i = (i + 1);
                             }
@@ -445,20 +445,20 @@ slop_list_extract_TestCase_ptr extract_extract_examples_from_ast(slop_arena* are
         __auto_type len = ((int64_t)((ast).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1534 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1534.has_value) {
-                __auto_type form = _mv_1534.value;
+            __auto_type _mv_1535 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1535.has_value) {
+                __auto_type form = _mv_1535.value;
                 if (parser_is_form(form, SLOP_STR("fn"))) {
                     {
                         __auto_type fn_tests = extract_extract_fn_examples(arena, form, ((slop_option_string){.has_value = false}));
                         __auto_type fn_tests_len = ((int64_t)((fn_tests).len));
                         __auto_type j = 0;
                         while (j < fn_tests_len) {
-                            __auto_type _mv_1535 = ({ __auto_type _lst = fn_tests; size_t _idx = (size_t)j; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1535.has_value) {
-                                __auto_type tc = _mv_1535.value;
+                            __auto_type _mv_1536 = ({ __auto_type _lst = fn_tests; size_t _idx = (size_t)j; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1536.has_value) {
+                                __auto_type tc = _mv_1536.value;
                                 ({ __auto_type _lst_p = &(result); __auto_type _item = (tc); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                            } else if (!_mv_1535.has_value) {
+                            } else if (!_mv_1536.has_value) {
                             }
                             j = (j + 1);
                         }
@@ -470,17 +470,17 @@ slop_list_extract_TestCase_ptr extract_extract_examples_from_ast(slop_arena* are
                         __auto_type mod_tests_len = ((int64_t)((mod_tests).len));
                         __auto_type k = 0;
                         while (k < mod_tests_len) {
-                            __auto_type _mv_1536 = ({ __auto_type _lst = mod_tests; size_t _idx = (size_t)k; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1536.has_value) {
-                                __auto_type tc = _mv_1536.value;
+                            __auto_type _mv_1537 = ({ __auto_type _lst = mod_tests; size_t _idx = (size_t)k; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1537.has_value) {
+                                __auto_type tc = _mv_1537.value;
                                 ({ __auto_type _lst_p = &(result); __auto_type _item = (tc); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                            } else if (!_mv_1536.has_value) {
+                            } else if (!_mv_1537.has_value) {
                             }
                             k = (k + 1);
                         }
                     }
                 }
-            } else if (!_mv_1534.has_value) {
+            } else if (!_mv_1535.has_value) {
             }
             i = (i + 1);
         }

--- a/bootstrap/tester/slop_match.c
+++ b/bootstrap/tester/slop_match.c
@@ -74,9 +74,9 @@ uint8_t match_is_option_match(slop_list_types_SExpr_ptr patterns) {
         uint8_t has_none = 0;
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_646 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_646.has_value) {
-                __auto_type pat_expr = _mv_646.value;
+            __auto_type _mv_647 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_647.has_value) {
+                __auto_type pat_expr = _mv_647.value;
                 {
                     __auto_type tag = match_get_pattern_tag(pat_expr);
                     if (string_eq(tag, SLOP_STR("some"))) {
@@ -86,7 +86,7 @@ uint8_t match_is_option_match(slop_list_types_SExpr_ptr patterns) {
                     } else {
                     }
                 }
-            } else if (!_mv_646.has_value) {
+            } else if (!_mv_647.has_value) {
             }
             i = (i + 1);
         }
@@ -101,9 +101,9 @@ uint8_t match_is_result_match(slop_list_types_SExpr_ptr patterns) {
         uint8_t has_error = 0;
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_647 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_647.has_value) {
-                __auto_type pat_expr = _mv_647.value;
+            __auto_type _mv_648 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_648.has_value) {
+                __auto_type pat_expr = _mv_648.value;
                 {
                     __auto_type tag = match_get_pattern_tag(pat_expr);
                     if (string_eq(tag, SLOP_STR("ok"))) {
@@ -113,7 +113,7 @@ uint8_t match_is_result_match(slop_list_types_SExpr_ptr patterns) {
                     } else {
                     }
                 }
-            } else if (!_mv_647.has_value) {
+            } else if (!_mv_648.has_value) {
             }
             i = (i + 1);
         }
@@ -127,14 +127,14 @@ uint8_t match_is_enum_match(slop_list_types_SExpr_ptr patterns) {
         uint8_t all_symbols = 1;
         int64_t i = 0;
         while ((i < len) && all_symbols) {
-            __auto_type _mv_648 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_648.has_value) {
-                __auto_type pat_expr = _mv_648.value;
-                __auto_type _mv_649 = (*pat_expr);
-                switch (_mv_649.tag) {
+            __auto_type _mv_649 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_649.has_value) {
+                __auto_type pat_expr = _mv_649.value;
+                __auto_type _mv_650 = (*pat_expr);
+                switch (_mv_650.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type _ = _mv_649.data.sym;
+                        __auto_type _ = _mv_650.data.sym;
                         break;
                     }
                     default: {
@@ -142,7 +142,7 @@ uint8_t match_is_enum_match(slop_list_types_SExpr_ptr patterns) {
                         break;
                     }
                 }
-            } else if (!_mv_648.has_value) {
+            } else if (!_mv_649.has_value) {
             }
             i = (i + 1);
         }
@@ -156,20 +156,20 @@ uint8_t match_is_literal_match(slop_list_types_SExpr_ptr patterns) {
         uint8_t has_literal = 0;
         int64_t i = 0;
         while ((i < len) && !(has_literal)) {
-            __auto_type _mv_650 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_650.has_value) {
-                __auto_type pat_expr = _mv_650.value;
-                __auto_type _mv_651 = (*pat_expr);
-                switch (_mv_651.tag) {
+            __auto_type _mv_651 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_651.has_value) {
+                __auto_type pat_expr = _mv_651.value;
+                __auto_type _mv_652 = (*pat_expr);
+                switch (_mv_652.tag) {
                     case types_SExpr_num:
                     {
-                        __auto_type _ = _mv_651.data.num;
+                        __auto_type _ = _mv_652.data.num;
                         has_literal = 1;
                         break;
                     }
                     case types_SExpr_str:
                     {
-                        __auto_type _ = _mv_651.data.str;
+                        __auto_type _ = _mv_652.data.str;
                         has_literal = 1;
                         break;
                     }
@@ -177,7 +177,7 @@ uint8_t match_is_literal_match(slop_list_types_SExpr_ptr patterns) {
                         break;
                     }
                 }
-            } else if (!_mv_650.has_value) {
+            } else if (!_mv_651.has_value) {
             }
             i = (i + 1);
         }
@@ -192,21 +192,21 @@ uint8_t match_is_union_match(context_TranspileContext* ctx, slop_list_types_SExp
         uint8_t has_union_variant = 0;
         int64_t i = 0;
         while ((i < len) && !(has_union_variant)) {
-            __auto_type _mv_652 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_652.has_value) {
-                __auto_type pat_expr = _mv_652.value;
+            __auto_type _mv_653 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_653.has_value) {
+                __auto_type pat_expr = _mv_653.value;
                 {
                     __auto_type tag = match_get_pattern_tag(pat_expr);
                     if ((!(string_eq(tag, SLOP_STR("")))) && (!(string_eq(tag, SLOP_STR("some")))) && (!(string_eq(tag, SLOP_STR("none")))) && (!(string_eq(tag, SLOP_STR("ok")))) && (!(string_eq(tag, SLOP_STR("error")))) && (!(string_eq(tag, SLOP_STR("else")))) && (!(string_eq(tag, SLOP_STR("_"))))) {
-                        __auto_type _mv_653 = context_ctx_lookup_enum_variant(ctx, tag);
-                        if (_mv_653.has_value) {
-                            __auto_type _ = _mv_653.value;
+                        __auto_type _mv_654 = context_ctx_lookup_enum_variant(ctx, tag);
+                        if (_mv_654.has_value) {
+                            __auto_type _ = _mv_654.value;
                             has_union_variant = 1;
-                        } else if (!_mv_653.has_value) {
+                        } else if (!_mv_654.has_value) {
                         }
                     }
                 }
-            } else if (!_mv_652.has_value) {
+            } else if (!_mv_653.has_value) {
             }
             i = (i + 1);
         }
@@ -216,31 +216,31 @@ uint8_t match_is_union_match(context_TranspileContext* ctx, slop_list_types_SExp
 
 slop_string match_get_pattern_tag(types_SExpr* pat_expr) {
     SLOP_PRE(((pat_expr != NULL)), "(!= pat-expr nil)");
-    __auto_type _mv_654 = (*pat_expr);
-    switch (_mv_654.tag) {
+    __auto_type _mv_655 = (*pat_expr);
+    switch (_mv_655.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_654.data.lst;
+            __auto_type lst = _mv_655.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return SLOP_STR("");
                 } else {
-                    __auto_type _mv_655 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_655.has_value) {
-                        __auto_type head = _mv_655.value;
-                        __auto_type _mv_656 = (*head);
-                        switch (_mv_656.tag) {
+                    __auto_type _mv_656 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_656.has_value) {
+                        __auto_type head = _mv_656.value;
+                        __auto_type _mv_657 = (*head);
+                        switch (_mv_657.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_656.data.sym;
+                                __auto_type sym = _mv_657.data.sym;
                                 return sym.name;
                             }
                             default: {
                                 return SLOP_STR("");
                             }
                         }
-                    } else if (!_mv_655.has_value) {
+                    } else if (!_mv_656.has_value) {
                         return SLOP_STR("");
                     }
                     SLOP_UNREACHABLE();
@@ -249,7 +249,7 @@ slop_string match_get_pattern_tag(types_SExpr* pat_expr) {
         }
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_654.data.sym;
+            __auto_type sym = _mv_655.data.sym;
             return sym.name;
         }
         default: {
@@ -260,31 +260,31 @@ slop_string match_get_pattern_tag(types_SExpr* pat_expr) {
 
 slop_option_string match_extract_binding_name(types_SExpr* pat_expr) {
     SLOP_PRE(((pat_expr != NULL)), "(!= pat-expr nil)");
-    __auto_type _mv_657 = (*pat_expr);
-    switch (_mv_657.tag) {
+    __auto_type _mv_658 = (*pat_expr);
+    switch (_mv_658.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_657.data.lst;
+            __auto_type lst = _mv_658.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return (slop_option_string){.has_value = false};
                 } else {
-                    __auto_type _mv_658 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_658.has_value) {
-                        __auto_type binding = _mv_658.value;
-                        __auto_type _mv_659 = (*binding);
-                        switch (_mv_659.tag) {
+                    __auto_type _mv_659 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_659.has_value) {
+                        __auto_type binding = _mv_659.value;
+                        __auto_type _mv_660 = (*binding);
+                        switch (_mv_660.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_659.data.sym;
+                                __auto_type sym = _mv_660.data.sym;
                                 return (slop_option_string){.has_value = 1, .value = sym.name};
                             }
                             default: {
                                 return (slop_option_string){.has_value = false};
                             }
                         }
-                    } else if (!_mv_658.has_value) {
+                    } else if (!_mv_659.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
                     SLOP_UNREACHABLE();
@@ -299,11 +299,11 @@ slop_option_string match_extract_binding_name(types_SExpr* pat_expr) {
 
 int64_t match_count_pattern_bindings(types_SExpr* pat_expr) {
     SLOP_PRE(((pat_expr != NULL)), "(!= pat-expr nil)");
-    __auto_type _mv_660 = (*pat_expr);
-    switch (_mv_660.tag) {
+    __auto_type _mv_661 = (*pat_expr);
+    switch (_mv_661.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_660.data.lst;
+            __auto_type lst = _mv_661.data.lst;
             {
                 __auto_type len = ((int64_t)((lst.items).len));
                 if (len > 1) {
@@ -324,20 +324,20 @@ void match_transpile_match(context_TranspileContext* ctx, types_SExpr* expr, uin
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_661 = (*expr);
-        switch (_mv_661.tag) {
+        __auto_type _mv_662 = (*expr);
+        switch (_mv_662.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_661.data.lst;
+                __auto_type lst = _mv_662.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 3) {
                         context_ctx_add_error_at(ctx, SLOP_STR("invalid match: need value and at least one branch"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     } else {
-                        __auto_type _mv_662 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_662.has_value) {
-                            __auto_type scrutinee = _mv_662.value;
+                        __auto_type _mv_663 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_663.has_value) {
+                            __auto_type scrutinee = _mv_663.value;
                             {
                                 __auto_type scrutinee_c = expr_transpile_expr(ctx, scrutinee);
                                 __auto_type patterns = match_collect_patterns(ctx, items);
@@ -371,7 +371,7 @@ void match_transpile_match(context_TranspileContext* ctx, types_SExpr* expr, uin
                                     match_transpile_generic_match(ctx, scrutinee_var, items, is_return);
                                 }
                             }
-                        } else if (!_mv_662.has_value) {
+                        } else if (!_mv_663.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing match scrutinee"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                     }
@@ -394,22 +394,22 @@ slop_list_types_SExpr_ptr match_collect_patterns(context_TranspileContext* ctx, 
         __auto_type result = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
         int64_t i = 2;
         while (i < len) {
-            __auto_type _mv_663 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_663.has_value) {
-                __auto_type branch = _mv_663.value;
-                __auto_type _mv_664 = (*branch);
-                switch (_mv_664.tag) {
+            __auto_type _mv_664 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_664.has_value) {
+                __auto_type branch = _mv_664.value;
+                __auto_type _mv_665 = (*branch);
+                switch (_mv_665.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type branch_lst = _mv_664.data.lst;
+                        __auto_type branch_lst = _mv_665.data.lst;
                         {
                             __auto_type branch_items = branch_lst.items;
                             if (((int64_t)((branch_items).len)) >= 1) {
-                                __auto_type _mv_665 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_665.has_value) {
-                                    __auto_type pattern = _mv_665.value;
+                                __auto_type _mv_666 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_666.has_value) {
+                                    __auto_type pattern = _mv_666.value;
                                     ({ __auto_type _lst_p = &(result); __auto_type _item = (pattern); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                                } else if (!_mv_665.has_value) {
+                                } else if (!_mv_666.has_value) {
                                 }
                             }
                         }
@@ -419,7 +419,7 @@ slop_list_types_SExpr_ptr match_collect_patterns(context_TranspileContext* ctx, 
                         break;
                     }
                 }
-            } else if (!_mv_663.has_value) {
+            } else if (!_mv_664.has_value) {
             }
             i = (i + 1);
         }
@@ -436,20 +436,20 @@ void match_transpile_option_match(context_TranspileContext* ctx, slop_string scr
         uint8_t first = 1;
         uint8_t has_else = 0;
         while (i < len) {
-            __auto_type _mv_666 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_666.has_value) {
-                __auto_type branch = _mv_666.value;
-                __auto_type _mv_667 = (*branch);
-                switch (_mv_667.tag) {
+            __auto_type _mv_667 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_667.has_value) {
+                __auto_type branch = _mv_667.value;
+                __auto_type _mv_668 = (*branch);
+                switch (_mv_668.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type branch_lst = _mv_667.data.lst;
+                        __auto_type branch_lst = _mv_668.data.lst;
                         {
                             __auto_type branch_items = branch_lst.items;
                             if (((int64_t)((branch_items).len)) >= 2) {
-                                __auto_type _mv_668 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_668.has_value) {
-                                    __auto_type pattern = _mv_668.value;
+                                __auto_type _mv_669 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_669.has_value) {
+                                    __auto_type pattern = _mv_669.value;
                                     {
                                         __auto_type tag = match_get_pattern_tag(pattern);
                                         if (string_eq(tag, SLOP_STR("some"))) {
@@ -465,7 +465,7 @@ void match_transpile_option_match(context_TranspileContext* ctx, slop_string scr
                                         } else {
                                         }
                                     }
-                                } else if (!_mv_668.has_value) {
+                                } else if (!_mv_669.has_value) {
                                 }
                             }
                         }
@@ -475,7 +475,7 @@ void match_transpile_option_match(context_TranspileContext* ctx, slop_string scr
                         break;
                     }
                 }
-            } else if (!_mv_666.has_value) {
+            } else if (!_mv_667.has_value) {
             }
             i = (i + 1);
         }
@@ -498,9 +498,9 @@ void match_emit_option_some_branch(context_TranspileContext* ctx, slop_string sc
         }
         context_ctx_indent(ctx);
         context_ctx_push_scope(ctx);
-        __auto_type _mv_669 = match_extract_binding_name(pattern);
-        if (_mv_669.has_value) {
-            __auto_type binding_name = _mv_669.value;
+        __auto_type _mv_670 = match_extract_binding_name(pattern);
+        if (_mv_670.has_value) {
+            __auto_type binding_name = _mv_670.value;
             {
                 __auto_type c_name = ctype_to_c_name(arena, binding_name);
                 __auto_type inner_slop_type = expr_infer_option_inner_slop_type(ctx, scrutinee_expr);
@@ -509,7 +509,7 @@ void match_emit_option_some_branch(context_TranspileContext* ctx, slop_string sc
                 context_ctx_emit(ctx, context_ctx_str4(ctx, SLOP_STR("__auto_type "), c_name, SLOP_STR(" = "), context_ctx_str(ctx, scrutinee_c, SLOP_STR(".value;"))));
                 context_ctx_bind_var(ctx, (context_VarEntry){binding_name, c_name, inner_c_type, inner_slop_type, is_ptr, 0, 0, SLOP_STR(""), SLOP_STR("")});
             }
-        } else if (!_mv_669.has_value) {
+        } else if (!_mv_670.has_value) {
         }
         match_emit_branch_body(ctx, branch_items, is_return);
         context_ctx_pop_scope(ctx);
@@ -539,20 +539,20 @@ void match_transpile_result_match(context_TranspileContext* ctx, slop_string scr
         uint8_t first = 1;
         uint8_t has_else = 0;
         while (i < len) {
-            __auto_type _mv_670 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_670.has_value) {
-                __auto_type branch = _mv_670.value;
-                __auto_type _mv_671 = (*branch);
-                switch (_mv_671.tag) {
+            __auto_type _mv_671 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_671.has_value) {
+                __auto_type branch = _mv_671.value;
+                __auto_type _mv_672 = (*branch);
+                switch (_mv_672.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type branch_lst = _mv_671.data.lst;
+                        __auto_type branch_lst = _mv_672.data.lst;
                         {
                             __auto_type branch_items = branch_lst.items;
                             if (((int64_t)((branch_items).len)) >= 2) {
-                                __auto_type _mv_672 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_672.has_value) {
-                                    __auto_type pattern = _mv_672.value;
+                                __auto_type _mv_673 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_673.has_value) {
+                                    __auto_type pattern = _mv_673.value;
                                     {
                                         __auto_type tag = match_get_pattern_tag(pattern);
                                         if (string_eq(tag, SLOP_STR("ok"))) {
@@ -568,7 +568,7 @@ void match_transpile_result_match(context_TranspileContext* ctx, slop_string scr
                                         } else {
                                         }
                                     }
-                                } else if (!_mv_672.has_value) {
+                                } else if (!_mv_673.has_value) {
                                 }
                             }
                         }
@@ -578,7 +578,7 @@ void match_transpile_result_match(context_TranspileContext* ctx, slop_string scr
                         break;
                     }
                 }
-            } else if (!_mv_670.has_value) {
+            } else if (!_mv_671.has_value) {
             }
             i = (i + 1);
         }
@@ -602,9 +602,9 @@ void match_emit_result_ok_branch(context_TranspileContext* ctx, slop_string scru
         }
         context_ctx_indent(ctx);
         context_ctx_push_scope(ctx);
-        __auto_type _mv_673 = match_extract_binding_name(pattern);
-        if (_mv_673.has_value) {
-            __auto_type binding_name = _mv_673.value;
+        __auto_type _mv_674 = match_extract_binding_name(pattern);
+        if (_mv_674.has_value) {
+            __auto_type binding_name = _mv_674.value;
             {
                 __auto_type c_name = ctype_to_c_name(arena, binding_name);
                 __auto_type ok_slop_type = expr_infer_result_ok_slop_type(ctx, scrutinee_expr);
@@ -613,7 +613,7 @@ void match_emit_result_ok_branch(context_TranspileContext* ctx, slop_string scru
                 context_ctx_emit(ctx, context_ctx_str4(ctx, SLOP_STR("__auto_type "), c_name, SLOP_STR(" = "), context_ctx_str(ctx, scrutinee_c, SLOP_STR(".data.ok;"))));
                 context_ctx_bind_var(ctx, (context_VarEntry){binding_name, c_name, ok_c_type, ok_slop_type, is_ptr, 0, 0, SLOP_STR(""), SLOP_STR("")});
             }
-        } else if (!_mv_673.has_value) {
+        } else if (!_mv_674.has_value) {
         }
         match_emit_branch_body(ctx, branch_items, is_return);
         context_ctx_pop_scope(ctx);
@@ -634,9 +634,9 @@ void match_emit_result_error_branch(context_TranspileContext* ctx, slop_string s
         }
         context_ctx_indent(ctx);
         context_ctx_push_scope(ctx);
-        __auto_type _mv_674 = match_extract_binding_name(pattern);
-        if (_mv_674.has_value) {
-            __auto_type binding_name = _mv_674.value;
+        __auto_type _mv_675 = match_extract_binding_name(pattern);
+        if (_mv_675.has_value) {
+            __auto_type binding_name = _mv_675.value;
             {
                 __auto_type c_name = ctype_to_c_name(arena, binding_name);
                 __auto_type err_slop_type = expr_infer_result_err_slop_type(ctx, scrutinee_expr);
@@ -645,7 +645,7 @@ void match_emit_result_error_branch(context_TranspileContext* ctx, slop_string s
                 context_ctx_emit(ctx, context_ctx_str4(ctx, SLOP_STR("__auto_type "), c_name, SLOP_STR(" = "), context_ctx_str(ctx, scrutinee_c, SLOP_STR(".data.err;"))));
                 context_ctx_bind_var(ctx, (context_VarEntry){binding_name, c_name, err_c_type, err_slop_type, is_ptr, 0, 0, SLOP_STR(""), SLOP_STR("")});
             }
-        } else if (!_mv_674.has_value) {
+        } else if (!_mv_675.has_value) {
         }
         match_emit_branch_body(ctx, branch_items, is_return);
         context_ctx_pop_scope(ctx);
@@ -663,20 +663,20 @@ void match_transpile_enum_match(context_TranspileContext* ctx, slop_string scrut
         context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("switch ("), scrutinee_c, SLOP_STR(") {")));
         context_ctx_indent(ctx);
         while (i < len) {
-            __auto_type _mv_675 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_675.has_value) {
-                __auto_type branch = _mv_675.value;
-                __auto_type _mv_676 = (*branch);
-                switch (_mv_676.tag) {
+            __auto_type _mv_676 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_676.has_value) {
+                __auto_type branch = _mv_676.value;
+                __auto_type _mv_677 = (*branch);
+                switch (_mv_677.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type branch_lst = _mv_676.data.lst;
+                        __auto_type branch_lst = _mv_677.data.lst;
                         {
                             __auto_type branch_items = branch_lst.items;
                             if (((int64_t)((branch_items).len)) >= 2) {
-                                __auto_type _mv_677 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_677.has_value) {
-                                    __auto_type pattern = _mv_677.value;
+                                __auto_type _mv_678 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_678.has_value) {
+                                    __auto_type pattern = _mv_678.value;
                                     {
                                         __auto_type tag = match_get_pattern_tag(pattern);
                                         if (string_eq(tag, SLOP_STR("else")) || string_eq(tag, SLOP_STR("_"))) {
@@ -684,7 +684,7 @@ void match_transpile_enum_match(context_TranspileContext* ctx, slop_string scrut
                                         }
                                     }
                                     match_emit_enum_case(ctx, pattern, branch_items, is_return);
-                                } else if (!_mv_677.has_value) {
+                                } else if (!_mv_678.has_value) {
                                 }
                             }
                         }
@@ -694,7 +694,7 @@ void match_transpile_enum_match(context_TranspileContext* ctx, slop_string scrut
                         break;
                     }
                 }
-            } else if (!_mv_675.has_value) {
+            } else if (!_mv_676.has_value) {
             }
             i = (i + 1);
         }
@@ -718,9 +718,9 @@ void match_emit_enum_case(context_TranspileContext* ctx, types_SExpr* pattern, s
             context_ctx_dedent(ctx);
             context_ctx_emit(ctx, SLOP_STR("}"));
         } else {
-            __auto_type _mv_678 = context_ctx_lookup_enum_variant(ctx, tag);
-            if (_mv_678.has_value) {
-                __auto_type type_name = _mv_678.value;
+            __auto_type _mv_679 = context_ctx_lookup_enum_variant(ctx, tag);
+            if (_mv_679.has_value) {
+                __auto_type type_name = _mv_679.value;
                 {
                     __auto_type c_case = context_ctx_str3(ctx, type_name, SLOP_STR("_"), ctype_to_c_name(arena, tag));
                     context_ctx_emit(ctx, context_ctx_str(ctx, SLOP_STR("case "), context_ctx_str(ctx, c_case, SLOP_STR(": {"))));
@@ -730,7 +730,7 @@ void match_emit_enum_case(context_TranspileContext* ctx, types_SExpr* pattern, s
                     context_ctx_dedent(ctx);
                     context_ctx_emit(ctx, SLOP_STR("}"));
                 }
-            } else if (!_mv_678.has_value) {
+            } else if (!_mv_679.has_value) {
                 context_ctx_add_error_at(ctx, context_ctx_str3(ctx, SLOP_STR("unknown enum variant '"), tag, SLOP_STR("' in match")), context_ctx_sexpr_line(pattern), context_ctx_sexpr_col(pattern));
                 context_ctx_emit(ctx, context_ctx_str(ctx, SLOP_STR("/* unknown enum variant: "), context_ctx_str(ctx, tag, SLOP_STR(" */"))));
             }
@@ -747,26 +747,26 @@ void match_transpile_literal_match(context_TranspileContext* ctx, slop_string sc
         uint8_t first = 1;
         uint8_t has_else = 0;
         while (i < len) {
-            __auto_type _mv_679 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_679.has_value) {
-                __auto_type branch = _mv_679.value;
-                __auto_type _mv_680 = (*branch);
-                switch (_mv_680.tag) {
+            __auto_type _mv_680 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_680.has_value) {
+                __auto_type branch = _mv_680.value;
+                __auto_type _mv_681 = (*branch);
+                switch (_mv_681.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type branch_lst = _mv_680.data.lst;
+                        __auto_type branch_lst = _mv_681.data.lst;
                         {
                             __auto_type branch_items = branch_lst.items;
                             if (((int64_t)((branch_items).len)) >= 2) {
-                                __auto_type _mv_681 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_681.has_value) {
-                                    __auto_type pattern = _mv_681.value;
+                                __auto_type _mv_682 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_682.has_value) {
+                                    __auto_type pattern = _mv_682.value;
                                     if (string_eq(match_get_pattern_tag(pattern), SLOP_STR("else"))) {
                                         has_else = 1;
                                     }
                                     match_emit_literal_case(ctx, scrutinee_c, pattern, branch_items, is_return, first);
                                     first = 0;
-                                } else if (!_mv_681.has_value) {
+                                } else if (!_mv_682.has_value) {
                                 }
                             }
                         }
@@ -776,7 +776,7 @@ void match_transpile_literal_match(context_TranspileContext* ctx, slop_string sc
                         break;
                     }
                 }
-            } else if (!_mv_679.has_value) {
+            } else if (!_mv_680.has_value) {
             }
             i = (i + 1);
         }
@@ -832,20 +832,20 @@ void match_transpile_union_match(context_TranspileContext* ctx, slop_string scru
             context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("switch ("), scrutinee_c, SLOP_STR(".tag) {")));
             context_ctx_indent(ctx);
             while (i < len) {
-                __auto_type _mv_682 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_682.has_value) {
-                    __auto_type branch = _mv_682.value;
-                    __auto_type _mv_683 = (*branch);
-                    switch (_mv_683.tag) {
+                __auto_type _mv_683 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_683.has_value) {
+                    __auto_type branch = _mv_683.value;
+                    __auto_type _mv_684 = (*branch);
+                    switch (_mv_684.tag) {
                         case types_SExpr_lst:
                         {
-                            __auto_type branch_lst = _mv_683.data.lst;
+                            __auto_type branch_lst = _mv_684.data.lst;
                             {
                                 __auto_type branch_items = branch_lst.items;
                                 if (((int64_t)((branch_items).len)) >= 2) {
-                                    __auto_type _mv_684 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_684.has_value) {
-                                        __auto_type pattern = _mv_684.value;
+                                    __auto_type _mv_685 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_685.has_value) {
+                                        __auto_type pattern = _mv_685.value;
                                         {
                                             __auto_type tag = match_get_pattern_tag(pattern);
                                             if (string_eq(tag, SLOP_STR("else")) || string_eq(tag, SLOP_STR("_"))) {
@@ -859,16 +859,16 @@ void match_transpile_union_match(context_TranspileContext* ctx, slop_string scru
                                                 context_ctx_dedent(ctx);
                                                 context_ctx_emit(ctx, SLOP_STR("}"));
                                             } else {
-                                                __auto_type _mv_685 = context_ctx_lookup_enum_variant(ctx, tag);
-                                                if (_mv_685.has_value) {
-                                                    __auto_type union_type_name = _mv_685.value;
+                                                __auto_type _mv_686 = context_ctx_lookup_enum_variant(ctx, tag);
+                                                if (_mv_686.has_value) {
+                                                    __auto_type union_type_name = _mv_686.value;
                                                     match_emit_union_case(ctx, scrutinee_c, pattern, tag, union_type_name, branch_items, is_return);
-                                                } else if (!_mv_685.has_value) {
+                                                } else if (!_mv_686.has_value) {
                                                     context_ctx_add_error(ctx, context_ctx_str3(ctx, SLOP_STR("unknown union variant in match: "), tag, SLOP_STR(" (not registered as enum variant)")));
                                                 }
                                             }
                                         }
-                                    } else if (!_mv_684.has_value) {
+                                    } else if (!_mv_685.has_value) {
                                     }
                                 }
                             }
@@ -878,7 +878,7 @@ void match_transpile_union_match(context_TranspileContext* ctx, slop_string scru
                             break;
                         }
                     }
-                } else if (!_mv_682.has_value) {
+                } else if (!_mv_683.has_value) {
                 }
                 i = (i + 1);
             }
@@ -905,18 +905,18 @@ void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_
             __auto_type count_key = context_ctx_str3(ctx, tag, SLOP_STR("__count"), SLOP_STR(""));
             __auto_type multi_field_count = ({ __auto_type _mv = context_ctx_lookup_field_type(ctx, union_type_name, count_key); _mv.has_value ? ({ __auto_type ct = _mv.value; ct; }) : (SLOP_STR("")); });
             if (!(string_eq(multi_field_count, SLOP_STR("")))) {
-                __auto_type _mv_686 = (*pattern);
-                switch (_mv_686.tag) {
+                __auto_type _mv_687 = (*pattern);
+                switch (_mv_687.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type pat_lst = _mv_686.data.lst;
+                        __auto_type pat_lst = _mv_687.data.lst;
                         {
                             __auto_type pat_items = pat_lst.items;
                             __auto_type pat_len = ((int64_t)((pat_items).len));
                             for (int64_t bi = 1; bi < pat_len; bi++) {
-                                __auto_type _mv_687 = ({ __auto_type _lst = pat_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_687.has_value) {
-                                    __auto_type binding_expr = _mv_687.value;
+                                __auto_type _mv_688 = ({ __auto_type _lst = pat_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_688.has_value) {
+                                    __auto_type binding_expr = _mv_688.value;
                                     {
                                         __auto_type binding_name = parser_sexpr_get_symbol_name(binding_expr);
                                         if (!(string_eq(binding_name, SLOP_STR(""))) && !(string_eq(binding_name, SLOP_STR("_")))) {
@@ -932,7 +932,7 @@ void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_
                                             }
                                         }
                                     }
-                                } else if (!_mv_687.has_value) {
+                                } else if (!_mv_688.has_value) {
                                 }
                             }
                         }
@@ -943,9 +943,9 @@ void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_
                     }
                 }
             } else {
-                __auto_type _mv_688 = match_extract_binding_name(pattern);
-                if (_mv_688.has_value) {
-                    __auto_type binding_name = _mv_688.value;
+                __auto_type _mv_689 = match_extract_binding_name(pattern);
+                if (_mv_689.has_value) {
+                    __auto_type binding_name = _mv_689.value;
                     {
                         __auto_type c_binding = ctype_to_c_name(arena, binding_name);
                         __auto_type payload_c_type = ({ __auto_type _mv = context_ctx_lookup_field_type(ctx, union_type_name, tag); _mv.has_value ? ({ __auto_type ct = _mv.value; ct; }) : (SLOP_STR("auto")); });
@@ -953,7 +953,7 @@ void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_
                         context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("__auto_type "), c_binding, SLOP_STR(" = "), scrutinee_c, context_ctx_str3(ctx, SLOP_STR(".data."), c_tag, SLOP_STR(";"))));
                         context_ctx_bind_var(ctx, (context_VarEntry){binding_name, c_binding, payload_c_type, payload_slop_type, 0, 0, 0, SLOP_STR(""), SLOP_STR("")});
                     }
-                } else if (!_mv_688.has_value) {
+                } else if (!_mv_689.has_value) {
                 }
             }
         }
@@ -997,14 +997,14 @@ void match_emit_branch_body(context_TranspileContext* ctx, slop_list_types_SExpr
         __auto_type len = ((int64_t)((branch_items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_689 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_689.has_value) {
-                __auto_type body_expr = _mv_689.value;
+            __auto_type _mv_690 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_690.has_value) {
+                __auto_type body_expr = _mv_690.value;
                 {
                     __auto_type is_last = (i == (len - 1));
                     match_emit_branch_body_item(ctx, body_expr, is_return, is_last);
                 }
-            } else if (!_mv_689.has_value) {
+            } else if (!_mv_690.has_value) {
             }
             i = (i + 1);
         }
@@ -1016,24 +1016,24 @@ void match_emit_branch_body_item(context_TranspileContext* ctx, types_SExpr* bod
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_690 = (*body_expr);
-        switch (_mv_690.tag) {
+        __auto_type _mv_691 = (*body_expr);
+        switch (_mv_691.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_690.data.lst;
+                __auto_type lst = _mv_691.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 1) {
                         context_ctx_emit(ctx, SLOP_STR("/* empty list */;"));
                     } else {
-                        __auto_type _mv_691 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_691.has_value) {
-                            __auto_type head_expr = _mv_691.value;
-                            __auto_type _mv_692 = (*head_expr);
-                            switch (_mv_692.tag) {
+                        __auto_type _mv_692 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_692.has_value) {
+                            __auto_type head_expr = _mv_692.value;
+                            __auto_type _mv_693 = (*head_expr);
+                            switch (_mv_693.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_692.data.sym;
+                                    __auto_type sym = _mv_693.data.sym;
                                     {
                                         __auto_type op = sym.name;
                                         if (string_eq(op, SLOP_STR("let"))) {
@@ -1080,7 +1080,7 @@ void match_emit_branch_body_item(context_TranspileContext* ctx, types_SExpr* bod
                                     break;
                                 }
                             }
-                        } else if (!_mv_691.has_value) {
+                        } else if (!_mv_692.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("empty"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         }
                     }
@@ -1112,23 +1112,23 @@ void match_emit_inline_let(context_TranspileContext* ctx, slop_list_types_SExpr_
             context_ctx_emit(ctx, SLOP_STR("{"));
             context_ctx_indent(ctx);
             context_ctx_push_scope(ctx);
-            __auto_type _mv_693 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_693.has_value) {
-                __auto_type bindings_expr = _mv_693.value;
+            __auto_type _mv_694 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_694.has_value) {
+                __auto_type bindings_expr = _mv_694.value;
                 match_emit_inline_bindings(ctx, bindings_expr);
-            } else if (!_mv_693.has_value) {
+            } else if (!_mv_694.has_value) {
             }
             {
                 int64_t i = 2;
                 while (i < len) {
-                    __auto_type _mv_694 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_694.has_value) {
-                        __auto_type body_item = _mv_694.value;
+                    __auto_type _mv_695 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_695.has_value) {
+                        __auto_type body_item = _mv_695.value;
                         {
                             __auto_type body_last = (i == (len - 1));
                             match_emit_branch_body_item(ctx, body_item, is_return, (is_last && body_last));
                         }
-                    } else if (!_mv_694.has_value) {
+                    } else if (!_mv_695.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -1145,21 +1145,21 @@ void match_emit_inline_bindings(context_TranspileContext* ctx, types_SExpr* bind
     SLOP_PRE(((bindings_expr != NULL)), "(!= bindings-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_695 = (*bindings_expr);
-        switch (_mv_695.tag) {
+        __auto_type _mv_696 = (*bindings_expr);
+        switch (_mv_696.tag) {
             case types_SExpr_lst:
             {
-                __auto_type bindings_lst = _mv_695.data.lst;
+                __auto_type bindings_lst = _mv_696.data.lst;
                 {
                     __auto_type bindings = bindings_lst.items;
                     __auto_type len = ((int64_t)((bindings).len));
                     __auto_type i = 0;
                     while (i < len) {
-                        __auto_type _mv_696 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_696.has_value) {
-                            __auto_type binding = _mv_696.value;
+                        __auto_type _mv_697 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_697.has_value) {
+                            __auto_type binding = _mv_697.value;
                             match_emit_single_inline_binding(ctx, binding);
-                        } else if (!_mv_696.has_value) {
+                        } else if (!_mv_697.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -1178,11 +1178,11 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
     SLOP_PRE(((binding != NULL)), "(!= binding nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_697 = (*binding);
-        switch (_mv_697.tag) {
+        __auto_type _mv_698 = (*binding);
+        switch (_mv_698.tag) {
             case types_SExpr_lst:
             {
-                __auto_type binding_lst = _mv_697.data.lst;
+                __auto_type binding_lst = _mv_698.data.lst;
                 {
                     __auto_type items = binding_lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -1192,14 +1192,14 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
                         if ((len - start_idx) < 2) {
                             context_ctx_add_error_at(ctx, SLOP_STR("invalid binding"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                         } else {
-                            __auto_type _mv_698 = ({ __auto_type _lst = items; size_t _idx = (size_t)start_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_698.has_value) {
-                                __auto_type name_expr = _mv_698.value;
-                                __auto_type _mv_699 = (*name_expr);
-                                switch (_mv_699.tag) {
+                            __auto_type _mv_699 = ({ __auto_type _lst = items; size_t _idx = (size_t)start_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_699.has_value) {
+                                __auto_type name_expr = _mv_699.value;
+                                __auto_type _mv_700 = (*name_expr);
+                                switch (_mv_700.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type name_sym = _mv_699.data.sym;
+                                        __auto_type name_sym = _mv_700.data.sym;
                                         {
                                             __auto_type raw_name = name_sym.name;
                                             __auto_type c_name = ctype_to_c_name(arena, raw_name);
@@ -1207,13 +1207,13 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
                                                 {
                                                     __auto_type type_idx = (start_idx + 1);
                                                     __auto_type val_idx = (start_idx + 2);
-                                                    __auto_type _mv_700 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_700.has_value) {
-                                                        __auto_type type_expr = _mv_700.value;
+                                                    __auto_type _mv_701 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_701.has_value) {
+                                                        __auto_type type_expr = _mv_701.value;
                                                         if (match_is_type_expr(type_expr)) {
-                                                            __auto_type _mv_701 = ({ __auto_type _lst = items; size_t _idx = (size_t)val_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                            if (_mv_701.has_value) {
-                                                                __auto_type val_expr = _mv_701.value;
+                                                            __auto_type _mv_702 = ({ __auto_type _lst = items; size_t _idx = (size_t)val_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                            if (_mv_702.has_value) {
+                                                                __auto_type val_expr = _mv_702.value;
                                                                 {
                                                                     __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                                     __auto_type is_ptr = strlib_ends_with(c_type, SLOP_STR("*"));
@@ -1224,23 +1224,23 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
                                                                         context_ctx_bind_var(ctx, (context_VarEntry){raw_name, c_name, c_type, slop_type_str, is_ptr, has_mut, 0, SLOP_STR(""), SLOP_STR("")});
                                                                     }
                                                                 }
-                                                            } else if (!_mv_701.has_value) {
+                                                            } else if (!_mv_702.has_value) {
                                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing value"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                             }
                                                         } else {
-                                                            __auto_type _mv_702 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                            if (_mv_702.has_value) {
-                                                                __auto_type val_expr = _mv_702.value;
+                                                            __auto_type _mv_703 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                            if (_mv_703.has_value) {
+                                                                __auto_type val_expr = _mv_703.value;
                                                                 {
                                                                     __auto_type val_c = expr_transpile_expr(ctx, val_expr);
                                                                     __auto_type inferred_slop_type = expr_infer_expr_slop_type(ctx, val_expr);
                                                                     __auto_type ptr_type_opt = match_get_arena_alloc_ptr_type_inline(ctx, val_expr);
-                                                                    __auto_type _mv_703 = ptr_type_opt;
-                                                                    if (_mv_703.has_value) {
-                                                                        __auto_type ptr_type = _mv_703.value;
+                                                                    __auto_type _mv_704 = ptr_type_opt;
+                                                                    if (_mv_704.has_value) {
+                                                                        __auto_type ptr_type = _mv_704.value;
                                                                         context_ctx_emit(ctx, context_ctx_str4(ctx, SLOP_STR("__auto_type "), c_name, SLOP_STR(" = "), context_ctx_str(ctx, val_c, SLOP_STR(";"))));
                                                                         context_ctx_bind_var(ctx, (context_VarEntry){raw_name, c_name, ptr_type, inferred_slop_type, 1, has_mut, 0, SLOP_STR(""), SLOP_STR("")});
-                                                                    } else if (!_mv_703.has_value) {
+                                                                    } else if (!_mv_704.has_value) {
                                                                         {
                                                                             __auto_type inferred_type = expr_infer_expr_c_type(ctx, val_expr);
                                                                             __auto_type is_ptr = strlib_ends_with(inferred_type, SLOP_STR("*"));
@@ -1249,30 +1249,30 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
                                                                         }
                                                                     }
                                                                 }
-                                                            } else if (!_mv_702.has_value) {
+                                                            } else if (!_mv_703.has_value) {
                                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing value"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                             }
                                                         }
-                                                    } else if (!_mv_700.has_value) {
+                                                    } else if (!_mv_701.has_value) {
                                                         context_ctx_add_error_at(ctx, SLOP_STR("missing type/value"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                     }
                                                 }
                                             } else {
                                                 {
                                                     __auto_type val_idx = (start_idx + 1);
-                                                    __auto_type _mv_704 = ({ __auto_type _lst = items; size_t _idx = (size_t)val_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_704.has_value) {
-                                                        __auto_type val_expr = _mv_704.value;
+                                                    __auto_type _mv_705 = ({ __auto_type _lst = items; size_t _idx = (size_t)val_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_705.has_value) {
+                                                        __auto_type val_expr = _mv_705.value;
                                                         {
                                                             __auto_type val_c = expr_transpile_expr(ctx, val_expr);
                                                             __auto_type inferred_slop_type = expr_infer_expr_slop_type(ctx, val_expr);
                                                             __auto_type ptr_type_opt = match_get_arena_alloc_ptr_type_inline(ctx, val_expr);
-                                                            __auto_type _mv_705 = ptr_type_opt;
-                                                            if (_mv_705.has_value) {
-                                                                __auto_type ptr_type = _mv_705.value;
+                                                            __auto_type _mv_706 = ptr_type_opt;
+                                                            if (_mv_706.has_value) {
+                                                                __auto_type ptr_type = _mv_706.value;
                                                                 context_ctx_emit(ctx, context_ctx_str4(ctx, SLOP_STR("__auto_type "), c_name, SLOP_STR(" = "), context_ctx_str(ctx, val_c, SLOP_STR(";"))));
                                                                 context_ctx_bind_var(ctx, (context_VarEntry){raw_name, c_name, ptr_type, inferred_slop_type, 1, has_mut, 0, SLOP_STR(""), SLOP_STR("")});
-                                                            } else if (!_mv_705.has_value) {
+                                                            } else if (!_mv_706.has_value) {
                                                                 {
                                                                     __auto_type inferred_type = expr_infer_expr_c_type(ctx, val_expr);
                                                                     __auto_type is_ptr = strlib_ends_with(inferred_type, SLOP_STR("*"));
@@ -1281,7 +1281,7 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
                                                                 }
                                                             }
                                                         }
-                                                    } else if (!_mv_704.has_value) {
+                                                    } else if (!_mv_705.has_value) {
                                                         context_ctx_add_error_at(ctx, SLOP_STR("missing value"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                     }
                                                 }
@@ -1294,7 +1294,7 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
                                         break;
                                     }
                                 }
-                            } else if (!_mv_698.has_value) {
+                            } else if (!_mv_699.has_value) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("missing binding name"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                             }
                         }
@@ -1314,21 +1314,21 @@ uint8_t match_binding_starts_with_mut(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_706 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_706.has_value) {
-            __auto_type first = _mv_706.value;
-            __auto_type _mv_707 = (*first);
-            switch (_mv_707.tag) {
+        __auto_type _mv_707 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_707.has_value) {
+            __auto_type first = _mv_707.value;
+            __auto_type _mv_708 = (*first);
+            switch (_mv_708.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_707.data.sym;
+                    __auto_type sym = _mv_708.data.sym;
                     return string_eq(sym.name, SLOP_STR("mut"));
                 }
                 default: {
                     return 0;
                 }
             }
-        } else if (!_mv_706.has_value) {
+        } else if (!_mv_707.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -1337,11 +1337,11 @@ uint8_t match_binding_starts_with_mut(slop_list_types_SExpr_ptr items) {
 
 uint8_t match_is_type_expr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_708 = (*expr);
-    switch (_mv_708.tag) {
+    __auto_type _mv_709 = (*expr);
+    switch (_mv_709.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_708.data.sym;
+            __auto_type sym = _mv_709.data.sym;
             {
                 __auto_type name = sym.name;
                 if (string_len(name) == 0) {
@@ -1356,7 +1356,7 @@ uint8_t match_is_type_expr(types_SExpr* expr) {
         }
         case types_SExpr_lst:
         {
-            __auto_type _ = _mv_708.data.lst;
+            __auto_type _ = _mv_709.data.lst;
             return 1;
         }
         default: {
@@ -1367,34 +1367,34 @@ uint8_t match_is_type_expr(types_SExpr* expr) {
 
 uint8_t match_is_none_form_inline(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_709 = (*expr);
-    switch (_mv_709.tag) {
+    __auto_type _mv_710 = (*expr);
+    switch (_mv_710.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_709.data.sym;
+            __auto_type sym = _mv_710.data.sym;
             return string_eq(sym.name, SLOP_STR("none"));
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_709.data.lst;
+            __auto_type lst = _mv_710.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) == 1) {
-                    __auto_type _mv_710 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_710.has_value) {
-                        __auto_type head = _mv_710.value;
-                        __auto_type _mv_711 = (*head);
-                        switch (_mv_711.tag) {
+                    __auto_type _mv_711 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_711.has_value) {
+                        __auto_type head = _mv_711.value;
+                        __auto_type _mv_712 = (*head);
+                        switch (_mv_712.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_711.data.sym;
+                                __auto_type sym = _mv_712.data.sym;
                                 return string_eq(sym.name, SLOP_STR("none"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_710.has_value) {
+                    } else if (!_mv_711.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1419,28 +1419,28 @@ slop_option_string match_get_arena_alloc_ptr_type_inline(context_TranspileContex
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_712 = (*expr);
-        switch (_mv_712.tag) {
+        __auto_type _mv_713 = (*expr);
+        switch (_mv_713.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_712.data.lst;
+                __auto_type lst = _mv_713.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_713 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_713.has_value) {
-                            __auto_type head_ptr = _mv_713.value;
-                            __auto_type _mv_714 = (*head_ptr);
-                            switch (_mv_714.tag) {
+                        __auto_type _mv_714 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_714.has_value) {
+                            __auto_type head_ptr = _mv_714.value;
+                            __auto_type _mv_715 = (*head_ptr);
+                            switch (_mv_715.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type head_sym = _mv_714.data.sym;
+                                    __auto_type head_sym = _mv_715.data.sym;
                                     if (string_eq(head_sym.name, SLOP_STR("arena-alloc"))) {
-                                        __auto_type _mv_715 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_715.has_value) {
-                                            __auto_type size_expr = _mv_715.value;
+                                        __auto_type _mv_716 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_716.has_value) {
+                                            __auto_type size_expr = _mv_716.value;
                                             return match_extract_sizeof_type_inline(ctx, size_expr);
-                                        } else if (!_mv_715.has_value) {
+                                        } else if (!_mv_716.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
                                         SLOP_UNREACHABLE();
@@ -1452,7 +1452,7 @@ slop_option_string match_get_arena_alloc_ptr_type_inline(context_TranspileContex
                                     return (slop_option_string){.has_value = false};
                                 }
                             }
-                        } else if (!_mv_713.has_value) {
+                        } else if (!_mv_714.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -1473,18 +1473,18 @@ slop_option_string match_extract_sizeof_type_inline(context_TranspileContext* ct
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_716 = (*expr);
-        switch (_mv_716.tag) {
+        __auto_type _mv_717 = (*expr);
+        switch (_mv_717.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_716.data.sym;
+                __auto_type sym = _mv_717.data.sym;
                 {
                     __auto_type type_name = sym.name;
-                    __auto_type _mv_717 = context_ctx_lookup_type(ctx, type_name);
-                    if (_mv_717.has_value) {
-                        __auto_type entry = _mv_717.value;
+                    __auto_type _mv_718 = context_ctx_lookup_type(ctx, type_name);
+                    if (_mv_718.has_value) {
+                        __auto_type entry = _mv_718.value;
                         return (slop_option_string){.has_value = 1, .value = context_ctx_str(ctx, entry.c_name, SLOP_STR("*"))};
-                    } else if (!_mv_717.has_value) {
+                    } else if (!_mv_718.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
                     SLOP_UNREACHABLE();
@@ -1492,27 +1492,27 @@ slop_option_string match_extract_sizeof_type_inline(context_TranspileContext* ct
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_716.data.lst;
+                __auto_type lst = _mv_717.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_718 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_718.has_value) {
-                            __auto_type head_ptr = _mv_718.value;
-                            __auto_type _mv_719 = (*head_ptr);
-                            switch (_mv_719.tag) {
+                        __auto_type _mv_719 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_719.has_value) {
+                            __auto_type head_ptr = _mv_719.value;
+                            __auto_type _mv_720 = (*head_ptr);
+                            switch (_mv_720.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type head_sym = _mv_719.data.sym;
+                                    __auto_type head_sym = _mv_720.data.sym;
                                     if (string_eq(head_sym.name, SLOP_STR("sizeof"))) {
-                                        __auto_type _mv_720 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_720.has_value) {
-                                            __auto_type type_expr = _mv_720.value;
+                                        __auto_type _mv_721 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_721.has_value) {
+                                            __auto_type type_expr = _mv_721.value;
                                             {
                                                 __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                 return (slop_option_string){.has_value = 1, .value = context_ctx_str(ctx, c_type, SLOP_STR("*"))};
                                             }
-                                        } else if (!_mv_720.has_value) {
+                                        } else if (!_mv_721.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
                                         SLOP_UNREACHABLE();
@@ -1524,7 +1524,7 @@ slop_option_string match_extract_sizeof_type_inline(context_TranspileContext* ct
                                     return (slop_option_string){.has_value = false};
                                 }
                             }
-                        } else if (!_mv_718.has_value) {
+                        } else if (!_mv_719.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -1546,14 +1546,14 @@ void match_emit_inline_do(context_TranspileContext* ctx, slop_list_types_SExpr_p
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_721 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_721.has_value) {
-                __auto_type item = _mv_721.value;
+            __auto_type _mv_722 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_722.has_value) {
+                __auto_type item = _mv_722.value;
                 {
                     __auto_type item_last = (i == (len - 1));
                     match_emit_branch_body_item(ctx, item, is_return, (is_last && item_last));
                 }
-            } else if (!_mv_721.has_value) {
+            } else if (!_mv_722.has_value) {
             }
             i = (i + 1);
         }
@@ -1568,32 +1568,32 @@ void match_emit_inline_if(context_TranspileContext* ctx, slop_list_types_SExpr_p
         if (len < 3) {
             context_ctx_add_error_at(ctx, SLOP_STR("invalid if"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         } else {
-            __auto_type _mv_722 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_722.has_value) {
-                __auto_type cond_expr = _mv_722.value;
+            __auto_type _mv_723 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_723.has_value) {
+                __auto_type cond_expr = _mv_723.value;
                 {
                     __auto_type cond_c = context_ctx_strip_cond_parens(ctx, expr_transpile_expr(ctx, cond_expr));
                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("if ("), cond_c, SLOP_STR(") {")));
                 }
-            } else if (!_mv_722.has_value) {
+            } else if (!_mv_723.has_value) {
                 context_ctx_emit(ctx, SLOP_STR("if (/* missing */) {"));
             }
             context_ctx_indent(ctx);
-            __auto_type _mv_723 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_723.has_value) {
-                __auto_type then_expr = _mv_723.value;
+            __auto_type _mv_724 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_724.has_value) {
+                __auto_type then_expr = _mv_724.value;
                 match_emit_branch_body_item(ctx, then_expr, is_return, 1);
-            } else if (!_mv_723.has_value) {
+            } else if (!_mv_724.has_value) {
             }
             context_ctx_dedent(ctx);
             if (len >= 4) {
                 context_ctx_emit(ctx, SLOP_STR("} else {"));
                 context_ctx_indent(ctx);
-                __auto_type _mv_724 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_724.has_value) {
-                    __auto_type else_expr = _mv_724.value;
+                __auto_type _mv_725 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_725.has_value) {
+                    __auto_type else_expr = _mv_725.value;
                     match_emit_branch_body_item(ctx, else_expr, is_return, 1);
-                } else if (!_mv_724.has_value) {
+                } else if (!_mv_725.has_value) {
                 }
                 context_ctx_dedent(ctx);
                 context_ctx_emit(ctx, SLOP_STR("}"));
@@ -1612,14 +1612,14 @@ void match_emit_inline_while(context_TranspileContext* ctx, slop_list_types_SExp
         if (len < 3) {
             context_ctx_add_error_at(ctx, SLOP_STR("invalid while"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         } else {
-            __auto_type _mv_725 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_725.has_value) {
-                __auto_type cond_expr = _mv_725.value;
+            __auto_type _mv_726 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_726.has_value) {
+                __auto_type cond_expr = _mv_726.value;
                 {
                     __auto_type cond_c = context_ctx_strip_cond_parens(ctx, expr_transpile_expr(ctx, cond_expr));
                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("while ("), cond_c, SLOP_STR(") {")));
                 }
-            } else if (!_mv_725.has_value) {
+            } else if (!_mv_726.has_value) {
                 context_ctx_emit(ctx, SLOP_STR("while (/* missing */) {"));
             }
             context_ctx_indent(ctx);
@@ -1632,18 +1632,18 @@ void match_emit_inline_while(context_TranspileContext* ctx, slop_list_types_SExp
 
 slop_option_string match_get_var_c_type_inline(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
-    __auto_type _mv_726 = (*expr);
-    switch (_mv_726.tag) {
+    __auto_type _mv_727 = (*expr);
+    switch (_mv_727.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_726.data.sym;
+            __auto_type sym = _mv_727.data.sym;
             {
                 __auto_type name = sym.name;
-                __auto_type _mv_727 = context_ctx_lookup_var(ctx, name);
-                if (_mv_727.has_value) {
-                    __auto_type var_entry = _mv_727.value;
+                __auto_type _mv_728 = context_ctx_lookup_var(ctx, name);
+                if (_mv_728.has_value) {
+                    __auto_type var_entry = _mv_728.value;
                     return (slop_option_string){.has_value = 1, .value = var_entry.c_type};
-                } else if (!_mv_727.has_value) {
+                } else if (!_mv_728.has_value) {
                     return (slop_option_string){.has_value = false};
                 }
                 SLOP_UNREACHABLE();
@@ -1659,28 +1659,28 @@ slop_option_types_SExpr_ptr match_get_some_value_inline(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         slop_option_types_SExpr_ptr result = (slop_option_types_SExpr_ptr){.has_value = false};
-        __auto_type _mv_728 = (*expr);
-        switch (_mv_728.tag) {
+        __auto_type _mv_729 = (*expr);
+        switch (_mv_729.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_728.data.lst;
+                __auto_type lst = _mv_729.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_729 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_729.has_value) {
-                            __auto_type head = _mv_729.value;
-                            __auto_type _mv_730 = (*head);
-                            switch (_mv_730.tag) {
+                        __auto_type _mv_730 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_730.has_value) {
+                            __auto_type head = _mv_730.value;
+                            __auto_type _mv_731 = (*head);
+                            switch (_mv_731.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_730.data.sym;
+                                    __auto_type sym = _mv_731.data.sym;
                                     if (string_eq(sym.name, SLOP_STR("some"))) {
-                                        __auto_type _mv_731 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_731.has_value) {
-                                            __auto_type val = _mv_731.value;
+                                        __auto_type _mv_732 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_732.has_value) {
+                                            __auto_type val = _mv_732.value;
                                             result = (slop_option_types_SExpr_ptr){.has_value = 1, .value = val};
-                                        } else if (!_mv_731.has_value) {
+                                        } else if (!_mv_732.has_value) {
                                         }
                                     }
                                     break;
@@ -1689,7 +1689,7 @@ slop_option_types_SExpr_ptr match_get_some_value_inline(types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_729.has_value) {
+                        } else if (!_mv_730.has_value) {
                         }
                     }
                 }
@@ -1710,18 +1710,18 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
         __auto_type len = ((int64_t)((items).len));
         if (expr_set_is_self_assign(items)) {
         } else if (len == 5) {
-            __auto_type _mv_732 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_732.has_value) {
-                __auto_type target_expr = _mv_732.value;
-                __auto_type _mv_733 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_733.has_value) {
-                    __auto_type field_expr = _mv_733.value;
-                    __auto_type _mv_734 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_734.has_value) {
-                        __auto_type type_expr = _mv_734.value;
-                        __auto_type _mv_735 = ({ __auto_type _lst = items; size_t _idx = (size_t)4; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_735.has_value) {
-                            __auto_type value_expr = _mv_735.value;
+            __auto_type _mv_733 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_733.has_value) {
+                __auto_type target_expr = _mv_733.value;
+                __auto_type _mv_734 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_734.has_value) {
+                    __auto_type field_expr = _mv_734.value;
+                    __auto_type _mv_735 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_735.has_value) {
+                        __auto_type type_expr = _mv_735.value;
+                        __auto_type _mv_736 = ({ __auto_type _lst = items; size_t _idx = (size_t)4; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_736.has_value) {
+                            __auto_type value_expr = _mv_736.value;
                             {
                                 __auto_type field_name = match_get_field_name_inline(ctx, field_expr);
                                 __auto_type c_type = ctype_to_c_type(arena, type_expr);
@@ -1731,14 +1731,14 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
                                         if (match_is_none_form_inline(value_expr)) {
                                             context_ctx_emit(ctx, context_ctx_str(ctx, target_access, context_ctx_str(ctx, field_name, context_ctx_str3(ctx, SLOP_STR(" = ("), c_type, SLOP_STR("){.has_value = false};")))));
                                         } else {
-                                            __auto_type _mv_736 = match_get_some_value_inline(value_expr);
-                                            if (_mv_736.has_value) {
-                                                __auto_type inner_val = _mv_736.value;
+                                            __auto_type _mv_737 = match_get_some_value_inline(value_expr);
+                                            if (_mv_737.has_value) {
+                                                __auto_type inner_val = _mv_737.value;
                                                 {
                                                     __auto_type val_c = expr_transpile_expr(ctx, inner_val);
                                                     context_ctx_emit(ctx, context_ctx_str(ctx, target_access, context_ctx_str(ctx, field_name, context_ctx_str5(ctx, SLOP_STR(" = ("), c_type, SLOP_STR("){.has_value = 1, .value = "), val_c, SLOP_STR("};")))));
                                                 }
-                                            } else if (!_mv_736.has_value) {
+                                            } else if (!_mv_737.has_value) {
                                                 {
                                                     __auto_type val_c = expr_transpile_expr(ctx, value_expr);
                                                     context_ctx_emit(ctx, context_ctx_str(ctx, target_access, context_ctx_str(ctx, field_name, context_ctx_str(ctx, SLOP_STR(" = "), context_ctx_str(ctx, val_c, SLOP_STR(";"))))));
@@ -1753,28 +1753,28 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
                                     }
                                 }
                             }
-                        } else if (!_mv_735.has_value) {
+                        } else if (!_mv_736.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing set! value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         }
-                    } else if (!_mv_734.has_value) {
+                    } else if (!_mv_735.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing set! type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     }
-                } else if (!_mv_733.has_value) {
+                } else if (!_mv_734.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("missing set! field"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 }
-            } else if (!_mv_732.has_value) {
+            } else if (!_mv_733.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing set! target"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             }
         } else if (len == 4) {
-            __auto_type _mv_737 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_737.has_value) {
-                __auto_type target_expr = _mv_737.value;
-                __auto_type _mv_738 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_738.has_value) {
-                    __auto_type field_expr = _mv_738.value;
-                    __auto_type _mv_739 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_739.has_value) {
-                        __auto_type value_expr = _mv_739.value;
+            __auto_type _mv_738 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_738.has_value) {
+                __auto_type target_expr = _mv_738.value;
+                __auto_type _mv_739 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_739.has_value) {
+                    __auto_type field_expr = _mv_739.value;
+                    __auto_type _mv_740 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_740.has_value) {
+                        __auto_type value_expr = _mv_740.value;
                         {
                             __auto_type field_name = match_get_field_name_inline(ctx, field_expr);
                             __auto_type value_c = expr_transpile_expr(ctx, value_expr);
@@ -1790,39 +1790,39 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
                                 }
                             }
                         }
-                    } else if (!_mv_739.has_value) {
+                    } else if (!_mv_740.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing set! value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     }
-                } else if (!_mv_738.has_value) {
+                } else if (!_mv_739.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("missing set! field"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 }
-            } else if (!_mv_737.has_value) {
+            } else if (!_mv_738.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing set! target"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             }
         } else if (len >= 3) {
-            __auto_type _mv_740 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_740.has_value) {
-                __auto_type target_expr = _mv_740.value;
-                __auto_type _mv_741 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_741.has_value) {
-                    __auto_type val_expr = _mv_741.value;
+            __auto_type _mv_741 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_741.has_value) {
+                __auto_type target_expr = _mv_741.value;
+                __auto_type _mv_742 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_742.has_value) {
+                    __auto_type val_expr = _mv_742.value;
                     {
                         __auto_type target_c = expr_transpile_expr(ctx, target_expr);
                         __auto_type target_type_opt = match_get_var_c_type_inline(ctx, target_expr);
-                        __auto_type _mv_742 = target_type_opt;
-                        if (_mv_742.has_value) {
-                            __auto_type target_type = _mv_742.value;
+                        __auto_type _mv_743 = target_type_opt;
+                        if (_mv_743.has_value) {
+                            __auto_type target_type = _mv_743.value;
                             if (strlib_starts_with(target_type, SLOP_STR("slop_option_"))) {
                                 {
                                     __auto_type some_val_opt = match_get_some_value_inline(val_expr);
-                                    __auto_type _mv_743 = some_val_opt;
-                                    if (_mv_743.has_value) {
-                                        __auto_type inner_expr = _mv_743.value;
+                                    __auto_type _mv_744 = some_val_opt;
+                                    if (_mv_744.has_value) {
+                                        __auto_type inner_expr = _mv_744.value;
                                         {
                                             __auto_type inner_c = expr_transpile_expr(ctx, inner_expr);
                                             context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str5(ctx, SLOP_STR(" = ("), target_type, SLOP_STR("){.has_value = 1, .value = "), inner_c, SLOP_STR("};"))));
                                         }
-                                    } else if (!_mv_743.has_value) {
+                                    } else if (!_mv_744.has_value) {
                                         {
                                             __auto_type val_c = expr_transpile_expr(ctx, val_expr);
                                             if (string_eq(val_c, SLOP_STR("none"))) {
@@ -1839,23 +1839,23 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
                                     context_ctx_emit(ctx, context_ctx_str4(ctx, target_c, SLOP_STR(" = "), val_c, SLOP_STR(";")));
                                 }
                             }
-                        } else if (!_mv_742.has_value) {
+                        } else if (!_mv_743.has_value) {
                             {
                                 __auto_type some_val_opt = match_get_some_value_inline(val_expr);
-                                __auto_type _mv_744 = some_val_opt;
-                                if (_mv_744.has_value) {
-                                    __auto_type inner_expr = _mv_744.value;
+                                __auto_type _mv_745 = some_val_opt;
+                                if (_mv_745.has_value) {
+                                    __auto_type inner_expr = _mv_745.value;
                                     {
                                         __auto_type inner_c = expr_transpile_expr(ctx, inner_expr);
                                         __auto_type inner_type = expr_infer_expr_c_type(ctx, inner_expr);
                                         __auto_type option_type = expr_c_type_to_option_type_name(ctx, inner_type);
                                         context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str5(ctx, SLOP_STR(" = ("), option_type, SLOP_STR("){.has_value = 1, .value = "), inner_c, SLOP_STR("};"))));
                                     }
-                                } else if (!_mv_744.has_value) {
+                                } else if (!_mv_745.has_value) {
                                     if (match_is_none_form_inline(val_expr)) {
-                                        __auto_type _mv_745 = context_ctx_get_current_return_type(ctx);
-                                        if (_mv_745.has_value) {
-                                            __auto_type ret_type = _mv_745.value;
+                                        __auto_type _mv_746 = context_ctx_get_current_return_type(ctx);
+                                        if (_mv_746.has_value) {
+                                            __auto_type ret_type = _mv_746.value;
                                             if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
                                                 context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str3(ctx, SLOP_STR(" = ("), ret_type, SLOP_STR("){.has_value = false};"))));
                                             } else {
@@ -1864,7 +1864,7 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
                                                     context_ctx_emit(ctx, context_ctx_str4(ctx, target_c, SLOP_STR(" = "), val_c, SLOP_STR(";")));
                                                 }
                                             }
-                                        } else if (!_mv_745.has_value) {
+                                        } else if (!_mv_746.has_value) {
                                             {
                                                 __auto_type val_c = expr_transpile_expr(ctx, val_expr);
                                                 context_ctx_emit(ctx, context_ctx_str4(ctx, target_c, SLOP_STR(" = "), val_c, SLOP_STR(";")));
@@ -1880,10 +1880,10 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
                             }
                         }
                     }
-                } else if (!_mv_741.has_value) {
+                } else if (!_mv_742.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("missing set! value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 }
-            } else if (!_mv_740.has_value) {
+            } else if (!_mv_741.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing set! target"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             }
         } else {
@@ -1894,31 +1894,31 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
 
 uint8_t match_is_deref_inline(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_746 = (*expr);
-    switch (_mv_746.tag) {
+    __auto_type _mv_747 = (*expr);
+    switch (_mv_747.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_746.data.lst;
+            __auto_type lst = _mv_747.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return 0;
                 } else {
-                    __auto_type _mv_747 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_747.has_value) {
-                        __auto_type head = _mv_747.value;
-                        __auto_type _mv_748 = (*head);
-                        switch (_mv_748.tag) {
+                    __auto_type _mv_748 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_748.has_value) {
+                        __auto_type head = _mv_748.value;
+                        __auto_type _mv_749 = (*head);
+                        switch (_mv_749.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_748.data.sym;
+                                __auto_type sym = _mv_749.data.sym;
                                 return string_eq(sym.name, SLOP_STR("deref"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_747.has_value) {
+                    } else if (!_mv_748.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1933,18 +1933,18 @@ uint8_t match_is_deref_inline(types_SExpr* expr) {
 
 slop_string match_get_deref_inner_inline(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_749 = (*expr);
-    switch (_mv_749.tag) {
+    __auto_type _mv_750 = (*expr);
+    switch (_mv_750.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_749.data.lst;
+            __auto_type lst = _mv_750.data.lst;
             {
                 __auto_type items = lst.items;
-                __auto_type _mv_750 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_750.has_value) {
-                    __auto_type inner = _mv_750.value;
+                __auto_type _mv_751 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_751.has_value) {
+                    __auto_type inner = _mv_751.value;
                     return expr_transpile_expr(ctx, inner);
-                } else if (!_mv_750.has_value) {
+                } else if (!_mv_751.has_value) {
                     return SLOP_STR("/* missing deref arg */");
                 }
                 SLOP_UNREACHABLE();
@@ -1961,11 +1961,11 @@ slop_string match_get_field_name_inline(context_TranspileContext* ctx, types_SEx
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_751 = (*expr);
-        switch (_mv_751.tag) {
+        __auto_type _mv_752 = (*expr);
+        switch (_mv_752.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_751.data.sym;
+                __auto_type sym = _mv_752.data.sym;
                 return ctype_to_c_name(arena, sym.name);
             }
             default: {
@@ -1983,14 +1983,14 @@ void match_emit_inline_when(context_TranspileContext* ctx, slop_list_types_SExpr
         if (len < 2) {
             context_ctx_add_error_at(ctx, SLOP_STR("invalid when"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         } else {
-            __auto_type _mv_752 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_752.has_value) {
-                __auto_type cond_expr = _mv_752.value;
+            __auto_type _mv_753 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_753.has_value) {
+                __auto_type cond_expr = _mv_753.value;
                 {
                     __auto_type cond_c = context_ctx_strip_cond_parens(ctx, expr_transpile_expr(ctx, cond_expr));
                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("if ("), cond_c, SLOP_STR(") {")));
                 }
-            } else if (!_mv_752.has_value) {
+            } else if (!_mv_753.has_value) {
                 context_ctx_emit(ctx, SLOP_STR("if (/* missing */) {"));
             }
             context_ctx_indent(ctx);
@@ -2010,28 +2010,28 @@ void match_emit_inline_cond(context_TranspileContext* ctx, slop_list_types_SExpr
         uint8_t first = 1;
         uint8_t has_else = 0;
         while (i < len) {
-            __auto_type _mv_753 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_753.has_value) {
-                __auto_type clause_expr = _mv_753.value;
-                __auto_type _mv_754 = (*clause_expr);
-                switch (_mv_754.tag) {
+            __auto_type _mv_754 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_754.has_value) {
+                __auto_type clause_expr = _mv_754.value;
+                __auto_type _mv_755 = (*clause_expr);
+                switch (_mv_755.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type clause_lst = _mv_754.data.lst;
+                        __auto_type clause_lst = _mv_755.data.lst;
                         {
                             __auto_type clause_items = clause_lst.items;
                             __auto_type clause_len = ((int64_t)((clause_items).len));
                             if (clause_len < 1) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("invalid cond clause"), context_ctx_sexpr_line(clause_expr), context_ctx_sexpr_col(clause_expr));
                             } else {
-                                __auto_type _mv_755 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_755.has_value) {
-                                    __auto_type test_expr = _mv_755.value;
-                                    __auto_type _mv_756 = (*test_expr);
-                                    switch (_mv_756.tag) {
+                                __auto_type _mv_756 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_756.has_value) {
+                                    __auto_type test_expr = _mv_756.value;
+                                    __auto_type _mv_757 = (*test_expr);
+                                    switch (_mv_757.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_756.data.sym;
+                                            __auto_type sym = _mv_757.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("else"))) {
                                                 has_else = 1;
                                                 context_ctx_emit(ctx, SLOP_STR("} else {"));
@@ -2070,7 +2070,7 @@ void match_emit_inline_cond(context_TranspileContext* ctx, slop_list_types_SExpr
                                             break;
                                         }
                                     }
-                                } else if (!_mv_755.has_value) {
+                                } else if (!_mv_756.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing test"), context_ctx_sexpr_line(clause_expr), context_ctx_sexpr_col(clause_expr));
                                 }
                             }
@@ -2082,7 +2082,7 @@ void match_emit_inline_cond(context_TranspileContext* ctx, slop_list_types_SExpr
                         break;
                     }
                 }
-            } else if (!_mv_753.has_value) {
+            } else if (!_mv_754.has_value) {
             }
             i = (i + 1);
         }
@@ -2099,14 +2099,14 @@ void match_emit_inline_cond_body(context_TranspileContext* ctx, slop_list_types_
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_757 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_757.has_value) {
-                __auto_type body_expr = _mv_757.value;
+            __auto_type _mv_758 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_758.has_value) {
+                __auto_type body_expr = _mv_758.value;
                 {
                     __auto_type body_is_last = (i == (len - 1));
                     match_emit_branch_body_item(ctx, body_expr, is_return, (is_last && body_is_last));
                 }
-            } else if (!_mv_757.has_value) {
+            } else if (!_mv_758.has_value) {
             }
             i = (i + 1);
         }
@@ -2126,41 +2126,42 @@ void match_emit_inline_with_arena(context_TranspileContext* ctx, slop_list_types
                 __auto_type arena_name = ((is_named) ? ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type name_expr = _mv.value; parser_sexpr_get_symbol_name(name_expr); }) : (SLOP_STR("arena")); }) : SLOP_STR("arena"));
                 __auto_type size_idx = ((is_named) ? 3 : 1);
                 __auto_type body_start = ((is_named) ? 4 : 2);
-                __auto_type c_local = ((is_named) ? string_concat(ctx_arena, SLOP_STR("_arena_"), arena_name) : SLOP_STR("_arena"));
+                __auto_type c_arena_name = ctype_to_c_name(ctx_arena, arena_name);
+                __auto_type c_local = ((is_named) ? string_concat(ctx_arena, SLOP_STR("_arena_"), c_arena_name) : SLOP_STR("_arena"));
                 if (is_named && (len < 4)) {
                     context_ctx_add_error_at(ctx, SLOP_STR("with-arena :as requires name and size"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 } else {
                     context_ctx_emit(ctx, SLOP_STR("{"));
                     context_ctx_indent(ctx);
                     context_ctx_push_scope(ctx);
-                    __auto_type _mv_758 = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_758.has_value) {
-                        __auto_type size_expr = _mv_758.value;
+                    __auto_type _mv_759 = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_759.has_value) {
+                        __auto_type size_expr = _mv_759.value;
                         {
                             __auto_type size_c = expr_transpile_expr(ctx, size_expr);
                             context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("slop_arena "), c_local, SLOP_STR(" = slop_arena_new("), size_c, SLOP_STR(");")));
-                            context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("slop_arena* "), arena_name, SLOP_STR(" = &"), c_local, SLOP_STR(";")));
+                            context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("slop_arena* "), c_arena_name, SLOP_STR(" = &"), c_local, SLOP_STR(";")));
                         }
-                    } else if (!_mv_758.has_value) {
+                    } else if (!_mv_759.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing size"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     }
-                    context_ctx_bind_var(ctx, (context_VarEntry){arena_name, arena_name, SLOP_STR("slop_arena*"), SLOP_STR(""), 1, 0, 0, SLOP_STR(""), SLOP_STR("")});
+                    context_ctx_bind_var(ctx, (context_VarEntry){arena_name, c_arena_name, SLOP_STR("slop_arena*"), SLOP_STR(""), 1, 0, 0, SLOP_STR(""), SLOP_STR("")});
                     {
                         int64_t i = body_start;
                         while (i < len) {
-                            __auto_type _mv_759 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_759.has_value) {
-                                __auto_type body_expr = _mv_759.value;
+                            __auto_type _mv_760 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_760.has_value) {
+                                __auto_type body_expr = _mv_760.value;
                                 {
                                     __auto_type is_last = (i == (len - 1));
                                     match_emit_branch_body_item(ctx, body_expr, (is_return && is_last), is_last);
                                 }
-                            } else if (!_mv_759.has_value) {
+                            } else if (!_mv_760.has_value) {
                             }
                             i = (i + 1);
                         }
                     }
-                    context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), arena_name, SLOP_STR(");")));
+                    context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), c_arena_name, SLOP_STR(");")));
                     context_ctx_pop_scope(ctx);
                     context_ctx_dedent(ctx);
                     context_ctx_emit(ctx, SLOP_STR("}"));
@@ -2176,11 +2177,11 @@ void match_emit_inline_body_items(context_TranspileContext* ctx, slop_list_types
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_760 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_760.has_value) {
-                __auto_type body_expr = _mv_760.value;
+            __auto_type _mv_761 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_761.has_value) {
+                __auto_type body_expr = _mv_761.value;
                 match_emit_branch_body_item(ctx, body_expr, 0, 0);
-            } else if (!_mv_760.has_value) {
+            } else if (!_mv_761.has_value) {
             }
             i = (i + 1);
         }
@@ -2195,36 +2196,36 @@ void match_emit_inline_for(context_TranspileContext* ctx, slop_list_types_SExpr_
         if (len < 2) {
             context_ctx_add_error_at(ctx, SLOP_STR("invalid for: need binding"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         } else {
-            __auto_type _mv_761 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_761.has_value) {
-                __auto_type binding_expr = _mv_761.value;
-                __auto_type _mv_762 = (*binding_expr);
-                switch (_mv_762.tag) {
+            __auto_type _mv_762 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_762.has_value) {
+                __auto_type binding_expr = _mv_762.value;
+                __auto_type _mv_763 = (*binding_expr);
+                switch (_mv_763.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type binding_lst = _mv_762.data.lst;
+                        __auto_type binding_lst = _mv_763.data.lst;
                         {
                             __auto_type binding_items = binding_lst.items;
                             __auto_type binding_len = ((int64_t)((binding_items).len));
                             if (binding_len < 3) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("for binding needs (var start end)"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                             } else {
-                                __auto_type _mv_763 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_763.has_value) {
-                                    __auto_type var_expr = _mv_763.value;
-                                    __auto_type _mv_764 = (*var_expr);
-                                    switch (_mv_764.tag) {
+                                __auto_type _mv_764 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_764.has_value) {
+                                    __auto_type var_expr = _mv_764.value;
+                                    __auto_type _mv_765 = (*var_expr);
+                                    switch (_mv_765.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type var_sym = _mv_764.data.sym;
+                                            __auto_type var_sym = _mv_765.data.sym;
                                             {
                                                 __auto_type var_name = ctype_to_c_name(arena, var_sym.name);
-                                                __auto_type _mv_765 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_765.has_value) {
-                                                    __auto_type start_expr = _mv_765.value;
-                                                    __auto_type _mv_766 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_766.has_value) {
-                                                        __auto_type end_expr = _mv_766.value;
+                                                __auto_type _mv_766 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_766.has_value) {
+                                                    __auto_type start_expr = _mv_766.value;
+                                                    __auto_type _mv_767 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_767.has_value) {
+                                                        __auto_type end_expr = _mv_767.value;
                                                         {
                                                             __auto_type start_c = expr_transpile_expr(ctx, start_expr);
                                                             __auto_type end_c = expr_transpile_expr(ctx, end_expr);
@@ -2237,10 +2238,10 @@ void match_emit_inline_for(context_TranspileContext* ctx, slop_list_types_SExpr_
                                                             context_ctx_dedent(ctx);
                                                             context_ctx_emit(ctx, SLOP_STR("}"));
                                                         }
-                                                    } else if (!_mv_766.has_value) {
+                                                    } else if (!_mv_767.has_value) {
                                                         context_ctx_add_error_at(ctx, SLOP_STR("missing end"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                                     }
-                                                } else if (!_mv_765.has_value) {
+                                                } else if (!_mv_766.has_value) {
                                                     context_ctx_add_error_at(ctx, SLOP_STR("missing start"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                                 }
                                             }
@@ -2251,7 +2252,7 @@ void match_emit_inline_for(context_TranspileContext* ctx, slop_list_types_SExpr_
                                             break;
                                         }
                                     }
-                                } else if (!_mv_763.has_value) {
+                                } else if (!_mv_764.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing var"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                 }
                             }
@@ -2263,7 +2264,7 @@ void match_emit_inline_for(context_TranspileContext* ctx, slop_list_types_SExpr_
                         break;
                     }
                 }
-            } else if (!_mv_761.has_value) {
+            } else if (!_mv_762.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing binding"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             }
         }
@@ -2338,38 +2339,38 @@ void match_emit_inline_for_each_map_kv(context_TranspileContext* ctx, slop_list_
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_767 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_767.has_value) {
-            __auto_type kv_list_expr = _mv_767.value;
-            __auto_type _mv_768 = (*kv_list_expr);
-            switch (_mv_768.tag) {
+        __auto_type _mv_768 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_768.has_value) {
+            __auto_type kv_list_expr = _mv_768.value;
+            __auto_type _mv_769 = (*kv_list_expr);
+            switch (_mv_769.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type kv_lst = _mv_768.data.lst;
+                    __auto_type kv_lst = _mv_769.data.lst;
                     {
                         __auto_type kv_items = kv_lst.items;
                         if (((int64_t)((kv_items).len)) < 2) {
                             context_ctx_add_error(ctx, SLOP_STR("Map for-each needs ((k v) map)"));
                         } else {
-                            __auto_type _mv_769 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_769.has_value) {
-                                __auto_type k_expr = _mv_769.value;
-                                __auto_type _mv_770 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_770.has_value) {
-                                    __auto_type v_expr = _mv_770.value;
-                                    __auto_type _mv_771 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_771.has_value) {
-                                        __auto_type map_expr = _mv_771.value;
-                                        __auto_type _mv_772 = (*k_expr);
-                                        switch (_mv_772.tag) {
+                            __auto_type _mv_770 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_770.has_value) {
+                                __auto_type k_expr = _mv_770.value;
+                                __auto_type _mv_771 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_771.has_value) {
+                                    __auto_type v_expr = _mv_771.value;
+                                    __auto_type _mv_772 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_772.has_value) {
+                                        __auto_type map_expr = _mv_772.value;
+                                        __auto_type _mv_773 = (*k_expr);
+                                        switch (_mv_773.tag) {
                                             case types_SExpr_sym:
                                             {
-                                                __auto_type k_sym = _mv_772.data.sym;
-                                                __auto_type _mv_773 = (*v_expr);
-                                                switch (_mv_773.tag) {
+                                                __auto_type k_sym = _mv_773.data.sym;
+                                                __auto_type _mv_774 = (*v_expr);
+                                                switch (_mv_774.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type v_sym = _mv_773.data.sym;
+                                                        __auto_type v_sym = _mv_774.data.sym;
                                                         {
                                                             __auto_type k_name = ctype_to_c_name(arena, k_sym.name);
                                                             __auto_type v_name = ctype_to_c_name(arena, v_sym.name);
@@ -2425,13 +2426,13 @@ void match_emit_inline_for_each_map_kv(context_TranspileContext* ctx, slop_list_
                                                 break;
                                             }
                                         }
-                                    } else if (!_mv_771.has_value) {
+                                    } else if (!_mv_772.has_value) {
                                         context_ctx_add_error(ctx, SLOP_STR("Missing map expression"));
                                     }
-                                } else if (!_mv_770.has_value) {
+                                } else if (!_mv_771.has_value) {
                                     context_ctx_add_error(ctx, SLOP_STR("Missing value binding"));
                                 }
-                            } else if (!_mv_769.has_value) {
+                            } else if (!_mv_770.has_value) {
                                 context_ctx_add_error(ctx, SLOP_STR("Missing key binding"));
                             }
                         }
@@ -2443,7 +2444,7 @@ void match_emit_inline_for_each_map_kv(context_TranspileContext* ctx, slop_list_
                     break;
                 }
             }
-        } else if (!_mv_767.has_value) {
+        } else if (!_mv_768.has_value) {
             context_ctx_add_error(ctx, SLOP_STR("Missing binding"));
         }
     }
@@ -2457,39 +2458,39 @@ void match_emit_inline_for_each(context_TranspileContext* ctx, slop_list_types_S
         if (len < 2) {
             context_ctx_add_error_at(ctx, SLOP_STR("invalid for-each: need binding"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         } else {
-            __auto_type _mv_774 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_774.has_value) {
-                __auto_type binding_expr = _mv_774.value;
-                __auto_type _mv_775 = (*binding_expr);
-                switch (_mv_775.tag) {
+            __auto_type _mv_775 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_775.has_value) {
+                __auto_type binding_expr = _mv_775.value;
+                __auto_type _mv_776 = (*binding_expr);
+                switch (_mv_776.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type binding_lst = _mv_775.data.lst;
+                        __auto_type binding_lst = _mv_776.data.lst;
                         {
                             __auto_type binding_items = binding_lst.items;
                             __auto_type binding_len = ((int64_t)((binding_items).len));
                             if (binding_len < 2) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("for-each binding needs (var coll)"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                             } else {
-                                __auto_type _mv_776 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_776.has_value) {
-                                    __auto_type first_elem = _mv_776.value;
-                                    __auto_type _mv_777 = (*first_elem);
-                                    switch (_mv_777.tag) {
+                                __auto_type _mv_777 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_777.has_value) {
+                                    __auto_type first_elem = _mv_777.value;
+                                    __auto_type _mv_778 = (*first_elem);
+                                    switch (_mv_778.tag) {
                                         case types_SExpr_lst:
                                         {
-                                            __auto_type _ = _mv_777.data.lst;
+                                            __auto_type _ = _mv_778.data.lst;
                                             match_emit_inline_for_each_map_kv(ctx, binding_items, items, len);
                                             break;
                                         }
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type var_sym = _mv_777.data.sym;
+                                            __auto_type var_sym = _mv_778.data.sym;
                                             {
                                                 __auto_type var_name = ctype_to_c_name(arena, var_sym.name);
-                                                __auto_type _mv_778 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_778.has_value) {
-                                                    __auto_type coll_expr = _mv_778.value;
+                                                __auto_type _mv_779 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_779.has_value) {
+                                                    __auto_type coll_expr = _mv_779.value;
                                                     {
                                                         __auto_type coll_slop_type = expr_infer_expr_slop_type(ctx, coll_expr);
                                                         __auto_type resolved_type = expr_resolve_type_alias(ctx, coll_slop_type);
@@ -2528,7 +2529,7 @@ void match_emit_inline_for_each(context_TranspileContext* ctx, slop_list_types_S
                                                             }
                                                         }
                                                     }
-                                                } else if (!_mv_778.has_value) {
+                                                } else if (!_mv_779.has_value) {
                                                     context_ctx_add_error_at(ctx, SLOP_STR("missing collection"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                                 }
                                             }
@@ -2539,7 +2540,7 @@ void match_emit_inline_for_each(context_TranspileContext* ctx, slop_list_types_S
                                             break;
                                         }
                                     }
-                                } else if (!_mv_776.has_value) {
+                                } else if (!_mv_777.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing var"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                 }
                             }
@@ -2551,7 +2552,7 @@ void match_emit_inline_for_each(context_TranspileContext* ctx, slop_list_types_S
                         break;
                     }
                 }
-            } else if (!_mv_774.has_value) {
+            } else if (!_mv_775.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing binding"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             }
         }
@@ -2565,11 +2566,11 @@ void match_emit_inline_return(context_TranspileContext* ctx, slop_list_types_SEx
         if (len < 2) {
             context_ctx_emit(ctx, SLOP_STR("return;"));
         } else {
-            __auto_type _mv_779 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_779.has_value) {
-                __auto_type val_expr = _mv_779.value;
+            __auto_type _mv_780 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_780.has_value) {
+                __auto_type val_expr = _mv_780.value;
                 match_emit_typed_return_expr(ctx, val_expr);
-            } else if (!_mv_779.has_value) {
+            } else if (!_mv_780.has_value) {
                 context_ctx_emit(ctx, SLOP_STR("return;"));
             }
         }
@@ -2587,61 +2588,61 @@ void match_emit_return_typed(context_TranspileContext* ctx, slop_string code) {
 void match_emit_typed_return_expr(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_780 = (*expr);
-    switch (_mv_780.tag) {
+    __auto_type _mv_781 = (*expr);
+    switch (_mv_781.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_780.data.lst;
+            __auto_type lst = _mv_781.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                 } else {
-                    __auto_type _mv_781 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_781.has_value) {
-                        __auto_type head = _mv_781.value;
-                        __auto_type _mv_782 = (*head);
-                        switch (_mv_782.tag) {
+                    __auto_type _mv_782 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_782.has_value) {
+                        __auto_type head = _mv_782.value;
+                        __auto_type _mv_783 = (*head);
+                        switch (_mv_783.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_782.data.sym;
+                                __auto_type sym = _mv_783.data.sym;
                                 {
                                     __auto_type op = sym.name;
                                     if (string_eq(op, SLOP_STR("some"))) {
-                                        __auto_type _mv_783 = context_ctx_get_current_return_type(ctx);
-                                        if (_mv_783.has_value) {
-                                            __auto_type ret_type = _mv_783.value;
+                                        __auto_type _mv_784 = context_ctx_get_current_return_type(ctx);
+                                        if (_mv_784.has_value) {
+                                            __auto_type ret_type = _mv_784.value;
                                             if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
                                                 if (((int64_t)((items).len)) < 2) {
                                                     match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                                                 } else {
-                                                    __auto_type _mv_784 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_784.has_value) {
-                                                        __auto_type inner_expr = _mv_784.value;
+                                                    __auto_type _mv_785 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_785.has_value) {
+                                                        __auto_type inner_expr = _mv_785.value;
                                                         {
                                                             __auto_type inner_c = expr_transpile_expr(ctx, inner_expr);
                                                             context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("return ("), ret_type, SLOP_STR("){.has_value = 1, .value = "), inner_c, SLOP_STR("};")));
                                                         }
-                                                    } else if (!_mv_784.has_value) {
+                                                    } else if (!_mv_785.has_value) {
                                                         match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                                                     }
                                                 }
                                             } else {
                                                 match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                                             }
-                                        } else if (!_mv_783.has_value) {
+                                        } else if (!_mv_784.has_value) {
                                             match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                                         }
                                     } else if (string_eq(op, SLOP_STR("none"))) {
-                                        __auto_type _mv_785 = context_ctx_get_current_return_type(ctx);
-                                        if (_mv_785.has_value) {
-                                            __auto_type ret_type = _mv_785.value;
+                                        __auto_type _mv_786 = context_ctx_get_current_return_type(ctx);
+                                        if (_mv_786.has_value) {
+                                            __auto_type ret_type = _mv_786.value;
                                             if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
                                                 context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("return ("), ret_type, SLOP_STR("){.has_value = false};")));
                                             } else {
                                                 match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                                             }
-                                        } else if (!_mv_785.has_value) {
+                                        } else if (!_mv_786.has_value) {
                                             match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                                         }
                                     } else {
@@ -2655,7 +2656,7 @@ void match_emit_typed_return_expr(context_TranspileContext* ctx, types_SExpr* ex
                                 break;
                             }
                         }
-                    } else if (!_mv_781.has_value) {
+                    } else if (!_mv_782.has_value) {
                         match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                     }
                 }
@@ -2671,11 +2672,11 @@ void match_emit_typed_return_expr(context_TranspileContext* ctx, types_SExpr* ex
 
 uint8_t match_is_pattern_literal(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_786 = (*expr);
-    switch (_mv_786.tag) {
+    __auto_type _mv_787 = (*expr);
+    switch (_mv_787.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_786.data.sym;
+            __auto_type sym = _mv_787.data.sym;
             {
                 __auto_type name = sym.name;
                 return (string_eq(name, SLOP_STR("true")) || string_eq(name, SLOP_STR("false")));
@@ -2683,7 +2684,7 @@ uint8_t match_is_pattern_literal(types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type _ = _mv_786.data.num;
+            __auto_type _ = _mv_787.data.num;
             return 1;
         }
         default: {
@@ -2694,11 +2695,11 @@ uint8_t match_is_pattern_literal(types_SExpr* expr) {
 
 slop_string match_pattern_literal_to_c(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_787 = (*expr);
-    switch (_mv_787.tag) {
+    __auto_type _mv_788 = (*expr);
+    switch (_mv_788.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_787.data.sym;
+            __auto_type sym = _mv_788.data.sym;
             {
                 __auto_type name = sym.name;
                 if (string_eq(name, SLOP_STR("true"))) {
@@ -2712,7 +2713,7 @@ slop_string match_pattern_literal_to_c(types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type n = _mv_787.data.num;
+            __auto_type n = _mv_788.data.num;
             return n.raw;
         }
         default: {
@@ -2723,24 +2724,24 @@ slop_string match_pattern_literal_to_c(types_SExpr* expr) {
 
 uint8_t match_has_literal_in_union_arm(types_SExpr* pat_expr) {
     SLOP_PRE(((pat_expr != NULL)), "(!= pat-expr nil)");
-    __auto_type _mv_788 = (*pat_expr);
-    switch (_mv_788.tag) {
+    __auto_type _mv_789 = (*pat_expr);
+    switch (_mv_789.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_788.data.lst;
+            __auto_type lst = _mv_789.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type found = 0;
                 for (int64_t i = 1; i < len; i++) {
                     if (!(found)) {
-                        __auto_type _mv_789 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_789.has_value) {
-                            __auto_type item = _mv_789.value;
+                        __auto_type _mv_790 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_790.has_value) {
+                            __auto_type item = _mv_790.value;
                             if (match_is_pattern_literal(item)) {
                                 found = 1;
                             }
-                        } else if (!_mv_789.has_value) {
+                        } else if (!_mv_790.has_value) {
                         }
                     }
                 }
@@ -2759,13 +2760,13 @@ uint8_t match_has_literal_in_patterns(slop_list_types_SExpr_ptr patterns) {
         uint8_t found = 0;
         int64_t i = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_790 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_790.has_value) {
-                __auto_type pat_expr = _mv_790.value;
+            __auto_type _mv_791 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_791.has_value) {
+                __auto_type pat_expr = _mv_791.value;
                 if (match_has_literal_in_union_arm(pat_expr)) {
                     found = 1;
                 }
-            } else if (!_mv_790.has_value) {
+            } else if (!_mv_791.has_value) {
             }
             i = (i + 1);
         }
@@ -2778,19 +2779,19 @@ slop_string match_build_literal_guard_cond(context_TranspileContext* ctx, slop_s
     SLOP_PRE(((pattern != NULL)), "(!= pattern nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_791 = (*pattern);
-        switch (_mv_791.tag) {
+        __auto_type _mv_792 = (*pattern);
+        switch (_mv_792.tag) {
             case types_SExpr_lst:
             {
-                __auto_type pat_lst = _mv_791.data.lst;
+                __auto_type pat_lst = _mv_792.data.lst;
                 {
                     __auto_type pat_items = pat_lst.items;
                     __auto_type pat_len = ((int64_t)((pat_items).len));
                     __auto_type cond = tag_cond;
                     for (int64_t bi = 1; bi < pat_len; bi++) {
-                        __auto_type _mv_792 = ({ __auto_type _lst = pat_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_792.has_value) {
-                            __auto_type item = _mv_792.value;
+                        __auto_type _mv_793 = ({ __auto_type _lst = pat_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_793.has_value) {
+                            __auto_type item = _mv_793.value;
                             if (match_is_pattern_literal(item)) {
                                 {
                                     __auto_type lit_c = match_pattern_literal_to_c(item);
@@ -2809,7 +2810,7 @@ slop_string match_build_literal_guard_cond(context_TranspileContext* ctx, slop_s
                                     }
                                 }
                             }
-                        } else if (!_mv_792.has_value) {
+                        } else if (!_mv_793.has_value) {
                         }
                     }
                     return cond;
@@ -2828,18 +2829,18 @@ void match_emit_union_literal_bindings(context_TranspileContext* ctx, slop_strin
     {
         __auto_type arena = (*ctx).arena;
         if (is_multi) {
-            __auto_type _mv_793 = (*pattern);
-            switch (_mv_793.tag) {
+            __auto_type _mv_794 = (*pattern);
+            switch (_mv_794.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type pat_lst = _mv_793.data.lst;
+                    __auto_type pat_lst = _mv_794.data.lst;
                     {
                         __auto_type pat_items = pat_lst.items;
                         __auto_type pat_len = ((int64_t)((pat_items).len));
                         for (int64_t bi = 1; bi < pat_len; bi++) {
-                            __auto_type _mv_794 = ({ __auto_type _lst = pat_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_794.has_value) {
-                                __auto_type binding_expr = _mv_794.value;
+                            __auto_type _mv_795 = ({ __auto_type _lst = pat_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_795.has_value) {
+                                __auto_type binding_expr = _mv_795.value;
                                 if (!(match_is_pattern_literal(binding_expr))) {
                                     {
                                         __auto_type binding_name = parser_sexpr_get_symbol_name(binding_expr);
@@ -2857,7 +2858,7 @@ void match_emit_union_literal_bindings(context_TranspileContext* ctx, slop_strin
                                         }
                                     }
                                 }
-                            } else if (!_mv_794.has_value) {
+                            } else if (!_mv_795.has_value) {
                             }
                         }
                     }
@@ -2868,9 +2869,9 @@ void match_emit_union_literal_bindings(context_TranspileContext* ctx, slop_strin
                 }
             }
         } else {
-            __auto_type _mv_795 = match_extract_binding_name(pattern);
-            if (_mv_795.has_value) {
-                __auto_type binding_name = _mv_795.value;
+            __auto_type _mv_796 = match_extract_binding_name(pattern);
+            if (_mv_796.has_value) {
+                __auto_type binding_name = _mv_796.value;
                 if ((!(string_eq(binding_name, SLOP_STR("true")))) && (!(string_eq(binding_name, SLOP_STR("false")))) && (!(string_eq(binding_name, SLOP_STR("_"))))) {
                     {
                         __auto_type c_binding = ctype_to_c_name(arena, binding_name);
@@ -2880,7 +2881,7 @@ void match_emit_union_literal_bindings(context_TranspileContext* ctx, slop_strin
                         context_ctx_bind_var(ctx, (context_VarEntry){binding_name, c_binding, payload_c_type, payload_slop_type, 0, 0, 0, SLOP_STR(""), SLOP_STR("")});
                     }
                 }
-            } else if (!_mv_795.has_value) {
+            } else if (!_mv_796.has_value) {
             }
         }
     }
@@ -2895,20 +2896,20 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
         uint8_t first = 1;
         uint8_t has_else = 0;
         while (i < len) {
-            __auto_type _mv_796 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_796.has_value) {
-                __auto_type branch = _mv_796.value;
-                __auto_type _mv_797 = (*branch);
-                switch (_mv_797.tag) {
+            __auto_type _mv_797 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_797.has_value) {
+                __auto_type branch = _mv_797.value;
+                __auto_type _mv_798 = (*branch);
+                switch (_mv_798.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type branch_lst = _mv_797.data.lst;
+                        __auto_type branch_lst = _mv_798.data.lst;
                         {
                             __auto_type branch_items = branch_lst.items;
                             if (((int64_t)((branch_items).len)) >= 2) {
-                                __auto_type _mv_798 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_798.has_value) {
-                                    __auto_type pattern = _mv_798.value;
+                                __auto_type _mv_799 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_799.has_value) {
+                                    __auto_type pattern = _mv_799.value;
                                     {
                                         __auto_type tag = match_get_pattern_tag(pattern);
                                         if (string_eq(tag, SLOP_STR("else")) || string_eq(tag, SLOP_STR("_"))) {
@@ -2923,9 +2924,9 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
                                             context_ctx_dedent(ctx);
                                             first = 0;
                                         } else {
-                                            __auto_type _mv_799 = context_ctx_lookup_enum_variant(ctx, tag);
-                                            if (_mv_799.has_value) {
-                                                __auto_type union_type_name = _mv_799.value;
+                                            __auto_type _mv_800 = context_ctx_lookup_enum_variant(ctx, tag);
+                                            if (_mv_800.has_value) {
+                                                __auto_type union_type_name = _mv_800.value;
                                                 {
                                                     __auto_type c_tag = ctype_to_c_name(arena, tag);
                                                     __auto_type tag_cond = context_ctx_str5(ctx, scrutinee_c, SLOP_STR(".tag == "), union_type_name, SLOP_STR("_"), c_tag);
@@ -2946,12 +2947,12 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
                                                     context_ctx_dedent(ctx);
                                                     first = 0;
                                                 }
-                                            } else if (!_mv_799.has_value) {
+                                            } else if (!_mv_800.has_value) {
                                                 context_ctx_add_error(ctx, context_ctx_str3(ctx, SLOP_STR("unknown union variant in match: "), tag, SLOP_STR(" (not registered as enum variant)")));
                                             }
                                         }
                                     }
-                                } else if (!_mv_798.has_value) {
+                                } else if (!_mv_799.has_value) {
                                 }
                             }
                         }
@@ -2961,7 +2962,7 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
                         break;
                     }
                 }
-            } else if (!_mv_796.has_value) {
+            } else if (!_mv_797.has_value) {
             }
             i = (i + 1);
         }

--- a/bootstrap/tester/slop_parser.c
+++ b/bootstrap/tester/slop_parser.c
@@ -346,15 +346,15 @@ slop_result_list_parser_Token_parser_ParseError parser_tokenize(slop_arena* aren
         uint8_t has_error = 0;
         __auto_type error_val = (parser_ParseError){SLOP_STR(""), 0, 0};
         while (!(done) && !(has_error)) {
-            __auto_type _mv_610 = parser_lexer_next_token(arena, (&state));
-            if (_mv_610.is_ok) {
-                __auto_type tok = _mv_610.data.ok;
+            __auto_type _mv_611 = parser_lexer_next_token(arena, (&state));
+            if (_mv_611.is_ok) {
+                __auto_type tok = _mv_611.data.ok;
                 ({ __auto_type _lst_p = &(tokens); __auto_type _item = (tok); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                 if (tok.kind == parser_TokenType_tok_eof) {
                     done = 1;
                 }
-            } else if (!_mv_610.is_ok) {
-                __auto_type e = _mv_610.data.err;
+            } else if (!_mv_611.is_ok) {
+                __auto_type e = _mv_611.data.err;
                 has_error = 1;
                 error_val = e;
             }
@@ -376,11 +376,11 @@ uint8_t parser_parser_at_end(parser_ParserState* state) {
 }
 
 parser_Token parser_parser_peek(parser_ParserState* state) {
-    __auto_type _mv_611 = ({ __auto_type _lst = (*state).tokens; size_t _idx = (size_t)(*state).pos; slop_option_parser_Token _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-    if (_mv_611.has_value) {
-        __auto_type tok = _mv_611.value;
+    __auto_type _mv_612 = ({ __auto_type _lst = (*state).tokens; size_t _idx = (size_t)(*state).pos; slop_option_parser_Token _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+    if (_mv_612.has_value) {
+        __auto_type tok = _mv_612.value;
         return tok;
-    } else if (!_mv_611.has_value) {
+    } else if (!_mv_612.has_value) {
         return (parser_Token){parser_TokenType_tok_eof, SLOP_STR(""), 1, 1};
     }
     SLOP_UNREACHABLE();
@@ -431,9 +431,9 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_expr(slop_arena* aren
             }
         } else if (tok.kind == parser_TokenType_tok_quote) {
             parser_parser_advance(state);
-            __auto_type _mv_612 = parser_parse_expr(arena, state);
-            if (_mv_612.is_ok) {
-                __auto_type quoted_expr = _mv_612.data.ok;
+            __auto_type _mv_613 = parser_parse_expr(arena, state);
+            if (_mv_613.is_ok) {
+                __auto_type quoted_expr = _mv_613.data.ok;
                 {
                     __auto_type node = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                     __auto_type quote_sym = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
@@ -444,8 +444,8 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_expr(slop_arena* aren
                     (*node) = ((types_SExpr){ .tag = types_SExpr_lst, .data.lst = (types_SExprList){items, tok.line, tok.col, ((slop_option_types_ResolvedType_ptr){.has_value = false})} });
                     return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = node });
                 }
-            } else if (!_mv_612.is_ok) {
-                __auto_type e = _mv_612.data.err;
+            } else if (!_mv_613.is_ok) {
+                __auto_type e = _mv_613.data.err;
                 return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
             }
             SLOP_UNREACHABLE();
@@ -521,12 +521,12 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_list(slop_arena* aren
                         has_error = 1;
                         error_val = (parser_ParseError){SLOP_STR("Unterminated list"), start_tok.line, start_tok.col};
                     } else {
-                        __auto_type _mv_613 = parser_parse_expr(arena, state);
-                        if (_mv_613.is_ok) {
-                            __auto_type expr = _mv_613.data.ok;
+                        __auto_type _mv_614 = parser_parse_expr(arena, state);
+                        if (_mv_614.is_ok) {
+                            __auto_type expr = _mv_614.data.ok;
                             ({ __auto_type _lst_p = &(items); __auto_type _item = (expr); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                        } else if (!_mv_613.is_ok) {
-                            __auto_type e = _mv_613.data.err;
+                        } else if (!_mv_614.is_ok) {
+                            __auto_type e = _mv_614.data.err;
                             has_error = 1;
                             error_val = e;
                         }
@@ -580,18 +580,18 @@ int64_t parser_get_precedence(slop_string op) {
 
 slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_paren_group(slop_arena* arena, parser_ParserState* state) {
     parser_parser_advance(state);
-    __auto_type _mv_614 = parser_parse_infix_prec(arena, state, 0);
-    if (!_mv_614.is_ok) {
-        __auto_type e = _mv_614.data.err;
+    __auto_type _mv_615 = parser_parse_infix_prec(arena, state, 0);
+    if (!_mv_615.is_ok) {
+        __auto_type e = _mv_615.data.err;
         return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-    } else if (_mv_614.is_ok) {
-        __auto_type expr = _mv_614.data.ok;
-        __auto_type _mv_615 = parser_parser_expect(state, parser_TokenType_tok_rparen);
-        if (!_mv_615.is_ok) {
-            __auto_type e = _mv_615.data.err;
+    } else if (_mv_615.is_ok) {
+        __auto_type expr = _mv_615.data.ok;
+        __auto_type _mv_616 = parser_parser_expect(state, parser_TokenType_tok_rparen);
+        if (!_mv_616.is_ok) {
+            __auto_type e = _mv_616.data.err;
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-        } else if (_mv_615.is_ok) {
-            __auto_type _ = _mv_615.data.ok;
+        } else if (_mv_616.is_ok) {
+            __auto_type _ = _mv_616.data.ok;
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = expr });
         }
         SLOP_UNREACHABLE();
@@ -616,12 +616,12 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
         } else if (tok.kind == parser_TokenType_tok_symbol) {
             if (string_eq(tok.value, SLOP_STR("not"))) {
                 parser_parser_advance(state);
-                __auto_type _mv_616 = parser_parse_infix_primary(arena, state);
-                if (!_mv_616.is_ok) {
-                    __auto_type e = _mv_616.data.err;
+                __auto_type _mv_617 = parser_parse_infix_primary(arena, state);
+                if (!_mv_617.is_ok) {
+                    __auto_type e = _mv_617.data.err;
                     return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-                } else if (_mv_616.is_ok) {
-                    __auto_type operand = _mv_616.data.ok;
+                } else if (_mv_617.is_ok) {
+                    __auto_type operand = _mv_617.data.ok;
                     {
                         __auto_type node = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                         __auto_type not_sym = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
@@ -644,12 +644,12 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
             }
         } else if ((tok.kind == parser_TokenType_tok_operator) && string_eq(tok.value, SLOP_STR("-"))) {
             parser_parser_advance(state);
-            __auto_type _mv_617 = parser_parse_infix_primary(arena, state);
-            if (!_mv_617.is_ok) {
-                __auto_type e = _mv_617.data.err;
+            __auto_type _mv_618 = parser_parse_infix_primary(arena, state);
+            if (!_mv_618.is_ok) {
+                __auto_type e = _mv_618.data.err;
                 return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-            } else if (_mv_617.is_ok) {
-                __auto_type operand = _mv_617.data.ok;
+            } else if (_mv_618.is_ok) {
+                __auto_type operand = _mv_618.data.ok;
                 {
                     __auto_type node = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                     __auto_type minus_sym = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
@@ -671,13 +671,13 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
             {
                 __auto_type saved_pos = (*state).pos;
                 parser_parser_advance(state);
-                __auto_type _mv_618 = parser_parse_infix_primary(arena, state);
-                if (!_mv_618.is_ok) {
-                    __auto_type _ = _mv_618.data.err;
+                __auto_type _mv_619 = parser_parse_infix_primary(arena, state);
+                if (!_mv_619.is_ok) {
+                    __auto_type _ = _mv_619.data.err;
                     (*state).pos = saved_pos;
                     return parser_parse_list(arena, state);
-                } else if (_mv_618.is_ok) {
-                    __auto_type _ = _mv_618.data.ok;
+                } else if (_mv_619.is_ok) {
+                    __auto_type _ = _mv_619.data.ok;
                     {
                         __auto_type next_tok = parser_parser_peek(state);
                         if ((next_tok.kind == parser_TokenType_tok_operator) || ((next_tok.kind == parser_TokenType_tok_symbol) && (string_eq(next_tok.value, SLOP_STR("and")) || string_eq(next_tok.value, SLOP_STR("or"))))) {
@@ -693,12 +693,12 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
             }
         } else if (tok.kind == parser_TokenType_tok_quote) {
             parser_parser_advance(state);
-            __auto_type _mv_619 = parser_parse_infix_primary(arena, state);
-            if (!_mv_619.is_ok) {
-                __auto_type e = _mv_619.data.err;
+            __auto_type _mv_620 = parser_parse_infix_primary(arena, state);
+            if (!_mv_620.is_ok) {
+                __auto_type e = _mv_620.data.err;
                 return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-            } else if (_mv_619.is_ok) {
-                __auto_type quoted_expr = _mv_619.data.ok;
+            } else if (_mv_620.is_ok) {
+                __auto_type quoted_expr = _mv_620.data.ok;
                 {
                     __auto_type node = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                     __auto_type quote_sym = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
@@ -718,12 +718,12 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
 }
 
 slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_prec(slop_arena* arena, parser_ParserState* state, int64_t min_prec) {
-    __auto_type _mv_620 = parser_parse_infix_primary(arena, state);
-    if (!_mv_620.is_ok) {
-        __auto_type e = _mv_620.data.err;
+    __auto_type _mv_621 = parser_parse_infix_primary(arena, state);
+    if (!_mv_621.is_ok) {
+        __auto_type e = _mv_621.data.err;
         return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-    } else if (_mv_620.is_ok) {
-        __auto_type left = _mv_620.data.ok;
+    } else if (_mv_621.is_ok) {
+        __auto_type left = _mv_621.data.ok;
         {
             __auto_type result = left;
             __auto_type done = 0;
@@ -741,13 +741,13 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_prec(slop_arena
                                 {
                                     __auto_type op_tok = tok;
                                     parser_parser_advance(state);
-                                    __auto_type _mv_621 = parser_parse_infix_prec(arena, state, (op_prec + 1));
-                                    if (!_mv_621.is_ok) {
-                                        __auto_type e = _mv_621.data.err;
+                                    __auto_type _mv_622 = parser_parse_infix_prec(arena, state, (op_prec + 1));
+                                    if (!_mv_622.is_ok) {
+                                        __auto_type e = _mv_622.data.err;
                                         has_error = 1;
                                         error_val = e;
-                                    } else if (_mv_621.is_ok) {
-                                        __auto_type right = _mv_621.data.ok;
+                                    } else if (_mv_622.is_ok) {
+                                        __auto_type right = _mv_622.data.ok;
                                         {
                                             __auto_type node = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                                             __auto_type op_sym = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
@@ -787,12 +787,12 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix(slop_arena* are
         {
             __auto_type result = parser_parse_infix_prec(arena, state, 0);
             (*state).in_infix = 0;
-            __auto_type _mv_622 = result;
-            if (!_mv_622.is_ok) {
-                __auto_type e = _mv_622.data.err;
+            __auto_type _mv_623 = result;
+            if (!_mv_623.is_ok) {
+                __auto_type e = _mv_623.data.err;
                 return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-            } else if (_mv_622.is_ok) {
-                __auto_type expr = _mv_622.data.ok;
+            } else if (_mv_623.is_ok) {
+                __auto_type expr = _mv_623.data.ok;
                 {
                     __auto_type tok = parser_parser_peek(state);
                     if (tok.kind == parser_TokenType_tok_rbrace) {
@@ -809,9 +809,9 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix(slop_arena* are
 }
 
 slop_result_list_types_SExpr_ptr_parser_ParseError parser_parse(slop_arena* arena, slop_string source) {
-    __auto_type _mv_623 = parser_tokenize(arena, source);
-    if (_mv_623.is_ok) {
-        __auto_type tokens = _mv_623.data.ok;
+    __auto_type _mv_624 = parser_tokenize(arena, source);
+    if (_mv_624.is_ok) {
+        __auto_type tokens = _mv_624.data.ok;
         {
             __auto_type state = parser_parser_new(tokens);
             __auto_type result = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
@@ -824,12 +824,12 @@ slop_result_list_types_SExpr_ptr_parser_ParseError parser_parse(slop_arena* aren
                     if (tok.kind == parser_TokenType_tok_eof) {
                         done = 1;
                     } else {
-                        __auto_type _mv_624 = parser_parse_expr(arena, (&state));
-                        if (_mv_624.is_ok) {
-                            __auto_type expr = _mv_624.data.ok;
+                        __auto_type _mv_625 = parser_parse_expr(arena, (&state));
+                        if (_mv_625.is_ok) {
+                            __auto_type expr = _mv_625.data.ok;
                             ({ __auto_type _lst_p = &(result); __auto_type _item = (expr); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                        } else if (!_mv_624.is_ok) {
-                            __auto_type e = _mv_624.data.err;
+                        } else if (!_mv_625.is_ok) {
+                            __auto_type e = _mv_625.data.err;
                             has_error = 1;
                             error_val = e;
                         }
@@ -842,34 +842,34 @@ slop_result_list_types_SExpr_ptr_parser_ParseError parser_parse(slop_arena* aren
                 return ((slop_result_list_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = result });
             }
         }
-    } else if (!_mv_623.is_ok) {
-        __auto_type e = _mv_623.data.err;
+    } else if (!_mv_624.is_ok) {
+        __auto_type e = _mv_624.data.err;
         return ((slop_result_list_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
     }
     SLOP_UNREACHABLE();
 }
 
 int64_t parser_sexpr_line(types_SExpr* expr) {
-    __auto_type _mv_625 = (*expr);
-    switch (_mv_625.tag) {
+    __auto_type _mv_626 = (*expr);
+    switch (_mv_626.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_625.data.sym;
+            __auto_type s = _mv_626.data.sym;
             return s.line;
         }
         case types_SExpr_str:
         {
-            __auto_type s = _mv_625.data.str;
+            __auto_type s = _mv_626.data.str;
             return s.line;
         }
         case types_SExpr_num:
         {
-            __auto_type n = _mv_625.data.num;
+            __auto_type n = _mv_626.data.num;
             return n.line;
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_625.data.lst;
+            __auto_type l = _mv_626.data.lst;
             return l.line;
         }
     }
@@ -877,26 +877,26 @@ int64_t parser_sexpr_line(types_SExpr* expr) {
 }
 
 int64_t parser_sexpr_col(types_SExpr* expr) {
-    __auto_type _mv_626 = (*expr);
-    switch (_mv_626.tag) {
+    __auto_type _mv_627 = (*expr);
+    switch (_mv_627.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_626.data.sym;
+            __auto_type s = _mv_627.data.sym;
             return s.col;
         }
         case types_SExpr_str:
         {
-            __auto_type s = _mv_626.data.str;
+            __auto_type s = _mv_627.data.str;
             return s.col;
         }
         case types_SExpr_num:
         {
-            __auto_type n = _mv_626.data.num;
+            __auto_type n = _mv_627.data.num;
             return n.col;
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_626.data.lst;
+            __auto_type l = _mv_627.data.lst;
             return l.col;
         }
     }
@@ -904,11 +904,11 @@ int64_t parser_sexpr_col(types_SExpr* expr) {
 }
 
 uint8_t parser_sexpr_is_symbol_with_name(types_SExpr* expr, slop_string name) {
-    __auto_type _mv_627 = (*expr);
-    switch (_mv_627.tag) {
+    __auto_type _mv_628 = (*expr);
+    switch (_mv_628.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_627.data.sym;
+            __auto_type sym = _mv_628.data.sym;
             return string_eq(sym.name, name);
         }
         default: {
@@ -918,19 +918,19 @@ uint8_t parser_sexpr_is_symbol_with_name(types_SExpr* expr, slop_string name) {
 }
 
 uint8_t parser_is_form(types_SExpr* expr, slop_string keyword) {
-    __auto_type _mv_628 = (*expr);
-    switch (_mv_628.tag) {
+    __auto_type _mv_629 = (*expr);
+    switch (_mv_629.tag) {
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_628.data.lst;
+            __auto_type l = _mv_629.data.lst;
             if (((int64_t)((l.items).len)) == 0) {
                 return 0;
             } else {
-                __auto_type _mv_629 = ({ __auto_type _lst = l.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_629.has_value) {
-                    __auto_type first = _mv_629.value;
+                __auto_type _mv_630 = ({ __auto_type _lst = l.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_630.has_value) {
+                    __auto_type first = _mv_630.value;
                     return parser_sexpr_is_symbol_with_name(first, keyword);
-                } else if (!_mv_629.has_value) {
+                } else if (!_mv_630.has_value) {
                     return 0;
                 }
                 SLOP_UNREACHABLE();
@@ -943,11 +943,11 @@ uint8_t parser_is_form(types_SExpr* expr, slop_string keyword) {
 }
 
 int64_t parser_sexpr_list_len(types_SExpr* expr) {
-    __auto_type _mv_630 = (*expr);
-    switch (_mv_630.tag) {
+    __auto_type _mv_631 = (*expr);
+    switch (_mv_631.tag) {
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_630.data.lst;
+            __auto_type l = _mv_631.data.lst;
             return ((int64_t)((l.items).len));
         }
         default: {
@@ -957,11 +957,11 @@ int64_t parser_sexpr_list_len(types_SExpr* expr) {
 }
 
 slop_option_types_SExpr_ptr parser_sexpr_list_get(types_SExpr* expr, int64_t index) {
-    __auto_type _mv_631 = (*expr);
-    switch (_mv_631.tag) {
+    __auto_type _mv_632 = (*expr);
+    switch (_mv_632.tag) {
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_631.data.lst;
+            __auto_type l = _mv_632.data.lst;
             return ({ __auto_type _lst = l.items; size_t _idx = (size_t)index; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
         }
         default: {
@@ -971,11 +971,11 @@ slop_option_types_SExpr_ptr parser_sexpr_list_get(types_SExpr* expr, int64_t ind
 }
 
 uint8_t parser_sexpr_is_list(types_SExpr* expr) {
-    __auto_type _mv_632 = (*expr);
-    switch (_mv_632.tag) {
+    __auto_type _mv_633 = (*expr);
+    switch (_mv_633.tag) {
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_632.data.lst;
+            __auto_type l = _mv_633.data.lst;
             return 1;
         }
         default: {
@@ -985,11 +985,11 @@ uint8_t parser_sexpr_is_list(types_SExpr* expr) {
 }
 
 slop_string parser_sexpr_get_symbol_name(types_SExpr* expr) {
-    __auto_type _mv_633 = (*expr);
-    switch (_mv_633.tag) {
+    __auto_type _mv_634 = (*expr);
+    switch (_mv_634.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_633.data.sym;
+            __auto_type sym = _mv_634.data.sym;
             return sym.name;
         }
         default: {
@@ -1003,11 +1003,11 @@ slop_string parser_sexpr_symbol_name(types_SExpr* expr) {
 }
 
 uint8_t parser_sexpr_is_symbol(types_SExpr* expr) {
-    __auto_type _mv_634 = (*expr);
-    switch (_mv_634.tag) {
+    __auto_type _mv_635 = (*expr);
+    switch (_mv_635.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_634.data.sym;
+            __auto_type s = _mv_635.data.sym;
             return 1;
         }
         default: {
@@ -1017,11 +1017,11 @@ uint8_t parser_sexpr_is_symbol(types_SExpr* expr) {
 }
 
 uint8_t parser_sexpr_is_number(types_SExpr* expr) {
-    __auto_type _mv_635 = (*expr);
-    switch (_mv_635.tag) {
+    __auto_type _mv_636 = (*expr);
+    switch (_mv_636.tag) {
         case types_SExpr_num:
         {
-            __auto_type n = _mv_635.data.num;
+            __auto_type n = _mv_636.data.num;
             return 1;
         }
         default: {
@@ -1031,11 +1031,11 @@ uint8_t parser_sexpr_is_number(types_SExpr* expr) {
 }
 
 uint8_t parser_sexpr_is_string(types_SExpr* expr) {
-    __auto_type _mv_636 = (*expr);
-    switch (_mv_636.tag) {
+    __auto_type _mv_637 = (*expr);
+    switch (_mv_637.tag) {
         case types_SExpr_str:
         {
-            __auto_type s = _mv_636.data.str;
+            __auto_type s = _mv_637.data.str;
             return 1;
         }
         default: {
@@ -1045,11 +1045,11 @@ uint8_t parser_sexpr_is_string(types_SExpr* expr) {
 }
 
 slop_string parser_sexpr_number_string(types_SExpr* expr) {
-    __auto_type _mv_637 = (*expr);
-    switch (_mv_637.tag) {
+    __auto_type _mv_638 = (*expr);
+    switch (_mv_638.tag) {
         case types_SExpr_num:
         {
-            __auto_type n = _mv_637.data.num;
+            __auto_type n = _mv_638.data.num;
             return n.raw;
         }
         default: {
@@ -1059,11 +1059,11 @@ slop_string parser_sexpr_number_string(types_SExpr* expr) {
 }
 
 slop_string parser_sexpr_string_value(types_SExpr* expr) {
-    __auto_type _mv_638 = (*expr);
-    switch (_mv_638.tag) {
+    __auto_type _mv_639 = (*expr);
+    switch (_mv_639.tag) {
         case types_SExpr_str:
         {
-            __auto_type s = _mv_638.data.str;
+            __auto_type s = _mv_639.data.str;
             return s.value;
         }
         default: {
@@ -1078,34 +1078,34 @@ slop_list_types_SExpr_ptr parser_find_holes(slop_arena* arena, types_SExpr* expr
         if (parser_is_form(expr, SLOP_STR("hole"))) {
             ({ __auto_type _lst_p = &(result); __auto_type _item = (expr); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
         }
-        __auto_type _mv_639 = (*expr);
-        switch (_mv_639.tag) {
+        __auto_type _mv_640 = (*expr);
+        switch (_mv_640.tag) {
             case types_SExpr_lst:
             {
-                __auto_type l = _mv_639.data.lst;
+                __auto_type l = _mv_640.data.lst;
                 {
                     __auto_type items = l.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type i = 0;
                     while (i < len) {
-                        __auto_type _mv_640 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_640.has_value) {
-                            __auto_type child = _mv_640.value;
+                        __auto_type _mv_641 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_641.has_value) {
+                            __auto_type child = _mv_641.value;
                             {
                                 __auto_type child_holes = parser_find_holes(arena, child);
                                 __auto_type child_len = ((int64_t)((child_holes).len));
                                 __auto_type j = 0;
                                 while (j < child_len) {
-                                    __auto_type _mv_641 = ({ __auto_type _lst = child_holes; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_641.has_value) {
-                                        __auto_type h = _mv_641.value;
+                                    __auto_type _mv_642 = ({ __auto_type _lst = child_holes; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_642.has_value) {
+                                        __auto_type h = _mv_642.value;
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (h); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                                    } else if (!_mv_641.has_value) {
+                                    } else if (!_mv_642.has_value) {
                                     }
                                     j = (j + 1);
                                 }
                             }
-                        } else if (!_mv_640.has_value) {
+                        } else if (!_mv_641.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -1121,16 +1121,16 @@ slop_list_types_SExpr_ptr parser_find_holes(slop_arena* arena, types_SExpr* expr
 }
 
 slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
-    __auto_type _mv_642 = (*expr);
-    switch (_mv_642.tag) {
+    __auto_type _mv_643 = (*expr);
+    switch (_mv_643.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_642.data.sym;
+            __auto_type sym = _mv_643.data.sym;
             return parser_string_copy(arena, sym.name);
         }
         case types_SExpr_str:
         {
-            __auto_type str = _mv_642.data.str;
+            __auto_type str = _mv_643.data.str;
             {
                 __auto_type val = str.value;
                 __auto_type slen = ((int64_t)(val.len));
@@ -1171,7 +1171,7 @@ slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type num = _mv_642.data.num;
+            __auto_type num = _mv_643.data.num;
             if (num.is_float) {
                 return parser_string_copy(arena, SLOP_STR("<float>"));
             } else {
@@ -1180,7 +1180,7 @@ slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_642.data.lst;
+            __auto_type lst = _mv_643.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
@@ -1191,9 +1191,9 @@ slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
                         __auto_type result = parser_string_copy(arena, SLOP_STR("("));
                         __auto_type i = 0;
                         while (i < len) {
-                            __auto_type _mv_643 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_643.has_value) {
-                                __auto_type child = _mv_643.value;
+                            __auto_type _mv_644 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_644.has_value) {
+                                __auto_type child = _mv_644.value;
                                 {
                                     __auto_type child_str = parser_pretty_print(arena, child);
                                     if (i > 0) {
@@ -1201,7 +1201,7 @@ slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
                                     }
                                     result = string_concat(arena, result, child_str);
                                 }
-                            } else if (!_mv_643.has_value) {
+                            } else if (!_mv_644.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -1266,9 +1266,9 @@ slop_string parser_json_print_list(slop_arena* arena, slop_list_types_SExpr_ptr 
                 __auto_type result = parser_string_copy(arena, SLOP_STR("["));
                 int64_t i = 0;
                 while (i < len) {
-                    __auto_type _mv_644 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_644.has_value) {
-                        __auto_type child = _mv_644.value;
+                    __auto_type _mv_645 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_645.has_value) {
+                        __auto_type child = _mv_645.value;
                         {
                             __auto_type child_json = parser_json_print(arena, child);
                             if (i > 0) {
@@ -1276,7 +1276,7 @@ slop_string parser_json_print_list(slop_arena* arena, slop_list_types_SExpr_ptr 
                             }
                             result = string_concat(arena, result, child_json);
                         }
-                    } else if (!_mv_644.has_value) {
+                    } else if (!_mv_645.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -1287,11 +1287,11 @@ slop_string parser_json_print_list(slop_arena* arena, slop_list_types_SExpr_ptr 
 }
 
 slop_string parser_json_print(slop_arena* arena, types_SExpr* expr) {
-    __auto_type _mv_645 = (*expr);
-    switch (_mv_645.tag) {
+    __auto_type _mv_646 = (*expr);
+    switch (_mv_646.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_645.data.sym;
+            __auto_type sym = _mv_646.data.sym;
             {
                 __auto_type escaped = parser_json_escape_string(arena, sym.name);
                 __auto_type line_str = int_to_string(arena, sym.line);
@@ -1301,7 +1301,7 @@ slop_string parser_json_print(slop_arena* arena, types_SExpr* expr) {
         }
         case types_SExpr_str:
         {
-            __auto_type str = _mv_645.data.str;
+            __auto_type str = _mv_646.data.str;
             {
                 __auto_type escaped = parser_json_escape_string(arena, str.value);
                 __auto_type line_str = int_to_string(arena, str.line);
@@ -1311,7 +1311,7 @@ slop_string parser_json_print(slop_arena* arena, types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type num = _mv_645.data.num;
+            __auto_type num = _mv_646.data.num;
             {
                 __auto_type line_str = int_to_string(arena, num.line);
                 __auto_type col_str = int_to_string(arena, num.col);
@@ -1330,7 +1330,7 @@ slop_string parser_json_print(slop_arena* arena, types_SExpr* expr) {
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_645.data.lst;
+            __auto_type lst = _mv_646.data.lst;
             {
                 __auto_type items_json = parser_json_print_list(arena, lst.items);
                 __auto_type line_str = int_to_string(arena, lst.line);

--- a/bootstrap/tester/slop_stmt.c
+++ b/bootstrap/tester/slop_stmt.c
@@ -38,25 +38,25 @@ void stmt_emit_return_with_typed_none(context_TranspileContext* ctx, slop_string
 
 slop_string stmt_sexpr_to_type_string(slop_arena* arena, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_800 = (*expr);
-    switch (_mv_800.tag) {
+    __auto_type _mv_801 = (*expr);
+    switch (_mv_801.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_800.data.sym;
+            __auto_type sym = _mv_801.data.sym;
             return sym.name;
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_800.data.lst;
+            __auto_type lst = _mv_801.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type result = SLOP_STR("(");
                 __auto_type i = 0;
                 while (i < len) {
-                    __auto_type _mv_801 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_801.has_value) {
-                        __auto_type item_expr = _mv_801.value;
+                    __auto_type _mv_802 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_802.has_value) {
+                        __auto_type item_expr = _mv_802.value;
                         {
                             __auto_type item_str = ctype_sexpr_to_type_string(arena, item_expr);
                             if (i > 0) {
@@ -65,7 +65,7 @@ slop_string stmt_sexpr_to_type_string(slop_arena* arena, types_SExpr* expr) {
                                 result = string_concat(arena, result, item_str);
                             }
                         }
-                    } else if (!_mv_801.has_value) {
+                    } else if (!_mv_802.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -83,39 +83,39 @@ slop_option_string stmt_get_arena_alloc_ptr_type(context_TranspileContext* ctx, 
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_802 = (*expr);
-        switch (_mv_802.tag) {
+        __auto_type _mv_803 = (*expr);
+        switch (_mv_803.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_802.data.lst;
+                __auto_type lst = _mv_803.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_803 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_803.has_value) {
-                            __auto_type head_ptr = _mv_803.value;
-                            __auto_type _mv_804 = (*head_ptr);
-                            switch (_mv_804.tag) {
+                        __auto_type _mv_804 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_804.has_value) {
+                            __auto_type head_ptr = _mv_804.value;
+                            __auto_type _mv_805 = (*head_ptr);
+                            switch (_mv_805.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type head_sym = _mv_804.data.sym;
+                                    __auto_type head_sym = _mv_805.data.sym;
                                     {
                                         __auto_type op = head_sym.name;
                                         if (string_eq(op, SLOP_STR("arena-alloc"))) {
-                                            __auto_type _mv_805 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_805.has_value) {
-                                                __auto_type size_expr = _mv_805.value;
+                                            __auto_type _mv_806 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_806.has_value) {
+                                                __auto_type size_expr = _mv_806.value;
                                                 return stmt_extract_sizeof_type_opt(ctx, size_expr);
-                                            } else if (!_mv_805.has_value) {
+                                            } else if (!_mv_806.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
                                             SLOP_UNREACHABLE();
                                         } else if (string_eq(op, SLOP_STR("cast")) && (((int64_t)((items).len)) >= 3)) {
-                                            __auto_type _mv_806 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_806.has_value) {
-                                                __auto_type inner_expr = _mv_806.value;
+                                            __auto_type _mv_807 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_807.has_value) {
+                                                __auto_type inner_expr = _mv_807.value;
                                                 return stmt_get_arena_alloc_ptr_type(ctx, inner_expr);
-                                            } else if (!_mv_806.has_value) {
+                                            } else if (!_mv_807.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
                                             SLOP_UNREACHABLE();
@@ -128,7 +128,7 @@ slop_option_string stmt_get_arena_alloc_ptr_type(context_TranspileContext* ctx, 
                                     return (slop_option_string){.has_value = false};
                                 }
                             }
-                        } else if (!_mv_803.has_value) {
+                        } else if (!_mv_804.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -149,18 +149,18 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_807 = (*expr);
-        switch (_mv_807.tag) {
+        __auto_type _mv_808 = (*expr);
+        switch (_mv_808.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_807.data.sym;
+                __auto_type sym = _mv_808.data.sym;
                 {
                     __auto_type type_name = sym.name;
-                    __auto_type _mv_808 = context_ctx_lookup_type(ctx, type_name);
-                    if (_mv_808.has_value) {
-                        __auto_type entry = _mv_808.value;
+                    __auto_type _mv_809 = context_ctx_lookup_type(ctx, type_name);
+                    if (_mv_809.has_value) {
+                        __auto_type entry = _mv_809.value;
                         return (slop_option_string){.has_value = 1, .value = context_ctx_str(ctx, entry.c_name, SLOP_STR("*"))};
-                    } else if (!_mv_808.has_value) {
+                    } else if (!_mv_809.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
                     SLOP_UNREACHABLE();
@@ -168,27 +168,27 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_807.data.lst;
+                __auto_type lst = _mv_808.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_809 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_809.has_value) {
-                            __auto_type head_ptr = _mv_809.value;
-                            __auto_type _mv_810 = (*head_ptr);
-                            switch (_mv_810.tag) {
+                        __auto_type _mv_810 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_810.has_value) {
+                            __auto_type head_ptr = _mv_810.value;
+                            __auto_type _mv_811 = (*head_ptr);
+                            switch (_mv_811.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type head_sym = _mv_810.data.sym;
+                                    __auto_type head_sym = _mv_811.data.sym;
                                     if (string_eq(head_sym.name, SLOP_STR("sizeof"))) {
-                                        __auto_type _mv_811 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_811.has_value) {
-                                            __auto_type type_expr = _mv_811.value;
+                                        __auto_type _mv_812 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_812.has_value) {
+                                            __auto_type type_expr = _mv_812.value;
                                             {
                                                 __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                 return (slop_option_string){.has_value = 1, .value = context_ctx_str(ctx, c_type, SLOP_STR("*"))};
                                             }
-                                        } else if (!_mv_811.has_value) {
+                                        } else if (!_mv_812.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
                                         SLOP_UNREACHABLE();
@@ -200,7 +200,7 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
                                     return (slop_option_string){.has_value = false};
                                 }
                             }
-                        } else if (!_mv_809.has_value) {
+                        } else if (!_mv_810.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -218,24 +218,24 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
 
 uint8_t stmt_is_stmt_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_812 = (*expr);
-    switch (_mv_812.tag) {
+    __auto_type _mv_813 = (*expr);
+    switch (_mv_813.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_812.data.lst;
+            __auto_type lst = _mv_813.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_813 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_813.has_value) {
-                        __auto_type head_expr = _mv_813.value;
-                        __auto_type _mv_814 = (*head_expr);
-                        switch (_mv_814.tag) {
+                    __auto_type _mv_814 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_814.has_value) {
+                        __auto_type head_expr = _mv_814.value;
+                        __auto_type _mv_815 = (*head_expr);
+                        switch (_mv_815.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_814.data.sym;
+                                __auto_type sym = _mv_815.data.sym;
                                 {
                                     __auto_type name = sym.name;
                                     return ((string_eq(name, SLOP_STR("let"))) || (string_eq(name, SLOP_STR("let*"))) || (string_eq(name, SLOP_STR("if"))) || (string_eq(name, SLOP_STR("when"))) || (string_eq(name, SLOP_STR("while"))) || (string_eq(name, SLOP_STR("for"))) || (string_eq(name, SLOP_STR("for-each"))) || (string_eq(name, SLOP_STR("set!"))) || (string_eq(name, SLOP_STR("do"))) || (string_eq(name, SLOP_STR("match"))) || (string_eq(name, SLOP_STR("cond"))) || (string_eq(name, SLOP_STR("with-arena"))));
@@ -245,7 +245,7 @@ uint8_t stmt_is_stmt_form(types_SExpr* expr) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_813.has_value) {
+                    } else if (!_mv_814.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -263,11 +263,11 @@ void stmt_transpile_let(context_TranspileContext* ctx, types_SExpr* expr, uint8_
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_815 = (*expr);
-        switch (_mv_815.tag) {
+        __auto_type _mv_816 = (*expr);
+        switch (_mv_816.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_815.data.lst;
+                __auto_type lst = _mv_816.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -277,14 +277,14 @@ void stmt_transpile_let(context_TranspileContext* ctx, types_SExpr* expr, uint8_
                         context_ctx_emit(ctx, SLOP_STR("{"));
                         context_ctx_indent(ctx);
                         context_ctx_push_scope(ctx);
-                        __auto_type _mv_816 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_816.has_value) {
-                            __auto_type bindings_expr = _mv_816.value;
-                            __auto_type _mv_817 = (*bindings_expr);
-                            switch (_mv_817.tag) {
+                        __auto_type _mv_817 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_817.has_value) {
+                            __auto_type bindings_expr = _mv_817.value;
+                            __auto_type _mv_818 = (*bindings_expr);
+                            switch (_mv_818.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type bindings_lst = _mv_817.data.lst;
+                                    __auto_type bindings_lst = _mv_818.data.lst;
                                     stmt_transpile_bindings(ctx, bindings_lst.items);
                                     break;
                                 }
@@ -293,20 +293,20 @@ void stmt_transpile_let(context_TranspileContext* ctx, types_SExpr* expr, uint8_
                                     break;
                                 }
                             }
-                        } else if (!_mv_816.has_value) {
+                        } else if (!_mv_817.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing bindings"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                         {
                             __auto_type i = 2;
                             while (i < len) {
-                                __auto_type _mv_818 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_818.has_value) {
-                                    __auto_type body_expr = _mv_818.value;
+                                __auto_type _mv_819 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_819.has_value) {
+                                    __auto_type body_expr = _mv_819.value;
                                     {
                                         __auto_type is_last = (i == (len - 1));
                                         stmt_transpile_stmt(ctx, body_expr, (is_return && is_last));
                                     }
-                                } else if (!_mv_818.has_value) {
+                                } else if (!_mv_819.has_value) {
                                 }
                                 i = (i + 1);
                             }
@@ -333,11 +333,11 @@ void stmt_transpile_bindings(context_TranspileContext* ctx, slop_list_types_SExp
         __auto_type len = ((int64_t)((bindings).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_819 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_819.has_value) {
-                __auto_type binding_expr = _mv_819.value;
+            __auto_type _mv_820 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_820.has_value) {
+                __auto_type binding_expr = _mv_820.value;
                 stmt_transpile_single_binding(ctx, binding_expr);
-            } else if (!_mv_819.has_value) {
+            } else if (!_mv_820.has_value) {
             }
             i = (i + 1);
         }
@@ -349,11 +349,11 @@ void stmt_transpile_single_binding(context_TranspileContext* ctx, types_SExpr* b
     SLOP_PRE(((binding != NULL)), "(!= binding nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_820 = (*binding);
-        switch (_mv_820.tag) {
+        __auto_type _mv_821 = (*binding);
+        switch (_mv_821.tag) {
             case types_SExpr_lst:
             {
-                __auto_type binding_lst = _mv_820.data.lst;
+                __auto_type binding_lst = _mv_821.data.lst;
                 {
                     __auto_type items = binding_lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -363,24 +363,24 @@ void stmt_transpile_single_binding(context_TranspileContext* ctx, types_SExpr* b
                         if ((len - start_idx) < 2) {
                             context_ctx_add_error_at(ctx, SLOP_STR("invalid binding: need name and value"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                         } else {
-                            __auto_type _mv_821 = ({ __auto_type _lst = items; size_t _idx = (size_t)start_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_821.has_value) {
-                                __auto_type name_expr = _mv_821.value;
-                                __auto_type _mv_822 = (*name_expr);
-                                switch (_mv_822.tag) {
+                            __auto_type _mv_822 = ({ __auto_type _lst = items; size_t _idx = (size_t)start_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_822.has_value) {
+                                __auto_type name_expr = _mv_822.value;
+                                __auto_type _mv_823 = (*name_expr);
+                                switch (_mv_823.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type name_sym = _mv_822.data.sym;
+                                        __auto_type name_sym = _mv_823.data.sym;
                                         {
                                             __auto_type raw_name = name_sym.name;
                                             __auto_type var_name = ctype_to_c_name(arena, raw_name);
                                             if ((len - start_idx) >= 3) {
-                                                __auto_type _mv_823 = ({ __auto_type _lst = items; size_t _idx = (size_t)(start_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_823.has_value) {
-                                                    __auto_type type_expr = _mv_823.value;
-                                                    __auto_type _mv_824 = ({ __auto_type _lst = items; size_t _idx = (size_t)(start_idx + 2); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_824.has_value) {
-                                                        __auto_type init_expr = _mv_824.value;
+                                                __auto_type _mv_824 = ({ __auto_type _lst = items; size_t _idx = (size_t)(start_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_824.has_value) {
+                                                    __auto_type type_expr = _mv_824.value;
+                                                    __auto_type _mv_825 = ({ __auto_type _lst = items; size_t _idx = (size_t)(start_idx + 2); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_825.has_value) {
+                                                        __auto_type init_expr = _mv_825.value;
                                                         {
                                                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                             {
@@ -392,26 +392,26 @@ void stmt_transpile_single_binding(context_TranspileContext* ctx, types_SExpr* b
                                                                 }
                                                             }
                                                         }
-                                                    } else if (!_mv_824.has_value) {
+                                                    } else if (!_mv_825.has_value) {
                                                         context_ctx_add_error_at(ctx, SLOP_STR("missing init"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                     }
-                                                } else if (!_mv_823.has_value) {
+                                                } else if (!_mv_824.has_value) {
                                                     context_ctx_add_error_at(ctx, SLOP_STR("missing type"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                 }
                                             } else {
-                                                __auto_type _mv_825 = ({ __auto_type _lst = items; size_t _idx = (size_t)(start_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_825.has_value) {
-                                                    __auto_type init_expr = _mv_825.value;
+                                                __auto_type _mv_826 = ({ __auto_type _lst = items; size_t _idx = (size_t)(start_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_826.has_value) {
+                                                    __auto_type init_expr = _mv_826.value;
                                                     {
                                                         __auto_type init_c = expr_transpile_expr(ctx, init_expr);
                                                         __auto_type inferred_slop_type = expr_infer_expr_slop_type(ctx, init_expr);
                                                         __auto_type ptr_type_opt = stmt_get_arena_alloc_ptr_type(ctx, init_expr);
-                                                        __auto_type _mv_826 = ptr_type_opt;
-                                                        if (_mv_826.has_value) {
-                                                            __auto_type ptr_type = _mv_826.value;
+                                                        __auto_type _mv_827 = ptr_type_opt;
+                                                        if (_mv_827.has_value) {
+                                                            __auto_type ptr_type = _mv_827.value;
                                                             context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("__auto_type "), var_name, SLOP_STR(" = "), init_c, SLOP_STR(";")));
                                                             context_ctx_bind_var(ctx, (context_VarEntry){raw_name, var_name, ptr_type, inferred_slop_type, 1, has_mut, 0, SLOP_STR(""), SLOP_STR("")});
-                                                        } else if (!_mv_826.has_value) {
+                                                        } else if (!_mv_827.has_value) {
                                                             {
                                                                 __auto_type inferred_type = expr_infer_expr_c_type(ctx, init_expr);
                                                                 __auto_type lambda_info = context_ctx_get_last_lambda_info(ctx);
@@ -428,7 +428,7 @@ void stmt_transpile_single_binding(context_TranspileContext* ctx, types_SExpr* b
                                                             }
                                                         }
                                                     }
-                                                } else if (!_mv_825.has_value) {
+                                                } else if (!_mv_826.has_value) {
                                                     context_ctx_add_error_at(ctx, SLOP_STR("missing init"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                 }
                                             }
@@ -440,7 +440,7 @@ void stmt_transpile_single_binding(context_TranspileContext* ctx, types_SExpr* b
                                         break;
                                     }
                                 }
-                            } else if (!_mv_821.has_value) {
+                            } else if (!_mv_822.has_value) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("missing binding name"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                             }
                         }
@@ -460,21 +460,21 @@ uint8_t stmt_binding_has_mut(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_827 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_827.has_value) {
-            __auto_type first = _mv_827.value;
-            __auto_type _mv_828 = (*first);
-            switch (_mv_828.tag) {
+        __auto_type _mv_828 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_828.has_value) {
+            __auto_type first = _mv_828.value;
+            __auto_type _mv_829 = (*first);
+            switch (_mv_829.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_828.data.sym;
+                    __auto_type sym = _mv_829.data.sym;
                     return string_eq(sym.name, SLOP_STR("mut"));
                 }
                 default: {
                     return 0;
                 }
             }
-        } else if (!_mv_827.has_value) {
+        } else if (!_mv_828.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -517,28 +517,28 @@ slop_option_types_SExpr_ptr stmt_get_some_value(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         slop_option_types_SExpr_ptr result = (slop_option_types_SExpr_ptr){.has_value = false};
-        __auto_type _mv_829 = (*expr);
-        switch (_mv_829.tag) {
+        __auto_type _mv_830 = (*expr);
+        switch (_mv_830.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_829.data.lst;
+                __auto_type lst = _mv_830.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_830 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_830.has_value) {
-                            __auto_type head_expr = _mv_830.value;
-                            __auto_type _mv_831 = (*head_expr);
-                            switch (_mv_831.tag) {
+                        __auto_type _mv_831 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_831.has_value) {
+                            __auto_type head_expr = _mv_831.value;
+                            __auto_type _mv_832 = (*head_expr);
+                            switch (_mv_832.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_831.data.sym;
+                                    __auto_type sym = _mv_832.data.sym;
                                     if (string_eq(sym.name, SLOP_STR("some"))) {
-                                        __auto_type _mv_832 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_832.has_value) {
-                                            __auto_type val = _mv_832.value;
+                                        __auto_type _mv_833 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_833.has_value) {
+                                            __auto_type val = _mv_833.value;
                                             result = (slop_option_types_SExpr_ptr){.has_value = 1, .value = val};
-                                        } else if (!_mv_832.has_value) {
+                                        } else if (!_mv_833.has_value) {
                                         }
                                     }
                                     break;
@@ -547,7 +547,7 @@ slop_option_types_SExpr_ptr stmt_get_some_value(types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_830.has_value) {
+                        } else if (!_mv_831.has_value) {
                         }
                     }
                 }
@@ -563,34 +563,34 @@ slop_option_types_SExpr_ptr stmt_get_some_value(types_SExpr* expr) {
 
 uint8_t stmt_is_none_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_833 = (*expr);
-    switch (_mv_833.tag) {
+    __auto_type _mv_834 = (*expr);
+    switch (_mv_834.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_833.data.sym;
+            __auto_type sym = _mv_834.data.sym;
             return string_eq(sym.name, SLOP_STR("none"));
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_833.data.lst;
+            __auto_type lst = _mv_834.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) == 1) {
-                    __auto_type _mv_834 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_834.has_value) {
-                        __auto_type head = _mv_834.value;
-                        __auto_type _mv_835 = (*head);
-                        switch (_mv_835.tag) {
+                    __auto_type _mv_835 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_835.has_value) {
+                        __auto_type head = _mv_835.value;
+                        __auto_type _mv_836 = (*head);
+                        switch (_mv_836.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_835.data.sym;
+                                __auto_type sym = _mv_836.data.sym;
                                 return string_eq(sym.name, SLOP_STR("none"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_834.has_value) {
+                    } else if (!_mv_835.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -608,39 +608,39 @@ uint8_t stmt_is_none_form(types_SExpr* expr) {
 void stmt_transpile_if(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_836 = (*expr);
-    switch (_mv_836.tag) {
+    __auto_type _mv_837 = (*expr);
+    switch (_mv_837.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_836.data.lst;
+            __auto_type lst = _mv_837.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 if (len < 3) {
                     context_ctx_add_error_at(ctx, SLOP_STR("invalid if: need condition and then-branch"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                 } else {
-                    __auto_type _mv_837 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_837.has_value) {
-                        __auto_type cond_expr = _mv_837.value;
+                    __auto_type _mv_838 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_838.has_value) {
+                        __auto_type cond_expr = _mv_838.value;
                         {
                             __auto_type cond_c = context_ctx_strip_cond_parens(ctx, expr_transpile_expr(ctx, cond_expr));
                             context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("if ("), cond_c, SLOP_STR(") {")));
                             context_ctx_indent(ctx);
-                            __auto_type _mv_838 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_838.has_value) {
-                                __auto_type then_expr = _mv_838.value;
+                            __auto_type _mv_839 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_839.has_value) {
+                                __auto_type then_expr = _mv_839.value;
                                 stmt_transpile_stmt(ctx, then_expr, is_return);
-                            } else if (!_mv_838.has_value) {
+                            } else if (!_mv_839.has_value) {
                             }
                             context_ctx_dedent(ctx);
                             if (len >= 4) {
                                 context_ctx_emit(ctx, SLOP_STR("} else {"));
                                 context_ctx_indent(ctx);
-                                __auto_type _mv_839 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_839.has_value) {
-                                    __auto_type else_expr = _mv_839.value;
+                                __auto_type _mv_840 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_840.has_value) {
+                                    __auto_type else_expr = _mv_840.value;
                                     stmt_transpile_stmt(ctx, else_expr, is_return);
-                                } else if (!_mv_839.has_value) {
+                                } else if (!_mv_840.has_value) {
                                 }
                                 context_ctx_dedent(ctx);
                                 context_ctx_emit(ctx, SLOP_STR("}"));
@@ -648,7 +648,7 @@ void stmt_transpile_if(context_TranspileContext* ctx, types_SExpr* expr, uint8_t
                                 context_ctx_emit(ctx, SLOP_STR("}"));
                             }
                         }
-                    } else if (!_mv_837.has_value) {
+                    } else if (!_mv_838.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing if condition"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     }
                 }
@@ -665,20 +665,20 @@ void stmt_transpile_if(context_TranspileContext* ctx, types_SExpr* expr, uint8_t
 void stmt_transpile_when(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_840 = (*expr);
-    switch (_mv_840.tag) {
+    __auto_type _mv_841 = (*expr);
+    switch (_mv_841.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_840.data.lst;
+            __auto_type lst = _mv_841.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 if (len < 3) {
                     context_ctx_add_error_at(ctx, SLOP_STR("invalid when: need condition and body"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                 } else {
-                    __auto_type _mv_841 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_841.has_value) {
-                        __auto_type cond_expr = _mv_841.value;
+                    __auto_type _mv_842 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_842.has_value) {
+                        __auto_type cond_expr = _mv_842.value;
                         {
                             __auto_type cond_c = context_ctx_strip_cond_parens(ctx, expr_transpile_expr(ctx, cond_expr));
                             context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("if ("), cond_c, SLOP_STR(") {")));
@@ -686,11 +686,11 @@ void stmt_transpile_when(context_TranspileContext* ctx, types_SExpr* expr) {
                             {
                                 __auto_type i = 2;
                                 while (i < len) {
-                                    __auto_type _mv_842 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_842.has_value) {
-                                        __auto_type body_expr = _mv_842.value;
+                                    __auto_type _mv_843 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_843.has_value) {
+                                        __auto_type body_expr = _mv_843.value;
                                         stmt_transpile_stmt(ctx, body_expr, 0);
-                                    } else if (!_mv_842.has_value) {
+                                    } else if (!_mv_843.has_value) {
                                     }
                                     i = (i + 1);
                                 }
@@ -698,7 +698,7 @@ void stmt_transpile_when(context_TranspileContext* ctx, types_SExpr* expr) {
                             context_ctx_dedent(ctx);
                             context_ctx_emit(ctx, SLOP_STR("}"));
                         }
-                    } else if (!_mv_841.has_value) {
+                    } else if (!_mv_842.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing when condition"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     }
                 }
@@ -715,20 +715,20 @@ void stmt_transpile_when(context_TranspileContext* ctx, types_SExpr* expr) {
 void stmt_transpile_while(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_843 = (*expr);
-    switch (_mv_843.tag) {
+    __auto_type _mv_844 = (*expr);
+    switch (_mv_844.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_843.data.lst;
+            __auto_type lst = _mv_844.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 if (len < 3) {
                     context_ctx_add_error_at(ctx, SLOP_STR("invalid while: need condition and body"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                 } else {
-                    __auto_type _mv_844 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_844.has_value) {
-                        __auto_type cond_expr = _mv_844.value;
+                    __auto_type _mv_845 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_845.has_value) {
+                        __auto_type cond_expr = _mv_845.value;
                         {
                             __auto_type cond_c = context_ctx_strip_cond_parens(ctx, expr_transpile_expr(ctx, cond_expr));
                             context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("while ("), cond_c, SLOP_STR(") {")));
@@ -736,11 +736,11 @@ void stmt_transpile_while(context_TranspileContext* ctx, types_SExpr* expr) {
                             {
                                 __auto_type i = 2;
                                 while (i < len) {
-                                    __auto_type _mv_845 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_845.has_value) {
-                                        __auto_type body_expr = _mv_845.value;
+                                    __auto_type _mv_846 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_846.has_value) {
+                                        __auto_type body_expr = _mv_846.value;
                                         stmt_transpile_stmt(ctx, body_expr, 0);
-                                    } else if (!_mv_845.has_value) {
+                                    } else if (!_mv_846.has_value) {
                                     }
                                     i = (i + 1);
                                 }
@@ -748,7 +748,7 @@ void stmt_transpile_while(context_TranspileContext* ctx, types_SExpr* expr) {
                             context_ctx_dedent(ctx);
                             context_ctx_emit(ctx, SLOP_STR("}"));
                         }
-                    } else if (!_mv_844.has_value) {
+                    } else if (!_mv_845.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing while condition"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     }
                 }
@@ -767,11 +767,11 @@ void stmt_transpile_set(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_846 = (*expr);
-        switch (_mv_846.tag) {
+        __auto_type _mv_847 = (*expr);
+        switch (_mv_847.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_846.data.lst;
+                __auto_type lst = _mv_847.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -781,29 +781,29 @@ void stmt_transpile_set(context_TranspileContext* ctx, types_SExpr* expr) {
                     } else if (len == 4) {
                         stmt_transpile_field_set(ctx, items);
                     } else if (len == 3) {
-                        __auto_type _mv_847 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_847.has_value) {
-                            __auto_type target_expr = _mv_847.value;
-                            __auto_type _mv_848 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_848.has_value) {
-                                __auto_type value_expr = _mv_848.value;
+                        __auto_type _mv_848 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_848.has_value) {
+                            __auto_type target_expr = _mv_848.value;
+                            __auto_type _mv_849 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_849.has_value) {
+                                __auto_type value_expr = _mv_849.value;
                                 {
                                     __auto_type target_c = expr_transpile_expr(ctx, target_expr);
                                     __auto_type target_type_opt = stmt_get_var_c_type(ctx, target_expr);
-                                    __auto_type _mv_849 = target_type_opt;
-                                    if (_mv_849.has_value) {
-                                        __auto_type target_type = _mv_849.value;
+                                    __auto_type _mv_850 = target_type_opt;
+                                    if (_mv_850.has_value) {
+                                        __auto_type target_type = _mv_850.value;
                                         if (strlib_starts_with(target_type, SLOP_STR("slop_option_"))) {
                                             {
                                                 __auto_type some_val_opt = stmt_get_some_value(value_expr);
-                                                __auto_type _mv_850 = some_val_opt;
-                                                if (_mv_850.has_value) {
-                                                    __auto_type val_expr = _mv_850.value;
+                                                __auto_type _mv_851 = some_val_opt;
+                                                if (_mv_851.has_value) {
+                                                    __auto_type val_expr = _mv_851.value;
                                                     {
                                                         __auto_type val_c = expr_transpile_expr(ctx, val_expr);
                                                         context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str5(ctx, SLOP_STR(" = ("), target_type, SLOP_STR("){.has_value = 1, .value = "), val_c, SLOP_STR("};"))));
                                                     }
-                                                } else if (!_mv_850.has_value) {
+                                                } else if (!_mv_851.has_value) {
                                                     if (stmt_is_none_form(value_expr)) {
                                                         context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str3(ctx, SLOP_STR(" = ("), target_type, SLOP_STR("){.has_value = false};"))));
                                                     } else {
@@ -820,23 +820,23 @@ void stmt_transpile_set(context_TranspileContext* ctx, types_SExpr* expr) {
                                                 context_ctx_emit(ctx, context_ctx_str4(ctx, target_c, SLOP_STR(" = "), value_c, SLOP_STR(";")));
                                             }
                                         }
-                                    } else if (!_mv_849.has_value) {
+                                    } else if (!_mv_850.has_value) {
                                         {
                                             __auto_type some_val_opt = stmt_get_some_value(value_expr);
-                                            __auto_type _mv_851 = some_val_opt;
-                                            if (_mv_851.has_value) {
-                                                __auto_type inner_expr = _mv_851.value;
+                                            __auto_type _mv_852 = some_val_opt;
+                                            if (_mv_852.has_value) {
+                                                __auto_type inner_expr = _mv_852.value;
                                                 {
                                                     __auto_type inner_c = expr_transpile_expr(ctx, inner_expr);
                                                     __auto_type inner_type = expr_infer_expr_c_type(ctx, inner_expr);
                                                     __auto_type option_type = expr_c_type_to_option_type_name(ctx, inner_type);
                                                     context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str5(ctx, SLOP_STR(" = ("), option_type, SLOP_STR("){.has_value = 1, .value = "), inner_c, SLOP_STR("};"))));
                                                 }
-                                            } else if (!_mv_851.has_value) {
+                                            } else if (!_mv_852.has_value) {
                                                 if (stmt_is_none_form(value_expr)) {
-                                                    __auto_type _mv_852 = context_ctx_get_current_return_type(ctx);
-                                                    if (_mv_852.has_value) {
-                                                        __auto_type ret_type = _mv_852.value;
+                                                    __auto_type _mv_853 = context_ctx_get_current_return_type(ctx);
+                                                    if (_mv_853.has_value) {
+                                                        __auto_type ret_type = _mv_853.value;
                                                         if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
                                                             context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str3(ctx, SLOP_STR(" = ("), ret_type, SLOP_STR("){.has_value = false};"))));
                                                         } else {
@@ -845,7 +845,7 @@ void stmt_transpile_set(context_TranspileContext* ctx, types_SExpr* expr) {
                                                                 context_ctx_emit(ctx, context_ctx_str4(ctx, target_c, SLOP_STR(" = "), value_c, SLOP_STR(";")));
                                                             }
                                                         }
-                                                    } else if (!_mv_852.has_value) {
+                                                    } else if (!_mv_853.has_value) {
                                                         {
                                                             __auto_type value_c = expr_transpile_expr(ctx, value_expr);
                                                             context_ctx_emit(ctx, context_ctx_str4(ctx, target_c, SLOP_STR(" = "), value_c, SLOP_STR(";")));
@@ -861,10 +861,10 @@ void stmt_transpile_set(context_TranspileContext* ctx, types_SExpr* expr) {
                                         }
                                     }
                                 }
-                            } else if (!_mv_848.has_value) {
+                            } else if (!_mv_849.has_value) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("missing set! value"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                             }
-                        } else if (!_mv_847.has_value) {
+                        } else if (!_mv_848.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing set! target"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                     } else {
@@ -883,18 +883,18 @@ void stmt_transpile_set(context_TranspileContext* ctx, types_SExpr* expr) {
 
 slop_option_string stmt_get_var_c_type(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
-    __auto_type _mv_853 = (*expr);
-    switch (_mv_853.tag) {
+    __auto_type _mv_854 = (*expr);
+    switch (_mv_854.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_853.data.sym;
+            __auto_type sym = _mv_854.data.sym;
             {
                 __auto_type name = sym.name;
-                __auto_type _mv_854 = context_ctx_lookup_var(ctx, name);
-                if (_mv_854.has_value) {
-                    __auto_type var_entry = _mv_854.value;
+                __auto_type _mv_855 = context_ctx_lookup_var(ctx, name);
+                if (_mv_855.has_value) {
+                    __auto_type var_entry = _mv_855.value;
                     return (slop_option_string){.has_value = 1, .value = var_entry.c_type};
-                } else if (!_mv_854.has_value) {
+                } else if (!_mv_855.has_value) {
                     return (slop_option_string){.has_value = false};
                 }
                 SLOP_UNREACHABLE();
@@ -909,18 +909,18 @@ slop_option_string stmt_get_var_c_type(context_TranspileContext* ctx, types_SExp
 uint8_t stmt_is_pointer_target(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_855 = (*expr);
-    switch (_mv_855.tag) {
+    __auto_type _mv_856 = (*expr);
+    switch (_mv_856.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_855.data.sym;
+            __auto_type sym = _mv_856.data.sym;
             {
                 __auto_type name = sym.name;
-                __auto_type _mv_856 = context_ctx_lookup_var(ctx, name);
-                if (_mv_856.has_value) {
-                    __auto_type var_entry = _mv_856.value;
+                __auto_type _mv_857 = context_ctx_lookup_var(ctx, name);
+                if (_mv_857.has_value) {
+                    __auto_type var_entry = _mv_857.value;
                     return (var_entry.is_pointer || ({ __auto_type c_type = var_entry.c_type; strlib_ends_with(c_type, SLOP_STR("*")); }));
-                } else if (!_mv_856.has_value) {
+                } else if (!_mv_857.has_value) {
                     return 0;
                 }
                 SLOP_UNREACHABLE();
@@ -936,15 +936,15 @@ void stmt_transpile_field_set(context_TranspileContext* ctx, slop_list_types_SEx
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_857 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_857.has_value) {
-            __auto_type target_expr = _mv_857.value;
-            __auto_type _mv_858 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_858.has_value) {
-                __auto_type field_expr = _mv_858.value;
-                __auto_type _mv_859 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_859.has_value) {
-                    __auto_type value_expr = _mv_859.value;
+        __auto_type _mv_858 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_858.has_value) {
+            __auto_type target_expr = _mv_858.value;
+            __auto_type _mv_859 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_859.has_value) {
+                __auto_type field_expr = _mv_859.value;
+                __auto_type _mv_860 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_860.has_value) {
+                    __auto_type value_expr = _mv_860.value;
                     {
                         __auto_type field_name = stmt_get_symbol_name(arena, field_expr);
                         __auto_type value_c = expr_transpile_expr(ctx, value_expr);
@@ -966,13 +966,13 @@ void stmt_transpile_field_set(context_TranspileContext* ctx, slop_list_types_SEx
                             }
                         }
                     }
-                } else if (!_mv_859.has_value) {
+                } else if (!_mv_860.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("missing set! value"), context_ctx_sexpr_line(target_expr), context_ctx_sexpr_col(target_expr));
                 }
-            } else if (!_mv_858.has_value) {
+            } else if (!_mv_859.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing set! field"), context_ctx_sexpr_line(target_expr), context_ctx_sexpr_col(target_expr));
             }
-        } else if (!_mv_857.has_value) {
+        } else if (!_mv_858.has_value) {
             context_ctx_add_error_at(ctx, SLOP_STR("missing set! target"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         }
     }
@@ -982,18 +982,18 @@ void stmt_transpile_typed_field_set(context_TranspileContext* ctx, slop_list_typ
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_860 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_860.has_value) {
-            __auto_type target_expr = _mv_860.value;
-            __auto_type _mv_861 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_861.has_value) {
-                __auto_type field_expr = _mv_861.value;
-                __auto_type _mv_862 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_862.has_value) {
-                    __auto_type type_expr = _mv_862.value;
-                    __auto_type _mv_863 = ({ __auto_type _lst = items; size_t _idx = (size_t)4; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_863.has_value) {
-                        __auto_type value_expr = _mv_863.value;
+        __auto_type _mv_861 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_861.has_value) {
+            __auto_type target_expr = _mv_861.value;
+            __auto_type _mv_862 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_862.has_value) {
+                __auto_type field_expr = _mv_862.value;
+                __auto_type _mv_863 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_863.has_value) {
+                    __auto_type type_expr = _mv_863.value;
+                    __auto_type _mv_864 = ({ __auto_type _lst = items; size_t _idx = (size_t)4; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_864.has_value) {
+                        __auto_type value_expr = _mv_864.value;
                         {
                             __auto_type field_name = stmt_get_symbol_name(arena, field_expr);
                             __auto_type c_type = ctype_to_c_type(arena, type_expr);
@@ -1003,14 +1003,14 @@ void stmt_transpile_typed_field_set(context_TranspileContext* ctx, slop_list_typ
                                     if (stmt_is_none_form(value_expr)) {
                                         context_ctx_emit(ctx, context_ctx_str(ctx, target_access, context_ctx_str(ctx, field_name, context_ctx_str3(ctx, SLOP_STR(" = ("), c_type, SLOP_STR("){.has_value = false};")))));
                                     } else {
-                                        __auto_type _mv_864 = stmt_get_some_value(value_expr);
-                                        if (_mv_864.has_value) {
-                                            __auto_type inner_val = _mv_864.value;
+                                        __auto_type _mv_865 = stmt_get_some_value(value_expr);
+                                        if (_mv_865.has_value) {
+                                            __auto_type inner_val = _mv_865.value;
                                             {
                                                 __auto_type val_c = expr_transpile_expr(ctx, inner_val);
                                                 context_ctx_emit(ctx, context_ctx_str(ctx, target_access, context_ctx_str(ctx, field_name, context_ctx_str5(ctx, SLOP_STR(" = ("), c_type, SLOP_STR("){.has_value = 1, .value = "), val_c, SLOP_STR("};")))));
                                             }
-                                        } else if (!_mv_864.has_value) {
+                                        } else if (!_mv_865.has_value) {
                                             {
                                                 __auto_type val_c = expr_transpile_expr(ctx, value_expr);
                                                 context_ctx_emit(ctx, context_ctx_str(ctx, target_access, context_ctx_str(ctx, field_name, context_ctx_str(ctx, SLOP_STR(" = "), context_ctx_str(ctx, val_c, SLOP_STR(";"))))));
@@ -1025,16 +1025,16 @@ void stmt_transpile_typed_field_set(context_TranspileContext* ctx, slop_list_typ
                                 }
                             }
                         }
-                    } else if (!_mv_863.has_value) {
+                    } else if (!_mv_864.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing set! value"), context_ctx_sexpr_line(type_expr), context_ctx_sexpr_col(type_expr));
                     }
-                } else if (!_mv_862.has_value) {
+                } else if (!_mv_863.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("missing set! type"), context_ctx_sexpr_line(field_expr), context_ctx_sexpr_col(field_expr));
                 }
-            } else if (!_mv_861.has_value) {
+            } else if (!_mv_862.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing set! field"), context_ctx_sexpr_line(target_expr), context_ctx_sexpr_col(target_expr));
             }
-        } else if (!_mv_860.has_value) {
+        } else if (!_mv_861.has_value) {
             context_ctx_add_error_at(ctx, SLOP_STR("missing set! target"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         }
     }
@@ -1042,31 +1042,31 @@ void stmt_transpile_typed_field_set(context_TranspileContext* ctx, slop_list_typ
 
 uint8_t stmt_is_deref_expr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_865 = (*expr);
-    switch (_mv_865.tag) {
+    __auto_type _mv_866 = (*expr);
+    switch (_mv_866.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_865.data.lst;
+            __auto_type lst = _mv_866.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_866 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_866.has_value) {
-                        __auto_type head = _mv_866.value;
-                        __auto_type _mv_867 = (*head);
-                        switch (_mv_867.tag) {
+                    __auto_type _mv_867 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_867.has_value) {
+                        __auto_type head = _mv_867.value;
+                        __auto_type _mv_868 = (*head);
+                        switch (_mv_868.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_867.data.sym;
+                                __auto_type sym = _mv_868.data.sym;
                                 return string_eq(sym.name, SLOP_STR("deref"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_866.has_value) {
+                    } else if (!_mv_867.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1081,18 +1081,18 @@ uint8_t stmt_is_deref_expr(types_SExpr* expr) {
 
 types_SExpr* stmt_get_deref_inner(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_868 = (*expr);
-    switch (_mv_868.tag) {
+    __auto_type _mv_869 = (*expr);
+    switch (_mv_869.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_868.data.lst;
+            __auto_type lst = _mv_869.data.lst;
             {
                 __auto_type items = lst.items;
-                __auto_type _mv_869 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_869.has_value) {
-                    __auto_type inner = _mv_869.value;
+                __auto_type _mv_870 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_870.has_value) {
+                    __auto_type inner = _mv_870.value;
                     return inner;
-                } else if (!_mv_869.has_value) {
+                } else if (!_mv_870.has_value) {
                     return expr;
                 }
                 SLOP_UNREACHABLE();
@@ -1106,11 +1106,11 @@ types_SExpr* stmt_get_deref_inner(types_SExpr* expr) {
 
 slop_string stmt_get_symbol_name(slop_arena* arena, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_870 = (*expr);
-    switch (_mv_870.tag) {
+    __auto_type _mv_871 = (*expr);
+    switch (_mv_871.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_870.data.sym;
+            __auto_type sym = _mv_871.data.sym;
             return ctype_to_c_name(arena, sym.name);
         }
         default: {
@@ -1122,24 +1122,24 @@ slop_string stmt_get_symbol_name(slop_arena* arena, types_SExpr* expr) {
 void stmt_transpile_do(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_871 = (*expr);
-    switch (_mv_871.tag) {
+    __auto_type _mv_872 = (*expr);
+    switch (_mv_872.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_871.data.lst;
+            __auto_type lst = _mv_872.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type i = 1;
                 while (i < len) {
-                    __auto_type _mv_872 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_872.has_value) {
-                        __auto_type body_expr = _mv_872.value;
+                    __auto_type _mv_873 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_873.has_value) {
+                        __auto_type body_expr = _mv_873.value;
                         {
                             __auto_type is_last = (i == (len - 1));
                             stmt_transpile_stmt(ctx, body_expr, (is_return && is_last));
                         }
-                    } else if (!_mv_872.has_value) {
+                    } else if (!_mv_873.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -1155,11 +1155,11 @@ void stmt_transpile_do(context_TranspileContext* ctx, types_SExpr* expr, uint8_t
 void stmt_transpile_with_arena(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_873 = (*expr);
-    switch (_mv_873.tag) {
+    __auto_type _mv_874 = (*expr);
+    switch (_mv_874.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_873.data.lst;
+            __auto_type lst = _mv_874.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
@@ -1171,16 +1171,17 @@ void stmt_transpile_with_arena(context_TranspileContext* ctx, types_SExpr* expr,
                         __auto_type arena_name = ((is_named) ? ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type name_expr = _mv.value; parser_sexpr_get_symbol_name(name_expr); }) : (SLOP_STR("arena")); }) : SLOP_STR("arena"));
                         __auto_type size_idx = ((is_named) ? 3 : 1);
                         __auto_type body_start = ((is_named) ? 4 : 2);
-                        __auto_type c_local = ((is_named) ? string_concat((*ctx).arena, SLOP_STR("_arena_"), arena_name) : SLOP_STR("_arena"));
+                        __auto_type c_arena_name = ctype_to_c_name((*ctx).arena, arena_name);
+                        __auto_type c_local = ((is_named) ? string_concat((*ctx).arena, SLOP_STR("_arena_"), c_arena_name) : SLOP_STR("_arena"));
                         if (is_named && (len < 4)) {
                             context_ctx_add_error_at(ctx, SLOP_STR("with-arena :as requires name and size"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         } else {
                             context_ctx_emit(ctx, SLOP_STR("{"));
                             context_ctx_indent(ctx);
                             context_ctx_push_scope(ctx);
-                            __auto_type _mv_874 = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_874.has_value) {
-                                __auto_type size_expr = _mv_874.value;
+                            __auto_type _mv_875 = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_875.has_value) {
+                                __auto_type size_expr = _mv_875.value;
                                 {
                                     __auto_type size_c = expr_transpile_expr(ctx, size_expr);
                                     context_ctx_emit(ctx, SLOP_STR("#ifdef SLOP_DEBUG"));
@@ -1190,28 +1191,28 @@ void stmt_transpile_with_arena(context_TranspileContext* ctx, types_SExpr* expr,
                                     context_ctx_emit(ctx, SLOP_STR("#ifdef SLOP_DEBUG"));
                                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("SLOP_PRE("), c_local, SLOP_STR(".base != NULL, \"arena allocation failed\");")));
                                     context_ctx_emit(ctx, SLOP_STR("#endif"));
-                                    context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("slop_arena* "), arena_name, SLOP_STR(" = &"), c_local, SLOP_STR(";")));
+                                    context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("slop_arena* "), c_arena_name, SLOP_STR(" = &"), c_local, SLOP_STR(";")));
                                 }
-                            } else if (!_mv_874.has_value) {
+                            } else if (!_mv_875.has_value) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("missing size"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                             }
-                            context_ctx_bind_var(ctx, (context_VarEntry){arena_name, arena_name, SLOP_STR("slop_arena*"), SLOP_STR(""), 1, 0, 0, SLOP_STR(""), SLOP_STR("")});
+                            context_ctx_bind_var(ctx, (context_VarEntry){arena_name, c_arena_name, SLOP_STR("slop_arena*"), SLOP_STR(""), 1, 0, 0, SLOP_STR(""), SLOP_STR("")});
                             {
                                 __auto_type i = body_start;
                                 while (i < len) {
-                                    __auto_type _mv_875 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_875.has_value) {
-                                        __auto_type body_expr = _mv_875.value;
+                                    __auto_type _mv_876 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_876.has_value) {
+                                        __auto_type body_expr = _mv_876.value;
                                         {
                                             __auto_type is_last = (i == (len - 1));
                                             stmt_transpile_stmt(ctx, body_expr, (is_return && is_last));
                                         }
-                                    } else if (!_mv_875.has_value) {
+                                    } else if (!_mv_876.has_value) {
                                     }
                                     i = (i + 1);
                                 }
                             }
-                            context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), arena_name, SLOP_STR(");")));
+                            context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), c_arena_name, SLOP_STR(");")));
                             context_ctx_pop_scope(ctx);
                             context_ctx_dedent(ctx);
                             context_ctx_emit(ctx, SLOP_STR("}"));
@@ -1231,39 +1232,39 @@ void stmt_transpile_with_arena(context_TranspileContext* ctx, types_SExpr* expr,
 void stmt_transpile_cond(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_876 = (*expr);
-    switch (_mv_876.tag) {
+    __auto_type _mv_877 = (*expr);
+    switch (_mv_877.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_876.data.lst;
+            __auto_type lst = _mv_877.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type i = 1;
                 __auto_type first = 1;
                 while (i < len) {
-                    __auto_type _mv_877 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_877.has_value) {
-                        __auto_type clause_expr = _mv_877.value;
-                        __auto_type _mv_878 = (*clause_expr);
-                        switch (_mv_878.tag) {
+                    __auto_type _mv_878 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_878.has_value) {
+                        __auto_type clause_expr = _mv_878.value;
+                        __auto_type _mv_879 = (*clause_expr);
+                        switch (_mv_879.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type clause_lst = _mv_878.data.lst;
+                                __auto_type clause_lst = _mv_879.data.lst;
                                 {
                                     __auto_type clause_items = clause_lst.items;
                                     __auto_type clause_len = ((int64_t)((clause_items).len));
                                     if (clause_len < 1) {
                                         context_ctx_add_error_at(ctx, SLOP_STR("invalid cond clause"), context_ctx_sexpr_line(clause_expr), context_ctx_sexpr_col(clause_expr));
                                     } else {
-                                        __auto_type _mv_879 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_879.has_value) {
-                                            __auto_type test_expr = _mv_879.value;
-                                            __auto_type _mv_880 = (*test_expr);
-                                            switch (_mv_880.tag) {
+                                        __auto_type _mv_880 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_880.has_value) {
+                                            __auto_type test_expr = _mv_880.value;
+                                            __auto_type _mv_881 = (*test_expr);
+                                            switch (_mv_881.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_880.data.sym;
+                                                    __auto_type sym = _mv_881.data.sym;
                                                     if (string_eq(sym.name, SLOP_STR("else"))) {
                                                         context_ctx_emit(ctx, SLOP_STR("} else {"));
                                                         context_ctx_indent(ctx);
@@ -1301,7 +1302,7 @@ void stmt_transpile_cond(context_TranspileContext* ctx, types_SExpr* expr, uint8
                                                     break;
                                                 }
                                             }
-                                        } else if (!_mv_879.has_value) {
+                                        } else if (!_mv_880.has_value) {
                                             context_ctx_add_error_at(ctx, SLOP_STR("missing test"), context_ctx_sexpr_line(clause_expr), context_ctx_sexpr_col(clause_expr));
                                         }
                                     }
@@ -1313,7 +1314,7 @@ void stmt_transpile_cond(context_TranspileContext* ctx, types_SExpr* expr, uint8
                                 break;
                             }
                         }
-                    } else if (!_mv_877.has_value) {
+                    } else if (!_mv_878.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -1336,14 +1337,14 @@ void stmt_transpile_cond_body(context_TranspileContext* ctx, slop_list_types_SEx
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_881 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_881.has_value) {
-                __auto_type body_expr = _mv_881.value;
+            __auto_type _mv_882 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_882.has_value) {
+                __auto_type body_expr = _mv_882.value;
                 {
                     __auto_type is_last = (i == (len - 1));
                     stmt_transpile_stmt(ctx, body_expr, (is_return && is_last));
                 }
-            } else if (!_mv_881.has_value) {
+            } else if (!_mv_882.has_value) {
             }
             i = (i + 1);
         }
@@ -1355,47 +1356,47 @@ void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_882 = (*expr);
-        switch (_mv_882.tag) {
+        __auto_type _mv_883 = (*expr);
+        switch (_mv_883.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_882.data.lst;
+                __auto_type lst = _mv_883.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 2) {
                         context_ctx_add_error_at(ctx, SLOP_STR("invalid for: need binding"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     } else {
-                        __auto_type _mv_883 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_883.has_value) {
-                            __auto_type binding_expr = _mv_883.value;
-                            __auto_type _mv_884 = (*binding_expr);
-                            switch (_mv_884.tag) {
+                        __auto_type _mv_884 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_884.has_value) {
+                            __auto_type binding_expr = _mv_884.value;
+                            __auto_type _mv_885 = (*binding_expr);
+                            switch (_mv_885.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type binding_lst = _mv_884.data.lst;
+                                    __auto_type binding_lst = _mv_885.data.lst;
                                     {
                                         __auto_type binding_items = binding_lst.items;
                                         __auto_type binding_len = ((int64_t)((binding_items).len));
                                         if (binding_len < 3) {
                                             context_ctx_add_error_at(ctx, SLOP_STR("for binding needs (var start end)"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                         } else {
-                                            __auto_type _mv_885 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_885.has_value) {
-                                                __auto_type var_expr = _mv_885.value;
-                                                __auto_type _mv_886 = (*var_expr);
-                                                switch (_mv_886.tag) {
+                                            __auto_type _mv_886 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_886.has_value) {
+                                                __auto_type var_expr = _mv_886.value;
+                                                __auto_type _mv_887 = (*var_expr);
+                                                switch (_mv_887.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type var_sym = _mv_886.data.sym;
+                                                        __auto_type var_sym = _mv_887.data.sym;
                                                         {
                                                             __auto_type var_name = ctype_to_c_name(arena, var_sym.name);
-                                                            __auto_type _mv_887 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                            if (_mv_887.has_value) {
-                                                                __auto_type start_expr = _mv_887.value;
-                                                                __auto_type _mv_888 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                if (_mv_888.has_value) {
-                                                                    __auto_type end_expr = _mv_888.value;
+                                                            __auto_type _mv_888 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                            if (_mv_888.has_value) {
+                                                                __auto_type start_expr = _mv_888.value;
+                                                                __auto_type _mv_889 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                if (_mv_889.has_value) {
+                                                                    __auto_type end_expr = _mv_889.value;
                                                                     {
                                                                         __auto_type start_c = expr_transpile_expr(ctx, start_expr);
                                                                         __auto_type end_c = expr_transpile_expr(ctx, end_expr);
@@ -1406,11 +1407,11 @@ void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr) {
                                                                         {
                                                                             __auto_type i = 2;
                                                                             while (i < len) {
-                                                                                __auto_type _mv_889 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                                if (_mv_889.has_value) {
-                                                                                    __auto_type body_expr = _mv_889.value;
+                                                                                __auto_type _mv_890 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                                if (_mv_890.has_value) {
+                                                                                    __auto_type body_expr = _mv_890.value;
                                                                                     stmt_transpile_stmt(ctx, body_expr, 0);
-                                                                                } else if (!_mv_889.has_value) {
+                                                                                } else if (!_mv_890.has_value) {
                                                                                 }
                                                                                 i = (i + 1);
                                                                             }
@@ -1419,10 +1420,10 @@ void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr) {
                                                                         context_ctx_dedent(ctx);
                                                                         context_ctx_emit(ctx, SLOP_STR("}"));
                                                                     }
-                                                                } else if (!_mv_888.has_value) {
+                                                                } else if (!_mv_889.has_value) {
                                                                     context_ctx_add_error_at(ctx, SLOP_STR("missing end"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                                                 }
-                                                            } else if (!_mv_887.has_value) {
+                                                            } else if (!_mv_888.has_value) {
                                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing start"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                                             }
                                                         }
@@ -1433,7 +1434,7 @@ void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr) {
                                                         break;
                                                     }
                                                 }
-                                            } else if (!_mv_885.has_value) {
+                                            } else if (!_mv_886.has_value) {
                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing var"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                             }
                                         }
@@ -1445,7 +1446,7 @@ void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_883.has_value) {
+                        } else if (!_mv_884.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing binding"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                     }
@@ -1484,11 +1485,11 @@ void stmt_transpile_for_each_set(context_TranspileContext* ctx, slop_string var_
         {
             int64_t i = 2;
             while (i < len) {
-                __auto_type _mv_890 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_890.has_value) {
-                    __auto_type body_expr = _mv_890.value;
+                __auto_type _mv_891 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_891.has_value) {
+                    __auto_type body_expr = _mv_891.value;
                     stmt_transpile_stmt(ctx, body_expr, 0);
-                } else if (!_mv_890.has_value) {
+                } else if (!_mv_891.has_value) {
                 }
                 i = (i + 1);
             }
@@ -1527,11 +1528,11 @@ void stmt_transpile_for_each_map_keys(context_TranspileContext* ctx, slop_string
         {
             int64_t i = 2;
             while (i < len) {
-                __auto_type _mv_891 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_891.has_value) {
-                    __auto_type body_expr = _mv_891.value;
+                __auto_type _mv_892 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_892.has_value) {
+                    __auto_type body_expr = _mv_892.value;
                     stmt_transpile_stmt(ctx, body_expr, 0);
-                } else if (!_mv_891.has_value) {
+                } else if (!_mv_892.has_value) {
                 }
                 i = (i + 1);
             }
@@ -1550,38 +1551,38 @@ void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_typ
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_892 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_892.has_value) {
-            __auto_type kv_list_expr = _mv_892.value;
-            __auto_type _mv_893 = (*kv_list_expr);
-            switch (_mv_893.tag) {
+        __auto_type _mv_893 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_893.has_value) {
+            __auto_type kv_list_expr = _mv_893.value;
+            __auto_type _mv_894 = (*kv_list_expr);
+            switch (_mv_894.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type kv_lst = _mv_893.data.lst;
+                    __auto_type kv_lst = _mv_894.data.lst;
                     {
                         __auto_type kv_items = kv_lst.items;
                         if (((int64_t)((kv_items).len)) < 2) {
                             context_ctx_add_error(ctx, SLOP_STR("Map for-each needs ((k v) map)"));
                         } else {
-                            __auto_type _mv_894 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_894.has_value) {
-                                __auto_type k_expr = _mv_894.value;
-                                __auto_type _mv_895 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_895.has_value) {
-                                    __auto_type v_expr = _mv_895.value;
-                                    __auto_type _mv_896 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_896.has_value) {
-                                        __auto_type map_expr = _mv_896.value;
-                                        __auto_type _mv_897 = (*k_expr);
-                                        switch (_mv_897.tag) {
+                            __auto_type _mv_895 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_895.has_value) {
+                                __auto_type k_expr = _mv_895.value;
+                                __auto_type _mv_896 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_896.has_value) {
+                                    __auto_type v_expr = _mv_896.value;
+                                    __auto_type _mv_897 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_897.has_value) {
+                                        __auto_type map_expr = _mv_897.value;
+                                        __auto_type _mv_898 = (*k_expr);
+                                        switch (_mv_898.tag) {
                                             case types_SExpr_sym:
                                             {
-                                                __auto_type k_sym = _mv_897.data.sym;
-                                                __auto_type _mv_898 = (*v_expr);
-                                                switch (_mv_898.tag) {
+                                                __auto_type k_sym = _mv_898.data.sym;
+                                                __auto_type _mv_899 = (*v_expr);
+                                                switch (_mv_899.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type v_sym = _mv_898.data.sym;
+                                                        __auto_type v_sym = _mv_899.data.sym;
                                                         {
                                                             __auto_type k_name = ctype_to_c_name(arena, k_sym.name);
                                                             __auto_type v_name = ctype_to_c_name(arena, v_sym.name);
@@ -1617,11 +1618,11 @@ void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_typ
                                                             {
                                                                 __auto_type i = 2;
                                                                 while (i < len) {
-                                                                    __auto_type _mv_899 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                    if (_mv_899.has_value) {
-                                                                        __auto_type body_expr = _mv_899.value;
+                                                                    __auto_type _mv_900 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                    if (_mv_900.has_value) {
+                                                                        __auto_type body_expr = _mv_900.value;
                                                                         stmt_transpile_stmt(ctx, body_expr, 0);
-                                                                    } else if (!_mv_899.has_value) {
+                                                                    } else if (!_mv_900.has_value) {
                                                                     }
                                                                     i = (i + 1);
                                                                 }
@@ -1648,13 +1649,13 @@ void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_typ
                                                 break;
                                             }
                                         }
-                                    } else if (!_mv_896.has_value) {
+                                    } else if (!_mv_897.has_value) {
                                         context_ctx_add_error(ctx, SLOP_STR("Missing map expression"));
                                     }
-                                } else if (!_mv_895.has_value) {
+                                } else if (!_mv_896.has_value) {
                                     context_ctx_add_error(ctx, SLOP_STR("Missing value binding"));
                                 }
-                            } else if (!_mv_894.has_value) {
+                            } else if (!_mv_895.has_value) {
                                 context_ctx_add_error(ctx, SLOP_STR("Missing key binding"));
                             }
                         }
@@ -1666,7 +1667,7 @@ void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_typ
                     break;
                 }
             }
-        } else if (!_mv_892.has_value) {
+        } else if (!_mv_893.has_value) {
             context_ctx_add_error(ctx, SLOP_STR("Missing binding"));
         }
     }
@@ -1677,50 +1678,50 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_900 = (*expr);
-        switch (_mv_900.tag) {
+        __auto_type _mv_901 = (*expr);
+        switch (_mv_901.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_900.data.lst;
+                __auto_type lst = _mv_901.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 2) {
                         context_ctx_add_error_at(ctx, SLOP_STR("invalid for-each: need binding"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     } else {
-                        __auto_type _mv_901 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_901.has_value) {
-                            __auto_type binding_expr = _mv_901.value;
-                            __auto_type _mv_902 = (*binding_expr);
-                            switch (_mv_902.tag) {
+                        __auto_type _mv_902 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_902.has_value) {
+                            __auto_type binding_expr = _mv_902.value;
+                            __auto_type _mv_903 = (*binding_expr);
+                            switch (_mv_903.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type binding_lst = _mv_902.data.lst;
+                                    __auto_type binding_lst = _mv_903.data.lst;
                                     {
                                         __auto_type binding_items = binding_lst.items;
                                         __auto_type binding_len = ((int64_t)((binding_items).len));
                                         if (binding_len < 2) {
                                             context_ctx_add_error_at(ctx, SLOP_STR("for-each binding needs (var coll)"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                         } else {
-                                            __auto_type _mv_903 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_903.has_value) {
-                                                __auto_type first_elem = _mv_903.value;
-                                                __auto_type _mv_904 = (*first_elem);
-                                                switch (_mv_904.tag) {
+                                            __auto_type _mv_904 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_904.has_value) {
+                                                __auto_type first_elem = _mv_904.value;
+                                                __auto_type _mv_905 = (*first_elem);
+                                                switch (_mv_905.tag) {
                                                     case types_SExpr_lst:
                                                     {
-                                                        __auto_type _ = _mv_904.data.lst;
+                                                        __auto_type _ = _mv_905.data.lst;
                                                         stmt_transpile_for_each_map_kv(ctx, binding_items, items, len);
                                                         break;
                                                     }
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type var_sym = _mv_904.data.sym;
+                                                        __auto_type var_sym = _mv_905.data.sym;
                                                         {
                                                             __auto_type var_name = ctype_to_c_name(arena, var_sym.name);
-                                                            __auto_type _mv_905 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                            if (_mv_905.has_value) {
-                                                                __auto_type coll_expr = _mv_905.value;
+                                                            __auto_type _mv_906 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                            if (_mv_906.has_value) {
+                                                                __auto_type coll_expr = _mv_906.value;
                                                                 {
                                                                     __auto_type coll_slop_type = expr_infer_expr_slop_type(ctx, coll_expr);
                                                                     __auto_type resolved_type = expr_resolve_type_alias(ctx, coll_slop_type);
@@ -1753,11 +1754,11 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
                                                                             {
                                                                                 __auto_type i = 2;
                                                                                 while (i < len) {
-                                                                                    __auto_type _mv_906 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                                    if (_mv_906.has_value) {
-                                                                                        __auto_type body_expr = _mv_906.value;
+                                                                                    __auto_type _mv_907 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                                    if (_mv_907.has_value) {
+                                                                                        __auto_type body_expr = _mv_907.value;
                                                                                         stmt_transpile_stmt(ctx, body_expr, 0);
-                                                                                    } else if (!_mv_906.has_value) {
+                                                                                    } else if (!_mv_907.has_value) {
                                                                                     }
                                                                                     i = (i + 1);
                                                                                 }
@@ -1770,7 +1771,7 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
                                                                         }
                                                                     }
                                                                 }
-                                                            } else if (!_mv_905.has_value) {
+                                                            } else if (!_mv_906.has_value) {
                                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing collection"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                                             }
                                                         }
@@ -1781,7 +1782,7 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
                                                         break;
                                                     }
                                                 }
-                                            } else if (!_mv_903.has_value) {
+                                            } else if (!_mv_904.has_value) {
                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing var"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                             }
                                         }
@@ -1793,7 +1794,7 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_901.has_value) {
+                        } else if (!_mv_902.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing binding"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                     }
@@ -1811,24 +1812,24 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
 void stmt_transpile_stmt(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_907 = (*expr);
-    switch (_mv_907.tag) {
+    __auto_type _mv_908 = (*expr);
+    switch (_mv_908.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_907.data.lst;
+            __auto_type lst = _mv_908.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     context_ctx_add_error_at(ctx, SLOP_STR("empty list"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                 } else {
-                    __auto_type _mv_908 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_908.has_value) {
-                        __auto_type head_expr = _mv_908.value;
-                        __auto_type _mv_909 = (*head_expr);
-                        switch (_mv_909.tag) {
+                    __auto_type _mv_909 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_909.has_value) {
+                        __auto_type head_expr = _mv_909.value;
+                        __auto_type _mv_910 = (*head_expr);
+                        switch (_mv_910.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_909.data.sym;
+                                __auto_type sym = _mv_910.data.sym;
                                 {
                                     __auto_type op = sym.name;
                                     if (string_eq(op, SLOP_STR("let")) || string_eq(op, SLOP_STR("let*"))) {
@@ -1857,11 +1858,11 @@ void stmt_transpile_stmt(context_TranspileContext* ctx, types_SExpr* expr, uint8
                                         if (((int64_t)((items).len)) < 2) {
                                             context_ctx_emit(ctx, SLOP_STR("return;"));
                                         } else {
-                                            __auto_type _mv_910 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_910.has_value) {
-                                                __auto_type val_expr = _mv_910.value;
+                                            __auto_type _mv_911 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_911.has_value) {
+                                                __auto_type val_expr = _mv_911.value;
                                                 stmt_emit_typed_return_expr(ctx, val_expr);
-                                            } else if (!_mv_910.has_value) {
+                                            } else if (!_mv_911.has_value) {
                                                 context_ctx_emit(ctx, SLOP_STR("return;"));
                                             }
                                         }
@@ -1893,7 +1894,7 @@ void stmt_transpile_stmt(context_TranspileContext* ctx, types_SExpr* expr, uint8
                                 break;
                             }
                         }
-                    } else if (!_mv_908.has_value) {
+                    } else if (!_mv_909.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("empty"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     }
                 }
@@ -1916,61 +1917,61 @@ void stmt_transpile_stmt(context_TranspileContext* ctx, types_SExpr* expr, uint8
 void stmt_emit_typed_return_expr(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_911 = (*expr);
-    switch (_mv_911.tag) {
+    __auto_type _mv_912 = (*expr);
+    switch (_mv_912.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_911.data.lst;
+            __auto_type lst = _mv_912.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                 } else {
-                    __auto_type _mv_912 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_912.has_value) {
-                        __auto_type head = _mv_912.value;
-                        __auto_type _mv_913 = (*head);
-                        switch (_mv_913.tag) {
+                    __auto_type _mv_913 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_913.has_value) {
+                        __auto_type head = _mv_913.value;
+                        __auto_type _mv_914 = (*head);
+                        switch (_mv_914.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_913.data.sym;
+                                __auto_type sym = _mv_914.data.sym;
                                 {
                                     __auto_type op = sym.name;
                                     if (string_eq(op, SLOP_STR("some"))) {
-                                        __auto_type _mv_914 = context_ctx_get_current_return_type(ctx);
-                                        if (_mv_914.has_value) {
-                                            __auto_type ret_type = _mv_914.value;
+                                        __auto_type _mv_915 = context_ctx_get_current_return_type(ctx);
+                                        if (_mv_915.has_value) {
+                                            __auto_type ret_type = _mv_915.value;
                                             if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
                                                 if (((int64_t)((items).len)) < 2) {
                                                     stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                                                 } else {
-                                                    __auto_type _mv_915 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_915.has_value) {
-                                                        __auto_type inner_expr = _mv_915.value;
+                                                    __auto_type _mv_916 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_916.has_value) {
+                                                        __auto_type inner_expr = _mv_916.value;
                                                         {
                                                             __auto_type inner_c = expr_transpile_expr(ctx, inner_expr);
                                                             context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("return ("), ret_type, SLOP_STR("){.has_value = 1, .value = "), inner_c, SLOP_STR("};")));
                                                         }
-                                                    } else if (!_mv_915.has_value) {
+                                                    } else if (!_mv_916.has_value) {
                                                         stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                                                     }
                                                 }
                                             } else {
                                                 stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                                             }
-                                        } else if (!_mv_914.has_value) {
+                                        } else if (!_mv_915.has_value) {
                                             stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                                         }
                                     } else if (string_eq(op, SLOP_STR("none"))) {
-                                        __auto_type _mv_916 = context_ctx_get_current_return_type(ctx);
-                                        if (_mv_916.has_value) {
-                                            __auto_type ret_type = _mv_916.value;
+                                        __auto_type _mv_917 = context_ctx_get_current_return_type(ctx);
+                                        if (_mv_917.has_value) {
+                                            __auto_type ret_type = _mv_917.value;
                                             if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
                                                 context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("return ("), ret_type, SLOP_STR("){.has_value = false};")));
                                             } else {
                                                 stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                                             }
-                                        } else if (!_mv_916.has_value) {
+                                        } else if (!_mv_917.has_value) {
                                             stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                                         }
                                     } else {
@@ -1984,7 +1985,7 @@ void stmt_emit_typed_return_expr(context_TranspileContext* ctx, types_SExpr* exp
                                 break;
                             }
                         }
-                    } else if (!_mv_912.has_value) {
+                    } else if (!_mv_913.has_value) {
                         stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                     }
                 }
@@ -2003,22 +2004,22 @@ void stmt_emit_return_with_typed_none(context_TranspileContext* ctx, slop_string
     {
         __auto_type final_code = code;
         if (string_eq(code, SLOP_STR("none"))) {
-            __auto_type _mv_917 = context_ctx_get_current_return_type(ctx);
-            if (_mv_917.has_value) {
-                __auto_type ret_type = _mv_917.value;
-                if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
-                    final_code = context_ctx_str3(ctx, SLOP_STR("("), ret_type, SLOP_STR("){.has_value = false}"));
-                }
-            } else if (!_mv_917.has_value) {
-            }
-        } else {
             __auto_type _mv_918 = context_ctx_get_current_return_type(ctx);
             if (_mv_918.has_value) {
                 __auto_type ret_type = _mv_918.value;
                 if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
-                    __auto_type _mv_919 = context_ctx_lookup_var(ctx, code);
-                    if (_mv_919.has_value) {
-                        __auto_type var_entry = _mv_919.value;
+                    final_code = context_ctx_str3(ctx, SLOP_STR("("), ret_type, SLOP_STR("){.has_value = false}"));
+                }
+            } else if (!_mv_918.has_value) {
+            }
+        } else {
+            __auto_type _mv_919 = context_ctx_get_current_return_type(ctx);
+            if (_mv_919.has_value) {
+                __auto_type ret_type = _mv_919.value;
+                if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
+                    __auto_type _mv_920 = context_ctx_lookup_var(ctx, code);
+                    if (_mv_920.has_value) {
+                        __auto_type var_entry = _mv_920.value;
                         {
                             __auto_type var_type = var_entry.c_type;
                             if (string_eq(var_type, SLOP_STR("_slop_option_generic")) || string_eq(var_type, SLOP_STR("auto"))) {
@@ -2033,10 +2034,10 @@ void stmt_emit_return_with_typed_none(context_TranspileContext* ctx, slop_string
                                 }
                             }
                         }
-                    } else if (!_mv_919.has_value) {
+                    } else if (!_mv_920.has_value) {
                     }
                 }
-            } else if (!_mv_918.has_value) {
+            } else if (!_mv_919.has_value) {
             }
         }
         if (context_ctx_is_capture_retval(ctx)) {

--- a/bootstrap/tester/slop_test_emit.c
+++ b/bootstrap/tester/slop_test_emit.c
@@ -97,29 +97,29 @@ types_SExpr* test_emit_make_sexpr_list(slop_arena* arena, slop_list_types_SExpr_
 
 uint8_t test_emit_has_ellipsis(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1537 = (*expr);
-    switch (_mv_1537.tag) {
+    __auto_type _mv_1538 = (*expr);
+    switch (_mv_1538.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_1537.data.sym;
+            __auto_type s = _mv_1538.data.sym;
             return string_eq(s.name, SLOP_STR(".."));
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_1537.data.lst;
+            __auto_type l = _mv_1538.data.lst;
             {
                 __auto_type items = l.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type i = 0;
                 __auto_type found = 0;
                 while ((i < len) && !(found)) {
-                    __auto_type _mv_1538 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1538.has_value) {
-                        __auto_type item = _mv_1538.value;
+                    __auto_type _mv_1539 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1539.has_value) {
+                        __auto_type item = _mv_1539.value;
                         if (test_emit_has_ellipsis(item)) {
                             found = 1;
                         }
-                    } else if (!_mv_1538.has_value) {
+                    } else if (!_mv_1539.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -128,12 +128,12 @@ uint8_t test_emit_has_ellipsis(types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type _ = _mv_1537.data.num;
+            __auto_type _ = _mv_1538.data.num;
             return 0;
         }
         case types_SExpr_str:
         {
-            __auto_type _ = _mv_1537.data.str;
+            __auto_type _ = _mv_1538.data.str;
             return 0;
         }
     }
@@ -146,13 +146,13 @@ uint8_t test_emit_args_have_ellipsis(slop_list_types_SExpr_ptr args) {
         int64_t i = 0;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1539 = ({ __auto_type _lst = args; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1539.has_value) {
-                __auto_type arg = _mv_1539.value;
+            __auto_type _mv_1540 = ({ __auto_type _lst = args; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1540.has_value) {
+                __auto_type arg = _mv_1540.value;
                 if (test_emit_has_ellipsis(arg)) {
                     found = 1;
                 }
-            } else if (!_mv_1539.has_value) {
+            } else if (!_mv_1540.has_value) {
             }
             i = (i + 1);
         }
@@ -173,29 +173,29 @@ uint8_t test_emit_is_type_constructor_name(slop_string name) {
 
 uint8_t test_emit_contains_wildcard(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1540 = (*expr);
-    switch (_mv_1540.tag) {
+    __auto_type _mv_1541 = (*expr);
+    switch (_mv_1541.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_1540.data.sym;
+            __auto_type s = _mv_1541.data.sym;
             return ((string_eq(s.name, SLOP_STR("_"))) || (string_eq(s.name, SLOP_STR(".."))) || (string_eq(s.name, SLOP_STR("."))));
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_1540.data.lst;
+            __auto_type l = _mv_1541.data.lst;
             {
                 __auto_type items = l.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type i = 0;
                 __auto_type found = 0;
                 while ((i < len) && !(found)) {
-                    __auto_type _mv_1541 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1541.has_value) {
-                        __auto_type item = _mv_1541.value;
+                    __auto_type _mv_1542 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1542.has_value) {
+                        __auto_type item = _mv_1542.value;
                         if (test_emit_contains_wildcard(item)) {
                             found = 1;
                         }
-                    } else if (!_mv_1541.has_value) {
+                    } else if (!_mv_1542.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -204,12 +204,12 @@ uint8_t test_emit_contains_wildcard(types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type _ = _mv_1540.data.num;
+            __auto_type _ = _mv_1541.data.num;
             return 0;
         }
         case types_SExpr_str:
         {
-            __auto_type _ = _mv_1540.data.str;
+            __auto_type _ = _mv_1541.data.str;
             return 0;
         }
     }
@@ -218,11 +218,11 @@ uint8_t test_emit_contains_wildcard(types_SExpr* expr) {
 
 types_SExpr* test_emit_replace_wildcards(slop_arena* arena, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1542 = (*expr);
-    switch (_mv_1542.tag) {
+    __auto_type _mv_1543 = (*expr);
+    switch (_mv_1543.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_1542.data.sym;
+            __auto_type s = _mv_1543.data.sym;
             if ((string_eq(s.name, SLOP_STR("_"))) || (string_eq(s.name, SLOP_STR(".."))) || (string_eq(s.name, SLOP_STR(".")))) {
                 return test_emit_make_sexpr_sym(arena, SLOP_STR("__SLOP_WILDCARD__"));
             } else {
@@ -231,7 +231,7 @@ types_SExpr* test_emit_replace_wildcards(slop_arena* arena, types_SExpr* expr) {
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_1542.data.lst;
+            __auto_type l = _mv_1543.data.lst;
             {
                 __auto_type items = l.items;
                 __auto_type len = ((int64_t)((items).len));
@@ -239,15 +239,15 @@ types_SExpr* test_emit_replace_wildcards(slop_arena* arena, types_SExpr* expr) {
                 __auto_type i = 0;
                 __auto_type in_type_constructor = (((len > 0)) ? ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type first = _mv.value; ({ __auto_type _mv = (*first); uint8_t _mr = {0}; switch (_mv.tag) { case types_SExpr_sym: { __auto_type s = _mv.data.sym; _mr = test_emit_is_type_constructor_name(s.name); break; } default: { _mr = 0; break; }  } _mr; }); }) : (0); }) : 0);
                 while (i < len) {
-                    __auto_type _mv_1543 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1543.has_value) {
-                        __auto_type item = _mv_1543.value;
+                    __auto_type _mv_1544 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1544.has_value) {
+                        __auto_type item = _mv_1544.value;
                         if (in_type_constructor && (i > 0)) {
-                            __auto_type _mv_1544 = (*item);
-                            switch (_mv_1544.tag) {
+                            __auto_type _mv_1545 = (*item);
+                            switch (_mv_1545.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type s = _mv_1544.data.sym;
+                                    __auto_type s = _mv_1545.data.sym;
                                     if ((string_eq(s.name, SLOP_STR(".."))) && (((i + 1) < len)) && (({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)(i + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type next_item = _mv.value; ({ __auto_type _mv = (*next_item); uint8_t _mr = {0}; switch (_mv.tag) { case types_SExpr_sym: { __auto_type ns = _mv.data.sym; _mr = string_eq(ns.name, SLOP_STR(".")); break; } default: { _mr = 0; break; }  } _mr; }); }) : (0); }))) {
                                     } else if ((string_eq(s.name, SLOP_STR("_"))) || (string_eq(s.name, SLOP_STR(".."))) || (string_eq(s.name, SLOP_STR(".")))) {
                                         ({ __auto_type _lst_p = &(new_items); __auto_type _item = (test_emit_make_sexpr_sym(arena, SLOP_STR("__SLOP_WILDCARD__"))); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
@@ -264,7 +264,7 @@ types_SExpr* test_emit_replace_wildcards(slop_arena* arena, types_SExpr* expr) {
                         } else {
                             ({ __auto_type _lst_p = &(new_items); __auto_type _item = (test_emit_replace_wildcards(arena, item)); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                         }
-                    } else if (!_mv_1543.has_value) {
+                    } else if (!_mv_1544.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -273,12 +273,12 @@ types_SExpr* test_emit_replace_wildcards(slop_arena* arena, types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type _ = _mv_1542.data.num;
+            __auto_type _ = _mv_1543.data.num;
             return expr;
         }
         case types_SExpr_str:
         {
-            __auto_type _ = _mv_1542.data.str;
+            __auto_type _ = _mv_1543.data.str;
             return expr;
         }
     }
@@ -293,11 +293,11 @@ slop_string test_emit_prefix_symbol(slop_arena* arena, slop_string name, slop_st
     if (string_eq(name, SLOP_STR("arena"))) {
         return SLOP_STR("test_arena");
     } else {
-        __auto_type _mv_1545 = type_extract_registry_lookup_import(types, name);
-        if (_mv_1545.has_value) {
-            __auto_type mod_name = _mv_1545.value;
+        __auto_type _mv_1546 = type_extract_registry_lookup_import(types, name);
+        if (_mv_1546.has_value) {
+            __auto_type mod_name = _mv_1546.value;
             return string_concat(arena, ctype_to_c_name(arena, mod_name), string_concat(arena, SLOP_STR("_"), ctype_to_c_name(arena, name)));
-        } else if (!_mv_1545.has_value) {
+        } else if (!_mv_1546.has_value) {
             if (((int64_t)(prefix.len)) > 0) {
                 return string_concat(arena, prefix, string_concat(arena, SLOP_STR("_"), ctype_to_c_name(arena, name)));
             } else {
@@ -338,11 +338,11 @@ types_SExpr* test_emit_build_call_sexpr(slop_arena* arena, slop_string fn_name, 
                 ({ __auto_type _lst_p = &(call_items); __auto_type _item = (test_emit_make_sexpr_sym(arena, SLOP_STR("arena"))); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                 arg_idx = (arg_idx + 1);
             }
-            __auto_type _mv_1546 = ({ __auto_type _lst = args; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1546.has_value) {
-                __auto_type arg = _mv_1546.value;
+            __auto_type _mv_1547 = ({ __auto_type _lst = args; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1547.has_value) {
+                __auto_type arg = _mv_1547.value;
                 ({ __auto_type _lst_p = &(call_items); __auto_type _item = (arg); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-            } else if (!_mv_1546.has_value) {
+            } else if (!_mv_1547.has_value) {
             }
             i = (i + 1);
             arg_idx = (arg_idx + 1);
@@ -412,14 +412,14 @@ slop_list_string test_emit_emit_test_harness_typed(slop_arena* arena, slop_list_
             __auto_type import_count = ((int64_t)((imports).len));
             int64_t j = 0;
             while (j < import_count) {
-                __auto_type _mv_1547 = ({ __auto_type _lst = imports; size_t _idx = (size_t)j; slop_option_type_extract_ImportEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1547.has_value) {
-                    __auto_type entry = _mv_1547.value;
+                __auto_type _mv_1548 = ({ __auto_type _lst = imports; size_t _idx = (size_t)j; slop_option_type_extract_ImportEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1548.has_value) {
+                    __auto_type entry = _mv_1548.value;
                     {
                         __auto_type c_name = ctype_to_c_name(arena, entry.module_name);
                         test_emit_emit(ctx, string_concat(arena, SLOP_STR("#include \"slop_"), string_concat(arena, c_name, SLOP_STR(".h\""))));
                     }
-                } else if (!_mv_1547.has_value) {
+                } else if (!_mv_1548.has_value) {
                 }
                 j = (j + 1);
             }
@@ -442,11 +442,11 @@ slop_list_string test_emit_emit_test_harness_typed(slop_arena* arena, slop_list_
                 __auto_type test_count = ((int64_t)((tests).len));
                 int64_t i = 0;
                 while (i < test_count) {
-                    __auto_type _mv_1548 = ({ __auto_type _lst = tests; size_t _idx = (size_t)i; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1548.has_value) {
-                        __auto_type tc = _mv_1548.value;
+                    __auto_type _mv_1549 = ({ __auto_type _lst = tests; size_t _idx = (size_t)i; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1549.has_value) {
+                        __auto_type tc = _mv_1549.value;
                         test_emit_emit_test_function_typed(ctx, (*tc), i, module_prefix, types, tctx, file_name);
-                    } else if (!_mv_1548.has_value) {
+                    } else if (!_mv_1549.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -459,29 +459,29 @@ slop_list_string test_emit_emit_test_harness_typed(slop_arena* arena, slop_list_
 
 uint8_t test_emit_expr_mentions_arena(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1549 = (*expr);
-    switch (_mv_1549.tag) {
+    __auto_type _mv_1550 = (*expr);
+    switch (_mv_1550.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_1549.data.sym;
+            __auto_type s = _mv_1550.data.sym;
             return string_eq(s.name, SLOP_STR("arena"));
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_1549.data.lst;
+            __auto_type l = _mv_1550.data.lst;
             {
                 __auto_type items = l.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type i = 0;
                 __auto_type found = 0;
                 while ((i < len) && !(found)) {
-                    __auto_type _mv_1550 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1550.has_value) {
-                        __auto_type item = _mv_1550.value;
+                    __auto_type _mv_1551 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1551.has_value) {
+                        __auto_type item = _mv_1551.value;
                         if (test_emit_expr_mentions_arena(item)) {
                             found = 1;
                         }
-                    } else if (!_mv_1550.has_value) {
+                    } else if (!_mv_1551.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -490,12 +490,12 @@ uint8_t test_emit_expr_mentions_arena(types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type _ = _mv_1549.data.num;
+            __auto_type _ = _mv_1550.data.num;
             return 0;
         }
         case types_SExpr_str:
         {
-            __auto_type _ = _mv_1549.data.str;
+            __auto_type _ = _mv_1550.data.str;
             return 0;
         }
     }
@@ -513,13 +513,13 @@ uint8_t test_emit_test_mentions_arena(extract_TestCase tc) {
             int64_t i = 0;
             uint8_t found = test_emit_expr_mentions_arena(tc.expected);
             while ((i < len) && !(found)) {
-                __auto_type _mv_1551 = ({ __auto_type _lst = args; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1551.has_value) {
-                    __auto_type arg = _mv_1551.value;
+                __auto_type _mv_1552 = ({ __auto_type _lst = args; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1552.has_value) {
+                    __auto_type arg = _mv_1552.value;
                     if (test_emit_expr_mentions_arena(arg)) {
                         found = 1;
                     }
-                } else if (!_mv_1551.has_value) {
+                } else if (!_mv_1552.has_value) {
                 }
                 i = (i + 1);
             }
@@ -534,13 +534,13 @@ uint8_t test_emit_any_test_needs_arena(slop_list_extract_TestCase_ptr tests) {
         int64_t i = 0;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1552 = ({ __auto_type _lst = tests; size_t _idx = (size_t)i; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1552.has_value) {
-                __auto_type tc = _mv_1552.value;
+            __auto_type _mv_1553 = ({ __auto_type _lst = tests; size_t _idx = (size_t)i; slop_option_extract_TestCase_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1553.has_value) {
+                __auto_type tc = _mv_1553.value;
                 if (test_emit_test_mentions_arena((*tc))) {
                     found = 1;
                 }
-            } else if (!_mv_1552.has_value) {
+            } else if (!_mv_1553.has_value) {
             }
             i = (i + 1);
         }
@@ -554,29 +554,29 @@ slop_string test_emit_format_error_position(slop_arena* arena, slop_string file_
 
 slop_string test_emit_param_name_at(types_SExpr* params, int64_t idx) {
     SLOP_PRE(((params != NULL)), "(!= params nil)");
-    __auto_type _mv_1553 = parser_sexpr_list_get(params, idx);
-    if (_mv_1553.has_value) {
-        __auto_type param = _mv_1553.value;
+    __auto_type _mv_1554 = parser_sexpr_list_get(params, idx);
+    if (_mv_1554.has_value) {
+        __auto_type param = _mv_1554.value;
         {
             __auto_type plen = parser_sexpr_list_len(param);
             if (plen < 2) {
                 return SLOP_STR("");
             } else {
-                __auto_type _mv_1554 = parser_sexpr_list_get(param, (((plen == 2)) ? 0 : 1));
-                if (_mv_1554.has_value) {
-                    __auto_type name_expr = _mv_1554.value;
+                __auto_type _mv_1555 = parser_sexpr_list_get(param, (((plen == 2)) ? 0 : 1));
+                if (_mv_1555.has_value) {
+                    __auto_type name_expr = _mv_1555.value;
                     if (parser_sexpr_is_symbol(name_expr)) {
                         return parser_sexpr_get_symbol_name(name_expr);
                     } else {
                         return SLOP_STR("");
                     }
-                } else if (!_mv_1554.has_value) {
+                } else if (!_mv_1555.has_value) {
                     return SLOP_STR("");
                 }
                 SLOP_UNREACHABLE();
             }
         }
-    } else if (!_mv_1553.has_value) {
+    } else if (!_mv_1554.has_value) {
         return SLOP_STR("");
     }
     SLOP_UNREACHABLE();
@@ -585,11 +585,11 @@ slop_string test_emit_param_name_at(types_SExpr* params, int64_t idx) {
 types_SExpr* test_emit_substitute_symbol(slop_arena* arena, types_SExpr* expr, slop_string name, types_SExpr* replacement) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     SLOP_PRE(((replacement != NULL)), "(!= replacement nil)");
-    __auto_type _mv_1555 = (*expr);
-    switch (_mv_1555.tag) {
+    __auto_type _mv_1556 = (*expr);
+    switch (_mv_1556.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_1555.data.sym;
+            __auto_type s = _mv_1556.data.sym;
             if (string_eq(s.name, name)) {
                 return replacement;
             } else {
@@ -598,7 +598,7 @@ types_SExpr* test_emit_substitute_symbol(slop_arena* arena, types_SExpr* expr, s
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_1555.data.lst;
+            __auto_type l = _mv_1556.data.lst;
             {
                 __auto_type items = l.items;
                 __auto_type len = ((int64_t)((items).len));
@@ -606,15 +606,15 @@ types_SExpr* test_emit_substitute_symbol(slop_arena* arena, types_SExpr* expr, s
                 __auto_type is_field_access = ((len >= 3) && ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type head = _mv.value; ({ __auto_type _mv = (*head); uint8_t _mr = {0}; switch (_mv.tag) { case types_SExpr_sym: { __auto_type hs = _mv.data.sym; _mr = string_eq(hs.name, SLOP_STR(".")); break; } default: { _mr = 0; break; }  } _mr; }); }) : (0); }));
                 __auto_type i = 0;
                 while (i < len) {
-                    __auto_type _mv_1556 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1556.has_value) {
-                        __auto_type item = _mv_1556.value;
+                    __auto_type _mv_1557 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1557.has_value) {
+                        __auto_type item = _mv_1557.value;
                         if (is_field_access && (i >= 2)) {
                             ({ __auto_type _lst_p = &(new_items); __auto_type _item = (item); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                         } else {
                             ({ __auto_type _lst_p = &(new_items); __auto_type _item = (test_emit_substitute_symbol(arena, item, name, replacement)); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                         }
-                    } else if (!_mv_1556.has_value) {
+                    } else if (!_mv_1557.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -623,12 +623,12 @@ types_SExpr* test_emit_substitute_symbol(slop_arena* arena, types_SExpr* expr, s
         }
         case types_SExpr_num:
         {
-            __auto_type _ = _mv_1555.data.num;
+            __auto_type _ = _mv_1556.data.num;
             return expr;
         }
         case types_SExpr_str:
         {
-            __auto_type _ = _mv_1555.data.str;
+            __auto_type _ = _mv_1556.data.str;
             return expr;
         }
     }
@@ -654,11 +654,11 @@ types_SExpr* test_emit_bind_precondition_args(slop_arena* arena, extract_TestCas
                     } else {
                         {
                             __auto_type arg_idx = (((needs_arena && (i > arena_pos))) ? (i - 1) : i);
-                            __auto_type _mv_1557 = ({ __auto_type _lst = args; size_t _idx = (size_t)arg_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1557.has_value) {
-                                __auto_type arg = _mv_1557.value;
+                            __auto_type _mv_1558 = ({ __auto_type _lst = args; size_t _idx = (size_t)arg_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1558.has_value) {
+                                __auto_type arg = _mv_1558.value;
                                 result = test_emit_substitute_symbol(arena, result, pname, arg);
-                            } else if (!_mv_1557.has_value) {
+                            } else if (!_mv_1558.has_value) {
                             }
                         }
                     }
@@ -677,9 +677,9 @@ slop_string test_emit_build_precondition_check(slop_arena* arena, context_Transp
         __auto_type result = SLOP_STR("");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1558 = ({ __auto_type _lst = pres; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1558.has_value) {
-                __auto_type cond_expr = _mv_1558.value;
+            __auto_type _mv_1559 = ({ __auto_type _lst = pres; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1559.has_value) {
+                __auto_type cond_expr = _mv_1559.value;
                 {
                     __auto_type c = expr_transpile_expr(tctx, test_emit_bind_precondition_args(arena, tc, cond_expr));
                     if (string_eq(result, SLOP_STR(""))) {
@@ -688,7 +688,7 @@ slop_string test_emit_build_precondition_check(slop_arena* arena, context_Transp
                         result = string_concat(arena, result, string_concat(arena, SLOP_STR(" && ("), string_concat(arena, c, SLOP_STR(")"))));
                     }
                 }
-            } else if (!_mv_1558.has_value) {
+            } else if (!_mv_1559.has_value) {
             }
             i = (i + 1);
         }
@@ -703,9 +703,9 @@ slop_string test_emit_describe_preconditions(slop_arena* arena, extract_TestCase
         __auto_type result = SLOP_STR("");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1559 = ({ __auto_type _lst = pres; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1559.has_value) {
-                __auto_type cond_expr = _mv_1559.value;
+            __auto_type _mv_1560 = ({ __auto_type _lst = pres; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1560.has_value) {
+                __auto_type cond_expr = _mv_1560.value;
                 {
                     __auto_type txt = parser_pretty_print(arena, cond_expr);
                     if (string_eq(result, SLOP_STR(""))) {
@@ -714,7 +714,7 @@ slop_string test_emit_describe_preconditions(slop_arena* arena, extract_TestCase
                         result = string_concat(arena, result, string_concat(arena, SLOP_STR(" and "), txt));
                     }
                 }
-            } else if (!_mv_1559.has_value) {
+            } else if (!_mv_1560.has_value) {
             }
             i = (i + 1);
         }
@@ -728,15 +728,15 @@ slop_option_string test_emit_first_error_since(slop_arena* arena, context_Transp
     {
         __auto_type errors = context_ctx_get_errors(tctx);
         if (((int64_t)((errors).len)) > before) {
-            __auto_type _mv_1560 = ({ __auto_type _lst = errors; size_t _idx = (size_t)((int64_t)(before)); slop_option_context_TranspileError _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1560.has_value) {
-                __auto_type e = _mv_1560.value;
+            __auto_type _mv_1561 = ({ __auto_type _lst = errors; size_t _idx = (size_t)((int64_t)(before)); slop_option_context_TranspileError _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1561.has_value) {
+                __auto_type e = _mv_1561.value;
                 {
                     __auto_type line = (((e.line > 0)) ? e.line : fallback_line);
                     __auto_type col = (((e.line > 0)) ? e.col : fallback_col);
                     return (slop_option_string){.has_value = 1, .value = string_concat(arena, e.message, string_concat(arena, SLOP_STR(" at "), test_emit_format_error_position(arena, file_name, line, col)))};
                 }
-            } else if (!_mv_1560.has_value) {
+            } else if (!_mv_1561.has_value) {
                 return (slop_option_string){.has_value = false};
             }
             SLOP_UNREACHABLE();
@@ -749,11 +749,11 @@ slop_option_string test_emit_first_error_since(slop_arena* arena, context_Transp
 types_SExpr* test_emit_example_anchor(extract_TestCase tc) {
     SLOP_PRE(((tc.expected != NULL)), "(!= (. tc expected) nil)");
     types_SExpr* _retval = {0};
-    __auto_type _mv_1561 = ({ __auto_type _lst = tc.args; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-    if (_mv_1561.has_value) {
-        __auto_type a = _mv_1561.value;
+    __auto_type _mv_1562 = ({ __auto_type _lst = tc.args; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+    if (_mv_1562.has_value) {
+        __auto_type a = _mv_1562.value;
         return a;
-    } else if (!_mv_1561.has_value) {
+    } else if (!_mv_1562.has_value) {
         return tc.expected;
     }
     SLOP_UNREACHABLE();
@@ -781,14 +781,14 @@ void test_emit_emit_test_function_typed(test_emit_EmitContext* ctx, extract_Test
         __auto_type problem = ((test_emit_args_have_ellipsis(tc.args)) ? (slop_option_string){.has_value = 1, .value = string_concat(arena, SLOP_STR("'...' is not a value at "), test_emit_format_error_position(arena, file_name, anchor_line, anchor_col))} : test_emit_first_error_since(arena, tctx, errors_before, file_name, anchor_line, anchor_col));
         test_emit_emit(ctx, string_concat(arena, SLOP_STR("void test_"), string_concat(arena, int_to_string(arena, index), SLOP_STR("(void) {"))));
         test_emit_emit(ctx, string_concat(arena, SLOP_STR("    printf(\"  "), string_concat(arena, fn_name, string_concat(arena, SLOP_STR("("), string_concat(arena, test_emit_escape_string(arena, args_display), SLOP_STR(") -> \");"))))));
-        __auto_type _mv_1562 = problem;
-        if (_mv_1562.has_value) {
-            __auto_type reason = _mv_1562.value;
+        __auto_type _mv_1563 = problem;
+        if (_mv_1563.has_value) {
+            __auto_type reason = _mv_1563.value;
             test_emit_emit(ctx, string_concat(arena, SLOP_STR("    printf(\"ERROR: "), string_concat(arena, test_emit_escape_string(arena, reason), SLOP_STR("\\n\");"))));
             test_emit_emit(ctx, SLOP_STR("    tests_errored++;"));
             test_emit_emit(ctx, SLOP_STR("}"));
             test_emit_emit(ctx, SLOP_STR(""));
-        } else if (!_mv_1562.has_value) {
+        } else if (!_mv_1563.has_value) {
             if (string_len(pre_check) > 0) {
                 test_emit_emit(ctx, string_concat(arena, SLOP_STR("    if (!("), string_concat(arena, pre_check, SLOP_STR(")) {"))));
                 test_emit_emit(ctx, string_concat(arena, SLOP_STR("        printf(\"FAIL (precondition violated: "), string_concat(arena, test_emit_escape_string(arena, test_emit_describe_preconditions(arena, tc)), SLOP_STR(")\\n\");"))));
@@ -858,11 +858,11 @@ void test_emit_emit_main_function(test_emit_EmitContext* ctx, int64_t test_count
 slop_string test_emit_make_c_fn_name(slop_arena* arena, slop_string fn_name, slop_option_string module_name, slop_string prefix) {
     {
         __auto_type c_name = ctype_to_c_name(arena, fn_name);
-        __auto_type _mv_1563 = module_name;
-        if (_mv_1563.has_value) {
-            __auto_type mod = _mv_1563.value;
+        __auto_type _mv_1564 = module_name;
+        if (_mv_1564.has_value) {
+            __auto_type mod = _mv_1564.value;
             return string_concat(arena, ctype_to_c_name(arena, mod), string_concat(arena, SLOP_STR("_"), c_name));
-        } else if (!_mv_1563.has_value) {
+        } else if (!_mv_1564.has_value) {
             if (((int64_t)(prefix.len)) > 0) {
                 return string_concat(arena, prefix, string_concat(arena, SLOP_STR("_"), c_name));
             } else {
@@ -880,9 +880,9 @@ slop_string test_emit_build_args_display_typed(slop_arena* arena, slop_list_type
         uint8_t first = 1;
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1564 = ({ __auto_type _lst = args; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1564.has_value) {
-                __auto_type arg = _mv_1564.value;
+            __auto_type _mv_1565 = ({ __auto_type _lst = args; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1565.has_value) {
+                __auto_type arg = _mv_1565.value;
                 {
                     __auto_type arg_str = parser_pretty_print(arena, arg);
                     if (first) {
@@ -892,7 +892,7 @@ slop_string test_emit_build_args_display_typed(slop_arena* arena, slop_list_type
                         result = string_concat(arena, result, string_concat(arena, SLOP_STR(", "), arg_str));
                     }
                 }
-            } else if (!_mv_1564.has_value) {
+            } else if (!_mv_1565.has_value) {
             }
             i = (i + 1);
         }
@@ -925,15 +925,15 @@ test_emit_CompareInfo test_emit_build_comparison_typed(slop_arena* arena, types_
                                     {
                                         __auto_type record_name = test_emit_get_record_name_from_expr(inner_expr);
                                         __auto_type field_values = test_emit_get_record_field_values(arena, inner_expr);
-                                        __auto_type _mv_1565 = type_extract_registry_get_record_fields(types, record_name);
-                                        if (_mv_1565.has_value) {
-                                            __auto_type fields = _mv_1565.value;
+                                        __auto_type _mv_1566 = type_extract_registry_get_record_fields(types, record_name);
+                                        if (_mv_1566.has_value) {
+                                            __auto_type fields = _mv_1566.value;
                                             {
                                                 __auto_type expected_var_name = SLOP_STR("expected_value");
                                                 __auto_type compare_expr = test_emit_build_record_field_comparisons_with_values(arena, fields, field_values, SLOP_STR("result.value"), expected_var_name);
                                                 return (test_emit_CompareInfo){string_concat(arena, SLOP_STR("({ typeof(result.value) "), string_concat(arena, expected_var_name, string_concat(arena, SLOP_STR(" = "), string_concat(arena, inner_expected, string_concat(arena, SLOP_STR("; result.has_value && "), string_concat(arena, compare_expr, SLOP_STR("; })"))))))), SLOP_STR("%s"), SLOP_STR("result.has_value ? \"some(...)\" : \"none\""), SLOP_STR("%s"), SLOP_STR("\"some(...)\"")};
                                             }
-                                        } else if (!_mv_1565.has_value) {
+                                        } else if (!_mv_1566.has_value) {
                                             return (test_emit_CompareInfo){string_concat(arena, SLOP_STR("({ typeof(result.value) expected_value = "), string_concat(arena, inner_expected, SLOP_STR("; result.has_value && memcmp(&result.value, &expected_value, sizeof(result.value)) == 0; })"))), SLOP_STR("%s"), SLOP_STR("result.has_value ? \"some(...)\" : \"none\""), SLOP_STR("%s"), SLOP_STR("\"some(...)\"")};
                                         }
                                         SLOP_UNREACHABLE();
@@ -972,15 +972,15 @@ test_emit_CompareInfo test_emit_build_comparison_typed(slop_arena* arena, types_
                                                 {
                                                     __auto_type record_name = test_emit_get_record_name_from_expr(inner_expr);
                                                     __auto_type field_values = test_emit_get_record_field_values(arena, inner_expr);
-                                                    __auto_type _mv_1566 = type_extract_registry_get_record_fields(types, record_name);
-                                                    if (_mv_1566.has_value) {
-                                                        __auto_type fields = _mv_1566.value;
+                                                    __auto_type _mv_1567 = type_extract_registry_get_record_fields(types, record_name);
+                                                    if (_mv_1567.has_value) {
+                                                        __auto_type fields = _mv_1567.value;
                                                         {
                                                             __auto_type expected_var_name = SLOP_STR("expected_ok");
                                                             __auto_type compare_expr = test_emit_build_record_field_comparisons_with_values(arena, fields, field_values, SLOP_STR("result.data.ok"), expected_var_name);
                                                             return (test_emit_CompareInfo){string_concat(arena, SLOP_STR("({ typeof(result.data.ok) "), string_concat(arena, expected_var_name, string_concat(arena, SLOP_STR(" = "), string_concat(arena, inner_expected, string_concat(arena, SLOP_STR("; result.is_ok && "), string_concat(arena, compare_expr, SLOP_STR("; })"))))))), SLOP_STR("%s"), SLOP_STR("result.is_ok ? \"ok(...)\" : \"error(...)\""), SLOP_STR("%s"), SLOP_STR("\"ok(...)\"")};
                                                         }
-                                                    } else if (!_mv_1566.has_value) {
+                                                    } else if (!_mv_1567.has_value) {
                                                         return (test_emit_CompareInfo){string_concat(arena, SLOP_STR("({ typeof(result.data.ok) expected_ok = "), string_concat(arena, inner_expected, SLOP_STR("; result.is_ok && memcmp(&result.data.ok, &expected_ok, sizeof(result.data.ok)) == 0; })"))), SLOP_STR("%s"), SLOP_STR("result.is_ok ? \"ok(...)\" : \"error(...)\""), SLOP_STR("%s"), SLOP_STR("\"ok(...)\"")};
                                                     }
                                                     SLOP_UNREACHABLE();
@@ -1094,15 +1094,15 @@ test_emit_CompareInfo test_emit_build_record_comparison_typed(slop_arena* arena,
 }
 
 test_emit_CompareInfo test_emit_build_record_comparison_inner(slop_arena* arena, type_extract_TypeRegistry types, slop_string record_name, slop_list_types_SExpr_ptr field_values, slop_string c_expected, slop_string decl_type) {
-    __auto_type _mv_1567 = type_extract_registry_get_record_fields(types, record_name);
-    if (_mv_1567.has_value) {
-        __auto_type fields = _mv_1567.value;
+    __auto_type _mv_1568 = type_extract_registry_get_record_fields(types, record_name);
+    if (_mv_1568.has_value) {
+        __auto_type fields = _mv_1568.value;
         {
             __auto_type expected_var_name = SLOP_STR("expected_value");
             __auto_type compare_expr = test_emit_build_record_field_comparisons_with_values(arena, fields, field_values, SLOP_STR("result"), expected_var_name);
             return (test_emit_CompareInfo){string_concat(arena, SLOP_STR("({ typeof(result) "), string_concat(arena, expected_var_name, string_concat(arena, SLOP_STR(" = "), string_concat(arena, c_expected, string_concat(arena, SLOP_STR("; "), string_concat(arena, compare_expr, SLOP_STR("; })"))))))), SLOP_STR("%s"), SLOP_STR("\"<record>\""), SLOP_STR("%s"), SLOP_STR("\"<expected>\"")};
         }
-    } else if (!_mv_1567.has_value) {
+    } else if (!_mv_1568.has_value) {
         {
             __auto_type expected_var_name = SLOP_STR("expected_value");
             return (test_emit_CompareInfo){string_concat(arena, SLOP_STR("({ typeof(result) "), string_concat(arena, expected_var_name, string_concat(arena, SLOP_STR(" = "), string_concat(arena, c_expected, string_concat(arena, SLOP_STR("; memcmp(&result, &"), string_concat(arena, expected_var_name, SLOP_STR(", sizeof(result)) == 0; })"))))))), SLOP_STR("%s"), SLOP_STR("\"<record>\""), SLOP_STR("%s"), SLOP_STR("\"<expected>\"")};
@@ -1112,11 +1112,11 @@ test_emit_CompareInfo test_emit_build_record_comparison_inner(slop_arena* arena,
 }
 
 slop_string test_emit_get_record_decl_type(slop_arena* arena, type_extract_TypeRegistry types, slop_string record_name) {
-    __auto_type _mv_1568 = type_extract_registry_lookup(types, record_name);
-    if (_mv_1568.has_value) {
-        __auto_type entry = _mv_1568.value;
+    __auto_type _mv_1569 = type_extract_registry_lookup(types, record_name);
+    if (_mv_1569.has_value) {
+        __auto_type entry = _mv_1569.value;
         return (*entry).c_name;
-    } else if (!_mv_1568.has_value) {
+    } else if (!_mv_1569.has_value) {
         return SLOP_STR("");
     }
     SLOP_UNREACHABLE();
@@ -1124,25 +1124,25 @@ slop_string test_emit_get_record_decl_type(slop_arena* arena, type_extract_TypeR
 
 slop_string test_emit_get_record_name_from_expr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1569 = (*expr);
-    switch (_mv_1569.tag) {
+    __auto_type _mv_1570 = (*expr);
+    switch (_mv_1570.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1569.data.lst;
+            __auto_type lst = _mv_1570.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) == 0) {
                     return SLOP_STR("");
                 } else {
-                    __auto_type _mv_1570 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1570.has_value) {
-                        __auto_type first = _mv_1570.value;
+                    __auto_type _mv_1571 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1571.has_value) {
+                        __auto_type first = _mv_1571.value;
                         if (parser_sexpr_is_symbol(first)) {
                             return parser_sexpr_get_symbol_name(first);
                         } else {
                             return SLOP_STR("");
                         }
-                    } else if (!_mv_1570.has_value) {
+                    } else if (!_mv_1571.has_value) {
                         return SLOP_STR("");
                     }
                     SLOP_UNREACHABLE();
@@ -1157,11 +1157,11 @@ slop_string test_emit_get_record_name_from_expr(types_SExpr* expr) {
 
 slop_list_types_SExpr_ptr test_emit_get_record_field_values(slop_arena* arena, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1571 = (*expr);
-    switch (_mv_1571.tag) {
+    __auto_type _mv_1572 = (*expr);
+    switch (_mv_1572.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1571.data.lst;
+            __auto_type lst = _mv_1572.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
@@ -1172,11 +1172,11 @@ slop_list_types_SExpr_ptr test_emit_get_record_field_values(slop_arena* arena, t
                         __auto_type result = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
                         __auto_type i = 1;
                         while (i < len) {
-                            __auto_type _mv_1572 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1572.has_value) {
-                                __auto_type val = _mv_1572.value;
+                            __auto_type _mv_1573 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1573.has_value) {
+                                __auto_type val = _mv_1573.value;
                                 ({ __auto_type _lst_p = &(result); __auto_type _item = (val); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                            } else if (!_mv_1572.has_value) {
+                            } else if (!_mv_1573.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -1193,11 +1193,11 @@ slop_list_types_SExpr_ptr test_emit_get_record_field_values(slop_arena* arena, t
 
 uint8_t test_emit_is_wildcard_expr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1573 = (*expr);
-    switch (_mv_1573.tag) {
+    __auto_type _mv_1574 = (*expr);
+    switch (_mv_1574.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1573.data.sym;
+            __auto_type sym = _mv_1574.data.sym;
             return ((string_eq(sym.name, SLOP_STR("_"))) || (string_eq(sym.name, SLOP_STR(".."))) || (string_eq(sym.name, SLOP_STR("."))));
         }
         default: {
@@ -1213,13 +1213,13 @@ int64_t test_emit_count_wildcard_values(slop_list_types_SExpr_ptr field_values) 
         int64_t i = 0;
         int64_t n = 0;
         while (i < len) {
-            __auto_type _mv_1574 = ({ __auto_type _lst = field_values; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1574.has_value) {
-                __auto_type v = _mv_1574.value;
+            __auto_type _mv_1575 = ({ __auto_type _lst = field_values; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1575.has_value) {
+                __auto_type v = _mv_1575.value;
                 if (test_emit_is_wildcard_expr(v)) {
                     n = (n + 1);
                 }
-            } else if (!_mv_1574.has_value) {
+            } else if (!_mv_1575.has_value) {
             }
             i = (i + 1);
         }
@@ -1235,9 +1235,9 @@ slop_string test_emit_build_record_field_comparisons_with_values(slop_arena* are
         __auto_type comp_result = SLOP_STR("1");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1575 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_type_extract_TstFieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1575.has_value) {
-                __auto_type field = _mv_1575.value;
+            __auto_type _mv_1576 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_type_extract_TstFieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1576.has_value) {
+                __auto_type field = _mv_1576.value;
                 {
                     __auto_type is_wildcard = ({ __auto_type _mv = ({ __auto_type _lst = field_values; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type val = _mv.value; test_emit_is_wildcard_expr(val); }) : (0); });
                     if (!(is_wildcard)) {
@@ -1249,7 +1249,7 @@ slop_string test_emit_build_record_field_comparisons_with_values(slop_arena* are
                         }
                     }
                 }
-            } else if (!_mv_1575.has_value) {
+            } else if (!_mv_1576.has_value) {
             }
             i = (i + 1);
         }
@@ -1336,45 +1336,45 @@ uint8_t test_emit_is_likely_struct_type(slop_string type_name) {
 
 slop_string test_emit_get_first_symbol_name(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1576 = (*expr);
-    switch (_mv_1576.tag) {
+    __auto_type _mv_1577 = (*expr);
+    switch (_mv_1577.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_1576.data.sym;
+            __auto_type s = _mv_1577.data.sym;
             return s.name;
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_1576.data.lst;
+            __auto_type l = _mv_1577.data.lst;
             if (((int64_t)((l.items).len)) > 0) {
-                __auto_type _mv_1577 = ({ __auto_type _lst = l.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1577.has_value) {
-                    __auto_type first = _mv_1577.value;
-                    __auto_type _mv_1578 = (*first);
-                    switch (_mv_1578.tag) {
+                __auto_type _mv_1578 = ({ __auto_type _lst = l.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1578.has_value) {
+                    __auto_type first = _mv_1578.value;
+                    __auto_type _mv_1579 = (*first);
+                    switch (_mv_1579.tag) {
                         case types_SExpr_sym:
                         {
-                            __auto_type s = _mv_1578.data.sym;
+                            __auto_type s = _mv_1579.data.sym;
                             return s.name;
                         }
                         case types_SExpr_lst:
                         {
-                            __auto_type _ = _mv_1578.data.lst;
+                            __auto_type _ = _mv_1579.data.lst;
                             return SLOP_STR("");
                         }
                         case types_SExpr_num:
                         {
-                            __auto_type _ = _mv_1578.data.num;
+                            __auto_type _ = _mv_1579.data.num;
                             return SLOP_STR("");
                         }
                         case types_SExpr_str:
                         {
-                            __auto_type _ = _mv_1578.data.str;
+                            __auto_type _ = _mv_1579.data.str;
                             return SLOP_STR("");
                         }
                     }
                     SLOP_UNREACHABLE();
-                } else if (!_mv_1577.has_value) {
+                } else if (!_mv_1578.has_value) {
                     return SLOP_STR("");
                 }
                 SLOP_UNREACHABLE();
@@ -1384,12 +1384,12 @@ slop_string test_emit_get_first_symbol_name(types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type _ = _mv_1576.data.num;
+            __auto_type _ = _mv_1577.data.num;
             return SLOP_STR("");
         }
         case types_SExpr_str:
         {
-            __auto_type _ = _mv_1576.data.str;
+            __auto_type _ = _mv_1577.data.str;
             return SLOP_STR("");
         }
     }
@@ -1421,11 +1421,11 @@ slop_string test_emit_build_union_payload_comparison(slop_arena* arena, slop_str
         } else if (string_eq(payload_type, SLOP_STR("String"))) {
             return string_concat(arena, SLOP_STR("slop_string_eq(result.data."), string_concat(arena, c_variant, string_concat(arena, SLOP_STR(", "), string_concat(arena, expected_var, string_concat(arena, SLOP_STR(".data."), string_concat(arena, c_variant, SLOP_STR(")")))))));
         } else {
-            __auto_type _mv_1579 = type_extract_registry_get_record_fields(types, payload_type);
-            if (_mv_1579.has_value) {
-                __auto_type fields = _mv_1579.value;
+            __auto_type _mv_1580 = type_extract_registry_get_record_fields(types, payload_type);
+            if (_mv_1580.has_value) {
+                __auto_type fields = _mv_1580.value;
                 return test_emit_build_union_record_payload_comparison(arena, fields, field_values, c_variant, expected_var);
-            } else if (!_mv_1579.has_value) {
+            } else if (!_mv_1580.has_value) {
                 if (wildcard_count > 0) {
                     return SLOP_STR("1");
                 } else {
@@ -1443,9 +1443,9 @@ slop_string test_emit_build_union_record_payload_comparison(slop_arena* arena, s
         __auto_type result = SLOP_STR("1");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1580 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_type_extract_TstFieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1580.has_value) {
-                __auto_type field = _mv_1580.value;
+            __auto_type _mv_1581 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_type_extract_TstFieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1581.has_value) {
+                __auto_type field = _mv_1581.value;
                 {
                     __auto_type is_wildcard = ({ __auto_type _mv = ({ __auto_type _lst = field_values; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type val = _mv.value; test_emit_is_wildcard_expr(val); }) : (0); });
                     if (!(is_wildcard)) {
@@ -1457,7 +1457,7 @@ slop_string test_emit_build_union_record_payload_comparison(slop_arena* arena, s
                         }
                     }
                 }
-            } else if (!_mv_1580.has_value) {
+            } else if (!_mv_1581.has_value) {
             }
             i = (i + 1);
         }
@@ -1497,19 +1497,19 @@ slop_string test_emit_build_union_field_comparison(slop_arena* arena, slop_strin
 
 uint8_t test_emit_is_union_constructor_typed(types_SExpr* expr, type_extract_TypeRegistry types) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1581 = (*expr);
-    switch (_mv_1581.tag) {
+    __auto_type _mv_1582 = (*expr);
+    switch (_mv_1582.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1581.data.lst;
+            __auto_type lst = _mv_1582.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) == 0) {
                     return 0;
                 } else {
-                    __auto_type _mv_1582 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1582.has_value) {
-                        __auto_type first = _mv_1582.value;
+                    __auto_type _mv_1583 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1583.has_value) {
+                        __auto_type first = _mv_1583.value;
                         if (parser_sexpr_is_symbol(first)) {
                             {
                                 __auto_type name = parser_sexpr_get_symbol_name(first);
@@ -1519,11 +1519,11 @@ uint8_t test_emit_is_union_constructor_typed(types_SExpr* expr, type_extract_Typ
                                     if ((string_eq(name, SLOP_STR("none"))) || (string_eq(name, SLOP_STR("some"))) || (string_eq(name, SLOP_STR("ok"))) || (string_eq(name, SLOP_STR("error")))) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1583 = type_extract_registry_lookup_variant(types, name);
-                                        if (_mv_1583.has_value) {
-                                            __auto_type _ = _mv_1583.value;
+                                        __auto_type _mv_1584 = type_extract_registry_lookup_variant(types, name);
+                                        if (_mv_1584.has_value) {
+                                            __auto_type _ = _mv_1584.value;
                                             return 1;
-                                        } else if (!_mv_1583.has_value) {
+                                        } else if (!_mv_1584.has_value) {
                                             return 0;
                                         }
                                         SLOP_UNREACHABLE();
@@ -1533,7 +1533,7 @@ uint8_t test_emit_is_union_constructor_typed(types_SExpr* expr, type_extract_Typ
                         } else {
                             return 0;
                         }
-                    } else if (!_mv_1582.has_value) {
+                    } else if (!_mv_1583.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1548,32 +1548,32 @@ uint8_t test_emit_is_union_constructor_typed(types_SExpr* expr, type_extract_Typ
 
 slop_string test_emit_get_union_variant_name(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1584 = (*expr);
-    switch (_mv_1584.tag) {
+    __auto_type _mv_1585 = (*expr);
+    switch (_mv_1585.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1584.data.lst;
+            __auto_type lst = _mv_1585.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) == 0) {
                     return SLOP_STR("");
                 } else {
-                    __auto_type _mv_1585 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1585.has_value) {
-                        __auto_type first = _mv_1585.value;
+                    __auto_type _mv_1586 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1586.has_value) {
+                        __auto_type first = _mv_1586.value;
                         if (parser_sexpr_is_symbol(first)) {
                             {
                                 __auto_type name = parser_sexpr_get_symbol_name(first);
                                 if (string_eq(name, SLOP_STR("union-new"))) {
-                                    __auto_type _mv_1586 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_1586.has_value) {
-                                        __auto_type variant_expr = _mv_1586.value;
+                                    __auto_type _mv_1587 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_1587.has_value) {
+                                        __auto_type variant_expr = _mv_1587.value;
                                         if (parser_sexpr_is_symbol(variant_expr)) {
                                             return parser_sexpr_get_symbol_name(variant_expr);
                                         } else {
                                             return SLOP_STR("");
                                         }
-                                    } else if (!_mv_1586.has_value) {
+                                    } else if (!_mv_1587.has_value) {
                                         return SLOP_STR("");
                                     }
                                     SLOP_UNREACHABLE();
@@ -1584,7 +1584,7 @@ slop_string test_emit_get_union_variant_name(types_SExpr* expr) {
                         } else {
                             return SLOP_STR("");
                         }
-                    } else if (!_mv_1585.has_value) {
+                    } else if (!_mv_1586.has_value) {
                         return SLOP_STR("");
                     }
                     SLOP_UNREACHABLE();
@@ -1599,21 +1599,21 @@ slop_string test_emit_get_union_variant_name(types_SExpr* expr) {
 
 uint8_t test_emit_is_enum_value_typed(types_SExpr* expr, type_extract_TypeRegistry types) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1587 = (*expr);
-    switch (_mv_1587.tag) {
+    __auto_type _mv_1588 = (*expr);
+    switch (_mv_1588.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1587.data.sym;
+            __auto_type sym = _mv_1588.data.sym;
             {
                 __auto_type name = sym.name;
                 if (strlib_starts_with(name, SLOP_STR("'"))) {
                     {
                         __auto_type variant_name = test_emit_emit_string_slice(name, 1);
-                        __auto_type _mv_1588 = type_extract_registry_lookup_enum_value(types, variant_name);
-                        if (_mv_1588.has_value) {
-                            __auto_type _ = _mv_1588.value;
+                        __auto_type _mv_1589 = type_extract_registry_lookup_enum_value(types, variant_name);
+                        if (_mv_1589.has_value) {
+                            __auto_type _ = _mv_1589.value;
                             return 1;
-                        } else if (!_mv_1588.has_value) {
+                        } else if (!_mv_1589.has_value) {
                             return 0;
                         }
                         SLOP_UNREACHABLE();
@@ -1625,39 +1625,39 @@ uint8_t test_emit_is_enum_value_typed(types_SExpr* expr, type_extract_TypeRegist
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1587.data.lst;
+            __auto_type lst = _mv_1588.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return 0;
                 } else {
-                    __auto_type _mv_1589 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1589.has_value) {
-                        __auto_type first = _mv_1589.value;
+                    __auto_type _mv_1590 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1590.has_value) {
+                        __auto_type first = _mv_1590.value;
                         if (parser_sexpr_is_symbol(first) && string_eq(parser_sexpr_get_symbol_name(first), SLOP_STR("quote"))) {
-                            __auto_type _mv_1590 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1590.has_value) {
-                                __auto_type quoted = _mv_1590.value;
+                            __auto_type _mv_1591 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1591.has_value) {
+                                __auto_type quoted = _mv_1591.value;
                                 if (parser_sexpr_is_symbol(quoted)) {
-                                    __auto_type _mv_1591 = type_extract_registry_lookup_enum_value(types, parser_sexpr_get_symbol_name(quoted));
-                                    if (_mv_1591.has_value) {
-                                        __auto_type _ = _mv_1591.value;
+                                    __auto_type _mv_1592 = type_extract_registry_lookup_enum_value(types, parser_sexpr_get_symbol_name(quoted));
+                                    if (_mv_1592.has_value) {
+                                        __auto_type _ = _mv_1592.value;
                                         return 1;
-                                    } else if (!_mv_1591.has_value) {
+                                    } else if (!_mv_1592.has_value) {
                                         return 0;
                                     }
                                     SLOP_UNREACHABLE();
                                 } else {
                                     return 0;
                                 }
-                            } else if (!_mv_1590.has_value) {
+                            } else if (!_mv_1591.has_value) {
                                 return 0;
                             }
                             SLOP_UNREACHABLE();
                         } else {
                             return 0;
                         }
-                    } else if (!_mv_1589.has_value) {
+                    } else if (!_mv_1590.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1672,30 +1672,30 @@ uint8_t test_emit_is_enum_value_typed(types_SExpr* expr, type_extract_TypeRegist
 
 uint8_t test_emit_is_record_constructor_typed(types_SExpr* expr, type_extract_TypeRegistry types) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1592 = (*expr);
-    switch (_mv_1592.tag) {
+    __auto_type _mv_1593 = (*expr);
+    switch (_mv_1593.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1592.data.lst;
+            __auto_type lst = _mv_1593.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) == 0) {
                     return 0;
                 } else {
-                    __auto_type _mv_1593 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1593.has_value) {
-                        __auto_type first = _mv_1593.value;
+                    __auto_type _mv_1594 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1594.has_value) {
+                        __auto_type first = _mv_1594.value;
                         if (parser_sexpr_is_symbol(first)) {
                             {
                                 __auto_type name = parser_sexpr_get_symbol_name(first);
                                 if (string_eq(name, SLOP_STR("none")) || (string_eq(name, SLOP_STR("some")) || (string_eq(name, SLOP_STR("ok")) || (string_eq(name, SLOP_STR("error")) || string_eq(name, SLOP_STR("list")))))) {
                                     return 0;
                                 } else {
-                                    __auto_type _mv_1594 = type_extract_registry_lookup(types, name);
-                                    if (_mv_1594.has_value) {
-                                        __auto_type entry = _mv_1594.value;
+                                    __auto_type _mv_1595 = type_extract_registry_lookup(types, name);
+                                    if (_mv_1595.has_value) {
+                                        __auto_type entry = _mv_1595.value;
                                         return type_extract_registry_is_record(types, name);
-                                    } else if (!_mv_1594.has_value) {
+                                    } else if (!_mv_1595.has_value) {
                                         return 0;
                                     }
                                     SLOP_UNREACHABLE();
@@ -1704,7 +1704,7 @@ uint8_t test_emit_is_record_constructor_typed(types_SExpr* expr, type_extract_Ty
                         } else {
                             return 0;
                         }
-                    } else if (!_mv_1593.has_value) {
+                    } else if (!_mv_1594.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1727,11 +1727,11 @@ slop_string test_emit_emit_string_slice(slop_string s, int64_t start) {
 
 slop_string test_emit_get_some_inner_typed(slop_arena* arena, types_SExpr* expr, context_TranspileContext* tctx) {
     if (parser_sexpr_list_len(expr) > 1) {
-        __auto_type _mv_1595 = parser_sexpr_list_get(expr, 1);
-        if (_mv_1595.has_value) {
-            __auto_type inner = _mv_1595.value;
+        __auto_type _mv_1596 = parser_sexpr_list_get(expr, 1);
+        if (_mv_1596.has_value) {
+            __auto_type inner = _mv_1596.value;
             return test_emit_transpile_expr_safe(arena, tctx, inner);
-        } else if (!_mv_1595.has_value) {
+        } else if (!_mv_1596.has_value) {
             return SLOP_STR("0");
         }
         SLOP_UNREACHABLE();
@@ -1750,19 +1750,19 @@ slop_string test_emit_get_error_inner_typed(slop_arena* arena, types_SExpr* expr
 
 types_SExpr* test_emit_get_some_inner_expr(types_SExpr* expected) {
     SLOP_PRE(((expected != NULL)), "(!= expected nil)");
-    __auto_type _mv_1596 = (*expected);
-    switch (_mv_1596.tag) {
+    __auto_type _mv_1597 = (*expected);
+    switch (_mv_1597.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1596.data.lst;
+            __auto_type lst = _mv_1597.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) > 1) {
-                    __auto_type _mv_1597 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1597.has_value) {
-                        __auto_type inner = _mv_1597.value;
+                    __auto_type _mv_1598 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1598.has_value) {
+                        __auto_type inner = _mv_1598.value;
                         return inner;
-                    } else if (!_mv_1597.has_value) {
+                    } else if (!_mv_1598.has_value) {
                         return expected;
                     }
                     SLOP_UNREACHABLE();
@@ -1779,19 +1779,19 @@ types_SExpr* test_emit_get_some_inner_expr(types_SExpr* expected) {
 
 types_SExpr* test_emit_get_ok_inner_expr(types_SExpr* expected) {
     SLOP_PRE(((expected != NULL)), "(!= expected nil)");
-    __auto_type _mv_1598 = (*expected);
-    switch (_mv_1598.tag) {
+    __auto_type _mv_1599 = (*expected);
+    switch (_mv_1599.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1598.data.lst;
+            __auto_type lst = _mv_1599.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) > 1) {
-                    __auto_type _mv_1599 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1599.has_value) {
-                        __auto_type inner = _mv_1599.value;
+                    __auto_type _mv_1600 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1600.has_value) {
+                        __auto_type inner = _mv_1600.value;
                         return inner;
-                    } else if (!_mv_1599.has_value) {
+                    } else if (!_mv_1600.has_value) {
                         return expected;
                     }
                     SLOP_UNREACHABLE();
@@ -1808,16 +1808,16 @@ types_SExpr* test_emit_get_ok_inner_expr(types_SExpr* expected) {
 
 uint8_t test_emit_is_none_value(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1600 = (*expr);
-    switch (_mv_1600.tag) {
+    __auto_type _mv_1601 = (*expr);
+    switch (_mv_1601.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1600.data.sym;
+            __auto_type sym = _mv_1601.data.sym;
             return string_eq(sym.name, SLOP_STR("none"));
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1600.data.lst;
+            __auto_type lst = _mv_1601.data.lst;
             {
                 __auto_type items = lst.items;
                 return ((((int64_t)((items).len)) == 1) && ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type first = _mv.value; (parser_sexpr_is_symbol(first) && string_eq(parser_sexpr_get_symbol_name(first), SLOP_STR("none"))); }) : (0); }));
@@ -1875,9 +1875,9 @@ slop_string test_emit_extract_list_element_type(slop_arena* arena, slop_string l
 slop_string test_emit_build_eq_function_name(slop_arena* arena, slop_string type_name, slop_string prefix, type_extract_TypeRegistry types) {
     {
         __auto_type type_c = strlib_to_lower(arena, ctype_to_c_name(arena, type_name));
-        __auto_type _mv_1601 = type_extract_registry_lookup_import(types, type_name);
-        if (_mv_1601.has_value) {
-            __auto_type mod_name = _mv_1601.value;
+        __auto_type _mv_1602 = type_extract_registry_lookup_import(types, type_name);
+        if (_mv_1602.has_value) {
+            __auto_type mod_name = _mv_1602.value;
             {
                 __auto_type parts = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
                 ({ __auto_type _lst_p = &(parts); __auto_type _item = (ctype_to_c_name(arena, mod_name)); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
@@ -1886,7 +1886,7 @@ slop_string test_emit_build_eq_function_name(slop_arena* arena, slop_string type
                 ({ __auto_type _lst_p = &(parts); __auto_type _item = (SLOP_STR("_eq")); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                 return strlib_string_build(arena, parts);
             }
-        } else if (!_mv_1601.has_value) {
+        } else if (!_mv_1602.has_value) {
             if (((int64_t)(prefix.len)) > 0) {
                 {
                     __auto_type parts = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
@@ -1911,11 +1911,11 @@ slop_string test_emit_build_eq_function_name(slop_arena* arena, slop_string type
 
 test_emit_CompareInfo test_emit_build_list_comparison_typed(slop_arena* arena, types_SExpr* expected, slop_string prefix, type_extract_TypeRegistry types, slop_string ret_type_str, slop_option_string eq_fn, context_TranspileContext* tctx) {
     SLOP_PRE(((expected != NULL)), "(!= expected nil)");
-    __auto_type _mv_1602 = (*expected);
-    switch (_mv_1602.tag) {
+    __auto_type _mv_1603 = (*expected);
+    switch (_mv_1603.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1602.data.lst;
+            __auto_type lst = _mv_1603.data.lst;
             {
                 __auto_type elements = lst.items;
                 __auto_type total_count = ((int64_t)((elements).len));
@@ -1929,13 +1929,13 @@ test_emit_CompareInfo test_emit_build_list_comparison_typed(slop_arena* arena, t
                             __auto_type has_wildcard = 0;
                             __auto_type j = start_idx;
                             while (j < total_count) {
-                                __auto_type _mv_1603 = ({ __auto_type _lst = elements; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1603.has_value) {
-                                    __auto_type elem = _mv_1603.value;
+                                __auto_type _mv_1604 = ({ __auto_type _lst = elements; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1604.has_value) {
+                                    __auto_type elem = _mv_1604.value;
                                     if (test_emit_is_wildcard_expr(elem)) {
                                         has_wildcard = 1;
                                     }
-                                } else if (!_mv_1603.has_value) {
+                                } else if (!_mv_1604.has_value) {
                                 }
                                 j = (j + 1);
                             }
@@ -1952,9 +1952,9 @@ test_emit_CompareInfo test_emit_build_list_comparison_typed(slop_arena* arena, t
                                             __auto_type i = start_idx;
                                             __auto_type first = 1;
                                             while (i < total_count) {
-                                                __auto_type _mv_1604 = ({ __auto_type _lst = elements; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1604.has_value) {
-                                                    __auto_type elem = _mv_1604.value;
+                                                __auto_type _mv_1605 = ({ __auto_type _lst = elements; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1605.has_value) {
+                                                    __auto_type elem = _mv_1605.value;
                                                     {
                                                         __auto_type elem_c = test_emit_transpile_expr_safe(arena, tctx, elem);
                                                         if (first) {
@@ -1964,7 +1964,7 @@ test_emit_CompareInfo test_emit_build_list_comparison_typed(slop_arena* arena, t
                                                             arr_init = string_concat(arena, arr_init, string_concat(arena, SLOP_STR(", "), elem_c));
                                                         }
                                                     }
-                                                } else if (!_mv_1604.has_value) {
+                                                } else if (!_mv_1605.has_value) {
                                                 }
                                                 i = (i + 1);
                                             }
@@ -2036,32 +2036,32 @@ context_TranspileContext* test_emit_init_transpile_context(slop_arena* arena, sl
         context_ctx_bind_var(tctx, (context_VarEntry){SLOP_STR("__SLOP_WILDCARD__"), SLOP_STR("{0}"), SLOP_STR("int64_t"), SLOP_STR("Int"), 0, 0, 0, SLOP_STR(""), SLOP_STR("")});
         context_ctx_set_strict_unknown_symbols(tctx, 1);
         if (((int64_t)((ast).len)) > 0) {
-            __auto_type _mv_1605 = ({ __auto_type _lst = ast; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1605.has_value) {
-                __auto_type first_expr = _mv_1605.value;
+            __auto_type _mv_1606 = ({ __auto_type _lst = ast; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1606.has_value) {
+                __auto_type first_expr = _mv_1606.value;
                 if (parser_is_form(first_expr, SLOP_STR("module"))) {
                     {
                         __auto_type mod_len = parser_sexpr_list_len(first_expr);
                         __auto_type body_forms = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
                         __auto_type i = 2;
                         if (i < mod_len) {
-                            __auto_type _mv_1606 = parser_sexpr_list_get(first_expr, i);
-                            if (_mv_1606.has_value) {
-                                __auto_type maybe_export = _mv_1606.value;
+                            __auto_type _mv_1607 = parser_sexpr_list_get(first_expr, i);
+                            if (_mv_1607.has_value) {
+                                __auto_type maybe_export = _mv_1607.value;
                                 if (parser_is_form(maybe_export, SLOP_STR("export"))) {
                                     i = (i + 1);
                                 }
-                            } else if (!_mv_1606.has_value) {
+                            } else if (!_mv_1607.has_value) {
                             }
                         }
                         while (i < mod_len) {
-                            __auto_type _mv_1607 = parser_sexpr_list_get(first_expr, i);
-                            if (_mv_1607.has_value) {
-                                __auto_type form = _mv_1607.value;
+                            __auto_type _mv_1608 = parser_sexpr_list_get(first_expr, i);
+                            if (_mv_1608.has_value) {
+                                __auto_type form = _mv_1608.value;
                                 if (!(parser_is_form(form, SLOP_STR("@doc")))) {
                                     ({ __auto_type _lst_p = &(body_forms); __auto_type _item = (form); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                 }
-                            } else if (!_mv_1607.has_value) {
+                            } else if (!_mv_1608.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -2069,7 +2069,7 @@ context_TranspileContext* test_emit_init_transpile_context(slop_arena* arena, sl
                         test_emit_register_all_field_types(tctx, body_forms);
                     }
                 }
-            } else if (!_mv_1605.has_value) {
+            } else if (!_mv_1606.has_value) {
             }
         }
         return tctx;
@@ -2083,30 +2083,30 @@ void test_emit_init_transpile_context_for_imports(slop_arena* arena, context_Tra
             context_ctx_set_module(tctx, (slop_option_string){.has_value = 1, .value = import_mod_name});
         }
         if (((int64_t)((import_ast).len)) > 0) {
-            __auto_type _mv_1608 = ({ __auto_type _lst = import_ast; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1608.has_value) {
-                __auto_type first_expr = _mv_1608.value;
+            __auto_type _mv_1609 = ({ __auto_type _lst = import_ast; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1609.has_value) {
+                __auto_type first_expr = _mv_1609.value;
                 if (parser_is_form(first_expr, SLOP_STR("module"))) {
                     {
                         __auto_type mod_len = parser_sexpr_list_len(first_expr);
                         __auto_type body_forms = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
                         __auto_type i = 2;
                         if (i < mod_len) {
-                            __auto_type _mv_1609 = parser_sexpr_list_get(first_expr, i);
-                            if (_mv_1609.has_value) {
-                                __auto_type maybe_export = _mv_1609.value;
+                            __auto_type _mv_1610 = parser_sexpr_list_get(first_expr, i);
+                            if (_mv_1610.has_value) {
+                                __auto_type maybe_export = _mv_1610.value;
                                 if (parser_is_form(maybe_export, SLOP_STR("export"))) {
                                     i = (i + 1);
                                 }
-                            } else if (!_mv_1609.has_value) {
+                            } else if (!_mv_1610.has_value) {
                             }
                         }
                         while (i < mod_len) {
-                            __auto_type _mv_1610 = parser_sexpr_list_get(first_expr, i);
-                            if (_mv_1610.has_value) {
-                                __auto_type form = _mv_1610.value;
+                            __auto_type _mv_1611 = parser_sexpr_list_get(first_expr, i);
+                            if (_mv_1611.has_value) {
+                                __auto_type form = _mv_1611.value;
                                 ({ __auto_type _lst_p = &(body_forms); __auto_type _item = (form); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                            } else if (!_mv_1610.has_value) {
+                            } else if (!_mv_1611.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -2114,7 +2114,7 @@ void test_emit_init_transpile_context_for_imports(slop_arena* arena, context_Tra
                         test_emit_register_all_field_types(tctx, body_forms);
                     }
                 }
-            } else if (!_mv_1608.has_value) {
+            } else if (!_mv_1609.has_value) {
             }
         }
         if (((int64_t)(saved_module.len)) > 0) {
@@ -2127,32 +2127,32 @@ void test_emit_init_transpile_context_for_imports(slop_arena* arena, context_Tra
 
 void test_emit_re_prescan_main_module(slop_arena* arena, context_TranspileContext* tctx, slop_list_types_SExpr_ptr ast) {
     if (((int64_t)((ast).len)) > 0) {
-        __auto_type _mv_1611 = ({ __auto_type _lst = ast; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1611.has_value) {
-            __auto_type first_expr = _mv_1611.value;
+        __auto_type _mv_1612 = ({ __auto_type _lst = ast; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1612.has_value) {
+            __auto_type first_expr = _mv_1612.value;
             if (parser_is_form(first_expr, SLOP_STR("module"))) {
                 {
                     __auto_type mod_len = parser_sexpr_list_len(first_expr);
                     __auto_type body_forms = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
                     __auto_type i = 2;
                     if (i < mod_len) {
-                        __auto_type _mv_1612 = parser_sexpr_list_get(first_expr, i);
-                        if (_mv_1612.has_value) {
-                            __auto_type maybe_export = _mv_1612.value;
+                        __auto_type _mv_1613 = parser_sexpr_list_get(first_expr, i);
+                        if (_mv_1613.has_value) {
+                            __auto_type maybe_export = _mv_1613.value;
                             if (parser_is_form(maybe_export, SLOP_STR("export"))) {
                                 i = (i + 1);
                             }
-                        } else if (!_mv_1612.has_value) {
+                        } else if (!_mv_1613.has_value) {
                         }
                     }
                     while (i < mod_len) {
-                        __auto_type _mv_1613 = parser_sexpr_list_get(first_expr, i);
-                        if (_mv_1613.has_value) {
-                            __auto_type form = _mv_1613.value;
+                        __auto_type _mv_1614 = parser_sexpr_list_get(first_expr, i);
+                        if (_mv_1614.has_value) {
+                            __auto_type form = _mv_1614.value;
                             if (!(parser_is_form(form, SLOP_STR("@doc")))) {
                                 ({ __auto_type _lst_p = &(body_forms); __auto_type _item = (form); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                             }
-                        } else if (!_mv_1613.has_value) {
+                        } else if (!_mv_1614.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -2160,7 +2160,7 @@ void test_emit_re_prescan_main_module(slop_arena* arena, context_TranspileContex
                     test_emit_register_all_field_types(tctx, body_forms);
                 }
             }
-        } else if (!_mv_1611.has_value) {
+        } else if (!_mv_1612.has_value) {
         }
     }
 }
@@ -2170,13 +2170,13 @@ void test_emit_register_all_field_types(context_TranspileContext* tctx, slop_lis
         __auto_type len = ((int64_t)((body_forms).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1614 = ({ __auto_type _lst = body_forms; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1614.has_value) {
-                __auto_type form = _mv_1614.value;
+            __auto_type _mv_1615 = ({ __auto_type _lst = body_forms; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1615.has_value) {
+                __auto_type form = _mv_1615.value;
                 if (parser_is_form(form, SLOP_STR("type"))) {
                     test_emit_register_type_fields(tctx, form);
                 }
-            } else if (!_mv_1614.has_value) {
+            } else if (!_mv_1615.has_value) {
             }
             i = (i + 1);
         }
@@ -2186,33 +2186,33 @@ void test_emit_register_all_field_types(context_TranspileContext* tctx, slop_lis
 void test_emit_register_type_fields(context_TranspileContext* tctx, types_SExpr* type_form) {
     SLOP_PRE(((tctx != NULL)), "(!= tctx nil)");
     if (parser_sexpr_list_len(type_form) >= 3) {
-        __auto_type _mv_1615 = parser_sexpr_list_get(type_form, 1);
-        if (_mv_1615.has_value) {
-            __auto_type name_expr = _mv_1615.value;
+        __auto_type _mv_1616 = parser_sexpr_list_get(type_form, 1);
+        if (_mv_1616.has_value) {
+            __auto_type name_expr = _mv_1616.value;
             if (parser_sexpr_is_symbol(name_expr)) {
                 {
                     __auto_type type_name = parser_sexpr_get_symbol_name(name_expr);
-                    __auto_type _mv_1616 = parser_sexpr_list_get(type_form, 2);
-                    if (_mv_1616.has_value) {
-                        __auto_type def_expr = _mv_1616.value;
+                    __auto_type _mv_1617 = parser_sexpr_list_get(type_form, 2);
+                    if (_mv_1617.has_value) {
+                        __auto_type def_expr = _mv_1617.value;
                         if (parser_is_form(def_expr, SLOP_STR("record"))) {
                             {
                                 __auto_type field_count = parser_sexpr_list_len(def_expr);
                                 __auto_type j = 1;
                                 while (j < field_count) {
-                                    __auto_type _mv_1617 = parser_sexpr_list_get(def_expr, j);
-                                    if (_mv_1617.has_value) {
-                                        __auto_type field_def = _mv_1617.value;
+                                    __auto_type _mv_1618 = parser_sexpr_list_get(def_expr, j);
+                                    if (_mv_1618.has_value) {
+                                        __auto_type field_def = _mv_1618.value;
                                         if (parser_sexpr_list_len(field_def) >= 2) {
-                                            __auto_type _mv_1618 = parser_sexpr_list_get(field_def, 0);
-                                            if (_mv_1618.has_value) {
-                                                __auto_type field_name_expr = _mv_1618.value;
+                                            __auto_type _mv_1619 = parser_sexpr_list_get(field_def, 0);
+                                            if (_mv_1619.has_value) {
+                                                __auto_type field_name_expr = _mv_1619.value;
                                                 if (parser_sexpr_is_symbol(field_name_expr)) {
                                                     {
                                                         __auto_type field_name = parser_sexpr_get_symbol_name(field_name_expr);
-                                                        __auto_type _mv_1619 = parser_sexpr_list_get(field_def, 1);
-                                                        if (_mv_1619.has_value) {
-                                                            __auto_type field_type_expr = _mv_1619.value;
+                                                        __auto_type _mv_1620 = parser_sexpr_list_get(field_def, 1);
+                                                        if (_mv_1620.has_value) {
+                                                            __auto_type field_type_expr = _mv_1620.value;
                                                             {
                                                                 __auto_type arena = (*tctx).arena;
                                                                 __auto_type c_type = context_to_c_type_prefixed(tctx, field_type_expr);
@@ -2226,24 +2226,24 @@ void test_emit_register_type_fields(context_TranspileContext* tctx, types_SExpr*
                                                                     }
                                                                 }
                                                             }
-                                                        } else if (!_mv_1619.has_value) {
+                                                        } else if (!_mv_1620.has_value) {
                                                         }
                                                     }
                                                 }
-                                            } else if (!_mv_1618.has_value) {
+                                            } else if (!_mv_1619.has_value) {
                                             }
                                         }
-                                    } else if (!_mv_1617.has_value) {
+                                    } else if (!_mv_1618.has_value) {
                                     }
                                     j = (j + 1);
                                 }
                             }
                         }
-                    } else if (!_mv_1616.has_value) {
+                    } else if (!_mv_1617.has_value) {
                     }
                 }
             }
-        } else if (!_mv_1615.has_value) {
+        } else if (!_mv_1616.has_value) {
         }
     }
 }

--- a/bootstrap/tester/slop_tester.c
+++ b/bootstrap/tester/slop_tester.c
@@ -20,20 +20,20 @@ slop_string tester_extract_module_name(slop_list_types_SExpr_ptr exprs) {
     if (((int64_t)((exprs).len)) < 1) {
         return SLOP_STR("");
     } else {
-        __auto_type _mv_1620 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1620.has_value) {
-            __auto_type first_expr = _mv_1620.value;
+        __auto_type _mv_1621 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1621.has_value) {
+            __auto_type first_expr = _mv_1621.value;
             if (parser_is_form(first_expr, SLOP_STR("module"))) {
                 if (parser_sexpr_list_len(first_expr) >= 2) {
-                    __auto_type _mv_1621 = parser_sexpr_list_get(first_expr, 1);
-                    if (_mv_1621.has_value) {
-                        __auto_type name_expr = _mv_1621.value;
+                    __auto_type _mv_1622 = parser_sexpr_list_get(first_expr, 1);
+                    if (_mv_1622.has_value) {
+                        __auto_type name_expr = _mv_1622.value;
                         if (parser_sexpr_is_symbol(name_expr)) {
                             return parser_sexpr_get_symbol_name(name_expr);
                         } else {
                             return SLOP_STR("");
                         }
-                    } else if (!_mv_1621.has_value) {
+                    } else if (!_mv_1622.has_value) {
                         return SLOP_STR("");
                     }
                     SLOP_UNREACHABLE();
@@ -43,7 +43,7 @@ slop_string tester_extract_module_name(slop_list_types_SExpr_ptr exprs) {
             } else {
                 return SLOP_STR("");
             }
-        } else if (!_mv_1620.has_value) {
+        } else if (!_mv_1621.has_value) {
             return SLOP_STR("");
         }
         SLOP_UNREACHABLE();
@@ -54,60 +54,60 @@ slop_list_type_extract_ImportEntry tester_extract_imports(slop_arena* arena, slo
     {
         __auto_type result = ((slop_list_type_extract_ImportEntry){ .data = (type_extract_ImportEntry*)slop_arena_alloc(arena, 16 * sizeof(type_extract_ImportEntry)), .len = 0, .cap = 16 });
         if (((int64_t)((exprs).len)) > 0) {
-            __auto_type _mv_1622 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1622.has_value) {
-                __auto_type module_expr = _mv_1622.value;
+            __auto_type _mv_1623 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1623.has_value) {
+                __auto_type module_expr = _mv_1623.value;
                 if (parser_is_form(module_expr, SLOP_STR("module"))) {
                     {
                         __auto_type mod_len = parser_sexpr_list_len(module_expr);
                         __auto_type i = 2;
                         while (i < mod_len) {
-                            __auto_type _mv_1623 = parser_sexpr_list_get(module_expr, i);
-                            if (_mv_1623.has_value) {
-                                __auto_type child = _mv_1623.value;
+                            __auto_type _mv_1624 = parser_sexpr_list_get(module_expr, i);
+                            if (_mv_1624.has_value) {
+                                __auto_type child = _mv_1624.value;
                                 if (parser_is_form(child, SLOP_STR("import"))) {
                                     if (parser_sexpr_list_len(child) >= 3) {
-                                        __auto_type _mv_1624 = parser_sexpr_list_get(child, 1);
-                                        if (_mv_1624.has_value) {
-                                            __auto_type name_expr = _mv_1624.value;
+                                        __auto_type _mv_1625 = parser_sexpr_list_get(child, 1);
+                                        if (_mv_1625.has_value) {
+                                            __auto_type name_expr = _mv_1625.value;
                                             if (parser_sexpr_is_symbol(name_expr)) {
                                                 {
                                                     __auto_type mod_name = parser_sexpr_get_symbol_name(name_expr);
                                                     __auto_type symbols = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
-                                                    __auto_type _mv_1625 = parser_sexpr_list_get(child, 2);
-                                                    if (_mv_1625.has_value) {
-                                                        __auto_type sym_list = _mv_1625.value;
+                                                    __auto_type _mv_1626 = parser_sexpr_list_get(child, 2);
+                                                    if (_mv_1626.has_value) {
+                                                        __auto_type sym_list = _mv_1626.value;
                                                         {
                                                             __auto_type sym_len = parser_sexpr_list_len(sym_list);
                                                             __auto_type j = 0;
                                                             while (j < sym_len) {
-                                                                __auto_type _mv_1626 = parser_sexpr_list_get(sym_list, j);
-                                                                if (_mv_1626.has_value) {
-                                                                    __auto_type sym_expr = _mv_1626.value;
+                                                                __auto_type _mv_1627 = parser_sexpr_list_get(sym_list, j);
+                                                                if (_mv_1627.has_value) {
+                                                                    __auto_type sym_expr = _mv_1627.value;
                                                                     if (parser_sexpr_is_symbol(sym_expr)) {
                                                                         ({ __auto_type _lst_p = &(symbols); __auto_type _item = (parser_sexpr_get_symbol_name(sym_expr)); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                                     }
-                                                                } else if (!_mv_1626.has_value) {
+                                                                } else if (!_mv_1627.has_value) {
                                                                 }
                                                                 j = (j + 1);
                                                             }
                                                         }
-                                                    } else if (!_mv_1625.has_value) {
+                                                    } else if (!_mv_1626.has_value) {
                                                     }
                                                     ({ __auto_type _lst_p = &(result); __auto_type _item = ((type_extract_ImportEntry){mod_name, symbols}); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                 }
                                             }
-                                        } else if (!_mv_1624.has_value) {
+                                        } else if (!_mv_1625.has_value) {
                                         }
                                     }
                                 }
-                            } else if (!_mv_1623.has_value) {
+                            } else if (!_mv_1624.has_value) {
                             }
                             i = (i + 1);
                         }
                     }
                 }
-            } else if (!_mv_1622.has_value) {
+            } else if (!_mv_1623.has_value) {
             }
         }
         return result;
@@ -115,41 +115,6 @@ slop_list_type_extract_ImportEntry tester_extract_imports(slop_arena* arena, slo
 }
 
 tester_TestResult tester_generate_tests(slop_arena* arena, slop_string source, slop_string file_name) {
-    __auto_type _mv_1627 = parser_parse(arena, source);
-    if (_mv_1627.is_ok) {
-        __auto_type exprs = _mv_1627.data.ok;
-        {
-            __auto_type mod_name = tester_extract_module_name(exprs);
-            __auto_type imports = tester_extract_imports(arena, exprs);
-            {
-                __auto_type test_cases = extract_extract_examples_from_ast(arena, exprs);
-                __auto_type test_count = ((int64_t)((test_cases).len));
-                if (test_count == 0) {
-                    return (tester_TestResult){1, ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 }), 0, mod_name, SLOP_STR("")};
-                } else {
-                    {
-                        __auto_type prefix = (((((int64_t)(mod_name.len)) > 0)) ? ctype_to_c_name(arena, mod_name) : SLOP_STR(""));
-                        __auto_type types = type_extract_extract_types_from_ast_with_imports(arena, exprs, mod_name, imports);
-                        __auto_type tctx = test_emit_init_transpile_context(arena, exprs, mod_name);
-                        {
-                            __auto_type harness_lines = test_emit_emit_test_harness_typed(arena, test_cases, prefix, types, imports, tctx, file_name);
-                            return (tester_TestResult){1, harness_lines, test_count, mod_name, SLOP_STR("")};
-                        }
-                    }
-                }
-            }
-        }
-    } else if (!_mv_1627.is_ok) {
-        __auto_type err = _mv_1627.data.err;
-        {
-            __auto_type error_msg = string_concat(arena, SLOP_STR("Parse error at line "), string_concat(arena, int_to_string(arena, err.line), string_concat(arena, SLOP_STR(", col "), string_concat(arena, int_to_string(arena, err.col), string_concat(arena, SLOP_STR(": "), err.message)))));
-            return (tester_TestResult){0, ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 }), 0, SLOP_STR(""), error_msg};
-        }
-    }
-    SLOP_UNREACHABLE();
-}
-
-tester_TestResult tester_generate_tests_with_imports(slop_arena* arena, slop_string source, slop_list_string import_sources, slop_string file_name) {
     __auto_type _mv_1628 = parser_parse(arena, source);
     if (_mv_1628.is_ok) {
         __auto_type exprs = _mv_1628.data.ok;
@@ -166,33 +131,6 @@ tester_TestResult tester_generate_tests_with_imports(slop_arena* arena, slop_str
                         __auto_type prefix = (((((int64_t)(mod_name.len)) > 0)) ? ctype_to_c_name(arena, mod_name) : SLOP_STR(""));
                         __auto_type types = type_extract_extract_types_from_ast_with_imports(arena, exprs, mod_name, imports);
                         __auto_type tctx = test_emit_init_transpile_context(arena, exprs, mod_name);
-                        {
-                            __auto_type import_count = ((int64_t)((import_sources).len));
-                            __auto_type i = 0;
-                            while (i < import_count) {
-                                __auto_type _mv_1629 = ({ __auto_type _lst = import_sources; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1629.has_value) {
-                                    __auto_type import_src = _mv_1629.value;
-                                    __auto_type _mv_1630 = parser_parse(arena, import_src);
-                                    if (_mv_1630.is_ok) {
-                                        __auto_type import_exprs = _mv_1630.data.ok;
-                                        {
-                                            __auto_type import_mod_name = tester_extract_module_name(import_exprs);
-                                            __auto_type import_prefix = (((((int64_t)(import_mod_name.len)) > 0)) ? ctype_to_c_name(arena, import_mod_name) : SLOP_STR(""));
-                                            tester_extract_types_from_module_ast(arena, import_exprs, types, import_prefix);
-                                            test_emit_init_transpile_context_for_imports(arena, tctx, import_exprs, import_mod_name);
-                                            context_ctx_set_module(tctx, (slop_option_string){.has_value = 1, .value = mod_name});
-                                        }
-                                    } else if (!_mv_1630.is_ok) {
-                                        __auto_type _ = _mv_1630.data.err;
-                                    }
-                                } else if (!_mv_1629.has_value) {
-                                }
-                                i = (i + 1);
-                            }
-                        }
-                        context_ctx_set_module(tctx, (slop_option_string){.has_value = 1, .value = mod_name});
-                        test_emit_re_prescan_main_module(arena, tctx, exprs);
                         {
                             __auto_type harness_lines = test_emit_emit_test_harness_typed(arena, test_cases, prefix, types, imports, tctx, file_name);
                             return (tester_TestResult){1, harness_lines, test_count, mod_name, SLOP_STR("")};
@@ -211,21 +149,83 @@ tester_TestResult tester_generate_tests_with_imports(slop_arena* arena, slop_str
     SLOP_UNREACHABLE();
 }
 
+tester_TestResult tester_generate_tests_with_imports(slop_arena* arena, slop_string source, slop_list_string import_sources, slop_string file_name) {
+    __auto_type _mv_1629 = parser_parse(arena, source);
+    if (_mv_1629.is_ok) {
+        __auto_type exprs = _mv_1629.data.ok;
+        {
+            __auto_type mod_name = tester_extract_module_name(exprs);
+            __auto_type imports = tester_extract_imports(arena, exprs);
+            {
+                __auto_type test_cases = extract_extract_examples_from_ast(arena, exprs);
+                __auto_type test_count = ((int64_t)((test_cases).len));
+                if (test_count == 0) {
+                    return (tester_TestResult){1, ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 }), 0, mod_name, SLOP_STR("")};
+                } else {
+                    {
+                        __auto_type prefix = (((((int64_t)(mod_name.len)) > 0)) ? ctype_to_c_name(arena, mod_name) : SLOP_STR(""));
+                        __auto_type types = type_extract_extract_types_from_ast_with_imports(arena, exprs, mod_name, imports);
+                        __auto_type tctx = test_emit_init_transpile_context(arena, exprs, mod_name);
+                        {
+                            __auto_type import_count = ((int64_t)((import_sources).len));
+                            __auto_type i = 0;
+                            while (i < import_count) {
+                                __auto_type _mv_1630 = ({ __auto_type _lst = import_sources; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1630.has_value) {
+                                    __auto_type import_src = _mv_1630.value;
+                                    __auto_type _mv_1631 = parser_parse(arena, import_src);
+                                    if (_mv_1631.is_ok) {
+                                        __auto_type import_exprs = _mv_1631.data.ok;
+                                        {
+                                            __auto_type import_mod_name = tester_extract_module_name(import_exprs);
+                                            __auto_type import_prefix = (((((int64_t)(import_mod_name.len)) > 0)) ? ctype_to_c_name(arena, import_mod_name) : SLOP_STR(""));
+                                            tester_extract_types_from_module_ast(arena, import_exprs, types, import_prefix);
+                                            test_emit_init_transpile_context_for_imports(arena, tctx, import_exprs, import_mod_name);
+                                            context_ctx_set_module(tctx, (slop_option_string){.has_value = 1, .value = mod_name});
+                                        }
+                                    } else if (!_mv_1631.is_ok) {
+                                        __auto_type _ = _mv_1631.data.err;
+                                    }
+                                } else if (!_mv_1630.has_value) {
+                                }
+                                i = (i + 1);
+                            }
+                        }
+                        context_ctx_set_module(tctx, (slop_option_string){.has_value = 1, .value = mod_name});
+                        test_emit_re_prescan_main_module(arena, tctx, exprs);
+                        {
+                            __auto_type harness_lines = test_emit_emit_test_harness_typed(arena, test_cases, prefix, types, imports, tctx, file_name);
+                            return (tester_TestResult){1, harness_lines, test_count, mod_name, SLOP_STR("")};
+                        }
+                    }
+                }
+            }
+        }
+    } else if (!_mv_1629.is_ok) {
+        __auto_type err = _mv_1629.data.err;
+        {
+            __auto_type error_msg = string_concat(arena, SLOP_STR("Parse error at line "), string_concat(arena, int_to_string(arena, err.line), string_concat(arena, SLOP_STR(", col "), string_concat(arena, int_to_string(arena, err.col), string_concat(arena, SLOP_STR(": "), err.message)))));
+            return (tester_TestResult){0, ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 }), 0, SLOP_STR(""), error_msg};
+        }
+    }
+    SLOP_UNREACHABLE();
+}
+
 void tester_extract_types_from_module_ast(slop_arena* arena, slop_list_types_SExpr_ptr ast, type_extract_TypeRegistry* types, slop_string prefix) {
     {
         __auto_type len = ((int64_t)((ast).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1631 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1631.has_value) {
-                __auto_type expr = _mv_1631.value;
+            __auto_type _mv_1632 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1632.has_value) {
+                __auto_type expr = _mv_1632.value;
                 if (parser_is_form(expr, SLOP_STR("module"))) {
                     tester_extract_types_from_module_form(arena, expr, types, prefix);
                 }
                 if (parser_is_form(expr, SLOP_STR("type"))) {
                     tester_extract_single_type_def(arena, expr, types, prefix);
                 }
-            } else if (!_mv_1631.has_value) {
+            } else if (!_mv_1632.has_value) {
             }
             i = (i + 1);
         }
@@ -237,13 +237,13 @@ void tester_extract_types_from_module_form(slop_arena* arena, types_SExpr* modul
         __auto_type len = parser_sexpr_list_len(module_form);
         int64_t i = 2;
         while (i < len) {
-            __auto_type _mv_1632 = parser_sexpr_list_get(module_form, i);
-            if (_mv_1632.has_value) {
-                __auto_type form = _mv_1632.value;
+            __auto_type _mv_1633 = parser_sexpr_list_get(module_form, i);
+            if (_mv_1633.has_value) {
+                __auto_type form = _mv_1633.value;
                 if (parser_is_form(form, SLOP_STR("type"))) {
                     tester_extract_single_type_def(arena, form, types, prefix);
                 }
-            } else if (!_mv_1632.has_value) {
+            } else if (!_mv_1633.has_value) {
             }
             i = (i + 1);
         }
@@ -252,16 +252,16 @@ void tester_extract_types_from_module_form(slop_arena* arena, types_SExpr* modul
 
 void tester_extract_single_type_def(slop_arena* arena, types_SExpr* type_form, type_extract_TypeRegistry* types, slop_string prefix) {
     if (parser_sexpr_list_len(type_form) >= 3) {
-        __auto_type _mv_1633 = parser_sexpr_list_get(type_form, 1);
-        if (_mv_1633.has_value) {
-            __auto_type name_expr = _mv_1633.value;
+        __auto_type _mv_1634 = parser_sexpr_list_get(type_form, 1);
+        if (_mv_1634.has_value) {
+            __auto_type name_expr = _mv_1634.value;
             if (parser_sexpr_is_symbol(name_expr)) {
                 {
                     __auto_type type_name = parser_sexpr_get_symbol_name(name_expr);
                     __auto_type c_name = tester_make_prefixed_c_name(arena, prefix, type_name);
-                    __auto_type _mv_1634 = parser_sexpr_list_get(type_form, 2);
-                    if (_mv_1634.has_value) {
-                        __auto_type def_expr = _mv_1634.value;
+                    __auto_type _mv_1635 = parser_sexpr_list_get(type_form, 2);
+                    if (_mv_1635.has_value) {
+                        __auto_type def_expr = _mv_1635.value;
                         if (parser_is_form(def_expr, SLOP_STR("record"))) {
                             {
                                 __auto_type entry = tester_extract_record_type_entry(arena, type_name, c_name, def_expr);
@@ -279,11 +279,11 @@ void tester_extract_single_type_def(slop_arena* arena, types_SExpr* type_form, t
                             }
                         } else {
                         }
-                    } else if (!_mv_1634.has_value) {
+                    } else if (!_mv_1635.has_value) {
                     }
                 }
             }
-        } else if (!_mv_1633.has_value) {
+        } else if (!_mv_1634.has_value) {
         }
     }
 }
@@ -337,32 +337,32 @@ type_extract_TstTypeEntry* tester_extract_record_type_entry(slop_arena* arena, s
         __auto_type len = parser_sexpr_list_len(def);
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1635 = parser_sexpr_list_get(def, i);
-            if (_mv_1635.has_value) {
-                __auto_type field_def = _mv_1635.value;
+            __auto_type _mv_1636 = parser_sexpr_list_get(def, i);
+            if (_mv_1636.has_value) {
+                __auto_type field_def = _mv_1636.value;
                 if (parser_sexpr_list_len(field_def) >= 2) {
-                    __auto_type _mv_1636 = parser_sexpr_list_get(field_def, 0);
-                    if (_mv_1636.has_value) {
-                        __auto_type field_name_expr = _mv_1636.value;
+                    __auto_type _mv_1637 = parser_sexpr_list_get(field_def, 0);
+                    if (_mv_1637.has_value) {
+                        __auto_type field_name_expr = _mv_1637.value;
                         if (parser_sexpr_is_symbol(field_name_expr)) {
                             {
                                 __auto_type field_name = parser_sexpr_get_symbol_name(field_name_expr);
-                                __auto_type _mv_1637 = parser_sexpr_list_get(field_def, 1);
-                                if (_mv_1637.has_value) {
-                                    __auto_type field_type_expr = _mv_1637.value;
+                                __auto_type _mv_1638 = parser_sexpr_list_get(field_def, 1);
+                                if (_mv_1638.has_value) {
+                                    __auto_type field_type_expr = _mv_1638.value;
                                     {
                                         __auto_type field_type = tester_sexpr_to_string_simple(arena, field_type_expr);
                                         __auto_type fe = (type_extract_TstFieldEntry){field_name, field_type};
                                         ({ __auto_type _lst_p = &((*entry).fields); __auto_type _item = (fe); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
-                                } else if (!_mv_1637.has_value) {
+                                } else if (!_mv_1638.has_value) {
                                 }
                             }
                         }
-                    } else if (!_mv_1636.has_value) {
+                    } else if (!_mv_1637.has_value) {
                     }
                 }
-            } else if (!_mv_1635.has_value) {
+            } else if (!_mv_1636.has_value) {
             }
             i = (i + 1);
         }
@@ -377,15 +377,15 @@ type_extract_TstTypeEntry* tester_extract_union_type_entry(slop_arena* arena, sl
         int64_t i = 1;
         int64_t idx = 0;
         while (i < len) {
-            __auto_type _mv_1638 = parser_sexpr_list_get(def, i);
-            if (_mv_1638.has_value) {
-                __auto_type variant_def = _mv_1638.value;
+            __auto_type _mv_1639 = parser_sexpr_list_get(def, i);
+            if (_mv_1639.has_value) {
+                __auto_type variant_def = _mv_1639.value;
                 {
                     __auto_type vlen = parser_sexpr_list_len(variant_def);
                     if (vlen >= 1) {
-                        __auto_type _mv_1639 = parser_sexpr_list_get(variant_def, 0);
-                        if (_mv_1639.has_value) {
-                            __auto_type variant_name_expr = _mv_1639.value;
+                        __auto_type _mv_1640 = parser_sexpr_list_get(variant_def, 0);
+                        if (_mv_1640.has_value) {
+                            __auto_type variant_name_expr = _mv_1640.value;
                             if (parser_sexpr_is_symbol(variant_name_expr)) {
                                 {
                                     __auto_type variant_name = parser_sexpr_get_symbol_name(variant_name_expr);
@@ -395,11 +395,11 @@ type_extract_TstTypeEntry* tester_extract_union_type_entry(slop_arena* arena, sl
                                     idx = (idx + 1);
                                 }
                             }
-                        } else if (!_mv_1639.has_value) {
+                        } else if (!_mv_1640.has_value) {
                         }
                     }
                 }
-            } else if (!_mv_1638.has_value) {
+            } else if (!_mv_1639.has_value) {
             }
             i = (i + 1);
         }
@@ -414,9 +414,9 @@ type_extract_TstTypeEntry* tester_extract_enum_type_entry(slop_arena* arena, slo
         int64_t i = 1;
         int64_t idx = 0;
         while (i < len) {
-            __auto_type _mv_1640 = parser_sexpr_list_get(def, i);
-            if (_mv_1640.has_value) {
-                __auto_type val_expr = _mv_1640.value;
+            __auto_type _mv_1641 = parser_sexpr_list_get(def, i);
+            if (_mv_1641.has_value) {
+                __auto_type val_expr = _mv_1641.value;
                 if (parser_sexpr_is_symbol(val_expr)) {
                     {
                         __auto_type val_name = parser_sexpr_get_symbol_name(val_expr);
@@ -425,7 +425,7 @@ type_extract_TstTypeEntry* tester_extract_enum_type_entry(slop_arena* arena, slo
                         idx = (idx + 1);
                     }
                 }
-            } else if (!_mv_1640.has_value) {
+            } else if (!_mv_1641.has_value) {
             }
             i = (i + 1);
         }
@@ -434,35 +434,35 @@ type_extract_TstTypeEntry* tester_extract_enum_type_entry(slop_arena* arena, slo
 }
 
 slop_string tester_sexpr_to_string_simple(slop_arena* arena, types_SExpr* expr) {
-    __auto_type _mv_1641 = (*expr);
-    switch (_mv_1641.tag) {
+    __auto_type _mv_1642 = (*expr);
+    switch (_mv_1642.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1641.data.sym;
+            __auto_type sym = _mv_1642.data.sym;
             return sym.name;
         }
         case types_SExpr_num:
         {
-            __auto_type num = _mv_1641.data.num;
+            __auto_type num = _mv_1642.data.num;
             return num.raw;
         }
         case types_SExpr_str:
         {
-            __auto_type str = _mv_1641.data.str;
+            __auto_type str = _mv_1642.data.str;
             return str.value;
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_1641.data.lst;
+            __auto_type l = _mv_1642.data.lst;
             {
                 __auto_type items = l.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type result = SLOP_STR("");
                 __auto_type i = 0;
                 while (i < len) {
-                    __auto_type _mv_1642 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1642.has_value) {
-                        __auto_type child = _mv_1642.value;
+                    __auto_type _mv_1643 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1643.has_value) {
+                        __auto_type child = _mv_1643.value;
                         {
                             __auto_type child_str = tester_sexpr_to_string_simple(arena, child);
                             if (i == 0) {
@@ -471,7 +471,7 @@ slop_string tester_sexpr_to_string_simple(slop_arena* arena, types_SExpr* expr) 
                                 result = string_concat(arena, result, string_concat(arena, SLOP_STR(" "), child_str));
                             }
                         }
-                    } else if (!_mv_1642.has_value) {
+                    } else if (!_mv_1643.has_value) {
                     }
                     i = (i + 1);
                 }

--- a/bootstrap/tester/slop_tester_main.c
+++ b/bootstrap/tester/slop_tester_main.c
@@ -101,11 +101,11 @@ slop_string tester_main_lines_to_string(slop_arena* arena, slop_list_string line
                 int64_t total = 0;
                 int64_t i = 0;
                 while (i < len) {
-                    __auto_type _mv_1643 = ({ __auto_type _lst = lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1643.has_value) {
-                        __auto_type line = _mv_1643.value;
+                    __auto_type _mv_1644 = ({ __auto_type _lst = lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1644.has_value) {
+                        __auto_type line = _mv_1644.value;
                         total = (total + (((int64_t)(line.len)) + 1));
-                    } else if (!_mv_1643.has_value) {
+                    } else if (!_mv_1644.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -114,9 +114,9 @@ slop_string tester_main_lines_to_string(slop_arena* arena, slop_list_string line
                     int64_t pos = 0;
                     int64_t j = 0;
                     while (j < len) {
-                        __auto_type _mv_1644 = ({ __auto_type _lst = lines; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1644.has_value) {
-                            __auto_type line = _mv_1644.value;
+                        __auto_type _mv_1645 = ({ __auto_type _lst = lines; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1645.has_value) {
+                            __auto_type line = _mv_1645.value;
                             {
                                 __auto_type line_len = ((int64_t)(line.len));
                                 __auto_type line_data = line.data;
@@ -129,7 +129,7 @@ slop_string tester_main_lines_to_string(slop_arena* arena, slop_list_string line
                                 buf[pos] = 10;
                                 pos = (pos + 1);
                             }
-                        } else if (!_mv_1644.has_value) {
+                        } else if (!_mv_1645.has_value) {
                         }
                         j = (j + 1);
                     }
@@ -162,11 +162,11 @@ slop_list_string tester_main_read_import_files(slop_arena* arena, int64_t argc, 
         while (i < argc) {
             {
                 __auto_type path_ptr = ((char*)(argv[i]));
-                __auto_type _mv_1645 = tester_main_read_file(arena, path_ptr);
-                if (_mv_1645.has_value) {
-                    __auto_type source = _mv_1645.value;
+                __auto_type _mv_1646 = tester_main_read_file(arena, path_ptr);
+                if (_mv_1646.has_value) {
+                    __auto_type source = _mv_1646.value;
                     ({ __auto_type _lst_p = &(sources); __auto_type _item = (source); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                } else if (!_mv_1645.has_value) {
+                } else if (!_mv_1646.has_value) {
                 }
             }
             i = (i + 1);
@@ -196,9 +196,9 @@ int main(int argc, char** _c_argv) {
             SLOP_PRE(_arena.base != NULL, "arena allocation failed");
             #endif
             slop_arena* arena = &_arena;
-            __auto_type _mv_1646 = tester_main_read_file(arena, ((char*)(argv[1])));
-            if (_mv_1646.has_value) {
-                __auto_type source = _mv_1646.value;
+            __auto_type _mv_1647 = tester_main_read_file(arena, ((char*)(argv[1])));
+            if (_mv_1647.has_value) {
+                __auto_type source = _mv_1647.value;
                 {
                     __auto_type import_sources = tester_main_read_import_files(arena, argc, argv);
                     __auto_type result = tester_generate_tests_with_imports(arena, source, import_sources, strlib_cstring_to_string(argv[1]));
@@ -225,7 +225,7 @@ int main(int argc, char** _c_argv) {
                         return 1;
                     }
                 }
-            } else if (!_mv_1646.has_value) {
+            } else if (!_mv_1647.has_value) {
                 tester_main_print_str(((char*)(SLOP_STR("{\"error\":\"Could not read file\"}\n").data)));
                 return 1;
             }

--- a/bootstrap/tester/slop_transpiler.c
+++ b/bootstrap/tester/slop_transpiler.c
@@ -212,48 +212,48 @@ transpiler_GenericInfo transpiler_extract_generic_info(slop_arena* arena, slop_l
         __auto_type result_is_generic = 0;
         __auto_type result_type_params = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
         while (i < len) {
-            __auto_type _mv_1107 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1107.has_value) {
-                __auto_type item = _mv_1107.value;
-                __auto_type _mv_1108 = (*item);
-                switch (_mv_1108.tag) {
+            __auto_type _mv_1108 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1108.has_value) {
+                __auto_type item = _mv_1108.value;
+                __auto_type _mv_1109 = (*item);
+                switch (_mv_1109.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type lst = _mv_1108.data.lst;
+                        __auto_type lst = _mv_1109.data.lst;
                         {
                             __auto_type sub_items = lst.items;
                             if (((int64_t)((sub_items).len)) >= 1) {
-                                __auto_type _mv_1109 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1109.has_value) {
-                                    __auto_type head = _mv_1109.value;
-                                    __auto_type _mv_1110 = (*head);
-                                    switch (_mv_1110.tag) {
+                                __auto_type _mv_1110 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1110.has_value) {
+                                    __auto_type head = _mv_1110.value;
+                                    __auto_type _mv_1111 = (*head);
+                                    switch (_mv_1111.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_1110.data.sym;
+                                            __auto_type sym = _mv_1111.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("@generic"))) {
                                                 if (((int64_t)((sub_items).len)) >= 2) {
-                                                    __auto_type _mv_1111 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1111.has_value) {
-                                                        __auto_type params_expr = _mv_1111.value;
-                                                        __auto_type _mv_1112 = (*params_expr);
-                                                        switch (_mv_1112.tag) {
+                                                    __auto_type _mv_1112 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1112.has_value) {
+                                                        __auto_type params_expr = _mv_1112.value;
+                                                        __auto_type _mv_1113 = (*params_expr);
+                                                        switch (_mv_1113.tag) {
                                                             case types_SExpr_lst:
                                                             {
-                                                                __auto_type params_lst = _mv_1112.data.lst;
+                                                                __auto_type params_lst = _mv_1113.data.lst;
                                                                 {
                                                                     __auto_type param_items = params_lst.items;
                                                                     __auto_type param_len = ((int64_t)((param_items).len));
                                                                     __auto_type j = 0;
                                                                     while (j < param_len) {
-                                                                        __auto_type _mv_1113 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                        if (_mv_1113.has_value) {
-                                                                            __auto_type param = _mv_1113.value;
-                                                                            __auto_type _mv_1114 = (*param);
-                                                                            switch (_mv_1114.tag) {
+                                                                        __auto_type _mv_1114 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                        if (_mv_1114.has_value) {
+                                                                            __auto_type param = _mv_1114.value;
+                                                                            __auto_type _mv_1115 = (*param);
+                                                                            switch (_mv_1115.tag) {
                                                                                 case types_SExpr_sym:
                                                                                 {
-                                                                                    __auto_type param_sym = _mv_1114.data.sym;
+                                                                                    __auto_type param_sym = _mv_1115.data.sym;
                                                                                     ({ __auto_type _lst_p = &(result_type_params); __auto_type _item = (param_sym.name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                                                     break;
                                                                                 }
@@ -261,7 +261,7 @@ transpiler_GenericInfo transpiler_extract_generic_info(slop_arena* arena, slop_l
                                                                                     break;
                                                                                 }
                                                                             }
-                                                                        } else if (!_mv_1113.has_value) {
+                                                                        } else if (!_mv_1114.has_value) {
                                                                         }
                                                                         j = (j + 1);
                                                                     }
@@ -270,7 +270,7 @@ transpiler_GenericInfo transpiler_extract_generic_info(slop_arena* arena, slop_l
                                                             }
                                                             case types_SExpr_sym:
                                                             {
-                                                                __auto_type single_sym = _mv_1112.data.sym;
+                                                                __auto_type single_sym = _mv_1113.data.sym;
                                                                 ({ __auto_type _lst_p = &(result_type_params); __auto_type _item = (single_sym.name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                                 break;
                                                             }
@@ -278,7 +278,7 @@ transpiler_GenericInfo transpiler_extract_generic_info(slop_arena* arena, slop_l
                                                                 break;
                                                             }
                                                         }
-                                                    } else if (!_mv_1111.has_value) {
+                                                    } else if (!_mv_1112.has_value) {
                                                     }
                                                 }
                                             }
@@ -288,7 +288,7 @@ transpiler_GenericInfo transpiler_extract_generic_info(slop_arena* arena, slop_l
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1109.has_value) {
+                                } else if (!_mv_1110.has_value) {
                                 }
                             }
                         }
@@ -298,7 +298,7 @@ transpiler_GenericInfo transpiler_extract_generic_info(slop_arena* arena, slop_l
                         break;
                     }
                 }
-            } else if (!_mv_1107.has_value) {
+            } else if (!_mv_1108.has_value) {
             }
             i = (i + 1);
         }
@@ -312,11 +312,11 @@ void transpiler_prescan_module(context_TranspileContext* ctx, slop_list_types_SE
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1115 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1115.has_value) {
-                __auto_type item = _mv_1115.value;
+            __auto_type _mv_1116 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1116.has_value) {
+                __auto_type item = _mv_1116.value;
                 transpiler_prescan_top_level(ctx, item);
-            } else if (!_mv_1115.has_value) {
+            } else if (!_mv_1116.has_value) {
             }
             i = (i + 1);
         }
@@ -326,22 +326,22 @@ void transpiler_prescan_module(context_TranspileContext* ctx, slop_list_types_SE
 void transpiler_prescan_top_level(context_TranspileContext* ctx, types_SExpr* item) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1116 = (*item);
-    switch (_mv_1116.tag) {
+    __auto_type _mv_1117 = (*item);
+    switch (_mv_1117.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1116.data.lst;
+            __auto_type lst = _mv_1117.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) >= 1) {
-                    __auto_type _mv_1117 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1117.has_value) {
-                        __auto_type head = _mv_1117.value;
-                        __auto_type _mv_1118 = (*head);
-                        switch (_mv_1118.tag) {
+                    __auto_type _mv_1118 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1118.has_value) {
+                        __auto_type head = _mv_1118.value;
+                        __auto_type _mv_1119 = (*head);
+                        switch (_mv_1119.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1118.data.sym;
+                                __auto_type sym = _mv_1119.data.sym;
                                 {
                                     __auto_type name = sym.name;
                                     if (string_eq(name, SLOP_STR("type"))) {
@@ -365,7 +365,7 @@ void transpiler_prescan_top_level(context_TranspileContext* ctx, types_SExpr* it
                                 break;
                             }
                         }
-                    } else if (!_mv_1117.has_value) {
+                    } else if (!_mv_1118.has_value) {
                     }
                 }
             }
@@ -382,14 +382,14 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
     {
         __auto_type arena = (*ctx).arena;
         if (((int64_t)((items).len)) >= 2) {
-            __auto_type _mv_1119 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1119.has_value) {
-                __auto_type name_expr = _mv_1119.value;
-                __auto_type _mv_1120 = (*name_expr);
-                switch (_mv_1120.tag) {
+            __auto_type _mv_1120 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1120.has_value) {
+                __auto_type name_expr = _mv_1120.value;
+                __auto_type _mv_1121 = (*name_expr);
+                switch (_mv_1121.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_1120.data.sym;
+                        __auto_type sym = _mv_1121.data.sym;
                         {
                             __auto_type type_name = sym.name;
                             __auto_type base_c_name = ctype_to_c_name(arena, type_name);
@@ -408,14 +408,14 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
                                 }
                                 if (is_record || is_union) {
                                     if (((int64_t)((items).len)) >= 3) {
-                                        __auto_type _mv_1121 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1121.has_value) {
-                                            __auto_type def_expr = _mv_1121.value;
-                                            __auto_type _mv_1122 = (*def_expr);
-                                            switch (_mv_1122.tag) {
+                                        __auto_type _mv_1122 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1122.has_value) {
+                                            __auto_type def_expr = _mv_1122.value;
+                                            __auto_type _mv_1123 = (*def_expr);
+                                            switch (_mv_1123.tag) {
                                                 case types_SExpr_lst:
                                                 {
-                                                    __auto_type def_lst = _mv_1122.data.lst;
+                                                    __auto_type def_lst = _mv_1123.data.lst;
                                                     transpiler_scan_record_fields_for_generics(ctx, def_lst.items);
                                                     break;
                                                 }
@@ -423,7 +423,7 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
                                                     break;
                                                 }
                                             }
-                                        } else if (!_mv_1121.has_value) {
+                                        } else if (!_mv_1122.has_value) {
                                         }
                                     }
                                     {
@@ -433,9 +433,9 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
                                     }
                                 }
                                 if (((int64_t)((items).len)) >= 3) {
-                                    __auto_type _mv_1123 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_1123.has_value) {
-                                        __auto_type body_expr = _mv_1123.value;
+                                    __auto_type _mv_1124 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_1124.has_value) {
+                                        __auto_type body_expr = _mv_1124.value;
                                         transpiler_check_and_register_result_alias(ctx, type_name, body_expr);
                                         {
                                             __auto_type slop_type_str = parser_pretty_print(arena, body_expr);
@@ -446,7 +446,7 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
                                                 transpiler_scan_type_for_generics(ctx, body_expr);
                                             }
                                         }
-                                    } else if (!_mv_1123.has_value) {
+                                    } else if (!_mv_1124.has_value) {
                                     }
                                 }
                             }
@@ -457,7 +457,7 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
                         break;
                     }
                 }
-            } else if (!_mv_1119.has_value) {
+            } else if (!_mv_1120.has_value) {
             }
         }
     }
@@ -466,42 +466,42 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
 void transpiler_register_enum_variants(context_TranspileContext* ctx, slop_string enum_name, slop_list_types_SExpr_ptr items) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     if (((int64_t)((items).len)) >= 3) {
-        __auto_type _mv_1124 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1124.has_value) {
-            __auto_type def_expr = _mv_1124.value;
-            __auto_type _mv_1125 = (*def_expr);
-            switch (_mv_1125.tag) {
+        __auto_type _mv_1125 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1125.has_value) {
+            __auto_type def_expr = _mv_1125.value;
+            __auto_type _mv_1126 = (*def_expr);
+            switch (_mv_1126.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type def_lst = _mv_1125.data.lst;
+                    __auto_type def_lst = _mv_1126.data.lst;
                     {
                         __auto_type def_items = def_lst.items;
                         __auto_type len = ((int64_t)((def_items).len));
                         __auto_type i = 1;
                         while (i < len) {
-                            __auto_type _mv_1126 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1126.has_value) {
-                                __auto_type variant_expr = _mv_1126.value;
-                                __auto_type _mv_1127 = (*variant_expr);
-                                switch (_mv_1127.tag) {
+                            __auto_type _mv_1127 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1127.has_value) {
+                                __auto_type variant_expr = _mv_1127.value;
+                                __auto_type _mv_1128 = (*variant_expr);
+                                switch (_mv_1128.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1127.data.sym;
+                                        __auto_type sym = _mv_1128.data.sym;
                                         context_ctx_register_enum_variant(ctx, sym.name, enum_name);
                                         break;
                                     }
                                     case types_SExpr_lst:
                                     {
-                                        __auto_type variant_lst = _mv_1127.data.lst;
+                                        __auto_type variant_lst = _mv_1128.data.lst;
                                         if (((int64_t)((variant_lst.items).len)) > 0) {
-                                            __auto_type _mv_1128 = ({ __auto_type _lst = variant_lst.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1128.has_value) {
-                                                __auto_type name_expr = _mv_1128.value;
-                                                __auto_type _mv_1129 = (*name_expr);
-                                                switch (_mv_1129.tag) {
+                                            __auto_type _mv_1129 = ({ __auto_type _lst = variant_lst.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1129.has_value) {
+                                                __auto_type name_expr = _mv_1129.value;
+                                                __auto_type _mv_1130 = (*name_expr);
+                                                switch (_mv_1130.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type name_sym = _mv_1129.data.sym;
+                                                        __auto_type name_sym = _mv_1130.data.sym;
                                                         context_ctx_register_enum_variant(ctx, name_sym.name, enum_name);
                                                         break;
                                                     }
@@ -509,7 +509,7 @@ void transpiler_register_enum_variants(context_TranspileContext* ctx, slop_strin
                                                         break;
                                                     }
                                                 }
-                                            } else if (!_mv_1128.has_value) {
+                                            } else if (!_mv_1129.has_value) {
                                             }
                                         }
                                         break;
@@ -518,7 +518,7 @@ void transpiler_register_enum_variants(context_TranspileContext* ctx, slop_strin
                                         break;
                                     }
                                 }
-                            } else if (!_mv_1126.has_value) {
+                            } else if (!_mv_1127.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -529,7 +529,7 @@ void transpiler_register_enum_variants(context_TranspileContext* ctx, slop_strin
                     break;
                 }
             }
-        } else if (!_mv_1124.has_value) {
+        } else if (!_mv_1125.has_value) {
         }
     }
 }
@@ -539,27 +539,27 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
     {
         __auto_type arena = (*ctx).arena;
         if (((int64_t)((items).len)) >= 3) {
-            __auto_type _mv_1130 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1130.has_value) {
-                __auto_type def_expr = _mv_1130.value;
-                __auto_type _mv_1131 = (*def_expr);
-                switch (_mv_1131.tag) {
+            __auto_type _mv_1131 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1131.has_value) {
+                __auto_type def_expr = _mv_1131.value;
+                __auto_type _mv_1132 = (*def_expr);
+                switch (_mv_1132.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type def_lst = _mv_1131.data.lst;
+                        __auto_type def_lst = _mv_1132.data.lst;
                         {
                             __auto_type def_items = def_lst.items;
                             __auto_type len = ((int64_t)((def_items).len));
                             __auto_type i = 1;
                             while (i < len) {
-                                __auto_type _mv_1132 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1132.has_value) {
-                                    __auto_type variant_expr = _mv_1132.value;
-                                    __auto_type _mv_1133 = (*variant_expr);
-                                    switch (_mv_1133.tag) {
+                                __auto_type _mv_1133 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1133.has_value) {
+                                    __auto_type variant_expr = _mv_1133.value;
+                                    __auto_type _mv_1134 = (*variant_expr);
+                                    switch (_mv_1134.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_1133.data.sym;
+                                            __auto_type sym = _mv_1134.data.sym;
                                             {
                                                 __auto_type variant_name = sym.name;
                                                 context_ctx_register_enum_variant(ctx, variant_name, union_name);
@@ -569,26 +569,26 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                         }
                                         case types_SExpr_lst:
                                         {
-                                            __auto_type variant_lst = _mv_1133.data.lst;
+                                            __auto_type variant_lst = _mv_1134.data.lst;
                                             {
                                                 __auto_type vl_items = variant_lst.items;
                                                 __auto_type vl_len = ((int64_t)((vl_items).len));
                                                 if (vl_len >= 2) {
-                                                    __auto_type _mv_1134 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1134.has_value) {
-                                                        __auto_type name_expr = _mv_1134.value;
-                                                        __auto_type _mv_1135 = (*name_expr);
-                                                        switch (_mv_1135.tag) {
+                                                    __auto_type _mv_1135 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1135.has_value) {
+                                                        __auto_type name_expr = _mv_1135.value;
+                                                        __auto_type _mv_1136 = (*name_expr);
+                                                        switch (_mv_1136.tag) {
                                                             case types_SExpr_sym:
                                                             {
-                                                                __auto_type name_sym = _mv_1135.data.sym;
+                                                                __auto_type name_sym = _mv_1136.data.sym;
                                                                 {
                                                                     __auto_type variant_name = name_sym.name;
                                                                     __auto_type c_variant_name = ctype_to_c_name(arena, variant_name);
                                                                     context_ctx_register_enum_variant(ctx, variant_name, union_name);
-                                                                    __auto_type _mv_1136 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                    if (_mv_1136.has_value) {
-                                                                        __auto_type type_expr = _mv_1136.value;
+                                                                    __auto_type _mv_1137 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                    if (_mv_1137.has_value) {
+                                                                        __auto_type type_expr = _mv_1137.value;
                                                                         {
                                                                             __auto_type slop_type = parser_pretty_print(arena, type_expr);
                                                                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
@@ -596,7 +596,7 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                                                             context_ctx_register_union_variant(ctx, variant_name, union_name, c_variant_name, slop_type, c_type);
                                                                             context_ctx_register_field_type(ctx, union_name, variant_name, c_type, slop_type, is_ptr);
                                                                         }
-                                                                    } else if (!_mv_1136.has_value) {
+                                                                    } else if (!_mv_1137.has_value) {
                                                                         context_ctx_register_union_variant(ctx, variant_name, union_name, c_variant_name, SLOP_STR(""), SLOP_STR(""));
                                                                     }
                                                                     if (vl_len >= 3) {
@@ -606,9 +606,9 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                                                             context_ctx_register_field_type(ctx, union_name, count_key, count_str, SLOP_STR(""), 0);
                                                                         }
                                                                         for (int64_t fi = 1; fi < vl_len; fi++) {
-                                                                            __auto_type _mv_1137 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                            if (_mv_1137.has_value) {
-                                                                                __auto_type type_expr = _mv_1137.value;
+                                                                            __auto_type _mv_1138 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                            if (_mv_1138.has_value) {
+                                                                                __auto_type type_expr = _mv_1138.value;
                                                                                 {
                                                                                     __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                                                     __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
@@ -616,7 +616,7 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                                                                     __auto_type field_key = context_ctx_str3(ctx, variant_name, SLOP_STR("__"), int_to_string(arena, (fi - 1)));
                                                                                     context_ctx_register_field_type(ctx, union_name, field_key, c_type, slop_type_str, is_ptr);
                                                                                 }
-                                                                            } else if (!_mv_1137.has_value) {
+                                                                            } else if (!_mv_1138.has_value) {
                                                                             }
                                                                         }
                                                                     }
@@ -627,18 +627,18 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                                                 break;
                                                             }
                                                         }
-                                                    } else if (!_mv_1134.has_value) {
+                                                    } else if (!_mv_1135.has_value) {
                                                     }
                                                 } else {
                                                     if (((int64_t)((vl_items).len)) == 1) {
-                                                        __auto_type _mv_1138 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                        if (_mv_1138.has_value) {
-                                                            __auto_type name_expr = _mv_1138.value;
-                                                            __auto_type _mv_1139 = (*name_expr);
-                                                            switch (_mv_1139.tag) {
+                                                        __auto_type _mv_1139 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                        if (_mv_1139.has_value) {
+                                                            __auto_type name_expr = _mv_1139.value;
+                                                            __auto_type _mv_1140 = (*name_expr);
+                                                            switch (_mv_1140.tag) {
                                                                 case types_SExpr_sym:
                                                                 {
-                                                                    __auto_type name_sym = _mv_1139.data.sym;
+                                                                    __auto_type name_sym = _mv_1140.data.sym;
                                                                     {
                                                                         __auto_type variant_name = name_sym.name;
                                                                         context_ctx_register_enum_variant(ctx, variant_name, union_name);
@@ -650,7 +650,7 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                                                     break;
                                                                 }
                                                             }
-                                                        } else if (!_mv_1138.has_value) {
+                                                        } else if (!_mv_1139.has_value) {
                                                         }
                                                     }
                                                 }
@@ -661,7 +661,7 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1132.has_value) {
+                                } else if (!_mv_1133.has_value) {
                                 }
                                 i = (i + 1);
                             }
@@ -672,7 +672,7 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                         break;
                     }
                 }
-            } else if (!_mv_1130.has_value) {
+            } else if (!_mv_1131.has_value) {
             }
         }
     }
@@ -683,14 +683,14 @@ void transpiler_prescan_fn(context_TranspileContext* ctx, slop_list_types_SExpr_
     {
         __auto_type arena = (*ctx).arena;
         if (((int64_t)((items).len)) >= 2) {
-            __auto_type _mv_1140 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1140.has_value) {
-                __auto_type name_expr = _mv_1140.value;
-                __auto_type _mv_1141 = (*name_expr);
-                switch (_mv_1141.tag) {
+            __auto_type _mv_1141 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1141.has_value) {
+                __auto_type name_expr = _mv_1141.value;
+                __auto_type _mv_1142 = (*name_expr);
+                switch (_mv_1142.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_1141.data.sym;
+                        __auto_type sym = _mv_1142.data.sym;
                         {
                             __auto_type fn_name = sym.name;
                             __auto_type base_name = ctype_to_c_name(arena, fn_name);
@@ -720,7 +720,7 @@ void transpiler_prescan_fn(context_TranspileContext* ctx, slop_list_types_SExpr_
                         break;
                     }
                 }
-            } else if (!_mv_1140.has_value) {
+            } else if (!_mv_1141.has_value) {
             }
         }
     }
@@ -732,46 +732,46 @@ uint8_t transpiler_fn_returns_string(slop_list_types_SExpr_ptr items) {
         int64_t i = 3;
         uint8_t result = 0;
         while ((i < len) && !(result)) {
-            __auto_type _mv_1142 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1142.has_value) {
-                __auto_type item = _mv_1142.value;
-                __auto_type _mv_1143 = (*item);
-                switch (_mv_1143.tag) {
+            __auto_type _mv_1143 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1143.has_value) {
+                __auto_type item = _mv_1143.value;
+                __auto_type _mv_1144 = (*item);
+                switch (_mv_1144.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type lst = _mv_1143.data.lst;
+                        __auto_type lst = _mv_1144.data.lst;
                         {
                             __auto_type sub_items = lst.items;
                             if (((int64_t)((sub_items).len)) >= 2) {
-                                __auto_type _mv_1144 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1144.has_value) {
-                                    __auto_type head = _mv_1144.value;
-                                    __auto_type _mv_1145 = (*head);
-                                    switch (_mv_1145.tag) {
+                                __auto_type _mv_1145 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1145.has_value) {
+                                    __auto_type head = _mv_1145.value;
+                                    __auto_type _mv_1146 = (*head);
+                                    switch (_mv_1146.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_1145.data.sym;
+                                            __auto_type sym = _mv_1146.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("@spec"))) {
-                                                __auto_type _mv_1146 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1146.has_value) {
-                                                    __auto_type spec_body = _mv_1146.value;
-                                                    __auto_type _mv_1147 = (*spec_body);
-                                                    switch (_mv_1147.tag) {
+                                                __auto_type _mv_1147 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1147.has_value) {
+                                                    __auto_type spec_body = _mv_1147.value;
+                                                    __auto_type _mv_1148 = (*spec_body);
+                                                    switch (_mv_1148.tag) {
                                                         case types_SExpr_lst:
                                                         {
-                                                            __auto_type body_lst = _mv_1147.data.lst;
+                                                            __auto_type body_lst = _mv_1148.data.lst;
                                                             {
                                                                 __auto_type body_items = body_lst.items;
                                                                 __auto_type body_len = ((int64_t)((body_items).len));
                                                                 if (body_len >= 1) {
-                                                                    __auto_type _mv_1148 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                    if (_mv_1148.has_value) {
-                                                                        __auto_type ret_type = _mv_1148.value;
-                                                                        __auto_type _mv_1149 = (*ret_type);
-                                                                        switch (_mv_1149.tag) {
+                                                                    __auto_type _mv_1149 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                    if (_mv_1149.has_value) {
+                                                                        __auto_type ret_type = _mv_1149.value;
+                                                                        __auto_type _mv_1150 = (*ret_type);
+                                                                        switch (_mv_1150.tag) {
                                                                             case types_SExpr_sym:
                                                                             {
-                                                                                __auto_type ret_sym = _mv_1149.data.sym;
+                                                                                __auto_type ret_sym = _mv_1150.data.sym;
                                                                                 result = string_eq(ret_sym.name, SLOP_STR("String"));
                                                                                 break;
                                                                             }
@@ -779,7 +779,7 @@ uint8_t transpiler_fn_returns_string(slop_list_types_SExpr_ptr items) {
                                                                                 break;
                                                                             }
                                                                         }
-                                                                    } else if (!_mv_1148.has_value) {
+                                                                    } else if (!_mv_1149.has_value) {
                                                                     }
                                                                 }
                                                             }
@@ -789,7 +789,7 @@ uint8_t transpiler_fn_returns_string(slop_list_types_SExpr_ptr items) {
                                                             break;
                                                         }
                                                     }
-                                                } else if (!_mv_1146.has_value) {
+                                                } else if (!_mv_1147.has_value) {
                                                 }
                                             }
                                             break;
@@ -798,7 +798,7 @@ uint8_t transpiler_fn_returns_string(slop_list_types_SExpr_ptr items) {
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1144.has_value) {
+                                } else if (!_mv_1145.has_value) {
                                 }
                             }
                         }
@@ -808,7 +808,7 @@ uint8_t transpiler_fn_returns_string(slop_list_types_SExpr_ptr items) {
                         break;
                     }
                 }
-            } else if (!_mv_1142.has_value) {
+            } else if (!_mv_1143.has_value) {
             }
             i = (i + 1);
         }
@@ -823,43 +823,43 @@ slop_string transpiler_fn_return_type(context_TranspileContext* ctx, slop_list_t
         int64_t i = 3;
         __auto_type result = SLOP_STR("");
         while ((i < len) && string_eq(result, SLOP_STR(""))) {
-            __auto_type _mv_1150 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1150.has_value) {
-                __auto_type item = _mv_1150.value;
-                __auto_type _mv_1151 = (*item);
-                switch (_mv_1151.tag) {
+            __auto_type _mv_1151 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1151.has_value) {
+                __auto_type item = _mv_1151.value;
+                __auto_type _mv_1152 = (*item);
+                switch (_mv_1152.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type lst = _mv_1151.data.lst;
+                        __auto_type lst = _mv_1152.data.lst;
                         {
                             __auto_type sub_items = lst.items;
                             if (((int64_t)((sub_items).len)) >= 2) {
-                                __auto_type _mv_1152 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1152.has_value) {
-                                    __auto_type head = _mv_1152.value;
-                                    __auto_type _mv_1153 = (*head);
-                                    switch (_mv_1153.tag) {
+                                __auto_type _mv_1153 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1153.has_value) {
+                                    __auto_type head = _mv_1153.value;
+                                    __auto_type _mv_1154 = (*head);
+                                    switch (_mv_1154.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_1153.data.sym;
+                                            __auto_type sym = _mv_1154.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("@spec"))) {
-                                                __auto_type _mv_1154 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1154.has_value) {
-                                                    __auto_type spec_body = _mv_1154.value;
-                                                    __auto_type _mv_1155 = (*spec_body);
-                                                    switch (_mv_1155.tag) {
+                                                __auto_type _mv_1155 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1155.has_value) {
+                                                    __auto_type spec_body = _mv_1155.value;
+                                                    __auto_type _mv_1156 = (*spec_body);
+                                                    switch (_mv_1156.tag) {
                                                         case types_SExpr_lst:
                                                         {
-                                                            __auto_type body_lst = _mv_1155.data.lst;
+                                                            __auto_type body_lst = _mv_1156.data.lst;
                                                             {
                                                                 __auto_type body_items = body_lst.items;
                                                                 __auto_type body_len = ((int64_t)((body_items).len));
                                                                 if (body_len >= 1) {
-                                                                    __auto_type _mv_1156 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                    if (_mv_1156.has_value) {
-                                                                        __auto_type ret_type = _mv_1156.value;
+                                                                    __auto_type _mv_1157 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                    if (_mv_1157.has_value) {
+                                                                        __auto_type ret_type = _mv_1157.value;
                                                                         result = context_to_c_type_prefixed(ctx, ret_type);
-                                                                    } else if (!_mv_1156.has_value) {
+                                                                    } else if (!_mv_1157.has_value) {
                                                                     }
                                                                 }
                                                             }
@@ -869,7 +869,7 @@ slop_string transpiler_fn_return_type(context_TranspileContext* ctx, slop_list_t
                                                             break;
                                                         }
                                                     }
-                                                } else if (!_mv_1154.has_value) {
+                                                } else if (!_mv_1155.has_value) {
                                                 }
                                             }
                                             break;
@@ -878,7 +878,7 @@ slop_string transpiler_fn_return_type(context_TranspileContext* ctx, slop_list_t
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1152.has_value) {
+                                } else if (!_mv_1153.has_value) {
                                 }
                             }
                         }
@@ -888,7 +888,7 @@ slop_string transpiler_fn_return_type(context_TranspileContext* ctx, slop_list_t
                         break;
                     }
                 }
-            } else if (!_mv_1150.has_value) {
+            } else if (!_mv_1151.has_value) {
             }
             i = (i + 1);
         }
@@ -899,35 +899,35 @@ slop_string transpiler_fn_return_type(context_TranspileContext* ctx, slop_list_t
 void transpiler_prescan_fn_params(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     if (((int64_t)((items).len)) >= 3) {
-        __auto_type _mv_1157 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1157.has_value) {
-            __auto_type params_expr = _mv_1157.value;
-            __auto_type _mv_1158 = (*params_expr);
-            switch (_mv_1158.tag) {
+        __auto_type _mv_1158 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1158.has_value) {
+            __auto_type params_expr = _mv_1158.value;
+            __auto_type _mv_1159 = (*params_expr);
+            switch (_mv_1159.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type params_lst = _mv_1158.data.lst;
+                    __auto_type params_lst = _mv_1159.data.lst;
                     {
                         __auto_type params = params_lst.items;
                         __auto_type param_count = ((int64_t)((params).len));
                         __auto_type i = 0;
                         while (i < param_count) {
-                            __auto_type _mv_1159 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1159.has_value) {
-                                __auto_type param_expr = _mv_1159.value;
-                                __auto_type _mv_1160 = (*param_expr);
-                                switch (_mv_1160.tag) {
+                            __auto_type _mv_1160 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1160.has_value) {
+                                __auto_type param_expr = _mv_1160.value;
+                                __auto_type _mv_1161 = (*param_expr);
+                                switch (_mv_1161.tag) {
                                     case types_SExpr_lst:
                                     {
-                                        __auto_type param_lst = _mv_1160.data.lst;
+                                        __auto_type param_lst = _mv_1161.data.lst;
                                         {
                                             __auto_type param_items = param_lst.items;
                                             if (((int64_t)((param_items).len)) >= 2) {
-                                                __auto_type _mv_1161 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1161.has_value) {
-                                                    __auto_type type_expr = _mv_1161.value;
+                                                __auto_type _mv_1162 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1162.has_value) {
+                                                    __auto_type type_expr = _mv_1162.value;
                                                     transpiler_scan_type_for_generics(ctx, type_expr);
-                                                } else if (!_mv_1161.has_value) {
+                                                } else if (!_mv_1162.has_value) {
                                                 }
                                             }
                                         }
@@ -937,7 +937,7 @@ void transpiler_prescan_fn_params(context_TranspileContext* ctx, slop_list_types
                                         break;
                                     }
                                 }
-                            } else if (!_mv_1159.has_value) {
+                            } else if (!_mv_1160.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -948,7 +948,7 @@ void transpiler_prescan_fn_params(context_TranspileContext* ctx, slop_list_types
                     break;
                 }
             }
-        } else if (!_mv_1157.has_value) {
+        } else if (!_mv_1158.has_value) {
         }
     }
 }
@@ -959,29 +959,29 @@ slop_list_context_FuncParamType_ptr transpiler_prescan_collect_param_types(conte
         __auto_type arena = (*ctx).arena;
         __auto_type result = ((slop_list_context_FuncParamType_ptr){ .data = (context_FuncParamType**)slop_arena_alloc(arena, 16 * sizeof(context_FuncParamType*)), .len = 0, .cap = 16 });
         if (((int64_t)((items).len)) >= 3) {
-            __auto_type _mv_1162 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1162.has_value) {
-                __auto_type params_expr = _mv_1162.value;
-                __auto_type _mv_1163 = (*params_expr);
-                switch (_mv_1163.tag) {
+            __auto_type _mv_1163 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1163.has_value) {
+                __auto_type params_expr = _mv_1163.value;
+                __auto_type _mv_1164 = (*params_expr);
+                switch (_mv_1164.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type params_lst = _mv_1163.data.lst;
+                        __auto_type params_lst = _mv_1164.data.lst;
                         {
                             __auto_type params = params_lst.items;
                             __auto_type param_count = ((int64_t)((params).len));
                             __auto_type i = 0;
                             while (i < param_count) {
-                                __auto_type _mv_1164 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1164.has_value) {
-                                    __auto_type param_expr = _mv_1164.value;
+                                __auto_type _mv_1165 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1165.has_value) {
+                                    __auto_type param_expr = _mv_1165.value;
                                     {
                                         __auto_type c_type = transpiler_prescan_get_param_c_type(ctx, param_expr);
                                         __auto_type param_info = ((context_FuncParamType*)(({ __auto_type _alloc = (context_FuncParamType*)slop_arena_alloc(arena, sizeof(context_FuncParamType)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                                         (*param_info).c_type = c_type;
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (param_info); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
-                                } else if (!_mv_1164.has_value) {
+                                } else if (!_mv_1165.has_value) {
                                 }
                                 i = (i + 1);
                             }
@@ -992,7 +992,7 @@ slop_list_context_FuncParamType_ptr transpiler_prescan_collect_param_types(conte
                         break;
                     }
                 }
-            } else if (!_mv_1162.has_value) {
+            } else if (!_mv_1163.has_value) {
             }
         }
         return result;
@@ -1004,11 +1004,11 @@ slop_string transpiler_prescan_get_param_c_type(context_TranspileContext* ctx, t
     SLOP_PRE(((param != NULL)), "(!= param nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1165 = (*param);
-        switch (_mv_1165.tag) {
+        __auto_type _mv_1166 = (*param);
+        switch (_mv_1166.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1165.data.lst;
+                __auto_type lst = _mv_1166.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -1018,11 +1018,11 @@ slop_string transpiler_prescan_get_param_c_type(context_TranspileContext* ctx, t
                         {
                             __auto_type has_mode = ((len >= 3) && transpiler_prescan_is_param_mode(items));
                             __auto_type type_idx = ((has_mode) ? 2 : 1);
-                            __auto_type _mv_1166 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1166.has_value) {
-                                __auto_type type_expr = _mv_1166.value;
+                            __auto_type _mv_1167 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1167.has_value) {
+                                __auto_type type_expr = _mv_1167.value;
                                 return context_to_c_type_prefixed(ctx, type_expr);
-                            } else if (!_mv_1166.has_value) {
+                            } else if (!_mv_1167.has_value) {
                                 return SLOP_STR("void*");
                             }
                             SLOP_UNREACHABLE();
@@ -1041,14 +1041,14 @@ uint8_t transpiler_prescan_is_param_mode(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_1167 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1167.has_value) {
-            __auto_type first = _mv_1167.value;
-            __auto_type _mv_1168 = (*first);
-            switch (_mv_1168.tag) {
+        __auto_type _mv_1168 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1168.has_value) {
+            __auto_type first = _mv_1168.value;
+            __auto_type _mv_1169 = (*first);
+            switch (_mv_1169.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_1168.data.sym;
+                    __auto_type sym = _mv_1169.data.sym;
                     {
                         __auto_type name = sym.name;
                         if (string_eq(name, SLOP_STR("in"))) {
@@ -1068,7 +1068,7 @@ uint8_t transpiler_prescan_is_param_mode(slop_list_types_SExpr_ptr items) {
                     return 0;
                 }
             }
-        } else if (!_mv_1167.has_value) {
+        } else if (!_mv_1168.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -1082,13 +1082,13 @@ void transpiler_prescan_fn_result_type(context_TranspileContext* ctx, slop_list_
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 3;
         while (i < len) {
-            __auto_type _mv_1169 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1169.has_value) {
-                __auto_type item = _mv_1169.value;
+            __auto_type _mv_1170 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1170.has_value) {
+                __auto_type item = _mv_1170.value;
                 if (transpiler_is_spec_annotation(item)) {
                     transpiler_extract_result_type(ctx, item);
                 }
-            } else if (!_mv_1169.has_value) {
+            } else if (!_mv_1170.has_value) {
             }
             i = (i + 1);
         }
@@ -1097,31 +1097,31 @@ void transpiler_prescan_fn_result_type(context_TranspileContext* ctx, slop_list_
 
 uint8_t transpiler_is_spec_annotation(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1170 = (*expr);
-    switch (_mv_1170.tag) {
+    __auto_type _mv_1171 = (*expr);
+    switch (_mv_1171.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1170.data.lst;
+            __auto_type lst = _mv_1171.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1171 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1171.has_value) {
-                        __auto_type head = _mv_1171.value;
-                        __auto_type _mv_1172 = (*head);
-                        switch (_mv_1172.tag) {
+                    __auto_type _mv_1172 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1172.has_value) {
+                        __auto_type head = _mv_1172.value;
+                        __auto_type _mv_1173 = (*head);
+                        switch (_mv_1173.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1172.data.sym;
+                                __auto_type sym = _mv_1173.data.sym;
                                 return string_eq(sym.name, SLOP_STR("@spec"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1171.has_value) {
+                    } else if (!_mv_1172.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1139,32 +1139,32 @@ void transpiler_extract_result_type(context_TranspileContext* ctx, types_SExpr* 
     SLOP_PRE(((spec_expr != NULL)), "(!= spec-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1173 = (*spec_expr);
-        switch (_mv_1173.tag) {
+        __auto_type _mv_1174 = (*spec_expr);
+        switch (_mv_1174.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1173.data.lst;
+                __auto_type lst = _mv_1174.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_1174 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1174.has_value) {
-                            __auto_type spec_body = _mv_1174.value;
-                            __auto_type _mv_1175 = (*spec_body);
-                            switch (_mv_1175.tag) {
+                        __auto_type _mv_1175 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1175.has_value) {
+                            __auto_type spec_body = _mv_1175.value;
+                            __auto_type _mv_1176 = (*spec_body);
+                            switch (_mv_1176.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type body_lst = _mv_1175.data.lst;
+                                    __auto_type body_lst = _mv_1176.data.lst;
                                     {
                                         __auto_type body_items = body_lst.items;
                                         __auto_type body_len = ((int64_t)((body_items).len));
                                         if (body_len >= 1) {
-                                            __auto_type _mv_1176 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1176.has_value) {
-                                                __auto_type ret_type = _mv_1176.value;
+                                            __auto_type _mv_1177 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1177.has_value) {
+                                                __auto_type ret_type = _mv_1177.value;
                                                 transpiler_scan_type_for_generics(ctx, ret_type);
                                                 transpiler_check_and_register_result_type(ctx, ret_type);
-                                            } else if (!_mv_1176.has_value) {
+                                            } else if (!_mv_1177.has_value) {
                                             }
                                         }
                                     }
@@ -1174,7 +1174,7 @@ void transpiler_extract_result_type(context_TranspileContext* ctx, types_SExpr* 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1174.has_value) {
+                        } else if (!_mv_1175.has_value) {
                         }
                     }
                 }
@@ -1192,38 +1192,38 @@ void transpiler_check_and_register_result_type(context_TranspileContext* ctx, ty
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1177 = (*type_expr);
-        switch (_mv_1177.tag) {
+        __auto_type _mv_1178 = (*type_expr);
+        switch (_mv_1178.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1177.data.lst;
+                __auto_type lst = _mv_1178.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_1178 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1178.has_value) {
-                            __auto_type head = _mv_1178.value;
-                            __auto_type _mv_1179 = (*head);
-                            switch (_mv_1179.tag) {
+                        __auto_type _mv_1179 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1179.has_value) {
+                            __auto_type head = _mv_1179.value;
+                            __auto_type _mv_1180 = (*head);
+                            switch (_mv_1180.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1179.data.sym;
+                                    __auto_type sym = _mv_1180.data.sym;
                                     if (string_eq(sym.name, SLOP_STR("Result"))) {
-                                        __auto_type _mv_1180 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1180.has_value) {
-                                            __auto_type ok_type_expr = _mv_1180.value;
-                                            __auto_type _mv_1181 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1181.has_value) {
-                                                __auto_type err_type_expr = _mv_1181.value;
+                                        __auto_type _mv_1181 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1181.has_value) {
+                                            __auto_type ok_type_expr = _mv_1181.value;
+                                            __auto_type _mv_1182 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1182.has_value) {
+                                                __auto_type err_type_expr = _mv_1182.value;
                                                 {
                                                     __auto_type ok_c_type = context_to_c_type_prefixed(ctx, ok_type_expr);
                                                     __auto_type err_c_type = context_to_c_type_prefixed(ctx, err_type_expr);
                                                     __auto_type result_name = transpiler_build_result_type_name(ctx, ok_c_type, err_c_type);
                                                     context_ctx_register_result_type(ctx, ok_c_type, err_c_type, result_name);
                                                 }
-                                            } else if (!_mv_1181.has_value) {
+                                            } else if (!_mv_1182.has_value) {
                                             }
-                                        } else if (!_mv_1180.has_value) {
+                                        } else if (!_mv_1181.has_value) {
                                         }
                                     }
                                     break;
@@ -1232,7 +1232,7 @@ void transpiler_check_and_register_result_type(context_TranspileContext* ctx, ty
                                     break;
                                 }
                             }
-                        } else if (!_mv_1178.has_value) {
+                        } else if (!_mv_1179.has_value) {
                         }
                     }
                 }
@@ -1261,11 +1261,11 @@ void transpiler_prescan_fn_for_struct_keys(context_TranspileContext* ctx, slop_l
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 3;
         while (i < len) {
-            __auto_type _mv_1182 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1182.has_value) {
-                __auto_type item = _mv_1182.value;
+            __auto_type _mv_1183 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1183.has_value) {
+                __auto_type item = _mv_1183.value;
                 transpiler_prescan_expr_for_struct_keys(ctx, item);
-            } else if (!_mv_1182.has_value) {
+            } else if (!_mv_1183.has_value) {
             }
             i = (i + 1);
         }
@@ -1275,59 +1275,45 @@ void transpiler_prescan_fn_for_struct_keys(context_TranspileContext* ctx, slop_l
 void transpiler_prescan_expr_for_struct_keys(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1183 = (*expr);
-    switch (_mv_1183.tag) {
+    __auto_type _mv_1184 = (*expr);
+    switch (_mv_1184.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1183.data.lst;
+            __auto_type lst = _mv_1184.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 if (len >= 1) {
-                    __auto_type _mv_1184 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1184.has_value) {
-                        __auto_type head = _mv_1184.value;
-                        __auto_type _mv_1185 = (*head);
-                        switch (_mv_1185.tag) {
+                    __auto_type _mv_1185 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1185.has_value) {
+                        __auto_type head = _mv_1185.value;
+                        __auto_type _mv_1186 = (*head);
+                        switch (_mv_1186.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1185.data.sym;
+                                __auto_type sym = _mv_1186.data.sym;
                                 {
                                     __auto_type name = sym.name;
                                     if (string_eq(name, SLOP_STR("map-new"))) {
                                         if (len >= 3) {
-                                            __auto_type _mv_1186 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1186.has_value) {
-                                                __auto_type key_type_expr = _mv_1186.value;
+                                            __auto_type _mv_1187 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1187.has_value) {
+                                                __auto_type key_type_expr = _mv_1187.value;
                                                 transpiler_prescan_register_struct_key_type(ctx, key_type_expr);
-                                            } else if (!_mv_1186.has_value) {
+                                            } else if (!_mv_1187.has_value) {
                                             }
                                         }
                                     } else if (string_eq(name, SLOP_STR("set-new"))) {
                                         if (len >= 3) {
-                                            __auto_type _mv_1187 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1187.has_value) {
-                                                __auto_type elem_type_expr = _mv_1187.value;
+                                            __auto_type _mv_1188 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1188.has_value) {
+                                                __auto_type elem_type_expr = _mv_1188.value;
                                                 transpiler_prescan_register_struct_key_type(ctx, elem_type_expr);
-                                            } else if (!_mv_1187.has_value) {
+                                            } else if (!_mv_1188.has_value) {
                                             }
                                         }
                                     } else if (string_eq(name, SLOP_STR("chan-buffered"))) {
                                         if (len >= 4) {
-                                            __auto_type _mv_1188 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1188.has_value) {
-                                                __auto_type type_expr = _mv_1188.value;
-                                                {
-                                                    __auto_type elem_c = context_to_c_type_prefixed(ctx, type_expr);
-                                                    __auto_type elem_id = ctype_type_to_identifier((*ctx).arena, elem_c);
-                                                    __auto_type c_name = context_ctx_str(ctx, SLOP_STR("slop_chan_"), elem_id);
-                                                    context_ctx_register_chan_type(ctx, elem_c, c_name);
-                                                }
-                                            } else if (!_mv_1188.has_value) {
-                                            }
-                                        }
-                                    } else if (string_eq(name, SLOP_STR("chan"))) {
-                                        if (len >= 3) {
                                             __auto_type _mv_1189 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                             if (_mv_1189.has_value) {
                                                 __auto_type type_expr = _mv_1189.value;
@@ -1340,15 +1326,29 @@ void transpiler_prescan_expr_for_struct_keys(context_TranspileContext* ctx, type
                                             } else if (!_mv_1189.has_value) {
                                             }
                                         }
+                                    } else if (string_eq(name, SLOP_STR("chan"))) {
+                                        if (len >= 3) {
+                                            __auto_type _mv_1190 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1190.has_value) {
+                                                __auto_type type_expr = _mv_1190.value;
+                                                {
+                                                    __auto_type elem_c = context_to_c_type_prefixed(ctx, type_expr);
+                                                    __auto_type elem_id = ctype_type_to_identifier((*ctx).arena, elem_c);
+                                                    __auto_type c_name = context_ctx_str(ctx, SLOP_STR("slop_chan_"), elem_id);
+                                                    context_ctx_register_chan_type(ctx, elem_c, c_name);
+                                                }
+                                            } else if (!_mv_1190.has_value) {
+                                            }
+                                        }
                                     } else {
                                         {
                                             __auto_type i = 0;
                                             while (i < len) {
-                                                __auto_type _mv_1190 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1190.has_value) {
-                                                    __auto_type child = _mv_1190.value;
+                                                __auto_type _mv_1191 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1191.has_value) {
+                                                    __auto_type child = _mv_1191.value;
                                                     transpiler_prescan_expr_for_struct_keys(ctx, child);
-                                                } else if (!_mv_1190.has_value) {
+                                                } else if (!_mv_1191.has_value) {
                                                 }
                                                 i = (i + 1);
                                             }
@@ -1361,11 +1361,11 @@ void transpiler_prescan_expr_for_struct_keys(context_TranspileContext* ctx, type
                                 {
                                     __auto_type i = 0;
                                     while (i < len) {
-                                        __auto_type _mv_1191 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1191.has_value) {
-                                            __auto_type child = _mv_1191.value;
+                                        __auto_type _mv_1192 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1192.has_value) {
+                                            __auto_type child = _mv_1192.value;
                                             transpiler_prescan_expr_for_struct_keys(ctx, child);
-                                        } else if (!_mv_1191.has_value) {
+                                        } else if (!_mv_1192.has_value) {
                                         }
                                         i = (i + 1);
                                     }
@@ -1373,7 +1373,7 @@ void transpiler_prescan_expr_for_struct_keys(context_TranspileContext* ctx, type
                                 break;
                             }
                         }
-                    } else if (!_mv_1184.has_value) {
+                    } else if (!_mv_1185.has_value) {
                     }
                 }
             }
@@ -1390,33 +1390,33 @@ void transpiler_prescan_register_struct_key_type(context_TranspileContext* ctx, 
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1192 = (*type_expr);
-        switch (_mv_1192.tag) {
+        __auto_type _mv_1193 = (*type_expr);
+        switch (_mv_1193.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1192.data.sym;
+                __auto_type sym = _mv_1193.data.sym;
                 {
                     __auto_type name = sym.name;
                     if (!(transpiler_is_builtin_map_key_type(name))) {
-                        __auto_type _mv_1193 = context_ctx_lookup_type(ctx, name);
-                        if (_mv_1193.has_value) {
-                            __auto_type type_entry = _mv_1193.value;
+                        __auto_type _mv_1194 = context_ctx_lookup_type(ctx, name);
+                        if (_mv_1194.has_value) {
+                            __auto_type type_entry = _mv_1194.value;
                             context_ctx_register_struct_key_type(ctx, type_entry.c_name);
-                        } else if (!_mv_1193.has_value) {
-                            __auto_type _mv_1194 = context_ctx_get_module(ctx);
-                            if (_mv_1194.has_value) {
-                                __auto_type mod = _mv_1194.value;
+                        } else if (!_mv_1194.has_value) {
+                            __auto_type _mv_1195 = context_ctx_get_module(ctx);
+                            if (_mv_1195.has_value) {
+                                __auto_type mod = _mv_1195.value;
                                 {
                                     __auto_type prefixed = context_ctx_str3(ctx, mod, SLOP_STR("_"), name);
-                                    __auto_type _mv_1195 = context_ctx_lookup_type(ctx, prefixed);
-                                    if (_mv_1195.has_value) {
-                                        __auto_type type_entry = _mv_1195.value;
+                                    __auto_type _mv_1196 = context_ctx_lookup_type(ctx, prefixed);
+                                    if (_mv_1196.has_value) {
+                                        __auto_type type_entry = _mv_1196.value;
                                         context_ctx_register_struct_key_type(ctx, type_entry.c_name);
-                                    } else if (!_mv_1195.has_value) {
+                                    } else if (!_mv_1196.has_value) {
                                         context_ctx_register_struct_key_type(ctx, ctype_to_c_name(arena, name));
                                     }
                                 }
-                            } else if (!_mv_1194.has_value) {
+                            } else if (!_mv_1195.has_value) {
                                 context_ctx_register_struct_key_type(ctx, ctype_to_c_name(arena, name));
                             }
                         }
@@ -1440,29 +1440,29 @@ void transpiler_check_and_register_result_alias(context_TranspileContext* ctx, s
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1196 = (*body_expr);
-        switch (_mv_1196.tag) {
+        __auto_type _mv_1197 = (*body_expr);
+        switch (_mv_1197.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1196.data.lst;
+                __auto_type lst = _mv_1197.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_1197 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1197.has_value) {
-                            __auto_type head = _mv_1197.value;
-                            __auto_type _mv_1198 = (*head);
-                            switch (_mv_1198.tag) {
+                        __auto_type _mv_1198 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1198.has_value) {
+                            __auto_type head = _mv_1198.value;
+                            __auto_type _mv_1199 = (*head);
+                            switch (_mv_1199.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1198.data.sym;
+                                    __auto_type sym = _mv_1199.data.sym;
                                     if (string_eq(sym.name, SLOP_STR("Result"))) {
-                                        __auto_type _mv_1199 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1199.has_value) {
-                                            __auto_type ok_type_expr = _mv_1199.value;
-                                            __auto_type _mv_1200 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1200.has_value) {
-                                                __auto_type err_type_expr = _mv_1200.value;
+                                        __auto_type _mv_1200 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1200.has_value) {
+                                            __auto_type ok_type_expr = _mv_1200.value;
+                                            __auto_type _mv_1201 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1201.has_value) {
+                                                __auto_type err_type_expr = _mv_1201.value;
                                                 {
                                                     __auto_type ok_c_type = context_to_c_type_prefixed(ctx, ok_type_expr);
                                                     __auto_type err_c_type = context_to_c_type_prefixed(ctx, err_type_expr);
@@ -1470,9 +1470,9 @@ void transpiler_check_and_register_result_alias(context_TranspileContext* ctx, s
                                                     context_ctx_register_result_type_alias(ctx, alias_name, result_name);
                                                     context_ctx_register_result_type(ctx, ok_c_type, err_c_type, result_name);
                                                 }
-                                            } else if (!_mv_1200.has_value) {
+                                            } else if (!_mv_1201.has_value) {
                                             }
-                                        } else if (!_mv_1199.has_value) {
+                                        } else if (!_mv_1200.has_value) {
                                         }
                                     }
                                     break;
@@ -1481,7 +1481,7 @@ void transpiler_check_and_register_result_alias(context_TranspileContext* ctx, s
                                     break;
                                 }
                             }
-                        } else if (!_mv_1197.has_value) {
+                        } else if (!_mv_1198.has_value) {
                         }
                     }
                 }
@@ -1500,14 +1500,14 @@ void transpiler_prescan_ffi(context_TranspileContext* ctx, slop_list_types_SExpr
         __auto_type arena = (*ctx).arena;
         __auto_type len = ((int64_t)((items).len));
         if (len >= 2) {
-            __auto_type _mv_1201 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1201.has_value) {
-                __auto_type header_expr = _mv_1201.value;
-                __auto_type _mv_1202 = (*header_expr);
-                switch (_mv_1202.tag) {
+            __auto_type _mv_1202 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1202.has_value) {
+                __auto_type header_expr = _mv_1202.value;
+                __auto_type _mv_1203 = (*header_expr);
+                switch (_mv_1203.tag) {
                     case types_SExpr_str:
                     {
-                        __auto_type str = _mv_1202.data.str;
+                        __auto_type str = _mv_1203.data.str;
                         context_ctx_add_include(ctx, str.value);
                         break;
                     }
@@ -1515,16 +1515,16 @@ void transpiler_prescan_ffi(context_TranspileContext* ctx, slop_list_types_SExpr
                         break;
                     }
                 }
-            } else if (!_mv_1201.has_value) {
+            } else if (!_mv_1202.has_value) {
             }
             {
                 int64_t i = 2;
                 while (i < len) {
-                    __auto_type _mv_1203 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1203.has_value) {
-                        __auto_type func_decl = _mv_1203.value;
+                    __auto_type _mv_1204 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1204.has_value) {
+                        __auto_type func_decl = _mv_1204.value;
                         transpiler_register_ffi_function(ctx, func_decl);
-                    } else if (!_mv_1203.has_value) {
+                    } else if (!_mv_1204.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -1547,14 +1547,14 @@ uint8_t transpiler_is_type_name(slop_string name) {
 void transpiler_prescan_import(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     if (((int64_t)((items).len)) >= 3) {
-        __auto_type _mv_1204 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1204.has_value) {
-            __auto_type mod_expr = _mv_1204.value;
-            __auto_type _mv_1205 = (*mod_expr);
-            switch (_mv_1205.tag) {
+        __auto_type _mv_1205 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1205.has_value) {
+            __auto_type mod_expr = _mv_1205.value;
+            __auto_type _mv_1206 = (*mod_expr);
+            switch (_mv_1206.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type mod_sym = _mv_1205.data.sym;
+                    __auto_type mod_sym = _mv_1206.data.sym;
                     {
                         __auto_type mod_name = mod_sym.name;
                         __auto_type arena = (*ctx).arena;
@@ -1565,27 +1565,27 @@ void transpiler_prescan_import(context_TranspileContext* ctx, slop_list_types_SE
                         if (string_eq(mod_name, SLOP_STR("file"))) {
                             transpiler_register_file_module_variants(ctx);
                         }
-                        __auto_type _mv_1206 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1206.has_value) {
-                            __auto_type symbols_expr = _mv_1206.value;
-                            __auto_type _mv_1207 = (*symbols_expr);
-                            switch (_mv_1207.tag) {
+                        __auto_type _mv_1207 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1207.has_value) {
+                            __auto_type symbols_expr = _mv_1207.value;
+                            __auto_type _mv_1208 = (*symbols_expr);
+                            switch (_mv_1208.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type symbols_lst = _mv_1207.data.lst;
+                                    __auto_type symbols_lst = _mv_1208.data.lst;
                                     {
                                         __auto_type syms = symbols_lst.items;
                                         __auto_type sym_len = ((int64_t)((syms).len));
                                         __auto_type j = 0;
                                         while (j < sym_len) {
-                                            __auto_type _mv_1208 = ({ __auto_type _lst = syms; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1208.has_value) {
-                                                __auto_type sym_item = _mv_1208.value;
-                                                __auto_type _mv_1209 = (*sym_item);
-                                                switch (_mv_1209.tag) {
+                                            __auto_type _mv_1209 = ({ __auto_type _lst = syms; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1209.has_value) {
+                                                __auto_type sym_item = _mv_1209.value;
+                                                __auto_type _mv_1210 = (*sym_item);
+                                                switch (_mv_1210.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type s = _mv_1209.data.sym;
+                                                        __auto_type s = _mv_1210.data.sym;
                                                         {
                                                             __auto_type sym_name = s.name;
                                                             __auto_type c_mod_name = ctype_to_c_name(arena, mod_name);
@@ -1619,7 +1619,7 @@ void transpiler_prescan_import(context_TranspileContext* ctx, slop_list_types_SE
                                                         break;
                                                     }
                                                 }
-                                            } else if (!_mv_1208.has_value) {
+                                            } else if (!_mv_1209.has_value) {
                                             }
                                             j = (j + 1);
                                         }
@@ -1630,7 +1630,7 @@ void transpiler_prescan_import(context_TranspileContext* ctx, slop_list_types_SE
                                     break;
                                 }
                             }
-                        } else if (!_mv_1206.has_value) {
+                        } else if (!_mv_1207.has_value) {
                         }
                     }
                     break;
@@ -1639,7 +1639,7 @@ void transpiler_prescan_import(context_TranspileContext* ctx, slop_list_types_SE
                     break;
                 }
             }
-        } else if (!_mv_1204.has_value) {
+        } else if (!_mv_1205.has_value) {
         }
     }
 }
@@ -1685,14 +1685,14 @@ void transpiler_prescan_const(context_TranspileContext* ctx, slop_list_types_SEx
     {
         __auto_type arena = (*ctx).arena;
         if (((int64_t)((items).len)) >= 3) {
-            __auto_type _mv_1210 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1210.has_value) {
-                __auto_type name_expr = _mv_1210.value;
-                __auto_type _mv_1211 = (*name_expr);
-                switch (_mv_1211.tag) {
+            __auto_type _mv_1211 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1211.has_value) {
+                __auto_type name_expr = _mv_1211.value;
+                __auto_type _mv_1212 = (*name_expr);
+                switch (_mv_1212.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_1211.data.sym;
+                        __auto_type sym = _mv_1212.data.sym;
                         {
                             __auto_type const_name = sym.name;
                             __auto_type base_name = ctype_to_c_name(arena, const_name);
@@ -1705,7 +1705,7 @@ void transpiler_prescan_const(context_TranspileContext* ctx, slop_list_types_SEx
                         break;
                     }
                 }
-            } else if (!_mv_1210.has_value) {
+            } else if (!_mv_1211.has_value) {
             }
         }
     }
@@ -1716,23 +1716,23 @@ void transpiler_register_ffi_function(context_TranspileContext* ctx, types_SExpr
     SLOP_PRE(((func_decl != NULL)), "(!= func-decl nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1212 = (*func_decl);
-        switch (_mv_1212.tag) {
+        __auto_type _mv_1213 = (*func_decl);
+        switch (_mv_1213.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1212.data.lst;
+                __auto_type lst = _mv_1213.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 1) {
-                        __auto_type _mv_1213 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1213.has_value) {
-                            __auto_type name_expr = _mv_1213.value;
-                            __auto_type _mv_1214 = (*name_expr);
-                            switch (_mv_1214.tag) {
+                        __auto_type _mv_1214 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1214.has_value) {
+                            __auto_type name_expr = _mv_1214.value;
+                            __auto_type _mv_1215 = (*name_expr);
+                            switch (_mv_1215.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1214.data.sym;
+                                    __auto_type sym = _mv_1215.data.sym;
                                     {
                                         __auto_type fn_name = sym.name;
                                         __auto_type c_name = transpiler_extract_ffi_c_name(ctx, items, fn_name);
@@ -1749,7 +1749,7 @@ void transpiler_register_ffi_function(context_TranspileContext* ctx, types_SExpr
                                     break;
                                 }
                             }
-                        } else if (!_mv_1213.has_value) {
+                        } else if (!_mv_1214.has_value) {
                         }
                     }
                 }
@@ -1768,29 +1768,29 @@ slop_list_context_FuncParamType_ptr transpiler_extract_ffi_param_types(context_T
         __auto_type arena = (*ctx).arena;
         __auto_type result = ((slop_list_context_FuncParamType_ptr){ .data = (context_FuncParamType**)slop_arena_alloc(arena, 16 * sizeof(context_FuncParamType*)), .len = 0, .cap = 16 });
         if (((int64_t)((items).len)) >= 2) {
-            __auto_type _mv_1215 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1215.has_value) {
-                __auto_type params_expr = _mv_1215.value;
-                __auto_type _mv_1216 = (*params_expr);
-                switch (_mv_1216.tag) {
+            __auto_type _mv_1216 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1216.has_value) {
+                __auto_type params_expr = _mv_1216.value;
+                __auto_type _mv_1217 = (*params_expr);
+                switch (_mv_1217.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type params_lst = _mv_1216.data.lst;
+                        __auto_type params_lst = _mv_1217.data.lst;
                         {
                             __auto_type params = params_lst.items;
                             __auto_type param_count = ((int64_t)((params).len));
                             __auto_type i = 0;
                             while (i < param_count) {
-                                __auto_type _mv_1217 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1217.has_value) {
-                                    __auto_type param_expr = _mv_1217.value;
+                                __auto_type _mv_1218 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1218.has_value) {
+                                    __auto_type param_expr = _mv_1218.value;
                                     {
                                         __auto_type c_type = transpiler_prescan_get_param_c_type(ctx, param_expr);
                                         __auto_type param_info = ((context_FuncParamType*)(({ __auto_type _alloc = (context_FuncParamType*)slop_arena_alloc(arena, sizeof(context_FuncParamType)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                                         (*param_info).c_type = c_type;
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (param_info); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
-                                } else if (!_mv_1217.has_value) {
+                                } else if (!_mv_1218.has_value) {
                                 }
                                 i = (i + 1);
                             }
@@ -1801,7 +1801,7 @@ slop_list_context_FuncParamType_ptr transpiler_extract_ffi_param_types(context_T
                         break;
                     }
                 }
-            } else if (!_mv_1215.has_value) {
+            } else if (!_mv_1216.has_value) {
             }
         }
         return result;
@@ -1817,23 +1817,23 @@ slop_string transpiler_extract_ffi_c_name(context_TranspileContext* ctx, slop_li
         uint8_t found_c_name = 0;
         __auto_type c_name = SLOP_STR("");
         while (i < len) {
-            __auto_type _mv_1218 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1218.has_value) {
-                __auto_type item_expr = _mv_1218.value;
-                __auto_type _mv_1219 = (*item_expr);
-                switch (_mv_1219.tag) {
+            __auto_type _mv_1219 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1219.has_value) {
+                __auto_type item_expr = _mv_1219.value;
+                __auto_type _mv_1220 = (*item_expr);
+                switch (_mv_1220.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_1219.data.sym;
+                        __auto_type sym = _mv_1220.data.sym;
                         if (string_eq(sym.name, SLOP_STR(":c-name"))) {
-                            __auto_type _mv_1220 = ({ __auto_type _lst = items; size_t _idx = (size_t)(i + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1220.has_value) {
-                                __auto_type c_name_expr = _mv_1220.value;
-                                __auto_type _mv_1221 = (*c_name_expr);
-                                switch (_mv_1221.tag) {
+                            __auto_type _mv_1221 = ({ __auto_type _lst = items; size_t _idx = (size_t)(i + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1221.has_value) {
+                                __auto_type c_name_expr = _mv_1221.value;
+                                __auto_type _mv_1222 = (*c_name_expr);
+                                switch (_mv_1222.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type c_sym = _mv_1221.data.sym;
+                                        __auto_type c_sym = _mv_1222.data.sym;
                                         c_name = c_sym.name;
                                         found_c_name = 1;
                                         break;
@@ -1842,7 +1842,7 @@ slop_string transpiler_extract_ffi_c_name(context_TranspileContext* ctx, slop_li
                                         break;
                                     }
                                 }
-                            } else if (!_mv_1220.has_value) {
+                            } else if (!_mv_1221.has_value) {
                             }
                         }
                         break;
@@ -1851,7 +1851,7 @@ slop_string transpiler_extract_ffi_c_name(context_TranspileContext* ctx, slop_li
                         break;
                     }
                 }
-            } else if (!_mv_1218.has_value) {
+            } else if (!_mv_1219.has_value) {
             }
             i = (i + 1);
         }
@@ -1873,14 +1873,14 @@ void transpiler_prescan_ffi_struct(context_TranspileContext* ctx, slop_list_type
                 __auto_type has_header = ((len >= 2) && transpiler_is_ffi_string_item(items, 1));
                 __auto_type name_idx = ((((len >= 2) && transpiler_is_ffi_string_item(items, 1))) ? 2 : 1);
                 if (has_header) {
-                    __auto_type _mv_1222 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1222.has_value) {
-                        __auto_type header_expr = _mv_1222.value;
-                        __auto_type _mv_1223 = (*header_expr);
-                        switch (_mv_1223.tag) {
+                    __auto_type _mv_1223 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1223.has_value) {
+                        __auto_type header_expr = _mv_1223.value;
+                        __auto_type _mv_1224 = (*header_expr);
+                        switch (_mv_1224.tag) {
                             case types_SExpr_str:
                             {
-                                __auto_type str = _mv_1223.data.str;
+                                __auto_type str = _mv_1224.data.str;
                                 context_ctx_add_include(ctx, str.value);
                                 break;
                             }
@@ -1888,18 +1888,18 @@ void transpiler_prescan_ffi_struct(context_TranspileContext* ctx, slop_list_type
                                 break;
                             }
                         }
-                    } else if (!_mv_1222.has_value) {
+                    } else if (!_mv_1223.has_value) {
                     }
                 }
                 if (len >= (name_idx + 1)) {
-                    __auto_type _mv_1224 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1224.has_value) {
-                        __auto_type name_expr = _mv_1224.value;
-                        __auto_type _mv_1225 = (*name_expr);
-                        switch (_mv_1225.tag) {
+                    __auto_type _mv_1225 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1225.has_value) {
+                        __auto_type name_expr = _mv_1225.value;
+                        __auto_type _mv_1226 = (*name_expr);
+                        switch (_mv_1226.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1225.data.sym;
+                                __auto_type sym = _mv_1226.data.sym;
                                 {
                                     __auto_type type_name = sym.name;
                                     __auto_type c_name = transpiler_get_ffi_struct_c_name(arena, items, name_idx, type_name);
@@ -1911,7 +1911,7 @@ void transpiler_prescan_ffi_struct(context_TranspileContext* ctx, slop_list_type
                                 break;
                             }
                         }
-                    } else if (!_mv_1224.has_value) {
+                    } else if (!_mv_1225.has_value) {
                     }
                 }
             }
@@ -1924,30 +1924,30 @@ slop_string transpiler_get_ffi_struct_c_name(slop_arena* arena, slop_list_types_
         __auto_type len = ((int64_t)((items).len));
         __auto_type modifier_idx = (name_idx + 1);
         if (len >= (modifier_idx + 2)) {
-            __auto_type _mv_1226 = ({ __auto_type _lst = items; size_t _idx = (size_t)modifier_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1226.has_value) {
-                __auto_type mod_expr = _mv_1226.value;
-                __auto_type _mv_1227 = (*mod_expr);
-                switch (_mv_1227.tag) {
+            __auto_type _mv_1227 = ({ __auto_type _lst = items; size_t _idx = (size_t)modifier_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1227.has_value) {
+                __auto_type mod_expr = _mv_1227.value;
+                __auto_type _mv_1228 = (*mod_expr);
+                switch (_mv_1228.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_1227.data.sym;
+                        __auto_type sym = _mv_1228.data.sym;
                         if (string_eq(sym.name, SLOP_STR(":c-name"))) {
-                            __auto_type _mv_1228 = ({ __auto_type _lst = items; size_t _idx = (size_t)(modifier_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1228.has_value) {
-                                __auto_type cname_expr = _mv_1228.value;
-                                __auto_type _mv_1229 = (*cname_expr);
-                                switch (_mv_1229.tag) {
+                            __auto_type _mv_1229 = ({ __auto_type _lst = items; size_t _idx = (size_t)(modifier_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1229.has_value) {
+                                __auto_type cname_expr = _mv_1229.value;
+                                __auto_type _mv_1230 = (*cname_expr);
+                                switch (_mv_1230.tag) {
                                     case types_SExpr_str:
                                     {
-                                        __auto_type str = _mv_1229.data.str;
+                                        __auto_type str = _mv_1230.data.str;
                                         return transpiler_apply_struct_prefix_heuristic(arena, str.value);
                                     }
                                     default: {
                                         return transpiler_apply_struct_prefix_heuristic(arena, default_name);
                                     }
                                 }
-                            } else if (!_mv_1228.has_value) {
+                            } else if (!_mv_1229.has_value) {
                                 return transpiler_apply_struct_prefix_heuristic(arena, default_name);
                             }
                             SLOP_UNREACHABLE();
@@ -1959,7 +1959,7 @@ slop_string transpiler_get_ffi_struct_c_name(slop_arena* arena, slop_list_types_
                         return transpiler_apply_struct_prefix_heuristic(arena, default_name);
                     }
                 }
-            } else if (!_mv_1226.has_value) {
+            } else if (!_mv_1227.has_value) {
                 return transpiler_apply_struct_prefix_heuristic(arena, default_name);
             }
             SLOP_UNREACHABLE();
@@ -2005,21 +2005,21 @@ uint8_t transpiler_string_ends_with(slop_string s, slop_string suffix) {
 }
 
 uint8_t transpiler_is_ffi_string_item(slop_list_types_SExpr_ptr items, int64_t idx) {
-    __auto_type _mv_1230 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-    if (_mv_1230.has_value) {
-        __auto_type item = _mv_1230.value;
-        __auto_type _mv_1231 = (*item);
-        switch (_mv_1231.tag) {
+    __auto_type _mv_1231 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+    if (_mv_1231.has_value) {
+        __auto_type item = _mv_1231.value;
+        __auto_type _mv_1232 = (*item);
+        switch (_mv_1232.tag) {
             case types_SExpr_str:
             {
-                __auto_type _ = _mv_1231.data.str;
+                __auto_type _ = _mv_1232.data.str;
                 return 1;
             }
             default: {
                 return 0;
             }
         }
-    } else if (!_mv_1230.has_value) {
+    } else if (!_mv_1231.has_value) {
         return 0;
     }
     SLOP_UNREACHABLE();
@@ -2029,34 +2029,34 @@ uint8_t transpiler_is_enum_def(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 3) {
         return 0;
     } else {
-        __auto_type _mv_1232 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1232.has_value) {
-            __auto_type def_expr = _mv_1232.value;
-            __auto_type _mv_1233 = (*def_expr);
-            switch (_mv_1233.tag) {
+        __auto_type _mv_1233 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1233.has_value) {
+            __auto_type def_expr = _mv_1233.value;
+            __auto_type _mv_1234 = (*def_expr);
+            switch (_mv_1234.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type def_lst = _mv_1233.data.lst;
+                    __auto_type def_lst = _mv_1234.data.lst;
                     {
                         __auto_type def_items = def_lst.items;
                         if (((int64_t)((def_items).len)) < 1) {
                             return 0;
                         } else {
-                            __auto_type _mv_1234 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1234.has_value) {
-                                __auto_type head = _mv_1234.value;
-                                __auto_type _mv_1235 = (*head);
-                                switch (_mv_1235.tag) {
+                            __auto_type _mv_1235 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1235.has_value) {
+                                __auto_type head = _mv_1235.value;
+                                __auto_type _mv_1236 = (*head);
+                                switch (_mv_1236.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1235.data.sym;
+                                        __auto_type sym = _mv_1236.data.sym;
                                         return string_eq(sym.name, SLOP_STR("enum"));
                                     }
                                     default: {
                                         return 0;
                                     }
                                 }
-                            } else if (!_mv_1234.has_value) {
+                            } else if (!_mv_1235.has_value) {
                                 return 0;
                             }
                             SLOP_UNREACHABLE();
@@ -2067,7 +2067,7 @@ uint8_t transpiler_is_enum_def(slop_list_types_SExpr_ptr items) {
                     return 0;
                 }
             }
-        } else if (!_mv_1232.has_value) {
+        } else if (!_mv_1233.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -2078,34 +2078,34 @@ uint8_t transpiler_is_record_def(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 3) {
         return 0;
     } else {
-        __auto_type _mv_1236 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1236.has_value) {
-            __auto_type def_expr = _mv_1236.value;
-            __auto_type _mv_1237 = (*def_expr);
-            switch (_mv_1237.tag) {
+        __auto_type _mv_1237 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1237.has_value) {
+            __auto_type def_expr = _mv_1237.value;
+            __auto_type _mv_1238 = (*def_expr);
+            switch (_mv_1238.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type def_lst = _mv_1237.data.lst;
+                    __auto_type def_lst = _mv_1238.data.lst;
                     {
                         __auto_type def_items = def_lst.items;
                         if (((int64_t)((def_items).len)) < 1) {
                             return 0;
                         } else {
-                            __auto_type _mv_1238 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1238.has_value) {
-                                __auto_type head = _mv_1238.value;
-                                __auto_type _mv_1239 = (*head);
-                                switch (_mv_1239.tag) {
+                            __auto_type _mv_1239 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1239.has_value) {
+                                __auto_type head = _mv_1239.value;
+                                __auto_type _mv_1240 = (*head);
+                                switch (_mv_1240.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1239.data.sym;
+                                        __auto_type sym = _mv_1240.data.sym;
                                         return string_eq(sym.name, SLOP_STR("record"));
                                     }
                                     default: {
                                         return 0;
                                     }
                                 }
-                            } else if (!_mv_1238.has_value) {
+                            } else if (!_mv_1239.has_value) {
                                 return 0;
                             }
                             SLOP_UNREACHABLE();
@@ -2116,7 +2116,7 @@ uint8_t transpiler_is_record_def(slop_list_types_SExpr_ptr items) {
                     return 0;
                 }
             }
-        } else if (!_mv_1236.has_value) {
+        } else if (!_mv_1237.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -2127,34 +2127,34 @@ uint8_t transpiler_is_union_def(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 3) {
         return 0;
     } else {
-        __auto_type _mv_1240 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1240.has_value) {
-            __auto_type def_expr = _mv_1240.value;
-            __auto_type _mv_1241 = (*def_expr);
-            switch (_mv_1241.tag) {
+        __auto_type _mv_1241 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1241.has_value) {
+            __auto_type def_expr = _mv_1241.value;
+            __auto_type _mv_1242 = (*def_expr);
+            switch (_mv_1242.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type def_lst = _mv_1241.data.lst;
+                    __auto_type def_lst = _mv_1242.data.lst;
                     {
                         __auto_type def_items = def_lst.items;
                         if (((int64_t)((def_items).len)) < 1) {
                             return 0;
                         } else {
-                            __auto_type _mv_1242 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1242.has_value) {
-                                __auto_type head = _mv_1242.value;
-                                __auto_type _mv_1243 = (*head);
-                                switch (_mv_1243.tag) {
+                            __auto_type _mv_1243 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1243.has_value) {
+                                __auto_type head = _mv_1243.value;
+                                __auto_type _mv_1244 = (*head);
+                                switch (_mv_1244.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1243.data.sym;
+                                        __auto_type sym = _mv_1244.data.sym;
                                         return string_eq(sym.name, SLOP_STR("union"));
                                     }
                                     default: {
                                         return 0;
                                     }
                                 }
-                            } else if (!_mv_1242.has_value) {
+                            } else if (!_mv_1243.has_value) {
                                 return 0;
                             }
                             SLOP_UNREACHABLE();
@@ -2165,7 +2165,7 @@ uint8_t transpiler_is_union_def(slop_list_types_SExpr_ptr items) {
                     return 0;
                 }
             }
-        } else if (!_mv_1240.has_value) {
+        } else if (!_mv_1241.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -2177,36 +2177,36 @@ slop_string transpiler_get_array_c_type(context_TranspileContext* ctx, slop_list
     if (((int64_t)((items).len)) < 3) {
         return default_c_type;
     } else {
-        __auto_type _mv_1244 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1244.has_value) {
-            __auto_type body_expr = _mv_1244.value;
-            __auto_type _mv_1245 = (*body_expr);
-            switch (_mv_1245.tag) {
+        __auto_type _mv_1245 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1245.has_value) {
+            __auto_type body_expr = _mv_1245.value;
+            __auto_type _mv_1246 = (*body_expr);
+            switch (_mv_1246.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type body_lst = _mv_1245.data.lst;
+                    __auto_type body_lst = _mv_1246.data.lst;
                     {
                         __auto_type body_items = body_lst.items;
                         if (((int64_t)((body_items).len)) < 2) {
                             return default_c_type;
                         } else {
-                            __auto_type _mv_1246 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1246.has_value) {
-                                __auto_type head = _mv_1246.value;
-                                __auto_type _mv_1247 = (*head);
-                                switch (_mv_1247.tag) {
+                            __auto_type _mv_1247 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1247.has_value) {
+                                __auto_type head = _mv_1247.value;
+                                __auto_type _mv_1248 = (*head);
+                                switch (_mv_1248.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1247.data.sym;
+                                        __auto_type sym = _mv_1248.data.sym;
                                         if (string_eq(sym.name, SLOP_STR("Array"))) {
-                                            __auto_type _mv_1248 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1248.has_value) {
-                                                __auto_type elem_expr = _mv_1248.value;
+                                            __auto_type _mv_1249 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1249.has_value) {
+                                                __auto_type elem_expr = _mv_1249.value;
                                                 {
                                                     __auto_type elem_c = context_to_c_type_prefixed(ctx, elem_expr);
                                                     return context_ctx_str(ctx, elem_c, SLOP_STR("*"));
                                                 }
-                                            } else if (!_mv_1248.has_value) {
+                                            } else if (!_mv_1249.has_value) {
                                                 return default_c_type;
                                             }
                                             SLOP_UNREACHABLE();
@@ -2218,7 +2218,7 @@ slop_string transpiler_get_array_c_type(context_TranspileContext* ctx, slop_list
                                         return default_c_type;
                                     }
                                 }
-                            } else if (!_mv_1246.has_value) {
+                            } else if (!_mv_1247.has_value) {
                                 return default_c_type;
                             }
                             SLOP_UNREACHABLE();
@@ -2229,7 +2229,7 @@ slop_string transpiler_get_array_c_type(context_TranspileContext* ctx, slop_list
                     return default_c_type;
                 }
             }
-        } else if (!_mv_1244.has_value) {
+        } else if (!_mv_1245.has_value) {
             return default_c_type;
         }
         SLOP_UNREACHABLE();
@@ -2250,13 +2250,13 @@ void transpiler_emit_all_types(context_TranspileContext* ctx, slop_list_types_SE
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1249 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1249.has_value) {
-                __auto_type item = _mv_1249.value;
+            __auto_type _mv_1250 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1250.has_value) {
+                __auto_type item = _mv_1250.value;
                 if (transpiler_is_type_def(item) && !(transpiler_is_union_type_def(item))) {
                     defn_transpile_type(ctx, item);
                 }
-            } else if (!_mv_1249.has_value) {
+            } else if (!_mv_1250.has_value) {
             }
             i = (i + 1);
         }
@@ -2265,13 +2265,13 @@ void transpiler_emit_all_types(context_TranspileContext* ctx, slop_list_types_SE
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1250 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1250.has_value) {
-                __auto_type item = _mv_1250.value;
+            __auto_type _mv_1251 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1251.has_value) {
+                __auto_type item = _mv_1251.value;
                 if (transpiler_is_type_def(item) && transpiler_is_union_type_def(item)) {
                     defn_transpile_type(ctx, item);
                 }
-            } else if (!_mv_1250.has_value) {
+            } else if (!_mv_1251.has_value) {
             }
             i = (i + 1);
         }
@@ -2280,44 +2280,44 @@ void transpiler_emit_all_types(context_TranspileContext* ctx, slop_list_types_SE
 
 uint8_t transpiler_is_union_type_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1251 = (*item);
-    switch (_mv_1251.tag) {
+    __auto_type _mv_1252 = (*item);
+    switch (_mv_1252.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1251.data.lst;
+            __auto_type lst = _mv_1252.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 3) {
                     return 0;
                 } else {
-                    __auto_type _mv_1252 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1252.has_value) {
-                        __auto_type def_expr = _mv_1252.value;
-                        __auto_type _mv_1253 = (*def_expr);
-                        switch (_mv_1253.tag) {
+                    __auto_type _mv_1253 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1253.has_value) {
+                        __auto_type def_expr = _mv_1253.value;
+                        __auto_type _mv_1254 = (*def_expr);
+                        switch (_mv_1254.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type def_lst = _mv_1253.data.lst;
+                                __auto_type def_lst = _mv_1254.data.lst;
                                 {
                                     __auto_type def_items = def_lst.items;
                                     if (((int64_t)((def_items).len)) < 1) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1254 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1254.has_value) {
-                                            __auto_type head = _mv_1254.value;
-                                            __auto_type _mv_1255 = (*head);
-                                            switch (_mv_1255.tag) {
+                                        __auto_type _mv_1255 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1255.has_value) {
+                                            __auto_type head = _mv_1255.value;
+                                            __auto_type _mv_1256 = (*head);
+                                            switch (_mv_1256.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_1255.data.sym;
+                                                    __auto_type sym = _mv_1256.data.sym;
                                                     return string_eq(sym.name, SLOP_STR("union"));
                                                 }
                                                 default: {
                                                     return 0;
                                                 }
                                             }
-                                        } else if (!_mv_1254.has_value) {
+                                        } else if (!_mv_1255.has_value) {
                                             return 0;
                                         }
                                         SLOP_UNREACHABLE();
@@ -2328,7 +2328,7 @@ uint8_t transpiler_is_union_type_def(types_SExpr* item) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1252.has_value) {
+                    } else if (!_mv_1253.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2343,31 +2343,31 @@ uint8_t transpiler_is_union_type_def(types_SExpr* item) {
 
 uint8_t transpiler_is_type_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1256 = (*item);
-    switch (_mv_1256.tag) {
+    __auto_type _mv_1257 = (*item);
+    switch (_mv_1257.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1256.data.lst;
+            __auto_type lst = _mv_1257.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1257 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1257.has_value) {
-                        __auto_type head = _mv_1257.value;
-                        __auto_type _mv_1258 = (*head);
-                        switch (_mv_1258.tag) {
+                    __auto_type _mv_1258 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1258.has_value) {
+                        __auto_type head = _mv_1258.value;
+                        __auto_type _mv_1259 = (*head);
+                        switch (_mv_1259.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1258.data.sym;
+                                __auto_type sym = _mv_1259.data.sym;
                                 return string_eq(sym.name, SLOP_STR("type"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1257.has_value) {
+                    } else if (!_mv_1258.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2386,13 +2386,13 @@ void transpiler_emit_all_functions(context_TranspileContext* ctx, slop_list_type
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1259 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1259.has_value) {
-                __auto_type item = _mv_1259.value;
+            __auto_type _mv_1260 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1260.has_value) {
+                __auto_type item = _mv_1260.value;
                 if (transpiler_is_fn_def(item)) {
                     defn_transpile_function(ctx, item);
                 }
-            } else if (!_mv_1259.has_value) {
+            } else if (!_mv_1260.has_value) {
             }
             i = (i + 1);
         }
@@ -2401,31 +2401,31 @@ void transpiler_emit_all_functions(context_TranspileContext* ctx, slop_list_type
 
 uint8_t transpiler_is_fn_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1260 = (*item);
-    switch (_mv_1260.tag) {
+    __auto_type _mv_1261 = (*item);
+    switch (_mv_1261.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1260.data.lst;
+            __auto_type lst = _mv_1261.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1261 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1261.has_value) {
-                        __auto_type head = _mv_1261.value;
-                        __auto_type _mv_1262 = (*head);
-                        switch (_mv_1262.tag) {
+                    __auto_type _mv_1262 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1262.has_value) {
+                        __auto_type head = _mv_1262.value;
+                        __auto_type _mv_1263 = (*head);
+                        switch (_mv_1263.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1262.data.sym;
+                                __auto_type sym = _mv_1263.data.sym;
                                 return string_eq(sym.name, SLOP_STR("fn"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1261.has_value) {
+                    } else if (!_mv_1262.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2443,23 +2443,23 @@ void transpiler_transpile_module(context_TranspileContext* ctx, types_SExpr* mod
     SLOP_PRE(((module_expr != NULL)), "(!= module-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1263 = (*module_expr);
-        switch (_mv_1263.tag) {
+        __auto_type _mv_1264 = (*module_expr);
+        switch (_mv_1264.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1263.data.lst;
+                __auto_type lst = _mv_1264.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 2) {
-                        __auto_type _mv_1264 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1264.has_value) {
-                            __auto_type name_expr = _mv_1264.value;
-                            __auto_type _mv_1265 = (*name_expr);
-                            switch (_mv_1265.tag) {
+                        __auto_type _mv_1265 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1265.has_value) {
+                            __auto_type name_expr = _mv_1265.value;
+                            __auto_type _mv_1266 = (*name_expr);
+                            switch (_mv_1266.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1265.data.sym;
+                                    __auto_type sym = _mv_1266.data.sym;
                                     context_ctx_set_module(ctx, (slop_option_string){.has_value = 1, .value = sym.name});
                                     break;
                                 }
@@ -2467,7 +2467,7 @@ void transpiler_transpile_module(context_TranspileContext* ctx, types_SExpr* mod
                                     break;
                                 }
                             }
-                        } else if (!_mv_1264.has_value) {
+                        } else if (!_mv_1265.has_value) {
                         }
                         {
                             __auto_type body_start = transpiler_get_body_start(items);
@@ -2524,27 +2524,27 @@ int64_t transpiler_get_body_start(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 3) {
         return 2;
     } else {
-        __auto_type _mv_1266 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1266.has_value) {
-            __auto_type third = _mv_1266.value;
-            __auto_type _mv_1267 = (*third);
-            switch (_mv_1267.tag) {
+        __auto_type _mv_1267 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1267.has_value) {
+            __auto_type third = _mv_1267.value;
+            __auto_type _mv_1268 = (*third);
+            switch (_mv_1268.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type lst = _mv_1267.data.lst;
+                    __auto_type lst = _mv_1268.data.lst;
                     {
                         __auto_type sub_items = lst.items;
                         if (((int64_t)((sub_items).len)) < 1) {
                             return 2;
                         } else {
-                            __auto_type _mv_1268 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1268.has_value) {
-                                __auto_type head = _mv_1268.value;
-                                __auto_type _mv_1269 = (*head);
-                                switch (_mv_1269.tag) {
+                            __auto_type _mv_1269 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1269.has_value) {
+                                __auto_type head = _mv_1269.value;
+                                __auto_type _mv_1270 = (*head);
+                                switch (_mv_1270.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1269.data.sym;
+                                        __auto_type sym = _mv_1270.data.sym;
                                         if (string_eq(sym.name, SLOP_STR("export"))) {
                                             return 3;
                                         } else {
@@ -2555,7 +2555,7 @@ int64_t transpiler_get_body_start(slop_list_types_SExpr_ptr items) {
                                         return 2;
                                     }
                                 }
-                            } else if (!_mv_1268.has_value) {
+                            } else if (!_mv_1269.has_value) {
                                 return 2;
                             }
                             SLOP_UNREACHABLE();
@@ -2566,7 +2566,7 @@ int64_t transpiler_get_body_start(slop_list_types_SExpr_ptr items) {
                     return 2;
                 }
             }
-        } else if (!_mv_1266.has_value) {
+        } else if (!_mv_1267.has_value) {
             return 2;
         }
         SLOP_UNREACHABLE();
@@ -2579,38 +2579,38 @@ slop_list_string transpiler_get_export_names(slop_arena* arena, slop_list_types_
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 2;
         while (i < len) {
-            __auto_type _mv_1270 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1270.has_value) {
-                __auto_type item = _mv_1270.value;
-                __auto_type _mv_1271 = (*item);
-                switch (_mv_1271.tag) {
+            __auto_type _mv_1271 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1271.has_value) {
+                __auto_type item = _mv_1271.value;
+                __auto_type _mv_1272 = (*item);
+                switch (_mv_1272.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type lst = _mv_1271.data.lst;
+                        __auto_type lst = _mv_1272.data.lst;
                         {
                             __auto_type sub_items = lst.items;
                             if (((int64_t)((sub_items).len)) >= 1) {
-                                __auto_type _mv_1272 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1272.has_value) {
-                                    __auto_type head = _mv_1272.value;
-                                    __auto_type _mv_1273 = (*head);
-                                    switch (_mv_1273.tag) {
+                                __auto_type _mv_1273 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1273.has_value) {
+                                    __auto_type head = _mv_1273.value;
+                                    __auto_type _mv_1274 = (*head);
+                                    switch (_mv_1274.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_1273.data.sym;
+                                            __auto_type sym = _mv_1274.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("export"))) {
                                                 {
                                                     __auto_type export_len = ((int64_t)((sub_items).len));
                                                     __auto_type j = 1;
                                                     while (j < export_len) {
-                                                        __auto_type _mv_1274 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                        if (_mv_1274.has_value) {
-                                                            __auto_type name_expr = _mv_1274.value;
-                                                            __auto_type _mv_1275 = (*name_expr);
-                                                            switch (_mv_1275.tag) {
+                                                        __auto_type _mv_1275 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                        if (_mv_1275.has_value) {
+                                                            __auto_type name_expr = _mv_1275.value;
+                                                            __auto_type _mv_1276 = (*name_expr);
+                                                            switch (_mv_1276.tag) {
                                                                 case types_SExpr_sym:
                                                                 {
-                                                                    __auto_type name_sym = _mv_1275.data.sym;
+                                                                    __auto_type name_sym = _mv_1276.data.sym;
                                                                     ({ __auto_type _lst_p = &(result); __auto_type _item = (name_sym.name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                                     break;
                                                                 }
@@ -2618,7 +2618,7 @@ slop_list_string transpiler_get_export_names(slop_arena* arena, slop_list_types_
                                                                     break;
                                                                 }
                                                             }
-                                                        } else if (!_mv_1274.has_value) {
+                                                        } else if (!_mv_1275.has_value) {
                                                         }
                                                         j = (j + 1);
                                                     }
@@ -2630,7 +2630,7 @@ slop_list_string transpiler_get_export_names(slop_arena* arena, slop_list_types_
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1272.has_value) {
+                                } else if (!_mv_1273.has_value) {
                                 }
                             }
                         }
@@ -2640,7 +2640,7 @@ slop_list_string transpiler_get_export_names(slop_arena* arena, slop_list_types_
                         break;
                     }
                 }
-            } else if (!_mv_1270.has_value) {
+            } else if (!_mv_1271.has_value) {
             }
             i = (i + 1);
         }
@@ -2654,13 +2654,13 @@ uint8_t transpiler_list_contains_str(slop_list_string lst, slop_string needle) {
         int64_t i = 0;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1276 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1276.has_value) {
-                __auto_type s = _mv_1276.value;
+            __auto_type _mv_1277 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1277.has_value) {
+                __auto_type s = _mv_1277.value;
                 if (string_eq(s, needle)) {
                     found = 1;
                 }
-            } else if (!_mv_1276.has_value) {
+            } else if (!_mv_1277.has_value) {
             }
             i = (i + 1);
         }
@@ -2674,11 +2674,11 @@ void transpiler_prescan_module_body(context_TranspileContext* ctx, slop_list_typ
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1277 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1277.has_value) {
-                __auto_type item = _mv_1277.value;
+            __auto_type _mv_1278 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1278.has_value) {
+                __auto_type item = _mv_1278.value;
                 transpiler_prescan_top_level(ctx, item);
-            } else if (!_mv_1277.has_value) {
+            } else if (!_mv_1278.has_value) {
             }
             i = (i + 1);
         }
@@ -2690,30 +2690,30 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1278 = (*type_expr);
-        switch (_mv_1278.tag) {
+        __auto_type _mv_1279 = (*type_expr);
+        switch (_mv_1279.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1278.data.lst;
+                __auto_type lst = _mv_1279.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 1) {
-                        __auto_type _mv_1279 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1279.has_value) {
-                            __auto_type head = _mv_1279.value;
-                            __auto_type _mv_1280 = (*head);
-                            switch (_mv_1280.tag) {
+                        __auto_type _mv_1280 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1280.has_value) {
+                            __auto_type head = _mv_1280.value;
+                            __auto_type _mv_1281 = (*head);
+                            switch (_mv_1281.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1280.data.sym;
+                                    __auto_type sym = _mv_1281.data.sym;
                                     {
                                         __auto_type op = sym.name;
                                         if (string_eq(op, SLOP_STR("Option"))) {
                                             if (len >= 2) {
-                                                __auto_type _mv_1281 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1281.has_value) {
-                                                    __auto_type inner = _mv_1281.value;
+                                                __auto_type _mv_1282 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1282.has_value) {
+                                                    __auto_type inner = _mv_1282.value;
                                                     {
                                                         __auto_type inner_c = context_to_c_type_prefixed(ctx, inner);
                                                         __auto_type inner_id = ctype_type_to_identifier(arena, inner_c);
@@ -2721,14 +2721,14 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                         context_ctx_register_option_type(ctx, inner_c, c_name);
                                                         transpiler_scan_type_for_generics(ctx, inner);
                                                     }
-                                                } else if (!_mv_1281.has_value) {
+                                                } else if (!_mv_1282.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("List"))) {
                                             if (len >= 2) {
-                                                __auto_type _mv_1282 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1282.has_value) {
-                                                    __auto_type elem = _mv_1282.value;
+                                                __auto_type _mv_1283 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1283.has_value) {
+                                                    __auto_type elem = _mv_1283.value;
                                                     {
                                                         __auto_type elem_c = context_to_c_type_prefixed(ctx, elem);
                                                         __auto_type elem_id = ctype_type_to_identifier(arena, elem_c);
@@ -2738,26 +2738,26 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                         context_ctx_register_option_type(ctx, elem_c, option_c_name);
                                                         transpiler_scan_type_for_generics(ctx, elem);
                                                     }
-                                                } else if (!_mv_1282.has_value) {
+                                                } else if (!_mv_1283.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("Ptr"))) {
                                             if (len >= 2) {
-                                                __auto_type _mv_1283 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1283.has_value) {
-                                                    __auto_type inner = _mv_1283.value;
+                                                __auto_type _mv_1284 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1284.has_value) {
+                                                    __auto_type inner = _mv_1284.value;
                                                     transpiler_scan_type_for_generics(ctx, inner);
-                                                } else if (!_mv_1283.has_value) {
+                                                } else if (!_mv_1284.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("Result"))) {
                                             if (len >= 3) {
-                                                __auto_type _mv_1284 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1284.has_value) {
-                                                    __auto_type ok_type = _mv_1284.value;
-                                                    __auto_type _mv_1285 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1285.has_value) {
-                                                        __auto_type err_type = _mv_1285.value;
+                                                __auto_type _mv_1285 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1285.has_value) {
+                                                    __auto_type ok_type = _mv_1285.value;
+                                                    __auto_type _mv_1286 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1286.has_value) {
+                                                        __auto_type err_type = _mv_1286.value;
                                                         {
                                                             __auto_type ok_c = context_to_c_type_prefixed(ctx, ok_type);
                                                             __auto_type err_c = context_to_c_type_prefixed(ctx, err_type);
@@ -2768,16 +2768,16 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                             transpiler_scan_type_for_generics(ctx, ok_type);
                                                             transpiler_scan_type_for_generics(ctx, err_type);
                                                         }
-                                                    } else if (!_mv_1285.has_value) {
+                                                    } else if (!_mv_1286.has_value) {
                                                     }
-                                                } else if (!_mv_1284.has_value) {
+                                                } else if (!_mv_1285.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("Chan"))) {
                                             if (len >= 2) {
-                                                __auto_type _mv_1286 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1286.has_value) {
-                                                    __auto_type elem = _mv_1286.value;
+                                                __auto_type _mv_1287 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1287.has_value) {
+                                                    __auto_type elem = _mv_1287.value;
                                                     {
                                                         __auto_type elem_c = context_to_c_type_prefixed(ctx, elem);
                                                         __auto_type elem_id = ctype_type_to_identifier(arena, elem_c);
@@ -2785,14 +2785,14 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                         context_ctx_register_chan_type(ctx, elem_c, c_name);
                                                         transpiler_scan_type_for_generics(ctx, elem);
                                                     }
-                                                } else if (!_mv_1286.has_value) {
+                                                } else if (!_mv_1287.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("Thread"))) {
                                             if (len >= 2) {
-                                                __auto_type _mv_1287 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1287.has_value) {
-                                                    __auto_type result = _mv_1287.value;
+                                                __auto_type _mv_1288 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1288.has_value) {
+                                                    __auto_type result = _mv_1288.value;
                                                     {
                                                         __auto_type result_c = context_to_c_type_prefixed(ctx, result);
                                                         {
@@ -2803,14 +2803,14 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                             transpiler_scan_type_for_generics(ctx, result);
                                                         }
                                                     }
-                                                } else if (!_mv_1287.has_value) {
+                                                } else if (!_mv_1288.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("Map"))) {
                                             if (len >= 3) {
-                                                __auto_type _mv_1288 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1288.has_value) {
-                                                    __auto_type key_type = _mv_1288.value;
+                                                __auto_type _mv_1289 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1289.has_value) {
+                                                    __auto_type key_type = _mv_1289.value;
                                                     {
                                                         __auto_type key_c = context_to_c_type_prefixed(ctx, key_type);
                                                         __auto_type key_id = ctype_type_to_identifier(arena, key_c);
@@ -2819,9 +2819,9 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                         context_ctx_register_list_type(ctx, key_c, list_c_name);
                                                         context_ctx_register_option_type(ctx, key_c, option_c_name);
                                                         transpiler_scan_type_for_generics(ctx, key_type);
-                                                        __auto_type _mv_1289 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                        if (_mv_1289.has_value) {
-                                                            __auto_type val_type = _mv_1289.value;
+                                                        __auto_type _mv_1290 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                        if (_mv_1290.has_value) {
+                                                            __auto_type val_type = _mv_1290.value;
                                                             {
                                                                 __auto_type val_c = context_to_c_type_prefixed(ctx, val_type);
                                                                 __auto_type val_id = ctype_type_to_identifier(arena, val_c);
@@ -2829,17 +2829,17 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                                 context_ctx_register_option_type(ctx, val_c, val_option_c_name);
                                                                 transpiler_scan_type_for_generics(ctx, val_type);
                                                             }
-                                                        } else if (!_mv_1289.has_value) {
+                                                        } else if (!_mv_1290.has_value) {
                                                         }
                                                     }
-                                                } else if (!_mv_1288.has_value) {
+                                                } else if (!_mv_1289.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("Set"))) {
                                             if (len >= 2) {
-                                                __auto_type _mv_1290 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1290.has_value) {
-                                                    __auto_type elem_type = _mv_1290.value;
+                                                __auto_type _mv_1291 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1291.has_value) {
+                                                    __auto_type elem_type = _mv_1291.value;
                                                     {
                                                         __auto_type elem_c = context_to_c_type_prefixed(ctx, elem_type);
                                                         __auto_type elem_id = ctype_type_to_identifier(arena, elem_c);
@@ -2849,7 +2849,7 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                         context_ctx_register_option_type(ctx, elem_c, option_c_name);
                                                         transpiler_scan_type_for_generics(ctx, elem_type);
                                                     }
-                                                } else if (!_mv_1290.has_value) {
+                                                } else if (!_mv_1291.has_value) {
                                                 }
                                             }
                                         } else {
@@ -2861,7 +2861,7 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                     break;
                                 }
                             }
-                        } else if (!_mv_1279.has_value) {
+                        } else if (!_mv_1280.has_value) {
                         }
                     }
                 }
@@ -2880,22 +2880,22 @@ void transpiler_scan_record_fields_for_generics(context_TranspileContext* ctx, s
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1291 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1291.has_value) {
-                __auto_type field_expr = _mv_1291.value;
-                __auto_type _mv_1292 = (*field_expr);
-                switch (_mv_1292.tag) {
+            __auto_type _mv_1292 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1292.has_value) {
+                __auto_type field_expr = _mv_1292.value;
+                __auto_type _mv_1293 = (*field_expr);
+                switch (_mv_1293.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type field_lst = _mv_1292.data.lst;
+                        __auto_type field_lst = _mv_1293.data.lst;
                         {
                             __auto_type field_items = field_lst.items;
                             if (((int64_t)((field_items).len)) >= 2) {
-                                __auto_type _mv_1293 = ({ __auto_type _lst = field_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1293.has_value) {
-                                    __auto_type type_expr = _mv_1293.value;
+                                __auto_type _mv_1294 = ({ __auto_type _lst = field_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1294.has_value) {
+                                    __auto_type type_expr = _mv_1294.value;
                                     transpiler_scan_type_for_generics(ctx, type_expr);
-                                } else if (!_mv_1293.has_value) {
+                                } else if (!_mv_1294.has_value) {
                                 }
                             }
                         }
@@ -2905,7 +2905,7 @@ void transpiler_scan_record_fields_for_generics(context_TranspileContext* ctx, s
                         break;
                     }
                 }
-            } else if (!_mv_1291.has_value) {
+            } else if (!_mv_1292.has_value) {
             }
             i = (i + 1);
         }
@@ -2919,11 +2919,11 @@ void transpiler_emit_ffi_includes(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((includes).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1294 = ({ __auto_type _lst = includes; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1294.has_value) {
-                __auto_type header = _mv_1294.value;
+            __auto_type _mv_1295 = ({ __auto_type _lst = includes; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1295.has_value) {
+                __auto_type header = _mv_1295.value;
                 emit_emit_include(ctx, header, 1);
-            } else if (!_mv_1294.has_value) {
+            } else if (!_mv_1295.has_value) {
             }
             i = (i + 1);
         }
@@ -2937,11 +2937,11 @@ void transpiler_emit_ffi_includes_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((includes).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1295 = ({ __auto_type _lst = includes; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1295.has_value) {
-                __auto_type header = _mv_1295.value;
+            __auto_type _mv_1296 = ({ __auto_type _lst = includes; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1296.has_value) {
+                __auto_type header = _mv_1296.value;
                 context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("#include <"), header, SLOP_STR(">")));
-            } else if (!_mv_1295.has_value) {
+            } else if (!_mv_1296.has_value) {
             }
             i = (i + 1);
         }
@@ -2952,9 +2952,9 @@ void transpiler_emit_header_guard_open(context_TranspileContext* ctx) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1296 = context_ctx_get_module(ctx);
-        if (_mv_1296.has_value) {
-            __auto_type mod_name = _mv_1296.value;
+        __auto_type _mv_1297 = context_ctx_get_module(ctx);
+        if (_mv_1297.has_value) {
+            __auto_type mod_name = _mv_1297.value;
             {
                 __auto_type c_name = ctype_to_c_name(arena, mod_name);
                 __auto_type guard = context_ctx_str3(ctx, SLOP_STR("SLOP_"), c_name, SLOP_STR("_H"));
@@ -2962,7 +2962,7 @@ void transpiler_emit_header_guard_open(context_TranspileContext* ctx) {
                 context_ctx_emit_header(ctx, context_ctx_str(ctx, SLOP_STR("#define "), guard));
                 context_ctx_emit_header(ctx, SLOP_STR(""));
             }
-        } else if (!_mv_1296.has_value) {
+        } else if (!_mv_1297.has_value) {
         }
     }
 }
@@ -2988,14 +2988,14 @@ void transpiler_emit_header_dependency_includes(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((imports).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1297 = ({ __auto_type _lst = imports; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1297.has_value) {
-                __auto_type mod_name = _mv_1297.value;
+            __auto_type _mv_1298 = ({ __auto_type _lst = imports; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1298.has_value) {
+                __auto_type mod_name = _mv_1298.value;
                 {
                     __auto_type c_name = ctype_to_c_name(arena, mod_name);
                     context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("#include \"slop_"), c_name, SLOP_STR(".h\"")));
                 }
-            } else if (!_mv_1297.has_value) {
+            } else if (!_mv_1298.has_value) {
             }
             i = (i + 1);
         }
@@ -3010,22 +3010,22 @@ void transpiler_emit_forward_decls(context_TranspileContext* ctx, slop_list_type
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1298 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1298.has_value) {
-                __auto_type item = _mv_1298.value;
+            __auto_type _mv_1299 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1299.has_value) {
+                __auto_type item = _mv_1299.value;
                 if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
-                    __auto_type _mv_1299 = transpiler_get_type_name(item);
-                    if (_mv_1299.has_value) {
-                        __auto_type type_name = _mv_1299.value;
+                    __auto_type _mv_1300 = transpiler_get_type_name(item);
+                    if (_mv_1300.has_value) {
+                        __auto_type type_name = _mv_1300.value;
                         {
                             __auto_type c_name = ctype_to_c_name(arena, type_name);
                             context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("typedef struct "), c_name, context_ctx_str(ctx, SLOP_STR(" "), context_ctx_str(ctx, c_name, SLOP_STR(";")))));
                             emitted_any = 1;
                         }
-                    } else if (!_mv_1299.has_value) {
+                    } else if (!_mv_1300.has_value) {
                     }
                 }
-            } else if (!_mv_1298.has_value) {
+            } else if (!_mv_1299.has_value) {
             }
             i = (i + 1);
         }
@@ -3037,37 +3037,37 @@ void transpiler_emit_forward_decls(context_TranspileContext* ctx, slop_list_type
 
 uint8_t transpiler_is_struct_type_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1300 = (*item);
-    switch (_mv_1300.tag) {
+    __auto_type _mv_1301 = (*item);
+    switch (_mv_1301.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1300.data.lst;
+            __auto_type lst = _mv_1301.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 3) {
                     return 0;
                 } else {
-                    __auto_type _mv_1301 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1301.has_value) {
-                        __auto_type def_expr = _mv_1301.value;
-                        __auto_type _mv_1302 = (*def_expr);
-                        switch (_mv_1302.tag) {
+                    __auto_type _mv_1302 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1302.has_value) {
+                        __auto_type def_expr = _mv_1302.value;
+                        __auto_type _mv_1303 = (*def_expr);
+                        switch (_mv_1303.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type def_lst = _mv_1302.data.lst;
+                                __auto_type def_lst = _mv_1303.data.lst;
                                 {
                                     __auto_type def_items = def_lst.items;
                                     if (((int64_t)((def_items).len)) < 1) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1303 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1303.has_value) {
-                                            __auto_type head = _mv_1303.value;
-                                            __auto_type _mv_1304 = (*head);
-                                            switch (_mv_1304.tag) {
+                                        __auto_type _mv_1304 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1304.has_value) {
+                                            __auto_type head = _mv_1304.value;
+                                            __auto_type _mv_1305 = (*head);
+                                            switch (_mv_1305.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_1304.data.sym;
+                                                    __auto_type sym = _mv_1305.data.sym;
                                                     {
                                                         __auto_type kind = sym.name;
                                                         return ((string_eq(kind, SLOP_STR("record"))) || (string_eq(kind, SLOP_STR("union"))) || ((string_eq(kind, SLOP_STR("enum")) && transpiler_has_enum_payload_variants(def_items))));
@@ -3077,7 +3077,7 @@ uint8_t transpiler_is_struct_type_def(types_SExpr* item) {
                                                     return 0;
                                                 }
                                             }
-                                        } else if (!_mv_1303.has_value) {
+                                        } else if (!_mv_1304.has_value) {
                                             return 0;
                                         }
                                         SLOP_UNREACHABLE();
@@ -3088,7 +3088,7 @@ uint8_t transpiler_is_struct_type_def(types_SExpr* item) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1301.has_value) {
+                    } else if (!_mv_1302.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -3107,14 +3107,14 @@ uint8_t transpiler_has_enum_payload_variants(slop_list_types_SExpr_ptr items) {
         int64_t i = 1;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1305 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1305.has_value) {
-                __auto_type item = _mv_1305.value;
-                __auto_type _mv_1306 = (*item);
-                switch (_mv_1306.tag) {
+            __auto_type _mv_1306 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1306.has_value) {
+                __auto_type item = _mv_1306.value;
+                __auto_type _mv_1307 = (*item);
+                switch (_mv_1307.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type _ = _mv_1306.data.lst;
+                        __auto_type _ = _mv_1307.data.lst;
                         found = 1;
                         break;
                     }
@@ -3122,7 +3122,7 @@ uint8_t transpiler_has_enum_payload_variants(slop_list_types_SExpr_ptr items) {
                         break;
                     }
                 }
-            } else if (!_mv_1305.has_value) {
+            } else if (!_mv_1306.has_value) {
             }
             i = (i + 1);
         }
@@ -3132,42 +3132,42 @@ uint8_t transpiler_has_enum_payload_variants(slop_list_types_SExpr_ptr items) {
 
 uint8_t transpiler_is_type_alias_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1307 = (*item);
-    switch (_mv_1307.tag) {
+    __auto_type _mv_1308 = (*item);
+    switch (_mv_1308.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1307.data.lst;
+            __auto_type lst = _mv_1308.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 3) {
                     return 0;
                 } else {
-                    __auto_type _mv_1308 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1308.has_value) {
-                        __auto_type def_expr = _mv_1308.value;
-                        __auto_type _mv_1309 = (*def_expr);
-                        switch (_mv_1309.tag) {
+                    __auto_type _mv_1309 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1309.has_value) {
+                        __auto_type def_expr = _mv_1309.value;
+                        __auto_type _mv_1310 = (*def_expr);
+                        switch (_mv_1310.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type _ = _mv_1309.data.sym;
+                                __auto_type _ = _mv_1310.data.sym;
                                 return 1;
                             }
                             case types_SExpr_lst:
                             {
-                                __auto_type def_lst = _mv_1309.data.lst;
+                                __auto_type def_lst = _mv_1310.data.lst;
                                 {
                                     __auto_type def_items = def_lst.items;
                                     if (((int64_t)((def_items).len)) < 1) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1310 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1310.has_value) {
-                                            __auto_type head = _mv_1310.value;
-                                            __auto_type _mv_1311 = (*head);
-                                            switch (_mv_1311.tag) {
+                                        __auto_type _mv_1311 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1311.has_value) {
+                                            __auto_type head = _mv_1311.value;
+                                            __auto_type _mv_1312 = (*head);
+                                            switch (_mv_1312.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_1311.data.sym;
+                                                    __auto_type sym = _mv_1312.data.sym;
                                                     {
                                                         __auto_type kind = sym.name;
                                                         return ((!(string_eq(kind, SLOP_STR("record")))) && (!(string_eq(kind, SLOP_STR("enum")))) && (!(string_eq(kind, SLOP_STR("union")))));
@@ -3177,7 +3177,7 @@ uint8_t transpiler_is_type_alias_def(types_SExpr* item) {
                                                     return 0;
                                                 }
                                             }
-                                        } else if (!_mv_1310.has_value) {
+                                        } else if (!_mv_1311.has_value) {
                                             return 0;
                                         }
                                         SLOP_UNREACHABLE();
@@ -3188,7 +3188,7 @@ uint8_t transpiler_is_type_alias_def(types_SExpr* item) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1308.has_value) {
+                    } else if (!_mv_1309.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -3203,44 +3203,44 @@ uint8_t transpiler_is_type_alias_def(types_SExpr* item) {
 
 uint8_t transpiler_is_result_type_alias_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1312 = (*item);
-    switch (_mv_1312.tag) {
+    __auto_type _mv_1313 = (*item);
+    switch (_mv_1313.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1312.data.lst;
+            __auto_type lst = _mv_1313.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 3) {
                     return 0;
                 } else {
-                    __auto_type _mv_1313 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1313.has_value) {
-                        __auto_type def_expr = _mv_1313.value;
-                        __auto_type _mv_1314 = (*def_expr);
-                        switch (_mv_1314.tag) {
+                    __auto_type _mv_1314 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1314.has_value) {
+                        __auto_type def_expr = _mv_1314.value;
+                        __auto_type _mv_1315 = (*def_expr);
+                        switch (_mv_1315.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type def_lst = _mv_1314.data.lst;
+                                __auto_type def_lst = _mv_1315.data.lst;
                                 {
                                     __auto_type def_items = def_lst.items;
                                     if (((int64_t)((def_items).len)) < 1) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1315 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1315.has_value) {
-                                            __auto_type head = _mv_1315.value;
-                                            __auto_type _mv_1316 = (*head);
-                                            switch (_mv_1316.tag) {
+                                        __auto_type _mv_1316 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1316.has_value) {
+                                            __auto_type head = _mv_1316.value;
+                                            __auto_type _mv_1317 = (*head);
+                                            switch (_mv_1317.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_1316.data.sym;
+                                                    __auto_type sym = _mv_1317.data.sym;
                                                     return string_eq(sym.name, SLOP_STR("Result"));
                                                 }
                                                 default: {
                                                     return 0;
                                                 }
                                             }
-                                        } else if (!_mv_1315.has_value) {
+                                        } else if (!_mv_1316.has_value) {
                                             return 0;
                                         }
                                         SLOP_UNREACHABLE();
@@ -3251,7 +3251,7 @@ uint8_t transpiler_is_result_type_alias_def(types_SExpr* item) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1313.has_value) {
+                    } else if (!_mv_1314.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -3269,29 +3269,29 @@ void transpiler_emit_type_alias_to_header(context_TranspileContext* ctx, types_S
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1317 = (*type_def);
-        switch (_mv_1317.tag) {
+        __auto_type _mv_1318 = (*type_def);
+        switch (_mv_1318.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1317.data.lst;
+                __auto_type lst = _mv_1318.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_1318 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1318.has_value) {
-                            __auto_type name_expr = _mv_1318.value;
-                            __auto_type _mv_1319 = (*name_expr);
-                            switch (_mv_1319.tag) {
+                        __auto_type _mv_1319 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1319.has_value) {
+                            __auto_type name_expr = _mv_1319.value;
+                            __auto_type _mv_1320 = (*name_expr);
+                            switch (_mv_1320.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1319.data.sym;
+                                    __auto_type name_sym = _mv_1320.data.sym;
                                     {
                                         __auto_type type_name = name_sym.name;
                                         __auto_type base_c_name = ctype_to_c_name(arena, type_name);
                                         __auto_type c_name = context_ctx_prefix_type(ctx, base_c_name);
-                                        __auto_type _mv_1320 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1320.has_value) {
-                                            __auto_type body_expr = _mv_1320.value;
+                                        __auto_type _mv_1321 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1321.has_value) {
+                                            __auto_type body_expr = _mv_1321.value;
                                             if (transpiler_is_array_type_body(body_expr)) {
                                                 transpiler_emit_array_typedef_to_header(ctx, c_name, body_expr);
                                             } else if (transpiler_is_range_type_body(body_expr)) {
@@ -3304,7 +3304,7 @@ void transpiler_emit_type_alias_to_header(context_TranspileContext* ctx, types_S
                                                     context_ctx_mark_type_emitted(ctx, c_name);
                                                 }
                                             }
-                                        } else if (!_mv_1320.has_value) {
+                                        } else if (!_mv_1321.has_value) {
                                         }
                                     }
                                     break;
@@ -3313,7 +3313,7 @@ void transpiler_emit_type_alias_to_header(context_TranspileContext* ctx, types_S
                                     break;
                                 }
                             }
-                        } else if (!_mv_1318.has_value) {
+                        } else if (!_mv_1319.has_value) {
                         }
                     }
                 }
@@ -3328,31 +3328,31 @@ void transpiler_emit_type_alias_to_header(context_TranspileContext* ctx, types_S
 
 uint8_t transpiler_is_array_type_body(types_SExpr* body_expr) {
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
-    __auto_type _mv_1321 = (*body_expr);
-    switch (_mv_1321.tag) {
+    __auto_type _mv_1322 = (*body_expr);
+    switch (_mv_1322.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1321.data.lst;
+            __auto_type lst = _mv_1322.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1322 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1322.has_value) {
-                        __auto_type head = _mv_1322.value;
-                        __auto_type _mv_1323 = (*head);
-                        switch (_mv_1323.tag) {
+                    __auto_type _mv_1323 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1323.has_value) {
+                        __auto_type head = _mv_1323.value;
+                        __auto_type _mv_1324 = (*head);
+                        switch (_mv_1324.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1323.data.sym;
+                                __auto_type sym = _mv_1324.data.sym;
                                 return string_eq(sym.name, SLOP_STR("Array"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1322.has_value) {
+                    } else if (!_mv_1323.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -3370,33 +3370,33 @@ void transpiler_emit_array_typedef_to_header(context_TranspileContext* ctx, slop
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1324 = (*body_expr);
-        switch (_mv_1324.tag) {
+        __auto_type _mv_1325 = (*body_expr);
+        switch (_mv_1325.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1324.data.lst;
+                __auto_type lst = _mv_1325.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 3) {
                         context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("typedef void* "), c_name, SLOP_STR(";")));
                     } else {
-                        __auto_type _mv_1325 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1325.has_value) {
-                            __auto_type elem_type_expr = _mv_1325.value;
-                            __auto_type _mv_1326 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1326.has_value) {
-                                __auto_type size_expr = _mv_1326.value;
+                        __auto_type _mv_1326 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1326.has_value) {
+                            __auto_type elem_type_expr = _mv_1326.value;
+                            __auto_type _mv_1327 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1327.has_value) {
+                                __auto_type size_expr = _mv_1327.value;
                                 {
                                     __auto_type elem_c_type = context_to_c_type_prefixed(ctx, elem_type_expr);
                                     __auto_type size_str = transpiler_get_array_size_string(size_expr);
                                     context_ctx_emit_header(ctx, context_ctx_str5(ctx, SLOP_STR("typedef "), elem_c_type, SLOP_STR(" "), c_name, context_ctx_str3(ctx, SLOP_STR("["), size_str, SLOP_STR("];"))));
                                     context_ctx_emit_header(ctx, SLOP_STR(""));
                                 }
-                            } else if (!_mv_1326.has_value) {
+                            } else if (!_mv_1327.has_value) {
                                 context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("typedef void* "), c_name, SLOP_STR(";")));
                             }
-                        } else if (!_mv_1325.has_value) {
+                        } else if (!_mv_1326.has_value) {
                             context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("typedef void* "), c_name, SLOP_STR(";")));
                         }
                     }
@@ -3413,11 +3413,11 @@ void transpiler_emit_array_typedef_to_header(context_TranspileContext* ctx, slop
 
 slop_string transpiler_get_array_size_string(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1327 = (*expr);
-    switch (_mv_1327.tag) {
+    __auto_type _mv_1328 = (*expr);
+    switch (_mv_1328.tag) {
         case types_SExpr_num:
         {
-            __auto_type num = _mv_1327.data.num;
+            __auto_type num = _mv_1328.data.num;
             return num.raw;
         }
         default: {
@@ -3428,25 +3428,25 @@ slop_string transpiler_get_array_size_string(types_SExpr* expr) {
 
 uint8_t transpiler_is_range_type_body(types_SExpr* body_expr) {
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
-    __auto_type _mv_1328 = (*body_expr);
-    switch (_mv_1328.tag) {
+    __auto_type _mv_1329 = (*body_expr);
+    switch (_mv_1329.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1328.data.lst;
+            __auto_type lst = _mv_1329.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type found_dots = 0;
                 __auto_type i = 0;
                 while ((i < len) && !(found_dots)) {
-                    __auto_type _mv_1329 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1329.has_value) {
-                        __auto_type item = _mv_1329.value;
-                        __auto_type _mv_1330 = (*item);
-                        switch (_mv_1330.tag) {
+                    __auto_type _mv_1330 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1330.has_value) {
+                        __auto_type item = _mv_1330.value;
+                        __auto_type _mv_1331 = (*item);
+                        switch (_mv_1331.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1330.data.sym;
+                                __auto_type sym = _mv_1331.data.sym;
                                 if (string_eq(sym.name, SLOP_STR(".."))) {
                                     found_dots = 1;
                                 }
@@ -3456,7 +3456,7 @@ uint8_t transpiler_is_range_type_body(types_SExpr* body_expr) {
                                 break;
                             }
                         }
-                    } else if (!_mv_1329.has_value) {
+                    } else if (!_mv_1330.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -3477,24 +3477,24 @@ transpiler_RangeBoundsHeader transpiler_parse_range_bounds_header(types_SExpr* b
         uint8_t has_min = 0;
         uint8_t has_max = 0;
         uint8_t found_dots = 0;
-        __auto_type _mv_1331 = (*body_expr);
-        switch (_mv_1331.tag) {
+        __auto_type _mv_1332 = (*body_expr);
+        switch (_mv_1332.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1331.data.lst;
+                __auto_type lst = _mv_1332.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type i = 1;
                     while (i < len) {
-                        __auto_type _mv_1332 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1332.has_value) {
-                            __auto_type item = _mv_1332.value;
-                            __auto_type _mv_1333 = (*item);
-                            switch (_mv_1333.tag) {
+                        __auto_type _mv_1333 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1333.has_value) {
+                            __auto_type item = _mv_1333.value;
+                            __auto_type _mv_1334 = (*item);
+                            switch (_mv_1334.tag) {
                                 case types_SExpr_num:
                                 {
-                                    __auto_type num = _mv_1333.data.num;
+                                    __auto_type num = _mv_1334.data.num;
                                     if (!(found_dots)) {
                                         min_val = transpiler_string_to_int_header(num.raw);
                                         has_min = 1;
@@ -3506,7 +3506,7 @@ transpiler_RangeBoundsHeader transpiler_parse_range_bounds_header(types_SExpr* b
                                 }
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1333.data.sym;
+                                    __auto_type sym = _mv_1334.data.sym;
                                     if (string_eq(sym.name, SLOP_STR(".."))) {
                                         found_dots = 1;
                                     }
@@ -3516,7 +3516,7 @@ transpiler_RangeBoundsHeader transpiler_parse_range_bounds_header(types_SExpr* b
                                     break;
                                 }
                             }
-                        } else if (!_mv_1332.has_value) {
+                        } else if (!_mv_1333.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -3626,23 +3626,23 @@ void transpiler_emit_forward_decls_header(context_TranspileContext* ctx, slop_li
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1334 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1334.has_value) {
-                __auto_type item = _mv_1334.value;
+            __auto_type _mv_1335 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1335.has_value) {
+                __auto_type item = _mv_1335.value;
                 if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
-                    __auto_type _mv_1335 = transpiler_get_type_name(item);
-                    if (_mv_1335.has_value) {
-                        __auto_type type_name = _mv_1335.value;
+                    __auto_type _mv_1336 = transpiler_get_type_name(item);
+                    if (_mv_1336.has_value) {
+                        __auto_type type_name = _mv_1336.value;
                         {
                             __auto_type base_name = ctype_to_c_name(arena, type_name);
                             __auto_type c_name = ((context_ctx_prefixing_enabled(ctx)) ? ({ __auto_type _mv = context_ctx_get_module(ctx); _mv.has_value ? ({ __auto_type mod_name = _mv.value; context_ctx_str(ctx, ctype_to_c_name(arena, mod_name), context_ctx_str(ctx, SLOP_STR("_"), base_name)); }) : (base_name); }) : base_name);
                             context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("typedef struct "), c_name, context_ctx_str(ctx, SLOP_STR(" "), context_ctx_str(ctx, c_name, SLOP_STR(";")))));
                             emitted_any = 1;
                         }
-                    } else if (!_mv_1335.has_value) {
+                    } else if (!_mv_1336.has_value) {
                     }
                 }
-            } else if (!_mv_1334.has_value) {
+            } else if (!_mv_1335.has_value) {
             }
             i = (i + 1);
         }
@@ -3659,14 +3659,14 @@ void transpiler_emit_fn_forward_decls(context_TranspileContext* ctx, slop_list_t
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1336 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1336.has_value) {
-                __auto_type item = _mv_1336.value;
+            __auto_type _mv_1337 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1337.has_value) {
+                __auto_type item = _mv_1337.value;
                 if (transpiler_is_fn_def(item)) {
                     defn_emit_forward_declaration(ctx, item);
                     emitted_any = 1;
                 }
-            } else if (!_mv_1336.has_value) {
+            } else if (!_mv_1337.has_value) {
             }
             i = (i + 1);
         }
@@ -3683,14 +3683,14 @@ void transpiler_emit_fn_forward_decls_header(context_TranspileContext* ctx, slop
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1337 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1337.has_value) {
-                __auto_type item = _mv_1337.value;
+            __auto_type _mv_1338 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1338.has_value) {
+                __auto_type item = _mv_1338.value;
                 if (transpiler_is_fn_def(item)) {
                     transpiler_emit_fn_forward_decl_header(ctx, item);
                     emitted_any = 1;
                 }
-            } else if (!_mv_1337.has_value) {
+            } else if (!_mv_1338.has_value) {
             }
             i = (i + 1);
         }
@@ -3709,11 +3709,11 @@ void transpiler_emit_c_name_aliases(context_TranspileContext* ctx) {
         if (len > 0) {
             context_ctx_emit_header(ctx, SLOP_STR("/* Function name aliases for C interop */"));
             while (i < len) {
-                __auto_type _mv_1338 = ({ __auto_type _lst = aliases; size_t _idx = (size_t)i; slop_option_context_FuncCNameAlias _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1338.has_value) {
-                    __auto_type alias = _mv_1338.value;
+                __auto_type _mv_1339 = ({ __auto_type _lst = aliases; size_t _idx = (size_t)i; slop_option_context_FuncCNameAlias _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1339.has_value) {
+                    __auto_type alias = _mv_1339.value;
                     context_ctx_emit_header(ctx, context_ctx_str(ctx, SLOP_STR("#define "), context_ctx_str(ctx, alias.mangled_name, context_ctx_str(ctx, SLOP_STR(" "), alias.clean_name))));
-                } else if (!_mv_1338.has_value) {
+                } else if (!_mv_1339.has_value) {
                 }
                 i = (i + 1);
             }
@@ -3727,31 +3727,31 @@ void transpiler_emit_fn_forward_decl_header(context_TranspileContext* ctx, types
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1339 = (*expr);
-        switch (_mv_1339.tag) {
+        __auto_type _mv_1340 = (*expr);
+        switch (_mv_1340.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1339.data.lst;
+                __auto_type lst = _mv_1340.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 3) {
-                        __auto_type _mv_1340 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1340.has_value) {
-                            __auto_type name_expr = _mv_1340.value;
-                            __auto_type _mv_1341 = (*name_expr);
-                            switch (_mv_1341.tag) {
+                        __auto_type _mv_1341 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1341.has_value) {
+                            __auto_type name_expr = _mv_1341.value;
+                            __auto_type _mv_1342 = (*name_expr);
+                            switch (_mv_1342.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1341.data.sym;
+                                    __auto_type name_sym = _mv_1342.data.sym;
                                     {
                                         __auto_type raw_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, raw_name);
                                         __auto_type mangled_name = ((string_eq(base_name, SLOP_STR("main"))) ? base_name : context_ctx_prefix_type(ctx, base_name));
                                         __auto_type fn_name = context_extract_fn_c_name(arena, items, mangled_name);
-                                        __auto_type _mv_1342 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1342.has_value) {
-                                            __auto_type params_expr = _mv_1342.value;
+                                        __auto_type _mv_1343 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1343.has_value) {
+                                            __auto_type params_expr = _mv_1343.value;
                                             {
                                                 __auto_type result_type_opt = defn_get_result_type_name(ctx, items);
                                                 __auto_type raw_return = defn_get_return_type(ctx, items);
@@ -3762,7 +3762,7 @@ void transpiler_emit_fn_forward_decl_header(context_TranspileContext* ctx, types
                                                     context_ctx_emit_header(ctx, context_ctx_str5(ctx, actual_return, SLOP_STR(" "), fn_name, SLOP_STR("("), context_ctx_str(ctx, ((string_eq(param_str, SLOP_STR(""))) ? SLOP_STR("void") : param_str), SLOP_STR(");"))));
                                                 }
                                             }
-                                        } else if (!_mv_1342.has_value) {
+                                        } else if (!_mv_1343.has_value) {
                                         }
                                     }
                                     break;
@@ -3771,7 +3771,7 @@ void transpiler_emit_fn_forward_decl_header(context_TranspileContext* ctx, types
                                     break;
                                 }
                             }
-                        } else if (!_mv_1340.has_value) {
+                        } else if (!_mv_1341.has_value) {
                         }
                     }
                 }
@@ -3786,31 +3786,31 @@ void transpiler_emit_fn_forward_decl_header(context_TranspileContext* ctx, types
 
 slop_option_string transpiler_get_type_name(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1343 = (*item);
-    switch (_mv_1343.tag) {
+    __auto_type _mv_1344 = (*item);
+    switch (_mv_1344.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1343.data.lst;
+            __auto_type lst = _mv_1344.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return (slop_option_string){.has_value = false};
                 } else {
-                    __auto_type _mv_1344 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1344.has_value) {
-                        __auto_type name_expr = _mv_1344.value;
-                        __auto_type _mv_1345 = (*name_expr);
-                        switch (_mv_1345.tag) {
+                    __auto_type _mv_1345 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1345.has_value) {
+                        __auto_type name_expr = _mv_1345.value;
+                        __auto_type _mv_1346 = (*name_expr);
+                        switch (_mv_1346.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1345.data.sym;
+                                __auto_type sym = _mv_1346.data.sym;
                                 return (slop_option_string){.has_value = 1, .value = sym.name};
                             }
                             default: {
                                 return (slop_option_string){.has_value = false};
                             }
                         }
-                    } else if (!_mv_1344.has_value) {
+                    } else if (!_mv_1345.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
                     SLOP_UNREACHABLE();
@@ -3829,14 +3829,14 @@ void transpiler_emit_module_types(context_TranspileContext* ctx, slop_list_types
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1346 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1346.has_value) {
-                __auto_type item = _mv_1346.value;
+            __auto_type _mv_1347 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1347.has_value) {
+                __auto_type item = _mv_1347.value;
                 if (transpiler_is_type_def(item)) {
                     defn_transpile_type(ctx, item);
                     context_ctx_emit(ctx, SLOP_STR(""));
                 }
-            } else if (!_mv_1346.has_value) {
+            } else if (!_mv_1347.has_value) {
             }
             i = (i + 1);
         }
@@ -3850,14 +3850,14 @@ void transpiler_emit_type_aliases(context_TranspileContext* ctx, slop_list_types
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1347 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1347.has_value) {
-                __auto_type item = _mv_1347.value;
+            __auto_type _mv_1348 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1348.has_value) {
+                __auto_type item = _mv_1348.value;
                 if (transpiler_is_type_def(item) && transpiler_is_type_alias_def(item)) {
                     defn_transpile_type(ctx, item);
                     emitted_any = 1;
                 }
-            } else if (!_mv_1347.has_value) {
+            } else if (!_mv_1348.has_value) {
             }
             i = (i + 1);
         }
@@ -3874,14 +3874,14 @@ void transpiler_emit_enum_types(context_TranspileContext* ctx, slop_list_types_S
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1348 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1348.has_value) {
-                __auto_type item = _mv_1348.value;
+            __auto_type _mv_1349 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1349.has_value) {
+                __auto_type item = _mv_1349.value;
                 if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
                     defn_transpile_type(ctx, item);
                     emitted_any = 1;
                 }
-            } else if (!_mv_1348.has_value) {
+            } else if (!_mv_1349.has_value) {
             }
             i = (i + 1);
         }
@@ -3897,14 +3897,14 @@ void transpiler_emit_struct_types(context_TranspileContext* ctx, slop_list_types
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1349 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1349.has_value) {
-                __auto_type item = _mv_1349.value;
+            __auto_type _mv_1350 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1350.has_value) {
+                __auto_type item = _mv_1350.value;
                 if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                     defn_transpile_type(ctx, item);
                     context_ctx_emit(ctx, SLOP_STR(""));
                 }
-            } else if (!_mv_1349.has_value) {
+            } else if (!_mv_1350.has_value) {
             }
             i = (i + 1);
         }
@@ -3918,11 +3918,11 @@ void transpiler_emit_result_types(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((result_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1350 = ({ __auto_type _lst = result_types; size_t _idx = (size_t)i; slop_option_context_ResultType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1350.has_value) {
-                __auto_type rt = _mv_1350.value;
+            __auto_type _mv_1351 = ({ __auto_type _lst = result_types; size_t _idx = (size_t)i; slop_option_context_ResultType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1351.has_value) {
+                __auto_type rt = _mv_1351.value;
                 transpiler_emit_single_result_type(ctx, rt);
-            } else if (!_mv_1350.has_value) {
+            } else if (!_mv_1351.has_value) {
             }
             i = (i + 1);
         }
@@ -3957,11 +3957,11 @@ void transpiler_emit_result_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((result_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1351 = ({ __auto_type _lst = result_types; size_t _idx = (size_t)i; slop_option_context_ResultType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1351.has_value) {
-                __auto_type rt = _mv_1351.value;
+            __auto_type _mv_1352 = ({ __auto_type _lst = result_types; size_t _idx = (size_t)i; slop_option_context_ResultType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1352.has_value) {
+                __auto_type rt = _mv_1352.value;
                 transpiler_emit_single_result_type_header(ctx, rt);
-            } else if (!_mv_1351.has_value) {
+            } else if (!_mv_1352.has_value) {
             }
             i = (i + 1);
         }
@@ -3996,9 +3996,9 @@ void transpiler_emit_inline_records_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((inline_records).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1352 = ({ __auto_type _lst = inline_records; size_t _idx = (size_t)i; slop_option_context_InlineRecord _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1352.has_value) {
-                __auto_type ir = _mv_1352.value;
+            __auto_type _mv_1353 = ({ __auto_type _lst = inline_records; size_t _idx = (size_t)i; slop_option_context_InlineRecord _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1353.has_value) {
+                __auto_type ir = _mv_1353.value;
                 {
                     __auto_type type_name = ir.type_name;
                     __auto_type field_body = ir.field_body;
@@ -4009,7 +4009,7 @@ void transpiler_emit_inline_records_header(context_TranspileContext* ctx) {
                     context_ctx_emit_header(ctx, SLOP_STR("#endif"));
                     context_ctx_emit_header(ctx, SLOP_STR(""));
                 }
-            } else if (!_mv_1352.has_value) {
+            } else if (!_mv_1353.has_value) {
             }
             i = (i + 1);
         }
@@ -4023,13 +4023,13 @@ void transpiler_emit_option_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1353 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1353.has_value) {
-                __auto_type ot = _mv_1353.value;
+            __auto_type _mv_1354 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1354.has_value) {
+                __auto_type ot = _mv_1354.value;
                 if (transpiler_is_pointer_elem_type(ot.inner_type)) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1353.has_value) {
+            } else if (!_mv_1354.has_value) {
             }
             i = (i + 1);
         }
@@ -4043,13 +4043,13 @@ void transpiler_emit_value_option_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1354 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1354.has_value) {
-                __auto_type ot = _mv_1354.value;
+            __auto_type _mv_1355 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1355.has_value) {
+                __auto_type ot = _mv_1355.value;
                 if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_is_type_emitted_or_primitive(ctx, ot.inner_type)) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1354.has_value) {
+            } else if (!_mv_1355.has_value) {
             }
             i = (i + 1);
         }
@@ -4063,13 +4063,13 @@ void transpiler_emit_complex_value_option_types_header(context_TranspileContext*
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1355 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1355.has_value) {
-                __auto_type ot = _mv_1355.value;
+            __auto_type _mv_1356 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1356.has_value) {
+                __auto_type ot = _mv_1356.value;
                 if (!(transpiler_is_pointer_elem_type(ot.inner_type))) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1355.has_value) {
+            } else if (!_mv_1356.has_value) {
             }
             i = (i + 1);
         }
@@ -4111,14 +4111,14 @@ void transpiler_emit_list_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1356 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1356.has_value) {
-                __auto_type lt = _mv_1356.value;
+            __auto_type _mv_1357 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1357.has_value) {
+                __auto_type lt = _mv_1357.value;
                 if (transpiler_is_pointer_elem_type(lt.elem_type)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                     transpiler_emit_option_for_inner_type(ctx, lt.c_name);
                 }
-            } else if (!_mv_1356.has_value) {
+            } else if (!_mv_1357.has_value) {
             }
             i = (i + 1);
         }
@@ -4132,14 +4132,14 @@ void transpiler_emit_primitive_list_types_header(context_TranspileContext* ctx) 
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1357 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1357.has_value) {
-                __auto_type lt = _mv_1357.value;
+            __auto_type _mv_1358 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1358.has_value) {
+                __auto_type lt = _mv_1358.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_is_primitive_or_runtime_type(lt.elem_type)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                     transpiler_emit_option_for_inner_type(ctx, lt.c_name);
                 }
-            } else if (!_mv_1357.has_value) {
+            } else if (!_mv_1358.has_value) {
             }
             i = (i + 1);
         }
@@ -4153,13 +4153,13 @@ void transpiler_emit_primitive_option_types_header(context_TranspileContext* ctx
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1358 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1358.has_value) {
-                __auto_type ot = _mv_1358.value;
+            __auto_type _mv_1359 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1359.has_value) {
+                __auto_type ot = _mv_1359.value;
                 if ((!(transpiler_is_pointer_elem_type(ot.inner_type))) && (transpiler_is_primitive_or_runtime_type(ot.inner_type)) && (!(strlib_starts_with(ot.inner_type, SLOP_STR("slop_list_"))))) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1358.has_value) {
+            } else if (!_mv_1359.has_value) {
             }
             i = (i + 1);
         }
@@ -4177,14 +4177,14 @@ void transpiler_emit_imported_list_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1359 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1359.has_value) {
-                __auto_type lt = _mv_1359.value;
+            __auto_type _mv_1360 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1360.has_value) {
+                __auto_type lt = _mv_1360.value;
                 if ((!(transpiler_is_pointer_elem_type(lt.elem_type))) && (!(transpiler_is_primitive_or_runtime_type(lt.elem_type))) && (transpiler_is_imported_type(ctx, lt.elem_type))) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                     transpiler_emit_option_for_inner_type(ctx, lt.c_name);
                 }
-            } else if (!_mv_1359.has_value) {
+            } else if (!_mv_1360.has_value) {
             }
             i = (i + 1);
         }
@@ -4198,13 +4198,13 @@ void transpiler_emit_imported_option_types_header(context_TranspileContext* ctx)
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1360 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1360.has_value) {
-                __auto_type ot = _mv_1360.value;
+            __auto_type _mv_1361 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1361.has_value) {
+                __auto_type ot = _mv_1361.value;
                 if ((!(transpiler_is_pointer_elem_type(ot.inner_type))) && (!(transpiler_is_primitive_or_runtime_type(ot.inner_type))) && (!(strlib_starts_with(ot.inner_type, SLOP_STR("slop_list_")))) && (transpiler_is_imported_type(ctx, ot.inner_type))) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1360.has_value) {
+            } else if (!_mv_1361.has_value) {
             }
             i = (i + 1);
         }
@@ -4218,11 +4218,11 @@ void transpiler_emit_late_registered_list_types_header(context_TranspileContext*
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1361 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1361.has_value) {
-                __auto_type lt = _mv_1361.value;
+            __auto_type _mv_1362 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1362.has_value) {
+                __auto_type lt = _mv_1362.value;
                 transpiler_emit_single_list_type_header(ctx, lt);
-            } else if (!_mv_1361.has_value) {
+            } else if (!_mv_1362.has_value) {
             }
             i = (i + 1);
         }
@@ -4236,11 +4236,11 @@ void transpiler_emit_late_registered_option_types_header(context_TranspileContex
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1362 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1362.has_value) {
-                __auto_type ot = _mv_1362.value;
+            __auto_type _mv_1363 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1363.has_value) {
+                __auto_type ot = _mv_1363.value;
                 transpiler_emit_single_option_type_header(ctx, ot);
-            } else if (!_mv_1362.has_value) {
+            } else if (!_mv_1363.has_value) {
             }
             i = (i + 1);
         }
@@ -4254,13 +4254,13 @@ void transpiler_emit_value_list_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1363 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1363.has_value) {
-                __auto_type lt = _mv_1363.value;
+            __auto_type _mv_1364 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1364.has_value) {
+                __auto_type lt = _mv_1364.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_is_type_emitted_or_primitive(ctx, lt.elem_type)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1363.has_value) {
+            } else if (!_mv_1364.has_value) {
             }
             i = (i + 1);
         }
@@ -4274,13 +4274,13 @@ void transpiler_emit_complex_value_list_types_header(context_TranspileContext* c
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1364 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1364.has_value) {
-                __auto_type lt = _mv_1364.value;
+            __auto_type _mv_1365 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1365.has_value) {
+                __auto_type lt = _mv_1365.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && !(context_ctx_is_type_emitted(ctx, lt.c_name))) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1364.has_value) {
+            } else if (!_mv_1365.has_value) {
             }
             i = (i + 1);
         }
@@ -4316,9 +4316,9 @@ void transpiler_emit_union_payload_hash_eq(context_TranspileContext* ctx, slop_l
         __auto_type len = ((int64_t)((variants).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1365 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1365.has_value) {
-                __auto_type variant = _mv_1365.value;
+            __auto_type _mv_1366 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1366.has_value) {
+                __auto_type variant = _mv_1366.value;
                 {
                     __auto_type slop_type = variant.slop_type;
                     __auto_type c_payload_type = variant.c_type;
@@ -4338,7 +4338,7 @@ void transpiler_emit_union_payload_hash_eq(context_TranspileContext* ctx, slop_l
                         }
                     }
                 }
-            } else if (!_mv_1365.has_value) {
+            } else if (!_mv_1366.has_value) {
             }
             i = (i + 1);
         }
@@ -4351,9 +4351,9 @@ void transpiler_emit_record_field_dependencies(context_TranspileContext* ctx, sl
         __auto_type len = ((int64_t)((fields).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1366 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1366.has_value) {
-                __auto_type field = _mv_1366.value;
+            __auto_type _mv_1367 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1367.has_value) {
+                __auto_type field = _mv_1367.value;
                 {
                     __auto_type slop_type = field.slop_type;
                     __auto_type c_type = field.c_type;
@@ -4389,7 +4389,7 @@ void transpiler_emit_record_field_dependencies(context_TranspileContext* ctx, sl
                         }
                     }
                 }
-            } else if (!_mv_1366.has_value) {
+            } else if (!_mv_1367.has_value) {
             }
             i = (i + 1);
         }
@@ -4446,9 +4446,9 @@ uint8_t transpiler_is_primitive_slop_type(slop_string slop_type) {
 
 uint8_t transpiler_is_range_type_alias(context_TranspileContext* ctx, slop_string slop_type) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
-    __auto_type _mv_1367 = context_ctx_lookup_type_alias(ctx, slop_type);
-    if (_mv_1367.has_value) {
-        __auto_type underlying = _mv_1367.value;
+    __auto_type _mv_1368 = context_ctx_lookup_type_alias(ctx, slop_type);
+    if (_mv_1368.has_value) {
+        __auto_type underlying = _mv_1368.value;
         if (strlib_starts_with(underlying, SLOP_STR("(Int"))) {
             return 1;
         } else if (strlib_starts_with(underlying, SLOP_STR("(I64"))) {
@@ -4470,7 +4470,7 @@ uint8_t transpiler_is_range_type_alias(context_TranspileContext* ctx, slop_strin
         } else {
             return 0;
         }
-    } else if (!_mv_1367.has_value) {
+    } else if (!_mv_1368.has_value) {
         return 0;
     }
     SLOP_UNREACHABLE();
@@ -4487,11 +4487,11 @@ uint8_t transpiler_is_narrow_signed_payload_type(slop_string slop_type) {
 slop_string transpiler_resolve_payload_slop_type(context_TranspileContext* ctx, slop_string slop_type) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     if (transpiler_is_range_type_alias(ctx, slop_type)) {
-        __auto_type _mv_1368 = context_ctx_lookup_type_alias(ctx, slop_type);
-        if (_mv_1368.has_value) {
-            __auto_type underlying = _mv_1368.value;
+        __auto_type _mv_1369 = context_ctx_lookup_type_alias(ctx, slop_type);
+        if (_mv_1369.has_value) {
+            __auto_type underlying = _mv_1369.value;
             return underlying;
-        } else if (!_mv_1368.has_value) {
+        } else if (!_mv_1369.has_value) {
             return slop_type;
         }
         SLOP_UNREACHABLE();
@@ -4559,30 +4559,30 @@ slop_list_transpiler_PayloadSlot transpiler_union_variant_payloads(context_Trans
         __auto_type arena = (*ctx).arena;
         __auto_type slots = ((slop_list_transpiler_PayloadSlot){ .data = (transpiler_PayloadSlot*)slop_arena_alloc(arena, 16 * sizeof(transpiler_PayloadSlot)), .len = 0, .cap = 16 });
         __auto_type count_key = context_ctx_str(ctx, variant_name, SLOP_STR("__count"));
-        __auto_type _mv_1369 = context_ctx_lookup_field_type(ctx, union_name, count_key);
-        if (_mv_1369.has_value) {
-            __auto_type _ = _mv_1369.value;
+        __auto_type _mv_1370 = context_ctx_lookup_field_type(ctx, union_name, count_key);
+        if (_mv_1370.has_value) {
+            __auto_type _ = _mv_1370.value;
             {
                 __auto_type i = 0;
                 __auto_type more = 1;
                 while (more) {
                     {
                         __auto_type key = context_ctx_str3(ctx, variant_name, SLOP_STR("__"), int_to_string(arena, i));
-                        __auto_type _mv_1370 = context_ctx_lookup_field_type(ctx, union_name, key);
-                        if (_mv_1370.has_value) {
-                            __auto_type slot_c_type = _mv_1370.value;
+                        __auto_type _mv_1371 = context_ctx_lookup_field_type(ctx, union_name, key);
+                        if (_mv_1371.has_value) {
+                            __auto_type slot_c_type = _mv_1371.value;
                             {
                                 __auto_type slot_slop_type = ({ __auto_type _mv = context_ctx_lookup_field_slop_type(ctx, union_name, key); _mv.has_value ? ({ __auto_type st = _mv.value; st; }) : (SLOP_STR("")); });
                                 ({ __auto_type _lst_p = &(slots); __auto_type _item = ((transpiler_PayloadSlot){slot_slop_type, slot_c_type}); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                 i = (i + 1);
                             }
-                        } else if (!_mv_1370.has_value) {
+                        } else if (!_mv_1371.has_value) {
                             more = 0;
                         }
                     }
                 }
             }
-        } else if (!_mv_1369.has_value) {
+        } else if (!_mv_1370.has_value) {
         }
         return slots;
     }
@@ -4597,11 +4597,11 @@ void transpiler_emit_union_hash_fn(context_TranspileContext* ctx, slop_string c_
         __auto_type len = ((int64_t)((variants).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1371 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1371.has_value) {
-                __auto_type variant = _mv_1371.value;
+            __auto_type _mv_1372 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1372.has_value) {
+                __auto_type variant = _mv_1372.value;
                 transpiler_emit_union_variant_hash(ctx, c_type, variant);
-            } else if (!_mv_1371.has_value) {
+            } else if (!_mv_1372.has_value) {
             }
             i = (i + 1);
         }
@@ -4639,14 +4639,14 @@ void transpiler_emit_multi_payload_hash(context_TranspileContext* ctx, slop_stri
         context_ctx_emit_header(ctx, SLOP_STR("            {"));
         context_ctx_emit_header(ctx, SLOP_STR("                uint64_t hash = 14695981039346656037ULL;"));
         while (i < len) {
-            __auto_type _mv_1372 = ({ __auto_type _lst = payloads; size_t _idx = (size_t)i; slop_option_transpiler_PayloadSlot _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1372.has_value) {
-                __auto_type slot = _mv_1372.value;
+            __auto_type _mv_1373 = ({ __auto_type _lst = payloads; size_t _idx = (size_t)i; slop_option_transpiler_PayloadSlot _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1373.has_value) {
+                __auto_type slot = _mv_1373.value;
                 {
                     __auto_type access = context_ctx_str4(ctx, SLOP_STR("_k->data."), c_variant_name, SLOP_STR(".f"), int_to_string(arena, i));
                     context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("                hash ^= "), transpiler_payload_hash_expr(ctx, slot.slop_type, slot.c_type, access), SLOP_STR("; hash *= 1099511628211ULL;")));
                 }
-            } else if (!_mv_1372.has_value) {
+            } else if (!_mv_1373.has_value) {
             }
             i = (i + 1);
         }
@@ -4666,11 +4666,11 @@ void transpiler_emit_union_eq_fn(context_TranspileContext* ctx, slop_string c_ty
         __auto_type len = ((int64_t)((variants).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1373 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1373.has_value) {
-                __auto_type variant = _mv_1373.value;
+            __auto_type _mv_1374 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1374.has_value) {
+                __auto_type variant = _mv_1374.value;
                 transpiler_emit_union_variant_eq(ctx, c_type, variant);
-            } else if (!_mv_1373.has_value) {
+            } else if (!_mv_1374.has_value) {
             }
             i = (i + 1);
         }
@@ -4707,15 +4707,15 @@ void transpiler_emit_multi_payload_eq(context_TranspileContext* ctx, slop_string
         int64_t i = 0;
         context_ctx_emit_header(ctx, SLOP_STR("            return true"));
         while (i < len) {
-            __auto_type _mv_1374 = ({ __auto_type _lst = payloads; size_t _idx = (size_t)i; slop_option_transpiler_PayloadSlot _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1374.has_value) {
-                __auto_type slot = _mv_1374.value;
+            __auto_type _mv_1375 = ({ __auto_type _lst = payloads; size_t _idx = (size_t)i; slop_option_transpiler_PayloadSlot _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1375.has_value) {
+                __auto_type slot = _mv_1375.value;
                 {
                     __auto_type a_access = context_ctx_str4(ctx, SLOP_STR("_a->data."), c_variant_name, SLOP_STR(".f"), int_to_string(arena, i));
                     __auto_type b_access = context_ctx_str4(ctx, SLOP_STR("_b->data."), c_variant_name, SLOP_STR(".f"), int_to_string(arena, i));
                     context_ctx_emit_header(ctx, context_ctx_str(ctx, SLOP_STR("                && "), transpiler_payload_eq_expr(ctx, slot.slop_type, slot.c_type, a_access, b_access)));
                 }
-            } else if (!_mv_1374.has_value) {
+            } else if (!_mv_1375.has_value) {
             }
             i = (i + 1);
         }
@@ -4732,11 +4732,11 @@ void transpiler_emit_struct_hash_fn(context_TranspileContext* ctx, slop_string c
         __auto_type len = ((int64_t)((fields).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1375 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1375.has_value) {
-                __auto_type field = _mv_1375.value;
+            __auto_type _mv_1376 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1376.has_value) {
+                __auto_type field = _mv_1376.value;
                 transpiler_emit_field_hash(ctx, field);
-            } else if (!_mv_1375.has_value) {
+            } else if (!_mv_1376.has_value) {
             }
             i = (i + 1);
         }
@@ -4803,11 +4803,11 @@ void transpiler_emit_struct_eq_fn(context_TranspileContext* ctx, slop_string c_t
             {
                 int64_t i = 0;
                 while (i < len) {
-                    __auto_type _mv_1376 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1376.has_value) {
-                        __auto_type field = _mv_1376.value;
+                    __auto_type _mv_1377 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1377.has_value) {
+                        __auto_type field = _mv_1377.value;
                         transpiler_emit_field_eq(ctx, field);
-                    } else if (!_mv_1376.has_value) {
+                    } else if (!_mv_1377.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -4865,9 +4865,9 @@ void transpiler_emit_struct_key_types_header(context_TranspileContext* ctx) {
         uint8_t banner = 0;
         int64_t i = 0;
         while (i < ((int64_t)((struct_key_types).len))) {
-            __auto_type _mv_1377 = ({ __auto_type _lst = struct_key_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1377.has_value) {
-                __auto_type c_type = _mv_1377.value;
+            __auto_type _mv_1378 = ({ __auto_type _lst = struct_key_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1378.has_value) {
+                __auto_type c_type = _mv_1378.value;
                 {
                     __auto_type emitted_marker = context_ctx_str(ctx, SLOP_STR("hasheq:"), c_type);
                     if (!(context_ctx_is_type_emitted(ctx, emitted_marker))) {
@@ -4892,7 +4892,7 @@ void transpiler_emit_struct_key_types_header(context_TranspileContext* ctx) {
                         }
                     }
                 }
-            } else if (!_mv_1377.has_value) {
+            } else if (!_mv_1378.has_value) {
             }
             i = (i + 1);
         }
@@ -4993,9 +4993,9 @@ void transpiler_emit_chan_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((chan_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1378 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1378.has_value) {
-                __auto_type ct = _mv_1378.value;
+            __auto_type _mv_1379 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1379.has_value) {
+                __auto_type ct = _mv_1379.value;
                 {
                     __auto_type elem_type = ct.elem_type;
                     __auto_type c_name = ct.c_name;
@@ -5020,7 +5020,7 @@ void transpiler_emit_chan_types_header(context_TranspileContext* ctx) {
                         }
                     }
                 }
-            } else if (!_mv_1378.has_value) {
+            } else if (!_mv_1379.has_value) {
             }
             i = (i + 1);
         }
@@ -5034,9 +5034,9 @@ void transpiler_emit_chan_funcs_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((chan_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1379 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1379.has_value) {
-                __auto_type ct = _mv_1379.value;
+            __auto_type _mv_1380 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1380.has_value) {
+                __auto_type ct = _mv_1380.value;
                 {
                     __auto_type elem_type = ct.elem_type;
                     __auto_type c_name = ct.c_name;
@@ -5044,7 +5044,7 @@ void transpiler_emit_chan_funcs_header(context_TranspileContext* ctx) {
                         transpiler_emit_chan_send_recv_funcs(ctx, c_name, elem_type);
                     }
                 }
-            } else if (!_mv_1379.has_value) {
+            } else if (!_mv_1380.has_value) {
             }
             i = (i + 1);
         }
@@ -5180,9 +5180,9 @@ void transpiler_emit_thread_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((thread_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1380 = ({ __auto_type _lst = thread_types; size_t _idx = (size_t)i; slop_option_context_ThreadType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1380.has_value) {
-                __auto_type tt = _mv_1380.value;
+            __auto_type _mv_1381 = ({ __auto_type _lst = thread_types; size_t _idx = (size_t)i; slop_option_context_ThreadType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1381.has_value) {
+                __auto_type tt = _mv_1381.value;
                 {
                     __auto_type result_type = tt.result_type;
                     __auto_type c_name = tt.c_name;
@@ -5214,7 +5214,7 @@ void transpiler_emit_thread_types_header(context_TranspileContext* ctx) {
                         }
                     }
                 }
-            } else if (!_mv_1380.has_value) {
+            } else if (!_mv_1381.has_value) {
             }
             i = (i + 1);
         }
@@ -5259,44 +5259,44 @@ slop_string transpiler_uppercase_name(context_TranspileContext* ctx, slop_string
 
 uint8_t transpiler_is_simple_enum_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1381 = (*item);
-    switch (_mv_1381.tag) {
+    __auto_type _mv_1382 = (*item);
+    switch (_mv_1382.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1381.data.lst;
+            __auto_type lst = _mv_1382.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 3) {
                     return 0;
                 } else {
-                    __auto_type _mv_1382 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1382.has_value) {
-                        __auto_type def_expr = _mv_1382.value;
-                        __auto_type _mv_1383 = (*def_expr);
-                        switch (_mv_1383.tag) {
+                    __auto_type _mv_1383 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1383.has_value) {
+                        __auto_type def_expr = _mv_1383.value;
+                        __auto_type _mv_1384 = (*def_expr);
+                        switch (_mv_1384.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type def_lst = _mv_1383.data.lst;
+                                __auto_type def_lst = _mv_1384.data.lst;
                                 {
                                     __auto_type def_items = def_lst.items;
                                     if (((int64_t)((def_items).len)) < 1) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1384 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1384.has_value) {
-                                            __auto_type head = _mv_1384.value;
-                                            __auto_type _mv_1385 = (*head);
-                                            switch (_mv_1385.tag) {
+                                        __auto_type _mv_1385 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1385.has_value) {
+                                            __auto_type head = _mv_1385.value;
+                                            __auto_type _mv_1386 = (*head);
+                                            switch (_mv_1386.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_1385.data.sym;
+                                                    __auto_type sym = _mv_1386.data.sym;
                                                     return (string_eq(sym.name, SLOP_STR("enum")) && !(transpiler_has_enum_payload_variants(def_items)));
                                                 }
                                                 default: {
                                                     return 0;
                                                 }
                                             }
-                                        } else if (!_mv_1384.has_value) {
+                                        } else if (!_mv_1385.has_value) {
                                             return 0;
                                         }
                                         SLOP_UNREACHABLE();
@@ -5307,7 +5307,7 @@ uint8_t transpiler_is_simple_enum_def(types_SExpr* item) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1382.has_value) {
+                    } else if (!_mv_1383.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -5327,23 +5327,11 @@ void transpiler_emit_module_types_header(context_TranspileContext* ctx, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1386 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1386.has_value) {
-                __auto_type item = _mv_1386.value;
-                if (transpiler_is_type_def(item) && transpiler_is_type_alias_def(item)) {
-                    transpiler_emit_type_alias_to_header(ctx, item);
-                }
-            } else if (!_mv_1386.has_value) {
-            }
-            i = (i + 1);
-        }
-        i = start;
-        while (i < len) {
             __auto_type _mv_1387 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_1387.has_value) {
                 __auto_type item = _mv_1387.value;
-                if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
-                    transpiler_emit_type_to_header(ctx, item);
+                if (transpiler_is_type_def(item) && transpiler_is_type_alias_def(item)) {
+                    transpiler_emit_type_alias_to_header(ctx, item);
                 }
             } else if (!_mv_1387.has_value) {
             }
@@ -5354,10 +5342,22 @@ void transpiler_emit_module_types_header(context_TranspileContext* ctx, slop_lis
             __auto_type _mv_1388 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_1388.has_value) {
                 __auto_type item = _mv_1388.value;
-                if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
+                if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
                     transpiler_emit_type_to_header(ctx, item);
                 }
             } else if (!_mv_1388.has_value) {
+            }
+            i = (i + 1);
+        }
+        i = start;
+        while (i < len) {
+            __auto_type _mv_1389 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1389.has_value) {
+                __auto_type item = _mv_1389.value;
+                if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
+                    transpiler_emit_type_to_header(ctx, item);
+                }
+            } else if (!_mv_1389.has_value) {
             }
             i = (i + 1);
         }
@@ -5370,13 +5370,13 @@ void transpiler_emit_simple_type_aliases_header(context_TranspileContext* ctx, s
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1389 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1389.has_value) {
-                __auto_type item = _mv_1389.value;
+            __auto_type _mv_1390 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1390.has_value) {
+                __auto_type item = _mv_1390.value;
                 if ((transpiler_is_type_def(item)) && (transpiler_is_type_alias_def(item)) && (!(transpiler_is_result_type_alias_def(item)))) {
                     transpiler_emit_type_alias_to_header(ctx, item);
                 }
-            } else if (!_mv_1389.has_value) {
+            } else if (!_mv_1390.has_value) {
             }
             i = (i + 1);
         }
@@ -5389,13 +5389,13 @@ void transpiler_emit_type_aliases_header(context_TranspileContext* ctx, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1390 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1390.has_value) {
-                __auto_type item = _mv_1390.value;
+            __auto_type _mv_1391 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1391.has_value) {
+                __auto_type item = _mv_1391.value;
                 if ((transpiler_is_type_def(item)) && (transpiler_is_type_alias_def(item)) && (transpiler_is_result_type_alias_def(item))) {
                     transpiler_emit_type_alias_to_header(ctx, item);
                 }
-            } else if (!_mv_1390.has_value) {
+            } else if (!_mv_1391.has_value) {
             }
             i = (i + 1);
         }
@@ -5408,13 +5408,13 @@ void transpiler_emit_simple_enums_header(context_TranspileContext* ctx, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1391 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1391.has_value) {
-                __auto_type item = _mv_1391.value;
+            __auto_type _mv_1392 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1392.has_value) {
+                __auto_type item = _mv_1392.value;
                 if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
                     transpiler_emit_type_to_header(ctx, item);
                 }
-            } else if (!_mv_1391.has_value) {
+            } else if (!_mv_1392.has_value) {
             }
             i = (i + 1);
         }
@@ -5429,9 +5429,9 @@ void transpiler_emit_pending_container_deps(context_TranspileContext* ctx, types
         __auto_type len = ((int64_t)((field_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1392 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1392.has_value) {
-                __auto_type field_type = _mv_1392.value;
+            __auto_type _mv_1393 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1393.has_value) {
+                __auto_type field_type = _mv_1393.value;
                 if (!(context_ctx_is_type_emitted(ctx, field_type)) && transpiler_is_emittable_container_type(ctx, field_type)) {
                     if (strlib_starts_with(field_type, SLOP_STR("slop_option_"))) {
                         transpiler_emit_option_by_c_name(ctx, field_type);
@@ -5440,7 +5440,7 @@ void transpiler_emit_pending_container_deps(context_TranspileContext* ctx, types
                         transpiler_emit_list_by_c_name(ctx, field_type);
                     }
                 }
-            } else if (!_mv_1392.has_value) {
+            } else if (!_mv_1393.has_value) {
             }
             i = (i + 1);
         }
@@ -5454,13 +5454,13 @@ void transpiler_emit_option_by_c_name(context_TranspileContext* ctx, slop_string
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1393 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1393.has_value) {
-                __auto_type ot = _mv_1393.value;
+            __auto_type _mv_1394 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1394.has_value) {
+                __auto_type ot = _mv_1394.value;
                 if (string_eq(ot.c_name, c_name)) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1393.has_value) {
+            } else if (!_mv_1394.has_value) {
             }
             i = (i + 1);
         }
@@ -5474,13 +5474,13 @@ void transpiler_emit_list_by_c_name(context_TranspileContext* ctx, slop_string c
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1394 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1394.has_value) {
-                __auto_type lt = _mv_1394.value;
+            __auto_type _mv_1395 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1395.has_value) {
+                __auto_type lt = _mv_1395.value;
                 if (string_eq(lt.c_name, c_name)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1394.has_value) {
+            } else if (!_mv_1395.has_value) {
             }
             i = (i + 1);
         }
@@ -5501,9 +5501,9 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                 int64_t i = start;
                 while (i < len) {
                     if (!(transpiler_index_in_list(emitted, i))) {
-                        __auto_type _mv_1395 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1395.has_value) {
-                            __auto_type item = _mv_1395.value;
+                        __auto_type _mv_1396 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1396.has_value) {
+                            __auto_type item = _mv_1396.value;
                             if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                                 if (transpiler_type_deps_satisfied(ctx, item)) {
                                     transpiler_emit_pending_container_deps(ctx, item);
@@ -5513,7 +5513,7 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                                     transpiler_emit_option_list_for_type(ctx, item);
                                 }
                             }
-                        } else if (!_mv_1395.has_value) {
+                        } else if (!_mv_1396.has_value) {
                         }
                     }
                     i = (i + 1);
@@ -5530,9 +5530,9 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                     int64_t i = start;
                     while (i < len) {
                         if (!(transpiler_index_in_list(emitted, i))) {
-                            __auto_type _mv_1396 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1396.has_value) {
-                                __auto_type item = _mv_1396.value;
+                            __auto_type _mv_1397 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1397.has_value) {
+                                __auto_type item = _mv_1397.value;
                                 if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                                     if (transpiler_type_deps_satisfied(ctx, item)) {
                                         transpiler_emit_pending_container_deps(ctx, item);
@@ -5542,7 +5542,7 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                                         transpiler_emit_option_list_for_type(ctx, item);
                                     }
                                 }
-                            } else if (!_mv_1396.has_value) {
+                            } else if (!_mv_1397.has_value) {
                             }
                         }
                         i = (i + 1);
@@ -5559,13 +5559,13 @@ uint8_t transpiler_has_unemitted_struct_types(slop_list_types_SExpr_ptr items, i
         uint8_t found = 0;
         while ((i < len) && !(found)) {
             if (!(transpiler_index_in_list(emitted, i))) {
-                __auto_type _mv_1397 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1397.has_value) {
-                    __auto_type item = _mv_1397.value;
+                __auto_type _mv_1398 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1398.has_value) {
+                    __auto_type item = _mv_1398.value;
                     if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                         found = 1;
                     }
-                } else if (!_mv_1397.has_value) {
+                } else if (!_mv_1398.has_value) {
                 }
             }
             i = (i + 1);
@@ -5580,26 +5580,26 @@ void transpiler_break_list_cycles(context_TranspileContext* ctx, slop_list_types
         int64_t i = start;
         while (i < len) {
             if (!(transpiler_index_in_list(emitted, i))) {
-                __auto_type _mv_1398 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1398.has_value) {
-                    __auto_type item = _mv_1398.value;
+                __auto_type _mv_1399 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1399.has_value) {
+                    __auto_type item = _mv_1399.value;
                     if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                         {
                             __auto_type blocking_deps = transpiler_find_blocking_list_deps(ctx, item);
                             __auto_type dep_len = ((int64_t)((blocking_deps).len));
                             __auto_type j = 0;
                             while (j < dep_len) {
-                                __auto_type _mv_1399 = ({ __auto_type _lst = blocking_deps; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1399.has_value) {
-                                    __auto_type dep_name = _mv_1399.value;
+                                __auto_type _mv_1400 = ({ __auto_type _lst = blocking_deps; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1400.has_value) {
+                                    __auto_type dep_name = _mv_1400.value;
                                     transpiler_emit_list_declare_by_c_name(ctx, dep_name);
-                                } else if (!_mv_1399.has_value) {
+                                } else if (!_mv_1400.has_value) {
                                 }
                                 j = (j + 1);
                             }
                         }
                     }
-                } else if (!_mv_1398.has_value) {
+                } else if (!_mv_1399.has_value) {
                 }
             }
             i = (i + 1);
@@ -5617,13 +5617,13 @@ slop_list_string transpiler_find_blocking_list_deps(context_TranspileContext* ct
         __auto_type result = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1400 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1400.has_value) {
-                __auto_type field_type = _mv_1400.value;
+            __auto_type _mv_1401 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1401.has_value) {
+                __auto_type field_type = _mv_1401.value;
                 if ((strlib_starts_with(field_type, SLOP_STR("slop_list_"))) && (!(context_ctx_is_type_emitted(ctx, field_type))) && (!(transpiler_is_runtime_list_type(field_type)))) {
                     ({ __auto_type _lst_p = &(result); __auto_type _item = (field_type); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                 }
-            } else if (!_mv_1400.has_value) {
+            } else if (!_mv_1401.has_value) {
             }
             i = (i + 1);
         }
@@ -5638,13 +5638,13 @@ void transpiler_emit_list_declare_by_c_name(context_TranspileContext* ctx, slop_
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1401 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1401.has_value) {
-                __auto_type lt = _mv_1401.value;
+            __auto_type _mv_1402 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1402.has_value) {
+                __auto_type lt = _mv_1402.value;
                 if (string_eq(lt.c_name, c_name)) {
                     transpiler_emit_list_type_declare_only(ctx, lt);
                 }
-            } else if (!_mv_1401.has_value) {
+            } else if (!_mv_1402.has_value) {
             }
             i = (i + 1);
         }
@@ -5657,13 +5657,13 @@ uint8_t transpiler_index_in_list(slop_list_int lst, int64_t idx) {
         int64_t i = 0;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1402 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_int _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1402.has_value) {
-                __auto_type v = _mv_1402.value;
+            __auto_type _mv_1403 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_int _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1403.has_value) {
+                __auto_type v = _mv_1403.value;
                 if (v == idx) {
                     found = 1;
                 }
-            } else if (!_mv_1402.has_value) {
+            } else if (!_mv_1403.has_value) {
             }
             i = (i + 1);
         }
@@ -5680,13 +5680,13 @@ uint8_t transpiler_type_deps_satisfied(context_TranspileContext* ctx, types_SExp
         int64_t i = 0;
         uint8_t all_satisfied = 1;
         while ((i < len) && all_satisfied) {
-            __auto_type _mv_1403 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1403.has_value) {
-                __auto_type field_type = _mv_1403.value;
+            __auto_type _mv_1404 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1404.has_value) {
+                __auto_type field_type = _mv_1404.value;
                 if (!(transpiler_type_is_available(ctx, field_type))) {
                     all_satisfied = 0;
                 }
-            } else if (!_mv_1403.has_value) {
+            } else if (!_mv_1404.has_value) {
             }
             i = (i + 1);
         }
@@ -5733,34 +5733,34 @@ slop_list_string transpiler_get_type_field_types(context_TranspileContext* ctx, 
     {
         __auto_type arena = (*ctx).arena;
         __auto_type result = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
-        __auto_type _mv_1404 = (*type_def);
-        switch (_mv_1404.tag) {
+        __auto_type _mv_1405 = (*type_def);
+        switch (_mv_1405.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1404.data.lst;
+                __auto_type lst = _mv_1405.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_1405 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1405.has_value) {
-                            __auto_type def_expr = _mv_1405.value;
-                            __auto_type _mv_1406 = (*def_expr);
-                            switch (_mv_1406.tag) {
+                        __auto_type _mv_1406 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1406.has_value) {
+                            __auto_type def_expr = _mv_1406.value;
+                            __auto_type _mv_1407 = (*def_expr);
+                            switch (_mv_1407.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type def_lst = _mv_1406.data.lst;
+                                    __auto_type def_lst = _mv_1407.data.lst;
                                     {
                                         __auto_type def_items = def_lst.items;
                                         __auto_type def_len = ((int64_t)((def_items).len));
                                         if (def_len > 0) {
-                                            __auto_type _mv_1407 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1407.has_value) {
-                                                __auto_type head = _mv_1407.value;
-                                                __auto_type _mv_1408 = (*head);
-                                                switch (_mv_1408.tag) {
+                                            __auto_type _mv_1408 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1408.has_value) {
+                                                __auto_type head = _mv_1408.value;
+                                                __auto_type _mv_1409 = (*head);
+                                                switch (_mv_1409.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type sym = _mv_1408.data.sym;
+                                                        __auto_type sym = _mv_1409.data.sym;
                                                         {
                                                             __auto_type kind = sym.name;
                                                             if (string_eq(kind, SLOP_STR("record"))) {
@@ -5776,7 +5776,7 @@ slop_list_string transpiler_get_type_field_types(context_TranspileContext* ctx, 
                                                         break;
                                                     }
                                                 }
-                                            } else if (!_mv_1407.has_value) {
+                                            } else if (!_mv_1408.has_value) {
                                             }
                                         }
                                     }
@@ -5786,7 +5786,7 @@ slop_list_string transpiler_get_type_field_types(context_TranspileContext* ctx, 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1405.has_value) {
+                        } else if (!_mv_1406.has_value) {
                         }
                     }
                 }
@@ -5808,25 +5808,25 @@ slop_list_string transpiler_extract_record_field_types(context_TranspileContext*
         __auto_type len = ((int64_t)((def_items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1409 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1409.has_value) {
-                __auto_type field_expr = _mv_1409.value;
-                __auto_type _mv_1410 = (*field_expr);
-                switch (_mv_1410.tag) {
+            __auto_type _mv_1410 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1410.has_value) {
+                __auto_type field_expr = _mv_1410.value;
+                __auto_type _mv_1411 = (*field_expr);
+                switch (_mv_1411.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type field_lst = _mv_1410.data.lst;
+                        __auto_type field_lst = _mv_1411.data.lst;
                         if (((int64_t)((field_lst.items).len)) >= 2) {
-                            __auto_type _mv_1411 = ({ __auto_type _lst = field_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1411.has_value) {
-                                __auto_type type_expr = _mv_1411.value;
+                            __auto_type _mv_1412 = ({ __auto_type _lst = field_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1412.has_value) {
+                                __auto_type type_expr = _mv_1412.value;
                                 {
                                     __auto_type type_str = transpiler_get_field_type_string(ctx, type_expr);
                                     if (!(string_eq(type_str, SLOP_STR("")))) {
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (type_str); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
                                 }
-                            } else if (!_mv_1411.has_value) {
+                            } else if (!_mv_1412.has_value) {
                             }
                         }
                         break;
@@ -5835,7 +5835,7 @@ slop_list_string transpiler_extract_record_field_types(context_TranspileContext*
                         break;
                     }
                 }
-            } else if (!_mv_1409.has_value) {
+            } else if (!_mv_1410.has_value) {
             }
             i = (i + 1);
         }
@@ -5851,25 +5851,25 @@ slop_list_string transpiler_extract_union_variant_types(context_TranspileContext
         __auto_type len = ((int64_t)((def_items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1412 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1412.has_value) {
-                __auto_type variant_expr = _mv_1412.value;
-                __auto_type _mv_1413 = (*variant_expr);
-                switch (_mv_1413.tag) {
+            __auto_type _mv_1413 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1413.has_value) {
+                __auto_type variant_expr = _mv_1413.value;
+                __auto_type _mv_1414 = (*variant_expr);
+                switch (_mv_1414.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type variant_lst = _mv_1413.data.lst;
+                        __auto_type variant_lst = _mv_1414.data.lst;
                         if (((int64_t)((variant_lst.items).len)) >= 2) {
-                            __auto_type _mv_1414 = ({ __auto_type _lst = variant_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1414.has_value) {
-                                __auto_type type_expr = _mv_1414.value;
+                            __auto_type _mv_1415 = ({ __auto_type _lst = variant_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1415.has_value) {
+                                __auto_type type_expr = _mv_1415.value;
                                 {
                                     __auto_type type_str = transpiler_get_field_type_string(ctx, type_expr);
                                     if (!(string_eq(type_str, SLOP_STR("")))) {
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (type_str); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
                                 }
-                            } else if (!_mv_1414.has_value) {
+                            } else if (!_mv_1415.has_value) {
                             }
                         }
                         break;
@@ -5878,7 +5878,7 @@ slop_list_string transpiler_extract_union_variant_types(context_TranspileContext
                         break;
                     }
                 }
-            } else if (!_mv_1412.has_value) {
+            } else if (!_mv_1413.has_value) {
             }
             i = (i + 1);
         }
@@ -5891,18 +5891,18 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1415 = (*type_expr);
-        switch (_mv_1415.tag) {
+        __auto_type _mv_1416 = (*type_expr);
+        switch (_mv_1416.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1415.data.sym;
+                __auto_type sym = _mv_1416.data.sym;
                 {
                     __auto_type name = sym.name;
-                    __auto_type _mv_1416 = context_ctx_lookup_type(ctx, name);
-                    if (_mv_1416.has_value) {
-                        __auto_type entry = _mv_1416.value;
+                    __auto_type _mv_1417 = context_ctx_lookup_type(ctx, name);
+                    if (_mv_1417.has_value) {
+                        __auto_type entry = _mv_1417.value;
                         return entry.c_name;
-                    } else if (!_mv_1416.has_value) {
+                    } else if (!_mv_1417.has_value) {
                         return ctype_to_c_type(arena, type_expr);
                     }
                     SLOP_UNREACHABLE();
@@ -5910,45 +5910,25 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1415.data.lst;
+                __auto_type lst = _mv_1416.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 1) {
                         return SLOP_STR("");
                     } else {
-                        __auto_type _mv_1417 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1417.has_value) {
-                            __auto_type head = _mv_1417.value;
-                            __auto_type _mv_1418 = (*head);
-                            switch (_mv_1418.tag) {
+                        __auto_type _mv_1418 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1418.has_value) {
+                            __auto_type head = _mv_1418.value;
+                            __auto_type _mv_1419 = (*head);
+                            switch (_mv_1419.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1418.data.sym;
+                                    __auto_type sym = _mv_1419.data.sym;
                                     {
                                         __auto_type kind = sym.name;
                                         if (string_eq(kind, SLOP_STR("Ptr"))) {
                                             return SLOP_STR("");
                                         } else if (string_eq(kind, SLOP_STR("Option"))) {
-                                            if (((int64_t)((items).len)) >= 2) {
-                                                __auto_type _mv_1419 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1419.has_value) {
-                                                    __auto_type inner = _mv_1419.value;
-                                                    {
-                                                        __auto_type inner_str = transpiler_get_field_type_string(ctx, inner);
-                                                        if (string_eq(inner_str, SLOP_STR(""))) {
-                                                            return SLOP_STR("");
-                                                        } else {
-                                                            return context_ctx_str(ctx, SLOP_STR("slop_option_"), ctype_type_to_identifier(arena, inner_str));
-                                                        }
-                                                    }
-                                                } else if (!_mv_1419.has_value) {
-                                                    return SLOP_STR("");
-                                                }
-                                                SLOP_UNREACHABLE();
-                                            } else {
-                                                return SLOP_STR("");
-                                            }
-                                        } else if (string_eq(kind, SLOP_STR("List"))) {
                                             if (((int64_t)((items).len)) >= 2) {
                                                 __auto_type _mv_1420 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                                 if (_mv_1420.has_value) {
@@ -5958,10 +5938,30 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                                                         if (string_eq(inner_str, SLOP_STR(""))) {
                                                             return SLOP_STR("");
                                                         } else {
-                                                            return context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, inner_str));
+                                                            return context_ctx_str(ctx, SLOP_STR("slop_option_"), ctype_type_to_identifier(arena, inner_str));
                                                         }
                                                     }
                                                 } else if (!_mv_1420.has_value) {
+                                                    return SLOP_STR("");
+                                                }
+                                                SLOP_UNREACHABLE();
+                                            } else {
+                                                return SLOP_STR("");
+                                            }
+                                        } else if (string_eq(kind, SLOP_STR("List"))) {
+                                            if (((int64_t)((items).len)) >= 2) {
+                                                __auto_type _mv_1421 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1421.has_value) {
+                                                    __auto_type inner = _mv_1421.value;
+                                                    {
+                                                        __auto_type inner_str = transpiler_get_field_type_string(ctx, inner);
+                                                        if (string_eq(inner_str, SLOP_STR(""))) {
+                                                            return SLOP_STR("");
+                                                        } else {
+                                                            return context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, inner_str));
+                                                        }
+                                                    }
+                                                } else if (!_mv_1421.has_value) {
                                                     return SLOP_STR("");
                                                 }
                                                 SLOP_UNREACHABLE();
@@ -5977,7 +5977,7 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                                     return SLOP_STR("");
                                 }
                             }
-                        } else if (!_mv_1417.has_value) {
+                        } else if (!_mv_1418.has_value) {
                             return SLOP_STR("");
                         }
                         SLOP_UNREACHABLE();
@@ -6006,31 +6006,31 @@ void transpiler_emit_option_list_for_type(context_TranspileContext* ctx, types_S
 slop_string transpiler_get_type_c_name(context_TranspileContext* ctx, types_SExpr* type_def) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
-    __auto_type _mv_1421 = (*type_def);
-    switch (_mv_1421.tag) {
+    __auto_type _mv_1422 = (*type_def);
+    switch (_mv_1422.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1421.data.lst;
+            __auto_type lst = _mv_1422.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return SLOP_STR("");
                 } else {
-                    __auto_type _mv_1422 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1422.has_value) {
-                        __auto_type name_expr = _mv_1422.value;
-                        __auto_type _mv_1423 = (*name_expr);
-                        switch (_mv_1423.tag) {
+                    __auto_type _mv_1423 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1423.has_value) {
+                        __auto_type name_expr = _mv_1423.value;
+                        __auto_type _mv_1424 = (*name_expr);
+                        switch (_mv_1424.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1423.data.sym;
+                                __auto_type sym = _mv_1424.data.sym;
                                 {
                                     __auto_type name = sym.name;
-                                    __auto_type _mv_1424 = context_ctx_lookup_type(ctx, name);
-                                    if (_mv_1424.has_value) {
-                                        __auto_type entry = _mv_1424.value;
+                                    __auto_type _mv_1425 = context_ctx_lookup_type(ctx, name);
+                                    if (_mv_1425.has_value) {
+                                        __auto_type entry = _mv_1425.value;
                                         return entry.c_name;
-                                    } else if (!_mv_1424.has_value) {
+                                    } else if (!_mv_1425.has_value) {
                                         return SLOP_STR("");
                                     }
                                     SLOP_UNREACHABLE();
@@ -6040,7 +6040,7 @@ slop_string transpiler_get_type_c_name(context_TranspileContext* ctx, types_SExp
                                 return SLOP_STR("");
                             }
                         }
-                    } else if (!_mv_1422.has_value) {
+                    } else if (!_mv_1423.has_value) {
                         return SLOP_STR("");
                     }
                     SLOP_UNREACHABLE();
@@ -6060,13 +6060,13 @@ void transpiler_emit_option_for_inner_type(context_TranspileContext* ctx, slop_s
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1425 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1425.has_value) {
-                __auto_type ot = _mv_1425.value;
+            __auto_type _mv_1426 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1426.has_value) {
+                __auto_type ot = _mv_1426.value;
                 if (string_eq(ot.inner_type, inner_c_name) && !(transpiler_is_pointer_elem_type(ot.inner_type))) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1425.has_value) {
+            } else if (!_mv_1426.has_value) {
             }
             i = (i + 1);
         }
@@ -6080,14 +6080,14 @@ void transpiler_emit_list_for_elem_type(context_TranspileContext* ctx, slop_stri
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1426 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1426.has_value) {
-                __auto_type lt = _mv_1426.value;
+            __auto_type _mv_1427 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1427.has_value) {
+                __auto_type lt = _mv_1427.value;
                 if (string_eq(lt.elem_type, elem_c_name) && !(transpiler_is_pointer_elem_type(lt.elem_type))) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                     transpiler_emit_option_for_inner_type(ctx, lt.c_name);
                 }
-            } else if (!_mv_1426.has_value) {
+            } else if (!_mv_1427.has_value) {
             }
             i = (i + 1);
         }
@@ -6105,13 +6105,13 @@ uint8_t transpiler_struct_uses_value_list_or_option(context_TranspileContext* ct
             __auto_type len = ((int64_t)((list_types).len));
             int64_t i = 0;
             while ((i < len) && !(found)) {
-                __auto_type _mv_1427 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1427.has_value) {
-                    __auto_type lt = _mv_1427.value;
+                __auto_type _mv_1428 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1428.has_value) {
+                    __auto_type lt = _mv_1428.value;
                     if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_struct_uses_list_type(ctx, type_def, lt.c_name)) {
                         found = 1;
                     }
-                } else if (!_mv_1427.has_value) {
+                } else if (!_mv_1428.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6121,13 +6121,13 @@ uint8_t transpiler_struct_uses_value_list_or_option(context_TranspileContext* ct
                 __auto_type len2 = ((int64_t)((option_types).len));
                 int64_t j = 0;
                 while ((j < len2) && !(found)) {
-                    __auto_type _mv_1428 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)j; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1428.has_value) {
-                        __auto_type ot = _mv_1428.value;
+                    __auto_type _mv_1429 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)j; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1429.has_value) {
+                        __auto_type ot = _mv_1429.value;
                         if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_struct_uses_option_type(ctx, type_def, ot.c_name)) {
                             found = 1;
                         }
-                    } else if (!_mv_1428.has_value) {
+                    } else if (!_mv_1429.has_value) {
                     }
                     j = (j + 1);
                 }
@@ -6145,13 +6145,13 @@ void transpiler_emit_struct_dependent_list_types(context_TranspileContext* ctx, 
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1429 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1429.has_value) {
-                __auto_type lt = _mv_1429.value;
+            __auto_type _mv_1430 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1430.has_value) {
+                __auto_type lt = _mv_1430.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_struct_uses_list_type(ctx, type_def, lt.c_name)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1429.has_value) {
+            } else if (!_mv_1430.has_value) {
             }
             i = (i + 1);
         }
@@ -6166,14 +6166,14 @@ void transpiler_emit_struct_dependent_option_types(context_TranspileContext* ctx
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1430 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1430.has_value) {
-                __auto_type ot = _mv_1430.value;
+            __auto_type _mv_1431 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1431.has_value) {
+                __auto_type ot = _mv_1431.value;
                 if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_struct_uses_option_type(ctx, type_def, ot.c_name)) {
                     transpiler_emit_list_type_if_needed(ctx, ot.inner_type);
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1430.has_value) {
+            } else if (!_mv_1431.has_value) {
             }
             i = (i + 1);
         }
@@ -6188,15 +6188,15 @@ void transpiler_emit_struct_dependent_list_types_safe(context_TranspileContext* 
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1431 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1431.has_value) {
-                __auto_type lt = _mv_1431.value;
+            __auto_type _mv_1432 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1432.has_value) {
+                __auto_type lt = _mv_1432.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_struct_uses_list_type(ctx, type_def, lt.c_name)) {
                     if (transpiler_is_type_emitted_or_primitive(ctx, lt.elem_type)) {
                         transpiler_emit_single_list_type_header(ctx, lt);
                     }
                 }
-            } else if (!_mv_1431.has_value) {
+            } else if (!_mv_1432.has_value) {
             }
             i = (i + 1);
         }
@@ -6211,16 +6211,16 @@ void transpiler_emit_struct_dependent_option_types_safe(context_TranspileContext
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1432 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1432.has_value) {
-                __auto_type ot = _mv_1432.value;
+            __auto_type _mv_1433 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1433.has_value) {
+                __auto_type ot = _mv_1433.value;
                 if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_struct_uses_option_type(ctx, type_def, ot.c_name)) {
                     if (transpiler_is_type_emitted_or_primitive(ctx, ot.inner_type)) {
                         transpiler_emit_list_type_if_needed_safe(ctx, ot.inner_type);
                         transpiler_emit_single_option_type_header(ctx, ot);
                     }
                 }
-            } else if (!_mv_1432.has_value) {
+            } else if (!_mv_1433.has_value) {
             }
             i = (i + 1);
         }
@@ -6245,9 +6245,9 @@ uint8_t transpiler_is_imported_type(context_TranspileContext* ctx, slop_string t
     if (strlib_starts_with(type_name, SLOP_STR("slop_list_")) || strlib_starts_with(type_name, SLOP_STR("slop_option_"))) {
         return 0;
     } else {
-        __auto_type _mv_1433 = context_ctx_get_module(ctx);
-        if (_mv_1433.has_value) {
-            __auto_type current_mod = _mv_1433.value;
+        __auto_type _mv_1434 = context_ctx_get_module(ctx);
+        if (_mv_1434.has_value) {
+            __auto_type current_mod = _mv_1434.value;
             {
                 __auto_type arena = (*ctx).arena;
                 __auto_type c_mod = ctype_to_c_name(arena, current_mod);
@@ -6261,7 +6261,7 @@ uint8_t transpiler_is_imported_type(context_TranspileContext* ctx, slop_string t
                     }
                 }
             }
-        } else if (!_mv_1433.has_value) {
+        } else if (!_mv_1434.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -6293,13 +6293,13 @@ void transpiler_emit_list_type_if_needed_safe(context_TranspileContext* ctx, slo
             __auto_type len = ((int64_t)((list_types).len));
             int64_t i = 0;
             while (i < len) {
-                __auto_type _mv_1434 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1434.has_value) {
-                    __auto_type lt = _mv_1434.value;
+                __auto_type _mv_1435 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1435.has_value) {
+                    __auto_type lt = _mv_1435.value;
                     if (string_eq(lt.c_name, inner_type) && transpiler_is_type_emitted_or_primitive(ctx, lt.elem_type)) {
                         transpiler_emit_single_list_type_header(ctx, lt);
                     }
-                } else if (!_mv_1434.has_value) {
+                } else if (!_mv_1435.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6315,13 +6315,13 @@ void transpiler_emit_list_type_if_needed(context_TranspileContext* ctx, slop_str
             __auto_type len = ((int64_t)((list_types).len));
             int64_t i = 0;
             while (i < len) {
-                __auto_type _mv_1435 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1435.has_value) {
-                    __auto_type lt = _mv_1435.value;
+                __auto_type _mv_1436 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1436.has_value) {
+                    __auto_type lt = _mv_1436.value;
                     if (string_eq(lt.c_name, inner_type)) {
                         transpiler_emit_single_list_type_header(ctx, lt);
                     }
-                } else if (!_mv_1435.has_value) {
+                } else if (!_mv_1436.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6334,21 +6334,21 @@ uint8_t transpiler_struct_uses_list_type(context_TranspileContext* ctx, types_SE
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1436 = (*type_def);
-        switch (_mv_1436.tag) {
+        __auto_type _mv_1437 = (*type_def);
+        switch (_mv_1437.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1436.data.lst;
+                __auto_type lst = _mv_1437.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 3) {
                         return 0;
                     } else {
-                        __auto_type _mv_1437 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1437.has_value) {
-                            __auto_type body_expr = _mv_1437.value;
+                        __auto_type _mv_1438 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1438.has_value) {
+                            __auto_type body_expr = _mv_1438.value;
                             return transpiler_type_body_uses_typename(ctx, body_expr, list_type_name);
-                        } else if (!_mv_1437.has_value) {
+                        } else if (!_mv_1438.has_value) {
                             return 0;
                         }
                         SLOP_UNREACHABLE();
@@ -6373,24 +6373,24 @@ uint8_t transpiler_type_body_uses_typename(context_TranspileContext* ctx, types_
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1438 = (*body_expr);
-        switch (_mv_1438.tag) {
+        __auto_type _mv_1439 = (*body_expr);
+        switch (_mv_1439.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1438.data.lst;
+                __auto_type lst = _mv_1439.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type found = 0;
                     __auto_type i = 1;
                     while ((i < len) && !(found)) {
-                        __auto_type _mv_1439 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1439.has_value) {
-                            __auto_type field_expr = _mv_1439.value;
+                        __auto_type _mv_1440 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1440.has_value) {
+                            __auto_type field_expr = _mv_1440.value;
                             if (transpiler_field_uses_typename(ctx, field_expr, typename)) {
                                 found = 1;
                             }
-                        } else if (!_mv_1439.has_value) {
+                        } else if (!_mv_1440.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -6407,24 +6407,24 @@ uint8_t transpiler_type_body_uses_typename(context_TranspileContext* ctx, types_
 uint8_t transpiler_field_uses_typename(context_TranspileContext* ctx, types_SExpr* field_expr, slop_string typename) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((field_expr != NULL)), "(!= field-expr nil)");
-    __auto_type _mv_1440 = (*field_expr);
-    switch (_mv_1440.tag) {
+    __auto_type _mv_1441 = (*field_expr);
+    switch (_mv_1441.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1440.data.lst;
+            __auto_type lst = _mv_1441.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return 0;
                 } else {
-                    __auto_type _mv_1441 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1441.has_value) {
-                        __auto_type type_expr = _mv_1441.value;
+                    __auto_type _mv_1442 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1442.has_value) {
+                        __auto_type type_expr = _mv_1442.value;
                         {
                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                             return string_eq(c_type, typename);
                         }
-                    } else if (!_mv_1441.has_value) {
+                    } else if (!_mv_1442.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -6442,33 +6442,33 @@ void transpiler_emit_type_to_header(context_TranspileContext* ctx, types_SExpr* 
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1442 = (*type_def);
-        switch (_mv_1442.tag) {
+        __auto_type _mv_1443 = (*type_def);
+        switch (_mv_1443.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1442.data.lst;
+                __auto_type lst = _mv_1443.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 3) {
-                        __auto_type _mv_1443 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1443.has_value) {
-                            __auto_type name_expr = _mv_1443.value;
-                            __auto_type _mv_1444 = (*name_expr);
-                            switch (_mv_1444.tag) {
+                        __auto_type _mv_1444 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1444.has_value) {
+                            __auto_type name_expr = _mv_1444.value;
+                            __auto_type _mv_1445 = (*name_expr);
+                            switch (_mv_1445.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1444.data.sym;
+                                    __auto_type name_sym = _mv_1445.data.sym;
                                     {
                                         __auto_type type_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, type_name);
                                         __auto_type c_name = ((context_ctx_prefixing_enabled(ctx)) ? ({ __auto_type _mv = context_ctx_get_module(ctx); _mv.has_value ? ({ __auto_type mod_name = _mv.value; context_ctx_str(ctx, ctype_to_c_name(arena, mod_name), context_ctx_str(ctx, SLOP_STR("_"), base_name)); }) : (base_name); }) : base_name);
-                                        __auto_type _mv_1445 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1445.has_value) {
-                                            __auto_type body_expr = _mv_1445.value;
+                                        __auto_type _mv_1446 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1446.has_value) {
+                                            __auto_type body_expr = _mv_1446.value;
                                             transpiler_emit_type_body_to_header(ctx, type_name, c_name, body_expr);
                                             context_ctx_mark_type_emitted(ctx, c_name);
-                                        } else if (!_mv_1445.has_value) {
+                                        } else if (!_mv_1446.has_value) {
                                         }
                                     }
                                     break;
@@ -6477,7 +6477,7 @@ void transpiler_emit_type_to_header(context_TranspileContext* ctx, types_SExpr* 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1443.has_value) {
+                        } else if (!_mv_1444.has_value) {
                         }
                     }
                 }
@@ -6495,23 +6495,23 @@ void transpiler_emit_type_body_to_header(context_TranspileContext* ctx, slop_str
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1446 = (*body_expr);
-        switch (_mv_1446.tag) {
+        __auto_type _mv_1447 = (*body_expr);
+        switch (_mv_1447.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1446.data.lst;
+                __auto_type lst = _mv_1447.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 1) {
                     } else {
-                        __auto_type _mv_1447 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1447.has_value) {
-                            __auto_type kind_expr = _mv_1447.value;
-                            __auto_type _mv_1448 = (*kind_expr);
-                            switch (_mv_1448.tag) {
+                        __auto_type _mv_1448 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1448.has_value) {
+                            __auto_type kind_expr = _mv_1448.value;
+                            __auto_type _mv_1449 = (*kind_expr);
+                            switch (_mv_1449.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type kind_sym = _mv_1448.data.sym;
+                                    __auto_type kind_sym = _mv_1449.data.sym;
                                     {
                                         __auto_type kind = kind_sym.name;
                                         if (string_eq(kind, SLOP_STR("enum"))) {
@@ -6529,7 +6529,7 @@ void transpiler_emit_type_body_to_header(context_TranspileContext* ctx, slop_str
                                     break;
                                 }
                             }
-                        } else if (!_mv_1447.has_value) {
+                        } else if (!_mv_1448.has_value) {
                         }
                     }
                 }
@@ -6550,14 +6550,14 @@ void transpiler_emit_enum_to_header(context_TranspileContext* ctx, slop_string c
         int64_t i = 1;
         context_ctx_emit_header(ctx, SLOP_STR("typedef enum {"));
         while (i < len) {
-            __auto_type _mv_1449 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1449.has_value) {
-                __auto_type variant_expr = _mv_1449.value;
-                __auto_type _mv_1450 = (*variant_expr);
-                switch (_mv_1450.tag) {
+            __auto_type _mv_1450 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1450.has_value) {
+                __auto_type variant_expr = _mv_1450.value;
+                __auto_type _mv_1451 = (*variant_expr);
+                switch (_mv_1451.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type variant_sym = _mv_1450.data.sym;
+                        __auto_type variant_sym = _mv_1451.data.sym;
                         {
                             __auto_type variant_name = variant_sym.name;
                             __auto_type c_variant = context_ctx_str3(ctx, c_name, SLOP_STR("_"), ctype_to_c_name(arena, variant_name));
@@ -6574,7 +6574,7 @@ void transpiler_emit_enum_to_header(context_TranspileContext* ctx, slop_string c
                         break;
                     }
                 }
-            } else if (!_mv_1449.has_value) {
+            } else if (!_mv_1450.has_value) {
             }
             i = (i + 1);
         }
@@ -6592,11 +6592,11 @@ void transpiler_emit_struct_to_header(context_TranspileContext* ctx, slop_string
         int64_t i = 1;
         context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("struct "), c_name, SLOP_STR(" {")));
         while (i < len) {
-            __auto_type _mv_1451 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1451.has_value) {
-                __auto_type field_expr = _mv_1451.value;
+            __auto_type _mv_1452 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1452.has_value) {
+                __auto_type field_expr = _mv_1452.value;
                 transpiler_emit_field_to_header(ctx, raw_type_name, c_name, field_expr);
-            } else if (!_mv_1451.has_value) {
+            } else if (!_mv_1452.has_value) {
             }
             i = (i + 1);
         }
@@ -6611,28 +6611,28 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
     SLOP_PRE(((field_expr != NULL)), "(!= field-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1452 = (*field_expr);
-        switch (_mv_1452.tag) {
+        __auto_type _mv_1453 = (*field_expr);
+        switch (_mv_1453.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1452.data.lst;
+                __auto_type lst = _mv_1453.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_1453 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1453.has_value) {
-                            __auto_type name_expr = _mv_1453.value;
-                            __auto_type _mv_1454 = (*name_expr);
-                            switch (_mv_1454.tag) {
+                        __auto_type _mv_1454 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1454.has_value) {
+                            __auto_type name_expr = _mv_1454.value;
+                            __auto_type _mv_1455 = (*name_expr);
+                            switch (_mv_1455.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1454.data.sym;
+                                    __auto_type name_sym = _mv_1455.data.sym;
                                     {
                                         __auto_type field_name = name_sym.name;
                                         __auto_type c_field_name = ctype_to_c_name(arena, field_name);
-                                        __auto_type _mv_1455 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1455.has_value) {
-                                            __auto_type type_expr = _mv_1455.value;
+                                        __auto_type _mv_1456 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1456.has_value) {
+                                            __auto_type type_expr = _mv_1456.value;
                                             {
                                                 __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                 __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
@@ -6641,7 +6641,7 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
                                                 context_ctx_register_field_type(ctx, raw_type_name, field_name, c_type, slop_type_str, is_ptr);
                                                 context_ctx_register_field_type(ctx, c_type_name, field_name, c_type, slop_type_str, is_ptr);
                                             }
-                                        } else if (!_mv_1455.has_value) {
+                                        } else if (!_mv_1456.has_value) {
                                         }
                                     }
                                     break;
@@ -6650,7 +6650,7 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1453.has_value) {
+                        } else if (!_mv_1454.has_value) {
                         }
                     }
                 }
@@ -6665,31 +6665,31 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
 
 uint8_t transpiler_is_pointer_type_expr_header(types_SExpr* type_expr) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_1456 = (*type_expr);
-    switch (_mv_1456.tag) {
+    __auto_type _mv_1457 = (*type_expr);
+    switch (_mv_1457.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1456.data.lst;
+            __auto_type lst = _mv_1457.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1457 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1457.has_value) {
-                        __auto_type head = _mv_1457.value;
-                        __auto_type _mv_1458 = (*head);
-                        switch (_mv_1458.tag) {
+                    __auto_type _mv_1458 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1458.has_value) {
+                        __auto_type head = _mv_1458.value;
+                        __auto_type _mv_1459 = (*head);
+                        switch (_mv_1459.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1458.data.sym;
+                                __auto_type sym = _mv_1459.data.sym;
                                 return string_eq(sym.name, SLOP_STR("Ptr"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1457.has_value) {
+                    } else if (!_mv_1458.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -6712,9 +6712,9 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
         {
             int64_t i = 1;
             while (i < len) {
-                __auto_type _mv_1459 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1459.has_value) {
-                    __auto_type variant_expr = _mv_1459.value;
+                __auto_type _mv_1460 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1460.has_value) {
+                    __auto_type variant_expr = _mv_1460.value;
                     {
                         __auto_type variant_name = transpiler_get_variant_name(variant_expr);
                         __auto_type c_variant = context_ctx_str3(ctx, c_name, SLOP_STR("_"), ctype_to_c_name(arena, variant_name));
@@ -6725,7 +6725,7 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
                             context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("    "), c_variant, SLOP_STR(",")));
                         }
                     }
-                } else if (!_mv_1459.has_value) {
+                } else if (!_mv_1460.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6738,11 +6738,11 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
         {
             int64_t i = 1;
             while (i < len) {
-                __auto_type _mv_1460 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1460.has_value) {
-                    __auto_type variant_expr = _mv_1460.value;
+                __auto_type _mv_1461 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1461.has_value) {
+                    __auto_type variant_expr = _mv_1461.value;
                     transpiler_emit_union_variant_to_header(ctx, variant_expr);
-                } else if (!_mv_1460.has_value) {
+                } else if (!_mv_1461.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6756,36 +6756,36 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
 
 slop_string transpiler_get_variant_name(types_SExpr* variant_expr) {
     SLOP_PRE(((variant_expr != NULL)), "(!= variant-expr nil)");
-    __auto_type _mv_1461 = (*variant_expr);
-    switch (_mv_1461.tag) {
+    __auto_type _mv_1462 = (*variant_expr);
+    switch (_mv_1462.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1461.data.sym;
+            __auto_type sym = _mv_1462.data.sym;
             return sym.name;
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1461.data.lst;
+            __auto_type lst = _mv_1462.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return SLOP_STR("unknown");
                 } else {
-                    __auto_type _mv_1462 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1462.has_value) {
-                        __auto_type name_expr = _mv_1462.value;
-                        __auto_type _mv_1463 = (*name_expr);
-                        switch (_mv_1463.tag) {
+                    __auto_type _mv_1463 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1463.has_value) {
+                        __auto_type name_expr = _mv_1463.value;
+                        __auto_type _mv_1464 = (*name_expr);
+                        switch (_mv_1464.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type name_sym = _mv_1463.data.sym;
+                                __auto_type name_sym = _mv_1464.data.sym;
                                 return name_sym.name;
                             }
                             default: {
                                 return SLOP_STR("unknown");
                             }
                         }
-                    } else if (!_mv_1462.has_value) {
+                    } else if (!_mv_1463.has_value) {
                         return SLOP_STR("unknown");
                     }
                     SLOP_UNREACHABLE();
@@ -6803,35 +6803,35 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
     SLOP_PRE(((variant_expr != NULL)), "(!= variant-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1464 = (*variant_expr);
-        switch (_mv_1464.tag) {
+        __auto_type _mv_1465 = (*variant_expr);
+        switch (_mv_1465.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1464.data.sym;
+                __auto_type sym = _mv_1465.data.sym;
                 break;
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1464.data.lst;
+                __auto_type lst = _mv_1465.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type num_items = ((int64_t)((items).len));
                     if (num_items >= 2) {
-                        __auto_type _mv_1465 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1465.has_value) {
-                            __auto_type name_expr = _mv_1465.value;
-                            __auto_type _mv_1466 = (*name_expr);
-                            switch (_mv_1466.tag) {
+                        __auto_type _mv_1466 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1466.has_value) {
+                            __auto_type name_expr = _mv_1466.value;
+                            __auto_type _mv_1467 = (*name_expr);
+                            switch (_mv_1467.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1466.data.sym;
+                                    __auto_type name_sym = _mv_1467.data.sym;
                                     {
                                         __auto_type variant_name = name_sym.name;
                                         __auto_type c_field = ctype_to_c_name(arena, variant_name);
                                         if (num_items == 2) {
-                                            __auto_type _mv_1467 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1467.has_value) {
-                                                __auto_type type_expr = _mv_1467.value;
+                                            __auto_type _mv_1468 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1468.has_value) {
+                                                __auto_type type_expr = _mv_1468.value;
                                                 {
                                                     __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                     {
@@ -6839,14 +6839,14 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
                                                         context_ctx_emit_header(ctx, context_ctx_str4(ctx, SLOP_STR("        "), actual_type, SLOP_STR(" "), context_ctx_str(ctx, c_field, SLOP_STR(";"))));
                                                     }
                                                 }
-                                            } else if (!_mv_1467.has_value) {
+                                            } else if (!_mv_1468.has_value) {
                                             }
                                         } else if (num_items >= 3) {
                                             context_ctx_emit_header(ctx, SLOP_STR("        struct {"));
                                             for (int64_t fi = 1; fi < num_items; fi++) {
-                                                __auto_type _mv_1468 = ({ __auto_type _lst = items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1468.has_value) {
-                                                    __auto_type type_expr = _mv_1468.value;
+                                                __auto_type _mv_1469 = ({ __auto_type _lst = items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1469.has_value) {
+                                                    __auto_type type_expr = _mv_1469.value;
                                                     {
                                                         __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                         {
@@ -6855,7 +6855,7 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
                                                             context_ctx_emit_header(ctx, context_ctx_str5(ctx, SLOP_STR("            "), actual_type, SLOP_STR(" "), field_name, SLOP_STR(";")));
                                                         }
                                                     }
-                                                } else if (!_mv_1468.has_value) {
+                                                } else if (!_mv_1469.has_value) {
                                                 }
                                             }
                                             context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("        } "), c_field, SLOP_STR(";")));
@@ -6868,7 +6868,7 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
                                     break;
                                 }
                             }
-                        } else if (!_mv_1465.has_value) {
+                        } else if (!_mv_1466.has_value) {
                         }
                     }
                 }
@@ -6888,9 +6888,9 @@ void transpiler_emit_module_consts(context_TranspileContext* ctx, slop_list_type
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1469 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1469.has_value) {
-                __auto_type item = _mv_1469.value;
+            __auto_type _mv_1470 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1470.has_value) {
+                __auto_type item = _mv_1470.value;
                 if (transpiler_is_const_def(item)) {
                     {
                         __auto_type const_name = transpiler_get_const_name(item);
@@ -6899,7 +6899,7 @@ void transpiler_emit_module_consts(context_TranspileContext* ctx, slop_list_type
                     }
                     emitted_any = 1;
                 }
-            } else if (!_mv_1469.has_value) {
+            } else if (!_mv_1470.has_value) {
             }
             i = (i + 1);
         }
@@ -6911,31 +6911,31 @@ void transpiler_emit_module_consts(context_TranspileContext* ctx, slop_list_type
 
 slop_string transpiler_get_const_name(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1470 = (*item);
-    switch (_mv_1470.tag) {
+    __auto_type _mv_1471 = (*item);
+    switch (_mv_1471.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1470.data.lst;
+            __auto_type lst = _mv_1471.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return SLOP_STR("");
                 } else {
-                    __auto_type _mv_1471 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1471.has_value) {
-                        __auto_type name_expr = _mv_1471.value;
-                        __auto_type _mv_1472 = (*name_expr);
-                        switch (_mv_1472.tag) {
+                    __auto_type _mv_1472 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1472.has_value) {
+                        __auto_type name_expr = _mv_1472.value;
+                        __auto_type _mv_1473 = (*name_expr);
+                        switch (_mv_1473.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1472.data.sym;
+                                __auto_type sym = _mv_1473.data.sym;
                                 return sym.name;
                             }
                             default: {
                                 return SLOP_STR("");
                             }
                         }
-                    } else if (!_mv_1471.has_value) {
+                    } else if (!_mv_1472.has_value) {
                         return SLOP_STR("");
                     }
                     SLOP_UNREACHABLE();
@@ -6955,15 +6955,15 @@ void transpiler_emit_module_consts_header(context_TranspileContext* ctx, slop_li
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1473 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1473.has_value) {
-                __auto_type item = _mv_1473.value;
+            __auto_type _mv_1474 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1474.has_value) {
+                __auto_type item = _mv_1474.value;
                 if (transpiler_is_const_def(item)) {
                     if (transpiler_emit_const_header_if_exported(ctx, item, exports)) {
                         emitted_any = 1;
                     }
                 }
-            } else if (!_mv_1473.has_value) {
+            } else if (!_mv_1474.has_value) {
             }
             i = (i + 1);
         }
@@ -6976,35 +6976,35 @@ void transpiler_emit_module_consts_header(context_TranspileContext* ctx, slop_li
 uint8_t transpiler_emit_const_header_if_exported(context_TranspileContext* ctx, types_SExpr* item, slop_list_string exports) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1474 = (*item);
-    switch (_mv_1474.tag) {
+    __auto_type _mv_1475 = (*item);
+    switch (_mv_1475.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1474.data.lst;
+            __auto_type lst = _mv_1475.data.lst;
             {
                 __auto_type const_items = lst.items;
                 if (((int64_t)((const_items).len)) < 4) {
                     return 0;
                 } else {
-                    __auto_type _mv_1475 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1475.has_value) {
-                        __auto_type name_expr = _mv_1475.value;
-                        __auto_type _mv_1476 = (*name_expr);
-                        switch (_mv_1476.tag) {
+                    __auto_type _mv_1476 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1476.has_value) {
+                        __auto_type name_expr = _mv_1476.value;
+                        __auto_type _mv_1477 = (*name_expr);
+                        switch (_mv_1477.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type name_sym = _mv_1476.data.sym;
+                                __auto_type name_sym = _mv_1477.data.sym;
                                 {
                                     __auto_type raw_name = name_sym.name;
                                     if (!(transpiler_list_contains_str(exports, raw_name))) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1477 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1477.has_value) {
-                                            __auto_type type_expr = _mv_1477.value;
+                                        __auto_type _mv_1478 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1478.has_value) {
+                                            __auto_type type_expr = _mv_1478.value;
                                             transpiler_emit_const_header_decl(ctx, raw_name, type_expr, ({ __auto_type _mv = ({ __auto_type _lst = const_items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type v = _mv.value; v; }) : (NULL); }));
                                             return 1;
-                                        } else if (!_mv_1477.has_value) {
+                                        } else if (!_mv_1478.has_value) {
                                             return 0;
                                         }
                                         SLOP_UNREACHABLE();
@@ -7015,7 +7015,7 @@ uint8_t transpiler_emit_const_header_if_exported(context_TranspileContext* ctx, 
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1475.has_value) {
+                    } else if (!_mv_1476.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -7066,13 +7066,13 @@ void transpiler_emit_module_functions(context_TranspileContext* ctx, slop_list_t
         int64_t i = start;
         context_ctx_start_function_buffer(ctx);
         while (i < len) {
-            __auto_type _mv_1478 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1478.has_value) {
-                __auto_type item = _mv_1478.value;
+            __auto_type _mv_1479 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1479.has_value) {
+                __auto_type item = _mv_1479.value;
                 if (transpiler_is_fn_def(item)) {
                     defn_transpile_function(ctx, item);
                 }
-            } else if (!_mv_1478.has_value) {
+            } else if (!_mv_1479.has_value) {
             }
             i = (i + 1);
         }
@@ -7090,12 +7090,12 @@ void transpiler_emit_all_lambdas(context_TranspileContext* ctx) {
         int64_t i = 0;
         if (count > 0) {
             while (i < count) {
-                __auto_type _mv_1479 = ({ __auto_type _lst = lambdas; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1479.has_value) {
-                    __auto_type lambda_code = _mv_1479.value;
+                __auto_type _mv_1480 = ({ __auto_type _lst = lambdas; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1480.has_value) {
+                    __auto_type lambda_code = _mv_1480.value;
                     context_ctx_emit(ctx, lambda_code);
                     context_ctx_emit(ctx, SLOP_STR(""));
-                } else if (!_mv_1479.has_value) {
+                } else if (!_mv_1480.has_value) {
                 }
                 i = (i + 1);
             }
@@ -7113,11 +7113,11 @@ slop_string transpiler_generate_c_output(context_TranspileContext* ctx) {
         __auto_type result = SLOP_STR("");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1480 = ({ __auto_type _lst = output_lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1480.has_value) {
-                __auto_type line = _mv_1480.value;
+            __auto_type _mv_1481 = ({ __auto_type _lst = output_lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1481.has_value) {
+                __auto_type line = _mv_1481.value;
                 result = context_ctx_str3(ctx, result, line, SLOP_STR("\n"));
-            } else if (!_mv_1480.has_value) {
+            } else if (!_mv_1481.has_value) {
             }
             i = (i + 1);
         }
@@ -7131,11 +7131,11 @@ void transpiler_transpile_file(context_TranspileContext* ctx, slop_list_types_SE
         __auto_type len = ((int64_t)((exprs).len));
         int64_t i = 0;
         if ((len > 0) && transpiler_is_module_expr(exprs)) {
-            __auto_type _mv_1481 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1481.has_value) {
-                __auto_type module_expr = _mv_1481.value;
+            __auto_type _mv_1482 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1482.has_value) {
+                __auto_type module_expr = _mv_1482.value;
                 transpiler_transpile_module(ctx, module_expr);
-            } else if (!_mv_1481.has_value) {
+            } else if (!_mv_1482.has_value) {
             }
         } else {
             emit_emit_standard_includes(ctx);
@@ -7151,34 +7151,34 @@ uint8_t transpiler_is_module_expr(slop_list_types_SExpr_ptr exprs) {
     if (((int64_t)((exprs).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_1482 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1482.has_value) {
-            __auto_type first = _mv_1482.value;
-            __auto_type _mv_1483 = (*first);
-            switch (_mv_1483.tag) {
+        __auto_type _mv_1483 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1483.has_value) {
+            __auto_type first = _mv_1483.value;
+            __auto_type _mv_1484 = (*first);
+            switch (_mv_1484.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type lst = _mv_1483.data.lst;
+                    __auto_type lst = _mv_1484.data.lst;
                     {
                         __auto_type items = lst.items;
                         if (((int64_t)((items).len)) < 1) {
                             return 0;
                         } else {
-                            __auto_type _mv_1484 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1484.has_value) {
-                                __auto_type head = _mv_1484.value;
-                                __auto_type _mv_1485 = (*head);
-                                switch (_mv_1485.tag) {
+                            __auto_type _mv_1485 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1485.has_value) {
+                                __auto_type head = _mv_1485.value;
+                                __auto_type _mv_1486 = (*head);
+                                switch (_mv_1486.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1485.data.sym;
+                                        __auto_type sym = _mv_1486.data.sym;
                                         return string_eq(sym.name, SLOP_STR("module"));
                                     }
                                     default: {
                                         return 0;
                                     }
                                 }
-                            } else if (!_mv_1484.has_value) {
+                            } else if (!_mv_1485.has_value) {
                                 return 0;
                             }
                             SLOP_UNREACHABLE();
@@ -7189,7 +7189,7 @@ uint8_t transpiler_is_module_expr(slop_list_types_SExpr_ptr exprs) {
                     return 0;
                 }
             }
-        } else if (!_mv_1482.has_value) {
+        } else if (!_mv_1483.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();

--- a/bootstrap/tester/slop_type_extract.c
+++ b/bootstrap/tester/slop_type_extract.c
@@ -71,16 +71,16 @@ type_extract_TypeRegistry* type_extract_extract_types_from_ast_with_imports(slop
             __auto_type len = ((int64_t)((ast).len));
             int64_t i = 0;
             while (i < len) {
-                __auto_type _mv_1486 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1486.has_value) {
-                    __auto_type expr = _mv_1486.value;
+                __auto_type _mv_1487 = ({ __auto_type _lst = ast; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1487.has_value) {
+                    __auto_type expr = _mv_1487.value;
                     if (parser_is_form(expr, SLOP_STR("module"))) {
                         type_extract_extract_types_from_module(arena, expr, reg_ptr, module_prefix);
                     }
                     if (parser_is_form(expr, SLOP_STR("type"))) {
                         type_extract_extract_type_def(arena, expr, reg_ptr, module_prefix);
                     }
-                } else if (!_mv_1486.has_value) {
+                } else if (!_mv_1487.has_value) {
                 }
                 i = (i + 1);
             }
@@ -94,13 +94,13 @@ void type_extract_extract_types_from_module(slop_arena* arena, types_SExpr* modu
         __auto_type len = parser_sexpr_list_len(module_form);
         int64_t i = 2;
         while (i < len) {
-            __auto_type _mv_1487 = parser_sexpr_list_get(module_form, i);
-            if (_mv_1487.has_value) {
-                __auto_type form = _mv_1487.value;
+            __auto_type _mv_1488 = parser_sexpr_list_get(module_form, i);
+            if (_mv_1488.has_value) {
+                __auto_type form = _mv_1488.value;
                 if (parser_is_form(form, SLOP_STR("type"))) {
                     type_extract_extract_type_def(arena, form, reg_ptr, prefix);
                 }
-            } else if (!_mv_1487.has_value) {
+            } else if (!_mv_1488.has_value) {
             }
             i = (i + 1);
         }
@@ -109,16 +109,16 @@ void type_extract_extract_types_from_module(slop_arena* arena, types_SExpr* modu
 
 void type_extract_extract_type_def(slop_arena* arena, types_SExpr* type_form, type_extract_TypeRegistry* reg_ptr, slop_string prefix) {
     if (parser_sexpr_list_len(type_form) >= 3) {
-        __auto_type _mv_1488 = parser_sexpr_list_get(type_form, 1);
-        if (_mv_1488.has_value) {
-            __auto_type name_expr = _mv_1488.value;
+        __auto_type _mv_1489 = parser_sexpr_list_get(type_form, 1);
+        if (_mv_1489.has_value) {
+            __auto_type name_expr = _mv_1489.value;
             if (parser_sexpr_is_symbol(name_expr)) {
                 {
                     __auto_type type_name = parser_sexpr_get_symbol_name(name_expr);
                     __auto_type c_name = type_extract_make_c_type_name(arena, prefix, type_name);
-                    __auto_type _mv_1489 = parser_sexpr_list_get(type_form, 2);
-                    if (_mv_1489.has_value) {
-                        __auto_type def_expr = _mv_1489.value;
+                    __auto_type _mv_1490 = parser_sexpr_list_get(type_form, 2);
+                    if (_mv_1490.has_value) {
+                        __auto_type def_expr = _mv_1490.value;
                         if (parser_is_form(def_expr, SLOP_STR("record"))) {
                             {
                                 __auto_type entry = type_extract_extract_record_type(arena, type_name, c_name, def_expr);
@@ -148,11 +148,11 @@ void type_extract_extract_type_def(slop_arena* arena, types_SExpr* type_form, ty
                                 ({ __auto_type _lst_p = &((*reg_ptr).types); __auto_type _item = (entry); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                             }
                         }
-                    } else if (!_mv_1489.has_value) {
+                    } else if (!_mv_1490.has_value) {
                     }
                 }
             }
-        } else if (!_mv_1488.has_value) {
+        } else if (!_mv_1489.has_value) {
         }
     }
 }
@@ -163,32 +163,32 @@ type_extract_TstTypeEntry* type_extract_extract_record_type(slop_arena* arena, s
         __auto_type len = parser_sexpr_list_len(def);
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1490 = parser_sexpr_list_get(def, i);
-            if (_mv_1490.has_value) {
-                __auto_type field_def = _mv_1490.value;
+            __auto_type _mv_1491 = parser_sexpr_list_get(def, i);
+            if (_mv_1491.has_value) {
+                __auto_type field_def = _mv_1491.value;
                 if (parser_sexpr_list_len(field_def) >= 2) {
-                    __auto_type _mv_1491 = parser_sexpr_list_get(field_def, 0);
-                    if (_mv_1491.has_value) {
-                        __auto_type field_name_expr = _mv_1491.value;
+                    __auto_type _mv_1492 = parser_sexpr_list_get(field_def, 0);
+                    if (_mv_1492.has_value) {
+                        __auto_type field_name_expr = _mv_1492.value;
                         if (parser_sexpr_is_symbol(field_name_expr)) {
                             {
                                 __auto_type field_name = parser_sexpr_get_symbol_name(field_name_expr);
-                                __auto_type _mv_1492 = parser_sexpr_list_get(field_def, 1);
-                                if (_mv_1492.has_value) {
-                                    __auto_type field_type_expr = _mv_1492.value;
+                                __auto_type _mv_1493 = parser_sexpr_list_get(field_def, 1);
+                                if (_mv_1493.has_value) {
+                                    __auto_type field_type_expr = _mv_1493.value;
                                     {
                                         __auto_type field_type = parser_pretty_print(arena, field_type_expr);
                                         __auto_type fe = type_extract_field_entry_new(field_name, field_type);
                                         ({ __auto_type _lst_p = &((*entry).fields); __auto_type _item = (fe); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
-                                } else if (!_mv_1492.has_value) {
+                                } else if (!_mv_1493.has_value) {
                                 }
                             }
                         }
-                    } else if (!_mv_1491.has_value) {
+                    } else if (!_mv_1492.has_value) {
                     }
                 }
-            } else if (!_mv_1490.has_value) {
+            } else if (!_mv_1491.has_value) {
             }
             i = (i + 1);
         }
@@ -203,15 +203,15 @@ type_extract_TstTypeEntry* type_extract_extract_union_type(slop_arena* arena, sl
         int64_t i = 1;
         int64_t idx = 0;
         while (i < len) {
-            __auto_type _mv_1493 = parser_sexpr_list_get(def, i);
-            if (_mv_1493.has_value) {
-                __auto_type variant_def = _mv_1493.value;
+            __auto_type _mv_1494 = parser_sexpr_list_get(def, i);
+            if (_mv_1494.has_value) {
+                __auto_type variant_def = _mv_1494.value;
                 {
                     __auto_type vlen = parser_sexpr_list_len(variant_def);
                     if (vlen >= 1) {
-                        __auto_type _mv_1494 = parser_sexpr_list_get(variant_def, 0);
-                        if (_mv_1494.has_value) {
-                            __auto_type variant_name_expr = _mv_1494.value;
+                        __auto_type _mv_1495 = parser_sexpr_list_get(variant_def, 0);
+                        if (_mv_1495.has_value) {
+                            __auto_type variant_name_expr = _mv_1495.value;
                             if (parser_sexpr_is_symbol(variant_name_expr)) {
                                 {
                                     __auto_type variant_name = parser_sexpr_get_symbol_name(variant_name_expr);
@@ -221,11 +221,11 @@ type_extract_TstTypeEntry* type_extract_extract_union_type(slop_arena* arena, sl
                                     idx = (idx + 1);
                                 }
                             }
-                        } else if (!_mv_1494.has_value) {
+                        } else if (!_mv_1495.has_value) {
                         }
                     }
                 }
-            } else if (!_mv_1493.has_value) {
+            } else if (!_mv_1494.has_value) {
             }
             i = (i + 1);
         }
@@ -240,9 +240,9 @@ type_extract_TstTypeEntry* type_extract_extract_enum_type(slop_arena* arena, slo
         int64_t i = 1;
         int64_t idx = 0;
         while (i < len) {
-            __auto_type _mv_1495 = parser_sexpr_list_get(def, i);
-            if (_mv_1495.has_value) {
-                __auto_type val_expr = _mv_1495.value;
+            __auto_type _mv_1496 = parser_sexpr_list_get(def, i);
+            if (_mv_1496.has_value) {
+                __auto_type val_expr = _mv_1496.value;
                 if (parser_sexpr_is_symbol(val_expr)) {
                     {
                         __auto_type val_name = parser_sexpr_get_symbol_name(val_expr);
@@ -251,7 +251,7 @@ type_extract_TstTypeEntry* type_extract_extract_enum_type(slop_arena* arena, slo
                         idx = (idx + 1);
                     }
                 }
-            } else if (!_mv_1495.has_value) {
+            } else if (!_mv_1496.has_value) {
             }
             i = (i + 1);
         }
@@ -266,13 +266,13 @@ slop_option_type_extract_TstTypeEntry_ptr type_extract_registry_lookup(type_extr
         int64_t i = 0;
         slop_option_type_extract_TstTypeEntry_ptr found = (slop_option_type_extract_TstTypeEntry_ptr){.has_value = false};
         while ((i < len) && ({ __auto_type _mv = found; _mv.has_value ? (0) : (1); })) {
-            __auto_type _mv_1496 = ({ __auto_type _lst = types; size_t _idx = (size_t)i; slop_option_type_extract_TstTypeEntry_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1496.has_value) {
-                __auto_type entry = _mv_1496.value;
+            __auto_type _mv_1497 = ({ __auto_type _lst = types; size_t _idx = (size_t)i; slop_option_type_extract_TstTypeEntry_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1497.has_value) {
+                __auto_type entry = _mv_1497.value;
                 if (string_eq((*entry).name, name)) {
                     found = (slop_option_type_extract_TstTypeEntry_ptr){.has_value = 1, .value = entry};
                 }
-            } else if (!_mv_1496.has_value) {
+            } else if (!_mv_1497.has_value) {
             }
             i = (i + 1);
         }
@@ -287,9 +287,9 @@ slop_option_type_extract_TstTypeEntry_ptr type_extract_registry_lookup_variant(t
         int64_t i = 0;
         slop_option_type_extract_TstTypeEntry_ptr found = (slop_option_type_extract_TstTypeEntry_ptr){.has_value = false};
         while ((i < len) && ({ __auto_type _mv = found; _mv.has_value ? (0) : (1); })) {
-            __auto_type _mv_1497 = ({ __auto_type _lst = types; size_t _idx = (size_t)i; slop_option_type_extract_TstTypeEntry_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1497.has_value) {
-                __auto_type entry = _mv_1497.value;
+            __auto_type _mv_1498 = ({ __auto_type _lst = types; size_t _idx = (size_t)i; slop_option_type_extract_TstTypeEntry_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1498.has_value) {
+                __auto_type entry = _mv_1498.value;
                 if ((*entry).kind == type_extract_TstTypeEntryKind_te_union) {
                     {
                         __auto_type variants = (*entry).variants;
@@ -297,20 +297,20 @@ slop_option_type_extract_TstTypeEntry_ptr type_extract_registry_lookup_variant(t
                         __auto_type j = 0;
                         __auto_type vfound = 0;
                         while ((j < vlen) && !(vfound)) {
-                            __auto_type _mv_1498 = ({ __auto_type _lst = variants; size_t _idx = (size_t)j; slop_option_type_extract_VariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1498.has_value) {
-                                __auto_type ve = _mv_1498.value;
+                            __auto_type _mv_1499 = ({ __auto_type _lst = variants; size_t _idx = (size_t)j; slop_option_type_extract_VariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1499.has_value) {
+                                __auto_type ve = _mv_1499.value;
                                 if (string_eq(ve.name, variant_name)) {
                                     vfound = 1;
                                     found = (slop_option_type_extract_TstTypeEntry_ptr){.has_value = 1, .value = entry};
                                 }
-                            } else if (!_mv_1498.has_value) {
+                            } else if (!_mv_1499.has_value) {
                             }
                             j = (j + 1);
                         }
                     }
                 }
-            } else if (!_mv_1497.has_value) {
+            } else if (!_mv_1498.has_value) {
             }
             i = (i + 1);
         }
@@ -325,9 +325,9 @@ slop_option_type_extract_TstTypeEntry_ptr type_extract_registry_lookup_enum_valu
         int64_t i = 0;
         slop_option_type_extract_TstTypeEntry_ptr found = (slop_option_type_extract_TstTypeEntry_ptr){.has_value = false};
         while ((i < len) && ({ __auto_type _mv = found; _mv.has_value ? (0) : (1); })) {
-            __auto_type _mv_1499 = ({ __auto_type _lst = types; size_t _idx = (size_t)i; slop_option_type_extract_TstTypeEntry_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1499.has_value) {
-                __auto_type entry = _mv_1499.value;
+            __auto_type _mv_1500 = ({ __auto_type _lst = types; size_t _idx = (size_t)i; slop_option_type_extract_TstTypeEntry_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1500.has_value) {
+                __auto_type entry = _mv_1500.value;
                 if ((*entry).kind == type_extract_TstTypeEntryKind_te_enum) {
                     {
                         __auto_type values = (*entry).enum_values;
@@ -335,20 +335,20 @@ slop_option_type_extract_TstTypeEntry_ptr type_extract_registry_lookup_enum_valu
                         __auto_type j = 0;
                         __auto_type vfound = 0;
                         while ((j < vlen) && !(vfound)) {
-                            __auto_type _mv_1500 = ({ __auto_type _lst = values; size_t _idx = (size_t)j; slop_option_type_extract_EnumValueEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1500.has_value) {
-                                __auto_type eve = _mv_1500.value;
+                            __auto_type _mv_1501 = ({ __auto_type _lst = values; size_t _idx = (size_t)j; slop_option_type_extract_EnumValueEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1501.has_value) {
+                                __auto_type eve = _mv_1501.value;
                                 if (string_eq(eve.name, value_name)) {
                                     vfound = 1;
                                     found = (slop_option_type_extract_TstTypeEntry_ptr){.has_value = 1, .value = entry};
                                 }
-                            } else if (!_mv_1500.has_value) {
+                            } else if (!_mv_1501.has_value) {
                             }
                             j = (j + 1);
                         }
                     }
                 }
-            } else if (!_mv_1499.has_value) {
+            } else if (!_mv_1500.has_value) {
             }
             i = (i + 1);
         }
@@ -363,26 +363,26 @@ slop_option_string type_extract_registry_lookup_import(type_extract_TypeRegistry
         int64_t i = 0;
         slop_option_string found = (slop_option_string){.has_value = false};
         while ((i < len) && ({ __auto_type _mv = found; _mv.has_value ? (0) : (1); })) {
-            __auto_type _mv_1501 = ({ __auto_type _lst = entries; size_t _idx = (size_t)i; slop_option_type_extract_ImportEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1501.has_value) {
-                __auto_type entry = _mv_1501.value;
+            __auto_type _mv_1502 = ({ __auto_type _lst = entries; size_t _idx = (size_t)i; slop_option_type_extract_ImportEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1502.has_value) {
+                __auto_type entry = _mv_1502.value;
                 {
                     __auto_type symbols = entry.symbols;
                     __auto_type slen = ((int64_t)((symbols).len));
                     __auto_type j = 0;
                     while ((j < slen) && ({ __auto_type _mv = found; _mv.has_value ? (0) : (1); })) {
-                        __auto_type _mv_1502 = ({ __auto_type _lst = symbols; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1502.has_value) {
-                            __auto_type sym = _mv_1502.value;
+                        __auto_type _mv_1503 = ({ __auto_type _lst = symbols; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1503.has_value) {
+                            __auto_type sym = _mv_1503.value;
                             if (string_eq(sym, symbol_name)) {
                                 found = (slop_option_string){.has_value = 1, .value = entry.module_name};
                             }
-                        } else if (!_mv_1502.has_value) {
+                        } else if (!_mv_1503.has_value) {
                         }
                         j = (j + 1);
                     }
                 }
-            } else if (!_mv_1501.has_value) {
+            } else if (!_mv_1502.has_value) {
             }
             i = (i + 1);
         }
@@ -391,76 +391,76 @@ slop_option_string type_extract_registry_lookup_import(type_extract_TypeRegistry
 }
 
 uint8_t type_extract_registry_is_union(type_extract_TypeRegistry reg, slop_string name) {
-    __auto_type _mv_1503 = type_extract_registry_lookup(reg, name);
-    if (_mv_1503.has_value) {
-        __auto_type entry = _mv_1503.value;
-        return ((*entry).kind == type_extract_TstTypeEntryKind_te_union);
-    } else if (!_mv_1503.has_value) {
-        return 0;
-    }
-    SLOP_UNREACHABLE();
-}
-
-uint8_t type_extract_registry_is_record(type_extract_TypeRegistry reg, slop_string name) {
     __auto_type _mv_1504 = type_extract_registry_lookup(reg, name);
     if (_mv_1504.has_value) {
         __auto_type entry = _mv_1504.value;
-        return ((*entry).kind == type_extract_TstTypeEntryKind_te_record);
+        return ((*entry).kind == type_extract_TstTypeEntryKind_te_union);
     } else if (!_mv_1504.has_value) {
         return 0;
     }
     SLOP_UNREACHABLE();
 }
 
-uint8_t type_extract_registry_is_enum(type_extract_TypeRegistry reg, slop_string name) {
+uint8_t type_extract_registry_is_record(type_extract_TypeRegistry reg, slop_string name) {
     __auto_type _mv_1505 = type_extract_registry_lookup(reg, name);
     if (_mv_1505.has_value) {
         __auto_type entry = _mv_1505.value;
-        return ((*entry).kind == type_extract_TstTypeEntryKind_te_enum);
+        return ((*entry).kind == type_extract_TstTypeEntryKind_te_record);
     } else if (!_mv_1505.has_value) {
         return 0;
     }
     SLOP_UNREACHABLE();
 }
 
-slop_option_type_extract_VariantEntry type_extract_registry_get_variant_info(type_extract_TypeRegistry reg, slop_string variant_name) {
-    __auto_type _mv_1506 = type_extract_registry_lookup_variant(reg, variant_name);
+uint8_t type_extract_registry_is_enum(type_extract_TypeRegistry reg, slop_string name) {
+    __auto_type _mv_1506 = type_extract_registry_lookup(reg, name);
     if (_mv_1506.has_value) {
         __auto_type entry = _mv_1506.value;
+        return ((*entry).kind == type_extract_TstTypeEntryKind_te_enum);
+    } else if (!_mv_1506.has_value) {
+        return 0;
+    }
+    SLOP_UNREACHABLE();
+}
+
+slop_option_type_extract_VariantEntry type_extract_registry_get_variant_info(type_extract_TypeRegistry reg, slop_string variant_name) {
+    __auto_type _mv_1507 = type_extract_registry_lookup_variant(reg, variant_name);
+    if (_mv_1507.has_value) {
+        __auto_type entry = _mv_1507.value;
         {
             __auto_type variants = (*entry).variants;
             __auto_type vlen = ((int64_t)((variants).len));
             __auto_type i = 0;
             slop_option_type_extract_VariantEntry found = (slop_option_type_extract_VariantEntry){.has_value = false};
             while ((i < vlen) && ({ __auto_type _mv = found; _mv.has_value ? (0) : (1); })) {
-                __auto_type _mv_1507 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_type_extract_VariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1507.has_value) {
-                    __auto_type ve = _mv_1507.value;
+                __auto_type _mv_1508 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_type_extract_VariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1508.has_value) {
+                    __auto_type ve = _mv_1508.value;
                     if (string_eq(ve.name, variant_name)) {
                         found = (slop_option_type_extract_VariantEntry){.has_value = 1, .value = ve};
                     }
-                } else if (!_mv_1507.has_value) {
+                } else if (!_mv_1508.has_value) {
                 }
                 i = (i + 1);
             }
             return found;
         }
-    } else if (!_mv_1506.has_value) {
+    } else if (!_mv_1507.has_value) {
         return (slop_option_type_extract_VariantEntry){.has_value = false};
     }
     SLOP_UNREACHABLE();
 }
 
 slop_option_list_type_extract_TstFieldEntry type_extract_registry_get_record_fields(type_extract_TypeRegistry reg, slop_string name) {
-    __auto_type _mv_1508 = type_extract_registry_lookup(reg, name);
-    if (_mv_1508.has_value) {
-        __auto_type entry = _mv_1508.value;
+    __auto_type _mv_1509 = type_extract_registry_lookup(reg, name);
+    if (_mv_1509.has_value) {
+        __auto_type entry = _mv_1509.value;
         if ((*entry).kind == type_extract_TstTypeEntryKind_te_record) {
             return (slop_option_list_type_extract_TstFieldEntry){.has_value = 1, .value = (*entry).fields};
         } else {
             return (slop_option_list_type_extract_TstFieldEntry){.has_value = false};
         }
-    } else if (!_mv_1508.has_value) {
+    } else if (!_mv_1509.has_value) {
         return (slop_option_list_type_extract_TstFieldEntry){.has_value = false};
     }
     SLOP_UNREACHABLE();

--- a/bootstrap/transpiler/slop_defn.c
+++ b/bootstrap/transpiler/slop_defn.c
@@ -86,31 +86,31 @@ slop_string defn_escape_for_c_string(slop_arena* arena, slop_string s);
 
 uint8_t defn_is_type_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_920 = (*expr);
-    switch (_mv_920.tag) {
+    __auto_type _mv_921 = (*expr);
+    switch (_mv_921.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_920.data.lst;
+            __auto_type lst = _mv_921.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_921 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_921.has_value) {
-                        __auto_type head = _mv_921.value;
-                        __auto_type _mv_922 = (*head);
-                        switch (_mv_922.tag) {
+                    __auto_type _mv_922 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_922.has_value) {
+                        __auto_type head = _mv_922.value;
+                        __auto_type _mv_923 = (*head);
+                        switch (_mv_923.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_922.data.sym;
+                                __auto_type sym = _mv_923.data.sym;
                                 return string_eq(sym.name, SLOP_STR("type"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_921.has_value) {
+                    } else if (!_mv_922.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -125,31 +125,31 @@ uint8_t defn_is_type_form(types_SExpr* expr) {
 
 uint8_t defn_is_function_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_923 = (*expr);
-    switch (_mv_923.tag) {
+    __auto_type _mv_924 = (*expr);
+    switch (_mv_924.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_923.data.lst;
+            __auto_type lst = _mv_924.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_924 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_924.has_value) {
-                        __auto_type head = _mv_924.value;
-                        __auto_type _mv_925 = (*head);
-                        switch (_mv_925.tag) {
+                    __auto_type _mv_925 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_925.has_value) {
+                        __auto_type head = _mv_925.value;
+                        __auto_type _mv_926 = (*head);
+                        switch (_mv_926.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_925.data.sym;
+                                __auto_type sym = _mv_926.data.sym;
                                 return string_eq(sym.name, SLOP_STR("fn"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_924.has_value) {
+                    } else if (!_mv_925.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -164,31 +164,31 @@ uint8_t defn_is_function_form(types_SExpr* expr) {
 
 uint8_t defn_is_const_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_926 = (*expr);
-    switch (_mv_926.tag) {
+    __auto_type _mv_927 = (*expr);
+    switch (_mv_927.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_926.data.lst;
+            __auto_type lst = _mv_927.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_927 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_927.has_value) {
-                        __auto_type head = _mv_927.value;
-                        __auto_type _mv_928 = (*head);
-                        switch (_mv_928.tag) {
+                    __auto_type _mv_928 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_928.has_value) {
+                        __auto_type head = _mv_928.value;
+                        __auto_type _mv_929 = (*head);
+                        switch (_mv_929.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_928.data.sym;
+                                __auto_type sym = _mv_929.data.sym;
                                 return string_eq(sym.name, SLOP_STR("const"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_927.has_value) {
+                    } else if (!_mv_928.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -203,31 +203,31 @@ uint8_t defn_is_const_form(types_SExpr* expr) {
 
 uint8_t defn_is_ffi_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_929 = (*expr);
-    switch (_mv_929.tag) {
+    __auto_type _mv_930 = (*expr);
+    switch (_mv_930.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_929.data.lst;
+            __auto_type lst = _mv_930.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_930 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_930.has_value) {
-                        __auto_type head = _mv_930.value;
-                        __auto_type _mv_931 = (*head);
-                        switch (_mv_931.tag) {
+                    __auto_type _mv_931 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_931.has_value) {
+                        __auto_type head = _mv_931.value;
+                        __auto_type _mv_932 = (*head);
+                        switch (_mv_932.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_931.data.sym;
+                                __auto_type sym = _mv_932.data.sym;
                                 return string_eq(sym.name, SLOP_STR("ffi"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_930.has_value) {
+                    } else if (!_mv_931.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -242,31 +242,31 @@ uint8_t defn_is_ffi_form(types_SExpr* expr) {
 
 uint8_t defn_is_ffi_struct_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_932 = (*expr);
-    switch (_mv_932.tag) {
+    __auto_type _mv_933 = (*expr);
+    switch (_mv_933.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_932.data.lst;
+            __auto_type lst = _mv_933.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_933 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_933.has_value) {
-                        __auto_type head = _mv_933.value;
-                        __auto_type _mv_934 = (*head);
-                        switch (_mv_934.tag) {
+                    __auto_type _mv_934 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_934.has_value) {
+                        __auto_type head = _mv_934.value;
+                        __auto_type _mv_935 = (*head);
+                        switch (_mv_935.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_934.data.sym;
+                                __auto_type sym = _mv_935.data.sym;
                                 return string_eq(sym.name, SLOP_STR("ffi-struct"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_933.has_value) {
+                    } else if (!_mv_934.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -285,25 +285,25 @@ uint8_t defn_has_generic_annotation(slop_list_types_SExpr_ptr items) {
         __auto_type i = 0;
         __auto_type found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_935 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_935.has_value) {
-                __auto_type item = _mv_935.value;
-                __auto_type _mv_936 = (*item);
-                switch (_mv_936.tag) {
+            __auto_type _mv_936 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_936.has_value) {
+                __auto_type item = _mv_936.value;
+                __auto_type _mv_937 = (*item);
+                switch (_mv_937.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type lst = _mv_936.data.lst;
+                        __auto_type lst = _mv_937.data.lst;
                         {
                             __auto_type sub_items = lst.items;
                             if (((int64_t)((sub_items).len)) > 0) {
-                                __auto_type _mv_937 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_937.has_value) {
-                                    __auto_type head = _mv_937.value;
-                                    __auto_type _mv_938 = (*head);
-                                    switch (_mv_938.tag) {
+                                __auto_type _mv_938 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_938.has_value) {
+                                    __auto_type head = _mv_938.value;
+                                    __auto_type _mv_939 = (*head);
+                                    switch (_mv_939.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_938.data.sym;
+                                            __auto_type sym = _mv_939.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("@generic"))) {
                                                 found = 1;
                                             } else {
@@ -314,7 +314,7 @@ uint8_t defn_has_generic_annotation(slop_list_types_SExpr_ptr items) {
                                             break;
                                         }
                                     }
-                                } else if (!_mv_937.has_value) {
+                                } else if (!_mv_938.has_value) {
                                 }
                             } else {
                             }
@@ -325,7 +325,7 @@ uint8_t defn_has_generic_annotation(slop_list_types_SExpr_ptr items) {
                         break;
                     }
                 }
-            } else if (!_mv_935.has_value) {
+            } else if (!_mv_936.has_value) {
             }
             i = (i + 1);
         }
@@ -334,31 +334,31 @@ uint8_t defn_has_generic_annotation(slop_list_types_SExpr_ptr items) {
 }
 
 uint8_t defn_is_pointer_type_expr(types_SExpr* type_expr) {
-    __auto_type _mv_939 = (*type_expr);
-    switch (_mv_939.tag) {
+    __auto_type _mv_940 = (*type_expr);
+    switch (_mv_940.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_939.data.lst;
+            __auto_type lst = _mv_940.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_940 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_940.has_value) {
-                        __auto_type head = _mv_940.value;
-                        __auto_type _mv_941 = (*head);
-                        switch (_mv_941.tag) {
+                    __auto_type _mv_941 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_941.has_value) {
+                        __auto_type head = _mv_941.value;
+                        __auto_type _mv_942 = (*head);
+                        switch (_mv_942.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_941.data.sym;
+                                __auto_type sym = _mv_942.data.sym;
                                 return (string_eq(sym.name, SLOP_STR("Ptr")) || string_eq(sym.name, SLOP_STR("ScopedPtr")));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_940.has_value) {
+                    } else if (!_mv_941.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -376,44 +376,44 @@ void defn_transpile_const(context_TranspileContext* ctx, types_SExpr* expr, uint
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_942 = (*expr);
-        switch (_mv_942.tag) {
+        __auto_type _mv_943 = (*expr);
+        switch (_mv_943.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_942.data.lst;
+                __auto_type lst = _mv_943.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 4) {
                         context_ctx_fail(ctx, SLOP_STR("invalid const: need name, type, value"));
                     } else {
-                        __auto_type _mv_943 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_943.has_value) {
-                            __auto_type name_expr = _mv_943.value;
-                            __auto_type _mv_944 = (*name_expr);
-                            switch (_mv_944.tag) {
+                        __auto_type _mv_944 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_944.has_value) {
+                            __auto_type name_expr = _mv_944.value;
+                            __auto_type _mv_945 = (*name_expr);
+                            switch (_mv_945.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_944.data.sym;
+                                    __auto_type name_sym = _mv_945.data.sym;
                                     {
                                         __auto_type raw_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, raw_name);
                                         __auto_type c_name = context_ctx_prefix_type(ctx, base_name);
-                                        __auto_type _mv_945 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_945.has_value) {
-                                            __auto_type type_expr = _mv_945.value;
+                                        __auto_type _mv_946 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_946.has_value) {
+                                            __auto_type type_expr = _mv_946.value;
                                             {
                                                 __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
                                                 context_ctx_bind_var(ctx, (context_VarEntry){raw_name, c_name, SLOP_STR("auto"), slop_type_str, 0, 0, 0, SLOP_STR(""), SLOP_STR("")});
-                                                __auto_type _mv_946 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_946.has_value) {
-                                                    __auto_type value_expr = _mv_946.value;
+                                                __auto_type _mv_947 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_947.has_value) {
+                                                    __auto_type value_expr = _mv_947.value;
                                                     defn_emit_const_def(ctx, c_name, type_expr, value_expr, is_exported);
-                                                } else if (!_mv_946.has_value) {
+                                                } else if (!_mv_947.has_value) {
                                                     context_ctx_fail(ctx, SLOP_STR("missing const value"));
                                                 }
                                             }
-                                        } else if (!_mv_945.has_value) {
+                                        } else if (!_mv_946.has_value) {
                                             context_ctx_fail(ctx, SLOP_STR("missing const type"));
                                         }
                                     }
@@ -424,7 +424,7 @@ void defn_transpile_const(context_TranspileContext* ctx, types_SExpr* expr, uint
                                     break;
                                 }
                             }
-                        } else if (!_mv_943.has_value) {
+                        } else if (!_mv_944.has_value) {
                             context_ctx_fail(ctx, SLOP_STR("missing const name"));
                         }
                     }
@@ -458,11 +458,11 @@ void defn_emit_const_def(context_TranspileContext* ctx, slop_string c_name, type
             {
                 __auto_type storage = ((is_exported) ? SLOP_STR("const ") : SLOP_STR("static const "));
                 if (string_eq(type_name, SLOP_STR("String"))) {
-                    __auto_type _mv_947 = (*value_expr);
-                    switch (_mv_947.tag) {
+                    __auto_type _mv_948 = (*value_expr);
+                    switch (_mv_948.tag) {
                         case types_SExpr_str:
                         {
-                            __auto_type str = _mv_947.data.str;
+                            __auto_type str = _mv_948.data.str;
                             context_ctx_emit(ctx, context_ctx_str5(ctx, storage, c_type, SLOP_STR(" "), c_name, context_ctx_str3(ctx, SLOP_STR(" = SLOP_STR(\""), str.value, SLOP_STR("\");"))));
                             break;
                         }
@@ -487,11 +487,11 @@ void defn_emit_const_def(context_TranspileContext* ctx, slop_string c_name, type
 
 slop_string defn_get_type_name_str(types_SExpr* type_expr) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_948 = (*type_expr);
-    switch (_mv_948.tag) {
+    __auto_type _mv_949 = (*type_expr);
+    switch (_mv_949.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_948.data.sym;
+            __auto_type sym = _mv_949.data.sym;
             return sym.name;
         }
         default: {
@@ -505,26 +505,26 @@ slop_string defn_eval_const_value(context_TranspileContext* ctx, types_SExpr* ex
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_949 = (*expr);
-        switch (_mv_949.tag) {
+        __auto_type _mv_950 = (*expr);
+        switch (_mv_950.tag) {
             case types_SExpr_num:
             {
-                __auto_type num = _mv_949.data.num;
+                __auto_type num = _mv_950.data.num;
                 return num.raw;
             }
             case types_SExpr_str:
             {
-                __auto_type str = _mv_949.data.str;
+                __auto_type str = _mv_950.data.str;
                 return context_ctx_str3(ctx, SLOP_STR("\""), str.value, SLOP_STR("\""));
             }
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_949.data.sym;
+                __auto_type sym = _mv_950.data.sym;
                 return ctype_to_c_name(arena, sym.name);
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_949.data.lst;
+                __auto_type lst = _mv_950.data.lst;
                 return expr_transpile_expr(ctx, expr);
             }
         }
@@ -542,25 +542,25 @@ void defn_transpile_ffi_struct(context_TranspileContext* ctx, types_SExpr* expr)
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_950 = (*expr);
-        switch (_mv_950.tag) {
+        __auto_type _mv_951 = (*expr);
+        switch (_mv_951.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_950.data.lst;
+                __auto_type lst = _mv_951.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     {
                         __auto_type name_idx = ((((len >= 2) && defn_is_string_expr(items, 1))) ? 2 : 1);
                         if (len >= (name_idx + 1)) {
-                            __auto_type _mv_951 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_951.has_value) {
-                                __auto_type name_expr = _mv_951.value;
-                                __auto_type _mv_952 = (*name_expr);
-                                switch (_mv_952.tag) {
+                            __auto_type _mv_952 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_952.has_value) {
+                                __auto_type name_expr = _mv_952.value;
+                                __auto_type _mv_953 = (*name_expr);
+                                switch (_mv_953.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_952.data.sym;
+                                        __auto_type sym = _mv_953.data.sym;
                                         {
                                             __auto_type type_name = sym.name;
                                             __auto_type c_name = ctype_to_c_name(arena, type_name);
@@ -575,7 +575,7 @@ void defn_transpile_ffi_struct(context_TranspileContext* ctx, types_SExpr* expr)
                                         break;
                                     }
                                 }
-                            } else if (!_mv_951.has_value) {
+                            } else if (!_mv_952.has_value) {
                             }
                         }
                     }
@@ -590,21 +590,21 @@ void defn_transpile_ffi_struct(context_TranspileContext* ctx, types_SExpr* expr)
 }
 
 uint8_t defn_is_string_expr(slop_list_types_SExpr_ptr items, int64_t idx) {
-    __auto_type _mv_953 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-    if (_mv_953.has_value) {
-        __auto_type item = _mv_953.value;
-        __auto_type _mv_954 = (*item);
-        switch (_mv_954.tag) {
+    __auto_type _mv_954 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+    if (_mv_954.has_value) {
+        __auto_type item = _mv_954.value;
+        __auto_type _mv_955 = (*item);
+        switch (_mv_955.tag) {
             case types_SExpr_str:
             {
-                __auto_type _ = _mv_954.data.str;
+                __auto_type _ = _mv_955.data.str;
                 return 1;
             }
             default: {
                 return 0;
             }
         }
-    } else if (!_mv_953.has_value) {
+    } else if (!_mv_954.has_value) {
         return 0;
     }
     SLOP_UNREACHABLE();
@@ -619,34 +619,34 @@ void defn_transpile_type(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_955 = (*expr);
-        switch (_mv_955.tag) {
+        __auto_type _mv_956 = (*expr);
+        switch (_mv_956.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_955.data.lst;
+                __auto_type lst = _mv_956.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 3) {
                         context_ctx_add_error_at(ctx, SLOP_STR("invalid type: need name and definition"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     } else {
-                        __auto_type _mv_956 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_956.has_value) {
-                            __auto_type name_expr = _mv_956.value;
-                            __auto_type _mv_957 = (*name_expr);
-                            switch (_mv_957.tag) {
+                        __auto_type _mv_957 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_957.has_value) {
+                            __auto_type name_expr = _mv_957.value;
+                            __auto_type _mv_958 = (*name_expr);
+                            switch (_mv_958.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_957.data.sym;
+                                    __auto_type name_sym = _mv_958.data.sym;
                                     {
                                         __auto_type raw_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, raw_name);
                                         __auto_type qualified_name = ((context_ctx_prefixing_enabled(ctx)) ? ({ __auto_type _mv = context_ctx_get_module(ctx); _mv.has_value ? ({ __auto_type mod_name = _mv.value; context_ctx_str(ctx, ctype_to_c_name(arena, mod_name), context_ctx_str(ctx, SLOP_STR("_"), base_name)); }) : (base_name); }) : base_name);
-                                        __auto_type _mv_958 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_958.has_value) {
-                                            __auto_type type_def = _mv_958.value;
+                                        __auto_type _mv_959 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_959.has_value) {
+                                            __auto_type type_def = _mv_959.value;
                                             defn_dispatch_type_def(ctx, raw_name, qualified_name, type_def);
-                                        } else if (!_mv_958.has_value) {
+                                        } else if (!_mv_959.has_value) {
                                             context_ctx_add_error_at(ctx, SLOP_STR("missing type definition"), context_ctx_sexpr_line(name_expr), context_ctx_sexpr_col(name_expr));
                                         }
                                     }
@@ -657,7 +657,7 @@ void defn_transpile_type(context_TranspileContext* ctx, types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_956.has_value) {
+                        } else if (!_mv_957.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing type name"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                     }
@@ -675,24 +675,24 @@ void defn_transpile_type(context_TranspileContext* ctx, types_SExpr* expr) {
 void defn_dispatch_type_def(context_TranspileContext* ctx, slop_string raw_name, slop_string qualified_name, types_SExpr* type_def) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
-    __auto_type _mv_959 = (*type_def);
-    switch (_mv_959.tag) {
+    __auto_type _mv_960 = (*type_def);
+    switch (_mv_960.tag) {
         case types_SExpr_lst:
         {
-            __auto_type def_lst = _mv_959.data.lst;
+            __auto_type def_lst = _mv_960.data.lst;
             {
                 __auto_type items = def_lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     context_ctx_add_error_at(ctx, SLOP_STR("empty type definition"), context_ctx_sexpr_line(type_def), context_ctx_sexpr_col(type_def));
                 } else {
-                    __auto_type _mv_960 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_960.has_value) {
-                        __auto_type head = _mv_960.value;
-                        __auto_type _mv_961 = (*head);
-                        switch (_mv_961.tag) {
+                    __auto_type _mv_961 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_961.has_value) {
+                        __auto_type head = _mv_961.value;
+                        __auto_type _mv_962 = (*head);
+                        switch (_mv_962.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_961.data.sym;
+                                __auto_type sym = _mv_962.data.sym;
                                 {
                                     __auto_type kind = sym.name;
                                     if (string_eq(kind, SLOP_STR("record"))) {
@@ -716,7 +716,7 @@ void defn_dispatch_type_def(context_TranspileContext* ctx, slop_string raw_name,
                                 break;
                             }
                         }
-                    } else if (!_mv_960.has_value) {
+                    } else if (!_mv_961.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("empty type definition"), context_ctx_sexpr_line(type_def), context_ctx_sexpr_col(type_def));
                     }
                 }
@@ -725,7 +725,7 @@ void defn_dispatch_type_def(context_TranspileContext* ctx, slop_string raw_name,
         }
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_959.data.sym;
+            __auto_type sym = _mv_960.data.sym;
             defn_transpile_type_alias(ctx, raw_name, qualified_name, type_def);
             break;
         }
@@ -742,14 +742,14 @@ uint8_t defn_has_payload_variants(slop_list_types_SExpr_ptr items) {
         int64_t i = 1;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_962 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_962.has_value) {
-                __auto_type item = _mv_962.value;
-                __auto_type _mv_963 = (*item);
-                switch (_mv_963.tag) {
+            __auto_type _mv_963 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_963.has_value) {
+                __auto_type item = _mv_963.value;
+                __auto_type _mv_964 = (*item);
+                switch (_mv_964.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type _ = _mv_963.data.lst;
+                        __auto_type _ = _mv_964.data.lst;
                         found = 1;
                         break;
                     }
@@ -757,7 +757,7 @@ uint8_t defn_has_payload_variants(slop_list_types_SExpr_ptr items) {
                         break;
                     }
                 }
-            } else if (!_mv_962.has_value) {
+            } else if (!_mv_963.has_value) {
             }
             i = (i + 1);
         }
@@ -770,11 +770,11 @@ void defn_transpile_record(context_TranspileContext* ctx, slop_string raw_name, 
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_964 = (*expr);
-        switch (_mv_964.tag) {
+        __auto_type _mv_965 = (*expr);
+        switch (_mv_965.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_964.data.lst;
+                __auto_type lst = _mv_965.data.lst;
                 {
                     __auto_type items = lst.items;
                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("struct "), qualified_name, SLOP_STR(" {")));
@@ -801,11 +801,11 @@ void defn_emit_record_fields(context_TranspileContext* ctx, slop_string raw_type
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start_idx;
         while (i < len) {
-            __auto_type _mv_965 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_965.has_value) {
-                __auto_type field_expr = _mv_965.value;
+            __auto_type _mv_966 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_966.has_value) {
+                __auto_type field_expr = _mv_966.value;
                 defn_emit_record_field(ctx, raw_type_name, qualified_type_name, field_expr);
-            } else if (!_mv_965.has_value) {
+            } else if (!_mv_966.has_value) {
             }
             i = (i + 1);
         }
@@ -817,28 +817,28 @@ void defn_emit_record_field(context_TranspileContext* ctx, slop_string raw_type_
     SLOP_PRE(((field != NULL)), "(!= field nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_966 = (*field);
-        switch (_mv_966.tag) {
+        __auto_type _mv_967 = (*field);
+        switch (_mv_967.tag) {
             case types_SExpr_lst:
             {
-                __auto_type field_lst = _mv_966.data.lst;
+                __auto_type field_lst = _mv_967.data.lst;
                 {
                     __auto_type items = field_lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 2) {
                         context_ctx_emit(ctx, SLOP_STR("    /* invalid field */"));
                     } else {
-                        __auto_type _mv_967 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_967.has_value) {
-                            __auto_type name_expr = _mv_967.value;
-                            __auto_type _mv_968 = (*name_expr);
-                            switch (_mv_968.tag) {
+                        __auto_type _mv_968 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_968.has_value) {
+                            __auto_type name_expr = _mv_968.value;
+                            __auto_type _mv_969 = (*name_expr);
+                            switch (_mv_969.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_968.data.sym;
-                                    __auto_type _mv_969 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_969.has_value) {
-                                        __auto_type type_expr = _mv_969.value;
+                                    __auto_type name_sym = _mv_969.data.sym;
+                                    __auto_type _mv_970 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_970.has_value) {
+                                        __auto_type type_expr = _mv_970.value;
                                         {
                                             __auto_type raw_field_name = name_sym.name;
                                             __auto_type field_name = ctype_to_c_name(arena, raw_field_name);
@@ -849,7 +849,7 @@ void defn_emit_record_field(context_TranspileContext* ctx, slop_string raw_type_
                                             context_ctx_register_field_type(ctx, raw_type_name, raw_field_name, field_type, slop_type_str, is_ptr);
                                             context_ctx_register_field_type(ctx, qualified_type_name, raw_field_name, field_type, slop_type_str, is_ptr);
                                         }
-                                    } else if (!_mv_969.has_value) {
+                                    } else if (!_mv_970.has_value) {
                                         context_ctx_emit(ctx, SLOP_STR("    /* missing field type */"));
                                     }
                                     break;
@@ -859,7 +859,7 @@ void defn_emit_record_field(context_TranspileContext* ctx, slop_string raw_type_
                                     break;
                                 }
                             }
-                        } else if (!_mv_967.has_value) {
+                        } else if (!_mv_968.has_value) {
                             context_ctx_emit(ctx, SLOP_STR("    /* missing field name */"));
                         }
                     }
@@ -879,11 +879,11 @@ void defn_transpile_enum(context_TranspileContext* ctx, slop_string raw_name, sl
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_970 = (*expr);
-        switch (_mv_970.tag) {
+        __auto_type _mv_971 = (*expr);
+        switch (_mv_971.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_970.data.lst;
+                __auto_type lst = _mv_971.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -909,14 +909,14 @@ void defn_emit_enum_values(context_TranspileContext* ctx, slop_string type_name,
         __auto_type arena = (*ctx).arena;
         int64_t i = start_idx;
         while (i < len) {
-            __auto_type _mv_971 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_971.has_value) {
-                __auto_type val_expr = _mv_971.value;
-                __auto_type _mv_972 = (*val_expr);
-                switch (_mv_972.tag) {
+            __auto_type _mv_972 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_972.has_value) {
+                __auto_type val_expr = _mv_972.value;
+                __auto_type _mv_973 = (*val_expr);
+                switch (_mv_973.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_972.data.sym;
+                        __auto_type sym = _mv_973.data.sym;
                         {
                             __auto_type val_name = ctype_to_c_name(arena, sym.name);
                             __auto_type full_name = context_ctx_str3(ctx, type_name, SLOP_STR("_"), val_name);
@@ -933,7 +933,7 @@ void defn_emit_enum_values(context_TranspileContext* ctx, slop_string type_name,
                         break;
                     }
                 }
-            } else if (!_mv_971.has_value) {
+            } else if (!_mv_972.has_value) {
             }
             i = (i + 1);
         }
@@ -945,11 +945,11 @@ void defn_transpile_union(context_TranspileContext* ctx, slop_string raw_name, s
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_973 = (*expr);
-        switch (_mv_973.tag) {
+        __auto_type _mv_974 = (*expr);
+        switch (_mv_974.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_973.data.lst;
+                __auto_type lst = _mv_974.data.lst;
                 {
                     __auto_type items = lst.items;
                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("struct "), qualified_name, SLOP_STR(" {")));
@@ -982,33 +982,33 @@ void defn_emit_union_variants(context_TranspileContext* ctx, slop_list_types_SEx
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start_idx;
         while (i < len) {
-            __auto_type _mv_974 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_974.has_value) {
-                __auto_type variant_expr = _mv_974.value;
-                __auto_type _mv_975 = (*variant_expr);
-                switch (_mv_975.tag) {
+            __auto_type _mv_975 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_975.has_value) {
+                __auto_type variant_expr = _mv_975.value;
+                __auto_type _mv_976 = (*variant_expr);
+                switch (_mv_976.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type var_lst = _mv_975.data.lst;
+                        __auto_type var_lst = _mv_976.data.lst;
                         {
                             __auto_type var_items = var_lst.items;
                             __auto_type var_len = ((int64_t)((var_items).len));
                             if (var_len >= 1) {
-                                __auto_type _mv_976 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_976.has_value) {
-                                    __auto_type tag_expr = _mv_976.value;
-                                    __auto_type _mv_977 = (*tag_expr);
-                                    switch (_mv_977.tag) {
+                                __auto_type _mv_977 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_977.has_value) {
+                                    __auto_type tag_expr = _mv_977.value;
+                                    __auto_type _mv_978 = (*tag_expr);
+                                    switch (_mv_978.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type tag_sym = _mv_977.data.sym;
+                                            __auto_type tag_sym = _mv_978.data.sym;
                                             {
                                                 __auto_type tag_name = tag_sym.name;
                                                 __auto_type c_tag = ctype_to_c_name(arena, tag_name);
                                                 if (var_len == 2) {
-                                                    __auto_type _mv_978 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_978.has_value) {
-                                                        __auto_type type_expr = _mv_978.value;
+                                                    __auto_type _mv_979 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_979.has_value) {
+                                                        __auto_type type_expr = _mv_979.value;
                                                         {
                                                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                             {
@@ -1016,14 +1016,14 @@ void defn_emit_union_variants(context_TranspileContext* ctx, slop_list_types_SEx
                                                                 context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("        "), actual_type, SLOP_STR(" "), c_tag, SLOP_STR(";")));
                                                             }
                                                         }
-                                                    } else if (!_mv_978.has_value) {
+                                                    } else if (!_mv_979.has_value) {
                                                     }
                                                 } else if (var_len >= 3) {
                                                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("        struct { "), SLOP_STR(""), SLOP_STR("")));
                                                     for (int64_t fi = 1; fi < var_len; fi++) {
-                                                        __auto_type _mv_979 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                        if (_mv_979.has_value) {
-                                                            __auto_type type_expr = _mv_979.value;
+                                                        __auto_type _mv_980 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                        if (_mv_980.has_value) {
+                                                            __auto_type type_expr = _mv_980.value;
                                                             {
                                                                 __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                                 {
@@ -1032,7 +1032,7 @@ void defn_emit_union_variants(context_TranspileContext* ctx, slop_list_types_SEx
                                                                     context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("            "), actual_type, SLOP_STR(" "), field_name, SLOP_STR(";")));
                                                                 }
                                                             }
-                                                        } else if (!_mv_979.has_value) {
+                                                        } else if (!_mv_980.has_value) {
                                                         }
                                                     }
                                                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("        } "), c_tag, SLOP_STR(";")));
@@ -1045,7 +1045,7 @@ void defn_emit_union_variants(context_TranspileContext* ctx, slop_list_types_SEx
                                             break;
                                         }
                                     }
-                                } else if (!_mv_976.has_value) {
+                                } else if (!_mv_977.has_value) {
                                 }
                             }
                         }
@@ -1055,7 +1055,7 @@ void defn_emit_union_variants(context_TranspileContext* ctx, slop_list_types_SEx
                         break;
                     }
                 }
-            } else if (!_mv_974.has_value) {
+            } else if (!_mv_975.has_value) {
             }
             i = (i + 1);
         }
@@ -1070,25 +1070,25 @@ void defn_emit_tag_constants(context_TranspileContext* ctx, slop_string type_nam
         int64_t i = start_idx;
         int64_t tag_idx = 0;
         while (i < len) {
-            __auto_type _mv_980 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_980.has_value) {
-                __auto_type variant_expr = _mv_980.value;
-                __auto_type _mv_981 = (*variant_expr);
-                switch (_mv_981.tag) {
+            __auto_type _mv_981 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_981.has_value) {
+                __auto_type variant_expr = _mv_981.value;
+                __auto_type _mv_982 = (*variant_expr);
+                switch (_mv_982.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type var_lst = _mv_981.data.lst;
+                        __auto_type var_lst = _mv_982.data.lst;
                         {
                             __auto_type var_items = var_lst.items;
                             if (((int64_t)((var_items).len)) >= 1) {
-                                __auto_type _mv_982 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_982.has_value) {
-                                    __auto_type tag_expr = _mv_982.value;
-                                    __auto_type _mv_983 = (*tag_expr);
-                                    switch (_mv_983.tag) {
+                                __auto_type _mv_983 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_983.has_value) {
+                                    __auto_type tag_expr = _mv_983.value;
+                                    __auto_type _mv_984 = (*tag_expr);
+                                    switch (_mv_984.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type tag_sym = _mv_983.data.sym;
+                                            __auto_type tag_sym = _mv_984.data.sym;
                                             {
                                                 __auto_type tag_name = tag_sym.name;
                                                 __auto_type define_name = context_ctx_str4(ctx, type_name, SLOP_STR("_"), ctype_to_c_name(arena, tag_name), SLOP_STR("_TAG"));
@@ -1100,7 +1100,7 @@ void defn_emit_tag_constants(context_TranspileContext* ctx, slop_string type_nam
                                             break;
                                         }
                                     }
-                                } else if (!_mv_982.has_value) {
+                                } else if (!_mv_983.has_value) {
                                 }
                             }
                             tag_idx = (tag_idx + 1);
@@ -1111,7 +1111,7 @@ void defn_emit_tag_constants(context_TranspileContext* ctx, slop_string type_nam
                         break;
                     }
                 }
-            } else if (!_mv_980.has_value) {
+            } else if (!_mv_981.has_value) {
             }
             i = (i + 1);
         }
@@ -1125,32 +1125,32 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start_idx;
         while (i < len) {
-            __auto_type _mv_984 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_984.has_value) {
-                __auto_type variant_expr = _mv_984.value;
-                __auto_type _mv_985 = (*variant_expr);
-                switch (_mv_985.tag) {
+            __auto_type _mv_985 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_985.has_value) {
+                __auto_type variant_expr = _mv_985.value;
+                __auto_type _mv_986 = (*variant_expr);
+                switch (_mv_986.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type var_lst = _mv_985.data.lst;
+                        __auto_type var_lst = _mv_986.data.lst;
                         {
                             __auto_type var_items = var_lst.items;
                             __auto_type var_len = ((int64_t)((var_items).len));
                             if (var_len >= 2) {
-                                __auto_type _mv_986 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_986.has_value) {
-                                    __auto_type tag_expr = _mv_986.value;
-                                    __auto_type _mv_987 = (*tag_expr);
-                                    switch (_mv_987.tag) {
+                                __auto_type _mv_987 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_987.has_value) {
+                                    __auto_type tag_expr = _mv_987.value;
+                                    __auto_type _mv_988 = (*tag_expr);
+                                    switch (_mv_988.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type tag_sym = _mv_987.data.sym;
+                                            __auto_type tag_sym = _mv_988.data.sym;
                                             {
                                                 __auto_type tag_name = tag_sym.name;
                                                 if (var_len == 2) {
-                                                    __auto_type _mv_988 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_988.has_value) {
-                                                        __auto_type type_expr = _mv_988.value;
+                                                    __auto_type _mv_989 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_989.has_value) {
+                                                        __auto_type type_expr = _mv_989.value;
                                                         {
                                                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                             __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
@@ -1158,7 +1158,7 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
                                                             context_ctx_register_field_type(ctx, raw_name, tag_name, c_type, slop_type_str, is_ptr);
                                                             context_ctx_register_field_type(ctx, qualified_name, tag_name, c_type, slop_type_str, is_ptr);
                                                         }
-                                                    } else if (!_mv_988.has_value) {
+                                                    } else if (!_mv_989.has_value) {
                                                     }
                                                 } else if (var_len >= 3) {
                                                     {
@@ -1168,9 +1168,9 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
                                                         context_ctx_register_field_type(ctx, qualified_name, count_key, count_str, SLOP_STR(""), 0);
                                                     }
                                                     for (int64_t fi = 1; fi < var_len; fi++) {
-                                                        __auto_type _mv_989 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                        if (_mv_989.has_value) {
-                                                            __auto_type type_expr = _mv_989.value;
+                                                        __auto_type _mv_990 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                        if (_mv_990.has_value) {
+                                                            __auto_type type_expr = _mv_990.value;
                                                             {
                                                                 __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                                 __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
@@ -1179,12 +1179,12 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
                                                                 context_ctx_register_field_type(ctx, raw_name, field_key, c_type, slop_type_str, is_ptr);
                                                                 context_ctx_register_field_type(ctx, qualified_name, field_key, c_type, slop_type_str, is_ptr);
                                                             }
-                                                        } else if (!_mv_989.has_value) {
+                                                        } else if (!_mv_990.has_value) {
                                                         }
                                                     }
-                                                    __auto_type _mv_990 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_990.has_value) {
-                                                        __auto_type type_expr = _mv_990.value;
+                                                    __auto_type _mv_991 = ({ __auto_type _lst = var_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_991.has_value) {
+                                                        __auto_type type_expr = _mv_991.value;
                                                         {
                                                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                             __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
@@ -1192,7 +1192,7 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
                                                             context_ctx_register_field_type(ctx, raw_name, tag_name, c_type, slop_type_str, is_ptr);
                                                             context_ctx_register_field_type(ctx, qualified_name, tag_name, c_type, slop_type_str, is_ptr);
                                                         }
-                                                    } else if (!_mv_990.has_value) {
+                                                    } else if (!_mv_991.has_value) {
                                                     }
                                                 } else {
                                                 }
@@ -1203,7 +1203,7 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
                                             break;
                                         }
                                     }
-                                } else if (!_mv_986.has_value) {
+                                } else if (!_mv_987.has_value) {
                                 }
                             }
                         }
@@ -1213,7 +1213,7 @@ void defn_register_union_variant_fields(context_TranspileContext* ctx, slop_stri
                         break;
                     }
                 }
-            } else if (!_mv_984.has_value) {
+            } else if (!_mv_985.has_value) {
             }
             i = (i + 1);
         }
@@ -1250,31 +1250,31 @@ uint8_t defn_is_generic_type_alias(slop_string s) {
 
 uint8_t defn_is_array_type(types_SExpr* type_expr) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_991 = (*type_expr);
-    switch (_mv_991.tag) {
+    __auto_type _mv_992 = (*type_expr);
+    switch (_mv_992.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_991.data.lst;
+            __auto_type lst = _mv_992.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_992 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_992.has_value) {
-                        __auto_type head = _mv_992.value;
-                        __auto_type _mv_993 = (*head);
-                        switch (_mv_993.tag) {
+                    __auto_type _mv_993 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_993.has_value) {
+                        __auto_type head = _mv_993.value;
+                        __auto_type _mv_994 = (*head);
+                        switch (_mv_994.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_993.data.sym;
+                                __auto_type sym = _mv_994.data.sym;
                                 return string_eq(sym.name, SLOP_STR("Array"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_992.has_value) {
+                    } else if (!_mv_993.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1292,23 +1292,23 @@ void defn_emit_array_typedef(context_TranspileContext* ctx, slop_string qualifie
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_994 = (*type_expr);
-        switch (_mv_994.tag) {
+        __auto_type _mv_995 = (*type_expr);
+        switch (_mv_995.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_994.data.lst;
+                __auto_type lst = _mv_995.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 3) {
                         context_ctx_emit(ctx, context_ctx_str(ctx, SLOP_STR("typedef void* "), context_ctx_str(ctx, qualified_name, SLOP_STR(";"))));
                     } else {
-                        __auto_type _mv_995 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_995.has_value) {
-                            __auto_type elem_type_expr = _mv_995.value;
-                            __auto_type _mv_996 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_996.has_value) {
-                                __auto_type size_expr = _mv_996.value;
+                        __auto_type _mv_996 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_996.has_value) {
+                            __auto_type elem_type_expr = _mv_996.value;
+                            __auto_type _mv_997 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_997.has_value) {
+                                __auto_type size_expr = _mv_997.value;
                                 {
                                     __auto_type elem_c_type = context_to_c_type_prefixed(ctx, elem_type_expr);
                                     __auto_type size_str = defn_get_number_as_string(size_expr);
@@ -1319,10 +1319,10 @@ void defn_emit_array_typedef(context_TranspileContext* ctx, slop_string qualifie
                                         context_ctx_register_type(ctx, (context_TypeEntry){qualified_name, qualified_name, ptr_type, 0, 0, 0});
                                     }
                                 }
-                            } else if (!_mv_996.has_value) {
+                            } else if (!_mv_997.has_value) {
                                 context_ctx_emit(ctx, context_ctx_str(ctx, SLOP_STR("typedef void* "), context_ctx_str(ctx, qualified_name, SLOP_STR(";"))));
                             }
-                        } else if (!_mv_995.has_value) {
+                        } else if (!_mv_996.has_value) {
                             context_ctx_emit(ctx, context_ctx_str(ctx, SLOP_STR("typedef void* "), context_ctx_str(ctx, qualified_name, SLOP_STR(";"))));
                         }
                     }
@@ -1339,11 +1339,11 @@ void defn_emit_array_typedef(context_TranspileContext* ctx, slop_string qualifie
 
 slop_string defn_get_number_as_string(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_997 = (*expr);
-    switch (_mv_997.tag) {
+    __auto_type _mv_998 = (*expr);
+    switch (_mv_998.tag) {
         case types_SExpr_num:
         {
-            __auto_type num = _mv_997.data.num;
+            __auto_type num = _mv_998.data.num;
             return num.raw;
         }
         default: {
@@ -1354,25 +1354,25 @@ slop_string defn_get_number_as_string(types_SExpr* expr) {
 
 uint8_t defn_is_range_type(types_SExpr* type_expr) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_998 = (*type_expr);
-    switch (_mv_998.tag) {
+    __auto_type _mv_999 = (*type_expr);
+    switch (_mv_999.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_998.data.lst;
+            __auto_type lst = _mv_999.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type found_dots = 0;
                 __auto_type i = 0;
                 while ((i < len) && !(found_dots)) {
-                    __auto_type _mv_999 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_999.has_value) {
-                        __auto_type item = _mv_999.value;
-                        __auto_type _mv_1000 = (*item);
-                        switch (_mv_1000.tag) {
+                    __auto_type _mv_1000 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1000.has_value) {
+                        __auto_type item = _mv_1000.value;
+                        __auto_type _mv_1001 = (*item);
+                        switch (_mv_1001.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1000.data.sym;
+                                __auto_type sym = _mv_1001.data.sym;
                                 if (string_eq(sym.name, SLOP_STR(".."))) {
                                     found_dots = 1;
                                 }
@@ -1382,7 +1382,7 @@ uint8_t defn_is_range_type(types_SExpr* type_expr) {
                                 break;
                             }
                         }
-                    } else if (!_mv_999.has_value) {
+                    } else if (!_mv_1000.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -1403,24 +1403,24 @@ types_RangeBounds defn_parse_range_bounds(types_SExpr* type_expr) {
         uint8_t has_min = 0;
         uint8_t has_max = 0;
         uint8_t found_dots = 0;
-        __auto_type _mv_1001 = (*type_expr);
-        switch (_mv_1001.tag) {
+        __auto_type _mv_1002 = (*type_expr);
+        switch (_mv_1002.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1001.data.lst;
+                __auto_type lst = _mv_1002.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type i = 1;
                     while (i < len) {
-                        __auto_type _mv_1002 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1002.has_value) {
-                            __auto_type item = _mv_1002.value;
-                            __auto_type _mv_1003 = (*item);
-                            switch (_mv_1003.tag) {
+                        __auto_type _mv_1003 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1003.has_value) {
+                            __auto_type item = _mv_1003.value;
+                            __auto_type _mv_1004 = (*item);
+                            switch (_mv_1004.tag) {
                                 case types_SExpr_num:
                                 {
-                                    __auto_type num = _mv_1003.data.num;
+                                    __auto_type num = _mv_1004.data.num;
                                     if (!(found_dots)) {
                                         min_val = defn_string_to_int(num.raw);
                                         has_min = 1;
@@ -1432,7 +1432,7 @@ types_RangeBounds defn_parse_range_bounds(types_SExpr* type_expr) {
                                 }
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1003.data.sym;
+                                    __auto_type sym = _mv_1004.data.sym;
                                     if (string_eq(sym.name, SLOP_STR(".."))) {
                                         found_dots = 1;
                                     }
@@ -1442,7 +1442,7 @@ types_RangeBounds defn_parse_range_bounds(types_SExpr* type_expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_1002.has_value) {
+                        } else if (!_mv_1003.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -1549,25 +1549,25 @@ void defn_transpile_function(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1004 = (*expr);
-        switch (_mv_1004.tag) {
+        __auto_type _mv_1005 = (*expr);
+        switch (_mv_1005.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1004.data.lst;
+                __auto_type lst = _mv_1005.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 3) {
                         context_ctx_add_error_at(ctx, SLOP_STR("invalid fn: need name and params"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     } else {
-                        __auto_type _mv_1005 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1005.has_value) {
-                            __auto_type name_expr = _mv_1005.value;
-                            __auto_type _mv_1006 = (*name_expr);
-                            switch (_mv_1006.tag) {
+                        __auto_type _mv_1006 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1006.has_value) {
+                            __auto_type name_expr = _mv_1006.value;
+                            __auto_type _mv_1007 = (*name_expr);
+                            switch (_mv_1007.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1006.data.sym;
+                                    __auto_type name_sym = _mv_1007.data.sym;
                                     {
                                         __auto_type raw_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, raw_name);
@@ -1575,11 +1575,11 @@ void defn_transpile_function(context_TranspileContext* ctx, types_SExpr* expr) {
                                         __auto_type base_fn_name = context_extract_fn_c_name(arena, items, mangled_name);
                                         __auto_type fn_name = base_fn_name;
                                         __auto_type is_public_api = !(string_eq(base_fn_name, mangled_name));
-                                        __auto_type _mv_1007 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1007.has_value) {
-                                            __auto_type params_expr = _mv_1007.value;
+                                        __auto_type _mv_1008 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1008.has_value) {
+                                            __auto_type params_expr = _mv_1008.value;
                                             defn_emit_function_def(ctx, raw_name, fn_name, params_expr, items, is_public_api);
-                                        } else if (!_mv_1007.has_value) {
+                                        } else if (!_mv_1008.has_value) {
                                             context_ctx_add_error_at(ctx, SLOP_STR("missing params"), context_ctx_sexpr_line(name_expr), context_ctx_sexpr_col(name_expr));
                                         }
                                     }
@@ -1590,7 +1590,7 @@ void defn_transpile_function(context_TranspileContext* ctx, types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_1005.has_value) {
+                        } else if (!_mv_1006.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing function name"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                     }
@@ -1624,18 +1624,18 @@ void defn_emit_function_def(context_TranspileContext* ctx, slop_string raw_name,
             __auto_type has_post = ((((int64_t)((postconditions).len)) > 0) || (((int64_t)((assumptions).len)) > 0));
             __auto_type needs_retval = (has_post && !(string_eq(actual_return, SLOP_STR("void"))));
             context_ctx_set_current_return_type(ctx, actual_return);
-            __auto_type _mv_1008 = result_type_opt;
-            if (_mv_1008.has_value) {
-                __auto_type result_name = _mv_1008.value;
+            __auto_type _mv_1009 = result_type_opt;
+            if (_mv_1009.has_value) {
+                __auto_type result_name = _mv_1009.value;
                 context_ctx_set_current_result_type(ctx, result_name);
-            } else if (!_mv_1008.has_value) {
+            } else if (!_mv_1009.has_value) {
                 context_ctx_clear_current_result_type(ctx);
             }
-            __auto_type _mv_1009 = doc_string;
-            if (_mv_1009.has_value) {
-                __auto_type doc = _mv_1009.value;
+            __auto_type _mv_1010 = doc_string;
+            if (_mv_1010.has_value) {
+                __auto_type doc = _mv_1010.value;
                 context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("/* "), doc, SLOP_STR(" */")));
-            } else if (!_mv_1009.has_value) {
+            } else if (!_mv_1010.has_value) {
             }
             context_ctx_emit(ctx, context_ctx_str5(ctx, actual_return, SLOP_STR(" "), fn_name, SLOP_STR("("), context_ctx_str(ctx, ((string_eq(param_str, SLOP_STR(""))) ? SLOP_STR("void") : param_str), SLOP_STR(") {"))));
             context_ctx_indent(ctx);
@@ -1685,21 +1685,21 @@ void defn_bind_params_to_scope(context_TranspileContext* ctx, types_SExpr* param
     SLOP_PRE(((params_expr != NULL)), "(!= params-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1010 = (*params_expr);
-        switch (_mv_1010.tag) {
+        __auto_type _mv_1011 = (*params_expr);
+        switch (_mv_1011.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1010.data.lst;
+                __auto_type lst = _mv_1011.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type i = 0;
                     while (i < len) {
-                        __auto_type _mv_1011 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1011.has_value) {
-                            __auto_type param = _mv_1011.value;
+                        __auto_type _mv_1012 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1012.has_value) {
+                            __auto_type param = _mv_1012.value;
                             defn_bind_single_param(ctx, param);
-                        } else if (!_mv_1011.has_value) {
+                        } else if (!_mv_1012.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -1718,11 +1718,11 @@ void defn_bind_single_param(context_TranspileContext* ctx, types_SExpr* param) {
     SLOP_PRE(((param != NULL)), "(!= param nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1012 = (*param);
-        switch (_mv_1012.tag) {
+        __auto_type _mv_1013 = (*param);
+        switch (_mv_1013.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1012.data.lst;
+                __auto_type lst = _mv_1013.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -1731,17 +1731,17 @@ void defn_bind_single_param(context_TranspileContext* ctx, types_SExpr* param) {
                             __auto_type has_mode = ((len >= 3) && defn_is_param_mode(items));
                             __auto_type name_idx = ((has_mode) ? 1 : 0);
                             __auto_type type_idx = ((has_mode) ? 2 : 1);
-                            __auto_type _mv_1013 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1013.has_value) {
-                                __auto_type name_expr = _mv_1013.value;
-                                __auto_type _mv_1014 = (*name_expr);
-                                switch (_mv_1014.tag) {
+                            __auto_type _mv_1014 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1014.has_value) {
+                                __auto_type name_expr = _mv_1014.value;
+                                __auto_type _mv_1015 = (*name_expr);
+                                switch (_mv_1015.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type name_sym = _mv_1014.data.sym;
-                                        __auto_type _mv_1015 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1015.has_value) {
-                                            __auto_type type_expr = _mv_1015.value;
+                                        __auto_type name_sym = _mv_1015.data.sym;
+                                        __auto_type _mv_1016 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1016.has_value) {
+                                            __auto_type type_expr = _mv_1016.value;
                                             {
                                                 __auto_type param_name = name_sym.name;
                                                 __auto_type c_name = ctype_to_c_name(arena, param_name);
@@ -1751,7 +1751,7 @@ void defn_bind_single_param(context_TranspileContext* ctx, types_SExpr* param) {
                                                 __auto_type is_closure = defn_is_fn_type(type_expr);
                                                 context_ctx_bind_var(ctx, (context_VarEntry){param_name, c_name, c_type, slop_type_str, is_ptr, 0, is_closure, SLOP_STR(""), SLOP_STR("")});
                                             }
-                                        } else if (!_mv_1015.has_value) {
+                                        } else if (!_mv_1016.has_value) {
                                         }
                                         break;
                                     }
@@ -1759,7 +1759,7 @@ void defn_bind_single_param(context_TranspileContext* ctx, types_SExpr* param) {
                                         break;
                                     }
                                 }
-                            } else if (!_mv_1013.has_value) {
+                            } else if (!_mv_1014.has_value) {
                             }
                         }
                     }
@@ -1775,31 +1775,31 @@ void defn_bind_single_param(context_TranspileContext* ctx, types_SExpr* param) {
 
 uint8_t defn_is_pointer_type(types_SExpr* type_expr) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_1016 = (*type_expr);
-    switch (_mv_1016.tag) {
+    __auto_type _mv_1017 = (*type_expr);
+    switch (_mv_1017.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1016.data.lst;
+            __auto_type lst = _mv_1017.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1017 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1017.has_value) {
-                        __auto_type head = _mv_1017.value;
-                        __auto_type _mv_1018 = (*head);
-                        switch (_mv_1018.tag) {
+                    __auto_type _mv_1018 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1018.has_value) {
+                        __auto_type head = _mv_1018.value;
+                        __auto_type _mv_1019 = (*head);
+                        switch (_mv_1019.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1018.data.sym;
+                                __auto_type sym = _mv_1019.data.sym;
                                 return string_eq(sym.name, SLOP_STR("Ptr"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1017.has_value) {
+                    } else if (!_mv_1018.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1818,26 +1818,26 @@ slop_list_context_FuncParamType_ptr defn_collect_param_types(context_TranspileCo
     {
         __auto_type arena = (*ctx).arena;
         __auto_type result = ((slop_list_context_FuncParamType_ptr){ .data = (context_FuncParamType**)slop_arena_alloc(arena, 16 * sizeof(context_FuncParamType*)), .len = 0, .cap = 16 });
-        __auto_type _mv_1019 = (*params_expr);
-        switch (_mv_1019.tag) {
+        __auto_type _mv_1020 = (*params_expr);
+        switch (_mv_1020.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1019.data.lst;
+                __auto_type lst = _mv_1020.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type i = 0;
                     while (i < len) {
-                        __auto_type _mv_1020 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1020.has_value) {
-                            __auto_type param = _mv_1020.value;
+                        __auto_type _mv_1021 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1021.has_value) {
+                            __auto_type param = _mv_1021.value;
                             {
                                 __auto_type c_type = defn_get_param_c_type(ctx, param);
                                 __auto_type param_info = ((context_FuncParamType*)(({ __auto_type _alloc = (context_FuncParamType*)slop_arena_alloc(arena, sizeof(context_FuncParamType)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                                 (*param_info).c_type = c_type;
                                 ({ __auto_type _lst_p = &(result); __auto_type _item = (param_info); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                             }
-                        } else if (!_mv_1020.has_value) {
+                        } else if (!_mv_1021.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -1857,11 +1857,11 @@ slop_string defn_get_param_c_type(context_TranspileContext* ctx, types_SExpr* pa
     SLOP_PRE(((param != NULL)), "(!= param nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1021 = (*param);
-        switch (_mv_1021.tag) {
+        __auto_type _mv_1022 = (*param);
+        switch (_mv_1022.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1021.data.lst;
+                __auto_type lst = _mv_1022.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -1871,11 +1871,11 @@ slop_string defn_get_param_c_type(context_TranspileContext* ctx, types_SExpr* pa
                         {
                             __auto_type has_mode = ((len >= 3) && defn_is_param_mode(items));
                             __auto_type type_idx = ((has_mode) ? 2 : 1);
-                            __auto_type _mv_1022 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1022.has_value) {
-                                __auto_type type_expr = _mv_1022.value;
+                            __auto_type _mv_1023 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1023.has_value) {
+                                __auto_type type_expr = _mv_1023.value;
                                 return context_to_c_type_prefixed(ctx, type_expr);
-                            } else if (!_mv_1022.has_value) {
+                            } else if (!_mv_1023.has_value) {
                                 return SLOP_STR("void*");
                             }
                             SLOP_UNREACHABLE();
@@ -1895,31 +1895,31 @@ void defn_emit_forward_declaration(context_TranspileContext* ctx, types_SExpr* e
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1023 = (*expr);
-        switch (_mv_1023.tag) {
+        __auto_type _mv_1024 = (*expr);
+        switch (_mv_1024.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1023.data.lst;
+                __auto_type lst = _mv_1024.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 3) {
-                        __auto_type _mv_1024 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1024.has_value) {
-                            __auto_type name_expr = _mv_1024.value;
-                            __auto_type _mv_1025 = (*name_expr);
-                            switch (_mv_1025.tag) {
+                        __auto_type _mv_1025 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1025.has_value) {
+                            __auto_type name_expr = _mv_1025.value;
+                            __auto_type _mv_1026 = (*name_expr);
+                            switch (_mv_1026.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1025.data.sym;
+                                    __auto_type name_sym = _mv_1026.data.sym;
                                     {
                                         __auto_type raw_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, raw_name);
                                         __auto_type mangled_name = context_ctx_prefix_type(ctx, base_name);
                                         __auto_type fn_name = context_extract_fn_c_name(arena, items, mangled_name);
-                                        __auto_type _mv_1026 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1026.has_value) {
-                                            __auto_type params_expr = _mv_1026.value;
+                                        __auto_type _mv_1027 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1027.has_value) {
+                                            __auto_type params_expr = _mv_1027.value;
                                             {
                                                 __auto_type result_type_opt = defn_get_result_type_name(ctx, items);
                                                 __auto_type raw_return = defn_get_return_type(ctx, items);
@@ -1930,7 +1930,7 @@ void defn_emit_forward_declaration(context_TranspileContext* ctx, types_SExpr* e
                                                     context_ctx_emit(ctx, context_ctx_str5(ctx, actual_return, SLOP_STR(" "), fn_name, SLOP_STR("("), context_ctx_str(ctx, ((string_eq(param_str, SLOP_STR(""))) ? SLOP_STR("void") : param_str), SLOP_STR(");"))));
                                                 }
                                             }
-                                        } else if (!_mv_1026.has_value) {
+                                        } else if (!_mv_1027.has_value) {
                                         }
                                     }
                                     break;
@@ -1939,7 +1939,7 @@ void defn_emit_forward_declaration(context_TranspileContext* ctx, types_SExpr* e
                                     break;
                                 }
                             }
-                        } else if (!_mv_1024.has_value) {
+                        } else if (!_mv_1025.has_value) {
                         }
                     }
                 }
@@ -1960,13 +1960,13 @@ slop_string defn_get_return_type(context_TranspileContext* ctx, slop_list_types_
         int64_t i = 3;
         __auto_type result = SLOP_STR("void");
         while (i < len) {
-            __auto_type _mv_1027 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1027.has_value) {
-                __auto_type item = _mv_1027.value;
+            __auto_type _mv_1028 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1028.has_value) {
+                __auto_type item = _mv_1028.value;
                 if (defn_is_spec_form(item)) {
                     result = defn_extract_spec_return_type(ctx, item);
                 }
-            } else if (!_mv_1027.has_value) {
+            } else if (!_mv_1028.has_value) {
             }
             i = (i + 1);
         }
@@ -1976,31 +1976,31 @@ slop_string defn_get_return_type(context_TranspileContext* ctx, slop_list_types_
 
 uint8_t defn_is_spec_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1028 = (*expr);
-    switch (_mv_1028.tag) {
+    __auto_type _mv_1029 = (*expr);
+    switch (_mv_1029.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1028.data.lst;
+            __auto_type lst = _mv_1029.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1029 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1029.has_value) {
-                        __auto_type head = _mv_1029.value;
-                        __auto_type _mv_1030 = (*head);
-                        switch (_mv_1030.tag) {
+                    __auto_type _mv_1030 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1030.has_value) {
+                        __auto_type head = _mv_1030.value;
+                        __auto_type _mv_1031 = (*head);
+                        switch (_mv_1031.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1030.data.sym;
+                                __auto_type sym = _mv_1031.data.sym;
                                 return string_eq(sym.name, SLOP_STR("@spec"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1029.has_value) {
+                    } else if (!_mv_1030.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2018,35 +2018,35 @@ slop_string defn_extract_spec_return_type(context_TranspileContext* ctx, types_S
     SLOP_PRE(((spec_expr != NULL)), "(!= spec-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1031 = (*spec_expr);
-        switch (_mv_1031.tag) {
+        __auto_type _mv_1032 = (*spec_expr);
+        switch (_mv_1032.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1031.data.lst;
+                __auto_type lst = _mv_1032.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 2) {
                         return SLOP_STR("void");
                     } else {
-                        __auto_type _mv_1032 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1032.has_value) {
-                            __auto_type spec_body = _mv_1032.value;
-                            __auto_type _mv_1033 = (*spec_body);
-                            switch (_mv_1033.tag) {
+                        __auto_type _mv_1033 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1033.has_value) {
+                            __auto_type spec_body = _mv_1033.value;
+                            __auto_type _mv_1034 = (*spec_body);
+                            switch (_mv_1034.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type body_lst = _mv_1033.data.lst;
+                                    __auto_type body_lst = _mv_1034.data.lst;
                                     {
                                         __auto_type body_items = body_lst.items;
                                         __auto_type body_len = ((int64_t)((body_items).len));
                                         if (body_len < 1) {
                                             return SLOP_STR("void");
                                         } else {
-                                            __auto_type _mv_1034 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1034.has_value) {
-                                                __auto_type ret_type = _mv_1034.value;
+                                            __auto_type _mv_1035 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1035.has_value) {
+                                                __auto_type ret_type = _mv_1035.value;
                                                 return context_to_c_type_prefixed(ctx, ret_type);
-                                            } else if (!_mv_1034.has_value) {
+                                            } else if (!_mv_1035.has_value) {
                                                 return SLOP_STR("void");
                                             }
                                             SLOP_UNREACHABLE();
@@ -2057,7 +2057,7 @@ slop_string defn_extract_spec_return_type(context_TranspileContext* ctx, types_S
                                     return SLOP_STR("void");
                                 }
                             }
-                        } else if (!_mv_1032.has_value) {
+                        } else if (!_mv_1033.has_value) {
                             return SLOP_STR("void");
                         }
                         SLOP_UNREACHABLE();
@@ -2076,35 +2076,35 @@ slop_string defn_extract_spec_slop_return_type(context_TranspileContext* ctx, ty
     SLOP_PRE(((spec_expr != NULL)), "(!= spec-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1035 = (*spec_expr);
-        switch (_mv_1035.tag) {
+        __auto_type _mv_1036 = (*spec_expr);
+        switch (_mv_1036.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1035.data.lst;
+                __auto_type lst = _mv_1036.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 2) {
                         return SLOP_STR("");
                     } else {
-                        __auto_type _mv_1036 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1036.has_value) {
-                            __auto_type spec_body = _mv_1036.value;
-                            __auto_type _mv_1037 = (*spec_body);
-                            switch (_mv_1037.tag) {
+                        __auto_type _mv_1037 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1037.has_value) {
+                            __auto_type spec_body = _mv_1037.value;
+                            __auto_type _mv_1038 = (*spec_body);
+                            switch (_mv_1038.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type body_lst = _mv_1037.data.lst;
+                                    __auto_type body_lst = _mv_1038.data.lst;
                                     {
                                         __auto_type body_items = body_lst.items;
                                         __auto_type body_len = ((int64_t)((body_items).len));
                                         if (body_len < 1) {
                                             return SLOP_STR("");
                                         } else {
-                                            __auto_type _mv_1038 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1038.has_value) {
-                                                __auto_type ret_type = _mv_1038.value;
+                                            __auto_type _mv_1039 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1039.has_value) {
+                                                __auto_type ret_type = _mv_1039.value;
                                                 return parser_pretty_print(arena, ret_type);
-                                            } else if (!_mv_1038.has_value) {
+                                            } else if (!_mv_1039.has_value) {
                                                 return SLOP_STR("");
                                             }
                                             SLOP_UNREACHABLE();
@@ -2115,7 +2115,7 @@ slop_string defn_extract_spec_slop_return_type(context_TranspileContext* ctx, ty
                                     return SLOP_STR("");
                                 }
                             }
-                        } else if (!_mv_1036.has_value) {
+                        } else if (!_mv_1037.has_value) {
                             return SLOP_STR("");
                         }
                         SLOP_UNREACHABLE();
@@ -2136,13 +2136,13 @@ slop_string defn_get_slop_return_type(context_TranspileContext* ctx, slop_list_t
         int64_t i = 3;
         __auto_type result = SLOP_STR("");
         while (i < len) {
-            __auto_type _mv_1039 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1039.has_value) {
-                __auto_type item = _mv_1039.value;
+            __auto_type _mv_1040 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1040.has_value) {
+                __auto_type item = _mv_1040.value;
                 if (defn_is_spec_form(item)) {
                     result = defn_extract_spec_slop_return_type(ctx, item);
                 }
-            } else if (!_mv_1039.has_value) {
+            } else if (!_mv_1040.has_value) {
             }
             i = (i + 1);
         }
@@ -2158,13 +2158,13 @@ slop_option_string defn_get_result_type_name(context_TranspileContext* ctx, slop
         int64_t i = 3;
         slop_option_string result = (slop_option_string){.has_value = false};
         while ((i < len) && ({ __auto_type _mv = result; _mv.has_value ? ({ __auto_type _ = _mv.value; 0; }) : (1); })) {
-            __auto_type _mv_1040 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1040.has_value) {
-                __auto_type item = _mv_1040.value;
+            __auto_type _mv_1041 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1041.has_value) {
+                __auto_type item = _mv_1041.value;
                 if (defn_is_spec_form(item)) {
                     result = defn_extract_result_type_name(ctx, item);
                 }
-            } else if (!_mv_1040.has_value) {
+            } else if (!_mv_1041.has_value) {
             }
             i = (i + 1);
         }
@@ -2177,35 +2177,35 @@ slop_option_string defn_extract_result_type_name(context_TranspileContext* ctx, 
     SLOP_PRE(((spec_expr != NULL)), "(!= spec-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1041 = (*spec_expr);
-        switch (_mv_1041.tag) {
+        __auto_type _mv_1042 = (*spec_expr);
+        switch (_mv_1042.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1041.data.lst;
+                __auto_type lst = _mv_1042.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 2) {
                         return (slop_option_string){.has_value = false};
                     } else {
-                        __auto_type _mv_1042 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1042.has_value) {
-                            __auto_type spec_body = _mv_1042.value;
-                            __auto_type _mv_1043 = (*spec_body);
-                            switch (_mv_1043.tag) {
+                        __auto_type _mv_1043 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1043.has_value) {
+                            __auto_type spec_body = _mv_1043.value;
+                            __auto_type _mv_1044 = (*spec_body);
+                            switch (_mv_1044.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type body_lst = _mv_1043.data.lst;
+                                    __auto_type body_lst = _mv_1044.data.lst;
                                     {
                                         __auto_type body_items = body_lst.items;
                                         __auto_type body_len = ((int64_t)((body_items).len));
                                         if (body_len < 1) {
                                             return (slop_option_string){.has_value = false};
                                         } else {
-                                            __auto_type _mv_1044 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1044.has_value) {
-                                                __auto_type ret_type = _mv_1044.value;
+                                            __auto_type _mv_1045 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1045.has_value) {
+                                                __auto_type ret_type = _mv_1045.value;
                                                 return defn_check_result_type(ctx, ret_type);
-                                            } else if (!_mv_1044.has_value) {
+                                            } else if (!_mv_1045.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
                                             SLOP_UNREACHABLE();
@@ -2216,7 +2216,7 @@ slop_option_string defn_extract_result_type_name(context_TranspileContext* ctx, 
                                     return (slop_option_string){.has_value = false};
                                 }
                             }
-                        } else if (!_mv_1042.has_value) {
+                        } else if (!_mv_1043.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -2235,23 +2235,23 @@ slop_option_string defn_check_result_type(context_TranspileContext* ctx, types_S
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1045 = (*type_expr);
-        switch (_mv_1045.tag) {
+        __auto_type _mv_1046 = (*type_expr);
+        switch (_mv_1046.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1045.data.sym;
+                __auto_type sym = _mv_1046.data.sym;
                 {
                     __auto_type type_name = sym.name;
-                    __auto_type _mv_1046 = context_ctx_lookup_result_type_alias(ctx, type_name);
-                    if (_mv_1046.has_value) {
-                        __auto_type alias_result = _mv_1046.value;
+                    __auto_type _mv_1047 = context_ctx_lookup_result_type_alias(ctx, type_name);
+                    if (_mv_1047.has_value) {
+                        __auto_type alias_result = _mv_1047.value;
                         return (slop_option_string){.has_value = 1, .value = alias_result};
-                    } else if (!_mv_1046.has_value) {
-                        __auto_type _mv_1047 = context_ctx_lookup_type(ctx, type_name);
-                        if (_mv_1047.has_value) {
-                            __auto_type entry = _mv_1047.value;
+                    } else if (!_mv_1047.has_value) {
+                        __auto_type _mv_1048 = context_ctx_lookup_type(ctx, type_name);
+                        if (_mv_1048.has_value) {
+                            __auto_type entry = _mv_1048.value;
                             return (slop_option_string){.has_value = 1, .value = entry.c_name};
-                        } else if (!_mv_1047.has_value) {
+                        } else if (!_mv_1048.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -2261,38 +2261,38 @@ slop_option_string defn_check_result_type(context_TranspileContext* ctx, types_S
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1045.data.lst;
+                __auto_type lst = _mv_1046.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 3) {
                         return (slop_option_string){.has_value = false};
                     } else {
-                        __auto_type _mv_1048 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1048.has_value) {
-                            __auto_type head = _mv_1048.value;
-                            __auto_type _mv_1049 = (*head);
-                            switch (_mv_1049.tag) {
+                        __auto_type _mv_1049 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1049.has_value) {
+                            __auto_type head = _mv_1049.value;
+                            __auto_type _mv_1050 = (*head);
+                            switch (_mv_1050.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1049.data.sym;
+                                    __auto_type sym = _mv_1050.data.sym;
                                     if (string_eq(sym.name, SLOP_STR("Result"))) {
-                                        __auto_type _mv_1050 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1050.has_value) {
-                                            __auto_type ok_type_expr = _mv_1050.value;
-                                            __auto_type _mv_1051 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1051.has_value) {
-                                                __auto_type err_type_expr = _mv_1051.value;
+                                        __auto_type _mv_1051 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1051.has_value) {
+                                            __auto_type ok_type_expr = _mv_1051.value;
+                                            __auto_type _mv_1052 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1052.has_value) {
+                                                __auto_type err_type_expr = _mv_1052.value;
                                                 {
                                                     __auto_type ok_c_type = context_to_c_type_prefixed(ctx, ok_type_expr);
                                                     __auto_type err_c_type = context_to_c_type_prefixed(ctx, err_type_expr);
                                                     __auto_type result_name = defn_build_result_name(arena, ok_c_type, err_c_type);
                                                     return (slop_option_string){.has_value = 1, .value = result_name};
                                                 }
-                                            } else if (!_mv_1051.has_value) {
+                                            } else if (!_mv_1052.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
                                             SLOP_UNREACHABLE();
-                                        } else if (!_mv_1050.has_value) {
+                                        } else if (!_mv_1051.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
                                         SLOP_UNREACHABLE();
@@ -2304,7 +2304,7 @@ slop_option_string defn_check_result_type(context_TranspileContext* ctx, types_S
                                     return (slop_option_string){.has_value = false};
                                 }
                             }
-                        } else if (!_mv_1048.has_value) {
+                        } else if (!_mv_1049.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -2331,20 +2331,20 @@ slop_string defn_build_param_str(context_TranspileContext* ctx, types_SExpr* par
     SLOP_PRE(((params_expr != NULL)), "(!= params-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1052 = (*params_expr);
-        switch (_mv_1052.tag) {
+        __auto_type _mv_1053 = (*params_expr);
+        switch (_mv_1053.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1052.data.lst;
+                __auto_type lst = _mv_1053.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type result = SLOP_STR("");
                     __auto_type i = 0;
                     while (i < len) {
-                        __auto_type _mv_1053 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1053.has_value) {
-                            __auto_type param = _mv_1053.value;
+                        __auto_type _mv_1054 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1054.has_value) {
+                            __auto_type param = _mv_1054.value;
                             {
                                 __auto_type param_str = defn_build_single_param(ctx, param);
                                 if (string_eq(result, SLOP_STR(""))) {
@@ -2353,7 +2353,7 @@ slop_string defn_build_param_str(context_TranspileContext* ctx, types_SExpr* par
                                     result = context_ctx_str3(ctx, result, SLOP_STR(", "), param_str);
                                 }
                             }
-                        } else if (!_mv_1053.has_value) {
+                        } else if (!_mv_1054.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -2372,11 +2372,11 @@ slop_string defn_build_single_param(context_TranspileContext* ctx, types_SExpr* 
     SLOP_PRE(((param != NULL)), "(!= param nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1054 = (*param);
-        switch (_mv_1054.tag) {
+        __auto_type _mv_1055 = (*param);
+        switch (_mv_1055.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1054.data.lst;
+                __auto_type lst = _mv_1055.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -2387,17 +2387,17 @@ slop_string defn_build_single_param(context_TranspileContext* ctx, types_SExpr* 
                             __auto_type has_mode = ((len >= 3) && defn_is_param_mode(items));
                             __auto_type name_idx = ((((len >= 3) && defn_is_param_mode(items))) ? 1 : 0);
                             __auto_type type_idx = ((((len >= 3) && defn_is_param_mode(items))) ? 2 : 1);
-                            __auto_type _mv_1055 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1055.has_value) {
-                                __auto_type name_expr = _mv_1055.value;
-                                __auto_type _mv_1056 = (*name_expr);
-                                switch (_mv_1056.tag) {
+                            __auto_type _mv_1056 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1056.has_value) {
+                                __auto_type name_expr = _mv_1056.value;
+                                __auto_type _mv_1057 = (*name_expr);
+                                switch (_mv_1057.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type name_sym = _mv_1056.data.sym;
-                                        __auto_type _mv_1057 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1057.has_value) {
-                                            __auto_type type_expr = _mv_1057.value;
+                                        __auto_type name_sym = _mv_1057.data.sym;
+                                        __auto_type _mv_1058 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1058.has_value) {
+                                            __auto_type type_expr = _mv_1058.value;
                                             {
                                                 __auto_type param_name = ctype_to_c_name(arena, name_sym.name);
                                                 {
@@ -2405,7 +2405,7 @@ slop_string defn_build_single_param(context_TranspileContext* ctx, types_SExpr* 
                                                     return context_ctx_str3(ctx, param_type, SLOP_STR(" "), param_name);
                                                 }
                                             }
-                                        } else if (!_mv_1057.has_value) {
+                                        } else if (!_mv_1058.has_value) {
                                             return SLOP_STR("/* missing param type */");
                                         }
                                         SLOP_UNREACHABLE();
@@ -2414,7 +2414,7 @@ slop_string defn_build_single_param(context_TranspileContext* ctx, types_SExpr* 
                                         return SLOP_STR("/* param name must be symbol */");
                                     }
                                 }
-                            } else if (!_mv_1055.has_value) {
+                            } else if (!_mv_1056.has_value) {
                                 return SLOP_STR("/* missing param name */");
                             }
                             SLOP_UNREACHABLE();
@@ -2433,14 +2433,14 @@ uint8_t defn_is_param_mode(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_1058 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1058.has_value) {
-            __auto_type first = _mv_1058.value;
-            __auto_type _mv_1059 = (*first);
-            switch (_mv_1059.tag) {
+        __auto_type _mv_1059 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1059.has_value) {
+            __auto_type first = _mv_1059.value;
+            __auto_type _mv_1060 = (*first);
+            switch (_mv_1060.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_1059.data.sym;
+                    __auto_type sym = _mv_1060.data.sym;
                     {
                         __auto_type name = sym.name;
                         return ((string_eq(name, SLOP_STR("in"))) || (string_eq(name, SLOP_STR("out"))) || (string_eq(name, SLOP_STR("mut"))));
@@ -2450,7 +2450,7 @@ uint8_t defn_is_param_mode(slop_list_types_SExpr_ptr items) {
                     return 0;
                 }
             }
-        } else if (!_mv_1058.has_value) {
+        } else if (!_mv_1059.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -2458,31 +2458,31 @@ uint8_t defn_is_param_mode(slop_list_types_SExpr_ptr items) {
 }
 
 uint8_t defn_is_fn_type(types_SExpr* type_expr) {
-    __auto_type _mv_1060 = (*type_expr);
-    switch (_mv_1060.tag) {
+    __auto_type _mv_1061 = (*type_expr);
+    switch (_mv_1061.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1060.data.lst;
+            __auto_type lst = _mv_1061.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1061 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1061.has_value) {
-                        __auto_type first = _mv_1061.value;
-                        __auto_type _mv_1062 = (*first);
-                        switch (_mv_1062.tag) {
+                    __auto_type _mv_1062 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1062.has_value) {
+                        __auto_type first = _mv_1062.value;
+                        __auto_type _mv_1063 = (*first);
+                        switch (_mv_1063.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1062.data.sym;
+                                __auto_type sym = _mv_1063.data.sym;
                                 return string_eq(sym.name, SLOP_STR("Fn"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1061.has_value) {
+                    } else if (!_mv_1062.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2499,11 +2499,11 @@ slop_string defn_emit_fn_param_type(context_TranspileContext* ctx, types_SExpr* 
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1063 = (*type_expr);
-        switch (_mv_1063.tag) {
+        __auto_type _mv_1064 = (*type_expr);
+        switch (_mv_1064.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1063.data.lst;
+                __auto_type lst = _mv_1064.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -2515,14 +2515,14 @@ slop_string defn_emit_fn_param_type(context_TranspileContext* ctx, types_SExpr* 
                             if (len == 2) {
                                 return context_ctx_str(ctx, context_ctx_str(ctx, ret_type, SLOP_STR("(*")), context_ctx_str(ctx, param_name, SLOP_STR(")(void)")));
                             } else {
-                                __auto_type _mv_1064 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1064.has_value) {
-                                    __auto_type args_expr = _mv_1064.value;
+                                __auto_type _mv_1065 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1065.has_value) {
+                                    __auto_type args_expr = _mv_1065.value;
                                     {
                                         __auto_type args_str = defn_build_fn_args_str_for_param(ctx, args_expr);
                                         return context_ctx_str(ctx, context_ctx_str(ctx, ret_type, SLOP_STR("(*")), context_ctx_str(ctx, param_name, context_ctx_str(ctx, SLOP_STR(")"), args_str)));
                                     }
-                                } else if (!_mv_1064.has_value) {
+                                } else if (!_mv_1065.has_value) {
                                     return context_ctx_str(ctx, context_ctx_str(ctx, ret_type, SLOP_STR("(*")), context_ctx_str(ctx, param_name, SLOP_STR(")(void)")));
                                 }
                                 SLOP_UNREACHABLE();
@@ -2542,11 +2542,11 @@ slop_string defn_build_fn_args_str_for_param(context_TranspileContext* ctx, type
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1065 = (*args_expr);
-        switch (_mv_1065.tag) {
+        __auto_type _mv_1066 = (*args_expr);
+        switch (_mv_1066.tag) {
             case types_SExpr_lst:
             {
-                __auto_type args_list = _mv_1065.data.lst;
+                __auto_type args_list = _mv_1066.data.lst;
                 {
                     __auto_type arg_items = args_list.items;
                     __auto_type arg_count = ((int64_t)((arg_items).len));
@@ -2557,9 +2557,9 @@ slop_string defn_build_fn_args_str_for_param(context_TranspileContext* ctx, type
                             __auto_type result = SLOP_STR("(");
                             __auto_type i = 0;
                             while (i < arg_count) {
-                                __auto_type _mv_1066 = ({ __auto_type _lst = arg_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1066.has_value) {
-                                    __auto_type arg_expr = _mv_1066.value;
+                                __auto_type _mv_1067 = ({ __auto_type _lst = arg_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1067.has_value) {
+                                    __auto_type arg_expr = _mv_1067.value;
                                     {
                                         __auto_type arg_type = context_to_c_type_prefixed(ctx, arg_expr);
                                         if (i > 0) {
@@ -2568,7 +2568,7 @@ slop_string defn_build_fn_args_str_for_param(context_TranspileContext* ctx, type
                                             result = context_ctx_str(ctx, result, arg_type);
                                         }
                                     }
-                                } else if (!_mv_1066.has_value) {
+                                } else if (!_mv_1067.has_value) {
                                     /* empty list */;
                                 }
                                 i = (i + 1);
@@ -2594,9 +2594,9 @@ void defn_emit_function_body(context_TranspileContext* ctx, slop_list_types_SExp
         __auto_type body_start = defn_find_body_start(items);
         i = body_start;
         while (i < len) {
-            __auto_type _mv_1067 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1067.has_value) {
-                __auto_type item = _mv_1067.value;
+            __auto_type _mv_1068 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1068.has_value) {
+                __auto_type item = _mv_1068.value;
                 if (defn_is_c_name_attr(item)) {
                     i = (i + 1);
                 } else {
@@ -2608,7 +2608,7 @@ void defn_emit_function_body(context_TranspileContext* ctx, slop_list_types_SExp
                         }
                     }
                 }
-            } else if (!_mv_1067.has_value) {
+            } else if (!_mv_1068.has_value) {
             }
             i = (i + 1);
         }
@@ -2617,11 +2617,11 @@ void defn_emit_function_body(context_TranspileContext* ctx, slop_list_types_SExp
 
 uint8_t defn_is_c_name_attr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1068 = (*expr);
-    switch (_mv_1068.tag) {
+    __auto_type _mv_1069 = (*expr);
+    switch (_mv_1069.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1068.data.sym;
+            __auto_type sym = _mv_1069.data.sym;
             return string_eq(sym.name, SLOP_STR(":c-name"));
         }
         default: {
@@ -2636,9 +2636,9 @@ uint8_t defn_is_last_body_item(slop_list_types_SExpr_ptr items, int64_t current_
         int64_t i = (current_i + 1);
         uint8_t found_body = 0;
         while ((i < len) && !(found_body)) {
-            __auto_type _mv_1069 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1069.has_value) {
-                __auto_type item = _mv_1069.value;
+            __auto_type _mv_1070 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1070.has_value) {
+                __auto_type item = _mv_1070.value;
                 if (defn_is_annotation(item) || defn_is_c_name_attr(item)) {
                     i = (i + 1);
                 } else {
@@ -2648,7 +2648,7 @@ uint8_t defn_is_last_body_item(slop_list_types_SExpr_ptr items, int64_t current_
                         found_body = 1;
                     }
                 }
-            } else if (!_mv_1069.has_value) {
+            } else if (!_mv_1070.has_value) {
                 i = (i + 1);
             }
         }
@@ -2657,11 +2657,11 @@ uint8_t defn_is_last_body_item(slop_list_types_SExpr_ptr items, int64_t current_
 }
 
 uint8_t defn_is_c_name_attr_at(slop_list_types_SExpr_ptr items, int64_t idx) {
-    __auto_type _mv_1070 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-    if (_mv_1070.has_value) {
-        __auto_type item = _mv_1070.value;
+    __auto_type _mv_1071 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+    if (_mv_1071.has_value) {
+        __auto_type item = _mv_1071.value;
         return defn_is_c_name_attr(item);
-    } else if (!_mv_1070.has_value) {
+    } else if (!_mv_1071.has_value) {
         return 0;
     }
     SLOP_UNREACHABLE();
@@ -2673,15 +2673,15 @@ int64_t defn_find_body_start(slop_list_types_SExpr_ptr items) {
         int64_t i = 3;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1071 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1071.has_value) {
-                __auto_type item = _mv_1071.value;
+            __auto_type _mv_1072 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1072.has_value) {
+                __auto_type item = _mv_1072.value;
                 if (defn_is_annotation(item)) {
                     i = (i + 1);
                 } else {
                     found = 1;
                 }
-            } else if (!_mv_1071.has_value) {
+            } else if (!_mv_1072.has_value) {
                 found = 1;
             }
         }
@@ -2691,24 +2691,24 @@ int64_t defn_find_body_start(slop_list_types_SExpr_ptr items) {
 
 uint8_t defn_is_annotation(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1072 = (*expr);
-    switch (_mv_1072.tag) {
+    __auto_type _mv_1073 = (*expr);
+    switch (_mv_1073.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1072.data.lst;
+            __auto_type lst = _mv_1073.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1073 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1073.has_value) {
-                        __auto_type head = _mv_1073.value;
-                        __auto_type _mv_1074 = (*head);
-                        switch (_mv_1074.tag) {
+                    __auto_type _mv_1074 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1074.has_value) {
+                        __auto_type head = _mv_1074.value;
+                        __auto_type _mv_1075 = (*head);
+                        switch (_mv_1075.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1074.data.sym;
+                                __auto_type sym = _mv_1075.data.sym;
                                 {
                                     __auto_type name = sym.name;
                                     return ((string_eq(name, SLOP_STR("@intent"))) || (string_eq(name, SLOP_STR("@spec"))) || (string_eq(name, SLOP_STR("@pre"))) || (string_eq(name, SLOP_STR("@post"))) || (string_eq(name, SLOP_STR("@assume"))) || (string_eq(name, SLOP_STR("@alloc"))) || (string_eq(name, SLOP_STR("@example"))) || (string_eq(name, SLOP_STR("@pure"))) || (string_eq(name, SLOP_STR("@doc"))) || (string_eq(name, SLOP_STR("@loop-invariant"))) || (string_eq(name, SLOP_STR("@property"))) || (string_eq(name, SLOP_STR("@callback-assume"))) || (string_eq(name, SLOP_STR("@generic"))));
@@ -2718,7 +2718,7 @@ uint8_t defn_is_annotation(types_SExpr* expr) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1073.has_value) {
+                    } else if (!_mv_1074.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2733,31 +2733,31 @@ uint8_t defn_is_annotation(types_SExpr* expr) {
 
 uint8_t defn_is_pre_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1075 = (*expr);
-    switch (_mv_1075.tag) {
+    __auto_type _mv_1076 = (*expr);
+    switch (_mv_1076.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1075.data.lst;
+            __auto_type lst = _mv_1076.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1076 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1076.has_value) {
-                        __auto_type head = _mv_1076.value;
-                        __auto_type _mv_1077 = (*head);
-                        switch (_mv_1077.tag) {
+                    __auto_type _mv_1077 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1077.has_value) {
+                        __auto_type head = _mv_1077.value;
+                        __auto_type _mv_1078 = (*head);
+                        switch (_mv_1078.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1077.data.sym;
+                                __auto_type sym = _mv_1078.data.sym;
                                 return string_eq(sym.name, SLOP_STR("@pre"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1076.has_value) {
+                    } else if (!_mv_1077.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2772,31 +2772,31 @@ uint8_t defn_is_pre_form(types_SExpr* expr) {
 
 uint8_t defn_is_post_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1078 = (*expr);
-    switch (_mv_1078.tag) {
+    __auto_type _mv_1079 = (*expr);
+    switch (_mv_1079.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1078.data.lst;
+            __auto_type lst = _mv_1079.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1079 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1079.has_value) {
-                        __auto_type head = _mv_1079.value;
-                        __auto_type _mv_1080 = (*head);
-                        switch (_mv_1080.tag) {
+                    __auto_type _mv_1080 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1080.has_value) {
+                        __auto_type head = _mv_1080.value;
+                        __auto_type _mv_1081 = (*head);
+                        switch (_mv_1081.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1080.data.sym;
+                                __auto_type sym = _mv_1081.data.sym;
                                 return string_eq(sym.name, SLOP_STR("@post"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1079.has_value) {
+                    } else if (!_mv_1080.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2811,31 +2811,31 @@ uint8_t defn_is_post_form(types_SExpr* expr) {
 
 uint8_t defn_is_assume_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1081 = (*expr);
-    switch (_mv_1081.tag) {
+    __auto_type _mv_1082 = (*expr);
+    switch (_mv_1082.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1081.data.lst;
+            __auto_type lst = _mv_1082.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1082 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1082.has_value) {
-                        __auto_type head = _mv_1082.value;
-                        __auto_type _mv_1083 = (*head);
-                        switch (_mv_1083.tag) {
+                    __auto_type _mv_1083 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1083.has_value) {
+                        __auto_type head = _mv_1083.value;
+                        __auto_type _mv_1084 = (*head);
+                        switch (_mv_1084.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1083.data.sym;
+                                __auto_type sym = _mv_1084.data.sym;
                                 return string_eq(sym.name, SLOP_STR("@assume"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1082.has_value) {
+                    } else if (!_mv_1083.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2850,11 +2850,11 @@ uint8_t defn_is_assume_form(types_SExpr* expr) {
 
 uint8_t defn_is_verification_only_expr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1084 = (*expr);
-    switch (_mv_1084.tag) {
+    __auto_type _mv_1085 = (*expr);
+    switch (_mv_1085.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1084.data.lst;
+            __auto_type lst = _mv_1085.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
@@ -2864,14 +2864,14 @@ uint8_t defn_is_verification_only_expr(types_SExpr* expr) {
                     {
                         __auto_type found = 0;
                         __auto_type i = 0;
-                        __auto_type _mv_1085 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1085.has_value) {
-                            __auto_type head = _mv_1085.value;
-                            __auto_type _mv_1086 = (*head);
-                            switch (_mv_1086.tag) {
+                        __auto_type _mv_1086 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1086.has_value) {
+                            __auto_type head = _mv_1086.value;
+                            __auto_type _mv_1087 = (*head);
+                            switch (_mv_1087.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1086.data.sym;
+                                    __auto_type sym = _mv_1087.data.sym;
                                     {
                                         __auto_type name = sym.name;
                                         if ((string_eq(name, SLOP_STR("forall"))) || (string_eq(name, SLOP_STR("exists"))) || (string_eq(name, SLOP_STR("implies")))) {
@@ -2884,16 +2884,16 @@ uint8_t defn_is_verification_only_expr(types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_1085.has_value) {
+                        } else if (!_mv_1086.has_value) {
                         }
                         while ((i < len) && !(found)) {
-                            __auto_type _mv_1087 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1087.has_value) {
-                                __auto_type item = _mv_1087.value;
+                            __auto_type _mv_1088 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1088.has_value) {
+                                __auto_type item = _mv_1088.value;
                                 if (defn_is_verification_only_expr(item)) {
                                     found = 1;
                                 }
-                            } else if (!_mv_1087.has_value) {
+                            } else if (!_mv_1088.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -2910,31 +2910,31 @@ uint8_t defn_is_verification_only_expr(types_SExpr* expr) {
 
 uint8_t defn_is_doc_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1088 = (*expr);
-    switch (_mv_1088.tag) {
+    __auto_type _mv_1089 = (*expr);
+    switch (_mv_1089.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1088.data.lst;
+            __auto_type lst = _mv_1089.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1089 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1089.has_value) {
-                        __auto_type head = _mv_1089.value;
-                        __auto_type _mv_1090 = (*head);
-                        switch (_mv_1090.tag) {
+                    __auto_type _mv_1090 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1090.has_value) {
+                        __auto_type head = _mv_1090.value;
+                        __auto_type _mv_1091 = (*head);
+                        switch (_mv_1091.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1090.data.sym;
+                                __auto_type sym = _mv_1091.data.sym;
                                 return string_eq(sym.name, SLOP_STR("@doc"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1089.has_value) {
+                    } else if (!_mv_1090.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2951,22 +2951,22 @@ slop_option_string defn_get_doc_string(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         slop_option_string result = (slop_option_string){.has_value = false};
-        __auto_type _mv_1091 = (*expr);
-        switch (_mv_1091.tag) {
+        __auto_type _mv_1092 = (*expr);
+        switch (_mv_1092.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1091.data.lst;
+                __auto_type lst = _mv_1092.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_1092 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1092.has_value) {
-                            __auto_type val = _mv_1092.value;
-                            __auto_type _mv_1093 = (*val);
-                            switch (_mv_1093.tag) {
+                        __auto_type _mv_1093 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1093.has_value) {
+                            __auto_type val = _mv_1093.value;
+                            __auto_type _mv_1094 = (*val);
+                            switch (_mv_1094.tag) {
                                 case types_SExpr_str:
                                 {
-                                    __auto_type str = _mv_1093.data.str;
+                                    __auto_type str = _mv_1094.data.str;
                                     result = (slop_option_string){.has_value = 1, .value = str.value};
                                     break;
                                 }
@@ -2974,7 +2974,7 @@ slop_option_string defn_get_doc_string(types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_1092.has_value) {
+                        } else if (!_mv_1093.has_value) {
                         }
                     }
                 }
@@ -2994,13 +2994,13 @@ slop_option_string defn_collect_doc_string(slop_arena* arena, slop_list_types_SE
         int64_t i = 3;
         slop_option_string result = (slop_option_string){.has_value = false};
         while ((i < len) && ({ __auto_type _mv = result; _mv.has_value ? (0) : (1); })) {
-            __auto_type _mv_1094 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1094.has_value) {
-                __auto_type item = _mv_1094.value;
+            __auto_type _mv_1095 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1095.has_value) {
+                __auto_type item = _mv_1095.value;
                 if (defn_is_doc_form(item)) {
                     result = defn_get_doc_string(item);
                 }
-            } else if (!_mv_1094.has_value) {
+            } else if (!_mv_1095.has_value) {
             }
             i = (i + 1);
         }
@@ -3012,19 +3012,19 @@ slop_option_types_SExpr_ptr defn_get_annotation_condition(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         slop_option_types_SExpr_ptr result = (slop_option_types_SExpr_ptr){.has_value = false};
-        __auto_type _mv_1095 = (*expr);
-        switch (_mv_1095.tag) {
+        __auto_type _mv_1096 = (*expr);
+        switch (_mv_1096.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1095.data.lst;
+                __auto_type lst = _mv_1096.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_1096 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1096.has_value) {
-                            __auto_type val = _mv_1096.value;
+                        __auto_type _mv_1097 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1097.has_value) {
+                            __auto_type val = _mv_1097.value;
                             result = (slop_option_types_SExpr_ptr){.has_value = 1, .value = val};
-                        } else if (!_mv_1096.has_value) {
+                        } else if (!_mv_1097.has_value) {
                         }
                     }
                 }
@@ -3044,18 +3044,18 @@ slop_list_types_SExpr_ptr defn_collect_preconditions(slop_arena* arena, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 3;
         while (i < len) {
-            __auto_type _mv_1097 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1097.has_value) {
-                __auto_type item = _mv_1097.value;
+            __auto_type _mv_1098 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1098.has_value) {
+                __auto_type item = _mv_1098.value;
                 if (defn_is_pre_form(item)) {
-                    __auto_type _mv_1098 = defn_get_annotation_condition(item);
-                    if (_mv_1098.has_value) {
-                        __auto_type cond = _mv_1098.value;
+                    __auto_type _mv_1099 = defn_get_annotation_condition(item);
+                    if (_mv_1099.has_value) {
+                        __auto_type cond = _mv_1099.value;
                         ({ __auto_type _lst_p = &(result); __auto_type _item = (cond); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                    } else if (!_mv_1098.has_value) {
+                    } else if (!_mv_1099.has_value) {
                     }
                 }
-            } else if (!_mv_1097.has_value) {
+            } else if (!_mv_1098.has_value) {
             }
             i = (i + 1);
         }
@@ -3069,18 +3069,18 @@ slop_list_types_SExpr_ptr defn_collect_postconditions(slop_arena* arena, slop_li
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 3;
         while (i < len) {
-            __auto_type _mv_1099 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1099.has_value) {
-                __auto_type item = _mv_1099.value;
+            __auto_type _mv_1100 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1100.has_value) {
+                __auto_type item = _mv_1100.value;
                 if (defn_is_post_form(item)) {
-                    __auto_type _mv_1100 = defn_get_annotation_condition(item);
-                    if (_mv_1100.has_value) {
-                        __auto_type cond = _mv_1100.value;
+                    __auto_type _mv_1101 = defn_get_annotation_condition(item);
+                    if (_mv_1101.has_value) {
+                        __auto_type cond = _mv_1101.value;
                         ({ __auto_type _lst_p = &(result); __auto_type _item = (cond); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                    } else if (!_mv_1100.has_value) {
+                    } else if (!_mv_1101.has_value) {
                     }
                 }
-            } else if (!_mv_1099.has_value) {
+            } else if (!_mv_1100.has_value) {
             }
             i = (i + 1);
         }
@@ -3094,18 +3094,18 @@ slop_list_types_SExpr_ptr defn_collect_assumptions(slop_arena* arena, slop_list_
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 3;
         while (i < len) {
-            __auto_type _mv_1101 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1101.has_value) {
-                __auto_type item = _mv_1101.value;
+            __auto_type _mv_1102 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1102.has_value) {
+                __auto_type item = _mv_1102.value;
                 if (defn_is_assume_form(item)) {
-                    __auto_type _mv_1102 = defn_get_annotation_condition(item);
-                    if (_mv_1102.has_value) {
-                        __auto_type cond = _mv_1102.value;
+                    __auto_type _mv_1103 = defn_get_annotation_condition(item);
+                    if (_mv_1103.has_value) {
+                        __auto_type cond = _mv_1103.value;
                         ({ __auto_type _lst_p = &(result); __auto_type _item = (cond); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                    } else if (!_mv_1102.has_value) {
+                    } else if (!_mv_1103.has_value) {
                     }
                 }
-            } else if (!_mv_1101.has_value) {
+            } else if (!_mv_1102.has_value) {
             }
             i = (i + 1);
         }
@@ -3119,13 +3119,13 @@ uint8_t defn_has_postconditions(slop_list_types_SExpr_ptr items) {
         int64_t i = 3;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1103 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1103.has_value) {
-                __auto_type item = _mv_1103.value;
+            __auto_type _mv_1104 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1104.has_value) {
+                __auto_type item = _mv_1104.value;
                 if (defn_is_post_form(item) || defn_is_assume_form(item)) {
                     found = 1;
                 }
-            } else if (!_mv_1103.has_value) {
+            } else if (!_mv_1104.has_value) {
             }
             i = (i + 1);
         }
@@ -3140,16 +3140,16 @@ void defn_emit_preconditions(context_TranspileContext* ctx, slop_list_types_SExp
         __auto_type len = ((int64_t)((preconditions).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1104 = ({ __auto_type _lst = preconditions; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1104.has_value) {
-                __auto_type cond_expr = _mv_1104.value;
+            __auto_type _mv_1105 = ({ __auto_type _lst = preconditions; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1105.has_value) {
+                __auto_type cond_expr = _mv_1105.value;
                 {
                     __auto_type cond_c = expr_transpile_expr(ctx, cond_expr);
                     __auto_type expr_str = parser_pretty_print(arena, cond_expr);
                     __auto_type escaped_str = defn_escape_for_c_string(arena, expr_str);
                     context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("SLOP_PRE(("), cond_c, SLOP_STR("), \""), escaped_str, SLOP_STR("\");")));
                 }
-            } else if (!_mv_1104.has_value) {
+            } else if (!_mv_1105.has_value) {
             }
             i = (i + 1);
         }
@@ -3163,9 +3163,9 @@ void defn_emit_postconditions(context_TranspileContext* ctx, slop_list_types_SEx
         __auto_type len = ((int64_t)((postconditions).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1105 = ({ __auto_type _lst = postconditions; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1105.has_value) {
-                __auto_type cond_expr = _mv_1105.value;
+            __auto_type _mv_1106 = ({ __auto_type _lst = postconditions; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1106.has_value) {
+                __auto_type cond_expr = _mv_1106.value;
                 if (!(defn_is_verification_only_expr(cond_expr))) {
                     {
                         __auto_type cond_c = expr_transpile_expr(ctx, cond_expr);
@@ -3174,7 +3174,7 @@ void defn_emit_postconditions(context_TranspileContext* ctx, slop_list_types_SEx
                         context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("SLOP_POST(("), cond_c, SLOP_STR("), \""), escaped_str, SLOP_STR("\");")));
                     }
                 }
-            } else if (!_mv_1105.has_value) {
+            } else if (!_mv_1106.has_value) {
             }
             i = (i + 1);
         }
@@ -3188,9 +3188,9 @@ void defn_emit_assumptions(context_TranspileContext* ctx, slop_list_types_SExpr_
         __auto_type len = ((int64_t)((assumptions).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1106 = ({ __auto_type _lst = assumptions; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1106.has_value) {
-                __auto_type cond_expr = _mv_1106.value;
+            __auto_type _mv_1107 = ({ __auto_type _lst = assumptions; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1107.has_value) {
+                __auto_type cond_expr = _mv_1107.value;
                 if (!(defn_is_verification_only_expr(cond_expr))) {
                     {
                         __auto_type cond_c = expr_transpile_expr(ctx, cond_expr);
@@ -3199,7 +3199,7 @@ void defn_emit_assumptions(context_TranspileContext* ctx, slop_list_types_SExpr_
                         context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("SLOP_POST(("), cond_c, SLOP_STR("), \""), escaped_str, SLOP_STR("\");")));
                     }
                 }
-            } else if (!_mv_1106.has_value) {
+            } else if (!_mv_1107.has_value) {
             }
             i = (i + 1);
         }

--- a/bootstrap/transpiler/slop_expr.c
+++ b/bootstrap/transpiler/slop_expr.c
@@ -8621,14 +8621,15 @@ slop_string expr_transpile_with_arena_expr(context_TranspileContext* ctx, slop_l
                 __auto_type arena_name = ((is_named) ? ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type name_expr = _mv.value; ({ __auto_type _mv = (*name_expr); slop_string _mr = {0}; switch (_mv.tag) { case types_SExpr_sym: { __auto_type s2 = _mv.data.sym; _mr = s2.name; break; } default: { _mr = SLOP_STR("arena"); break; }  } _mr; }); }) : (SLOP_STR("arena")); }) : SLOP_STR("arena"));
                 __auto_type size_idx = ((is_named) ? 3 : 1);
                 __auto_type body_start = ((is_named) ? 4 : 2);
-                __auto_type c_local = ((is_named) ? string_concat(arena, SLOP_STR("_arena_"), arena_name) : SLOP_STR("_arena"));
+                __auto_type c_arena_name = ctype_to_c_name(arena, arena_name);
+                __auto_type c_local = ((is_named) ? string_concat(arena, SLOP_STR("_arena_"), c_arena_name) : SLOP_STR("_arena"));
                 if (is_named && (len < 5)) {
                     context_ctx_add_error_at(ctx, SLOP_STR("with-arena :as requires name, size and body"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     return SLOP_STR("({ (void)0; })");
                 } else {
                     context_ctx_push_scope(ctx);
                     {
-                        __auto_type result_str = ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type size_expr = _mv.value; ({ __auto_type size_c = expr_transpile_expr(ctx, size_expr); __auto_type result = context_ctx_str5(ctx, SLOP_STR("({ slop_arena "), c_local, SLOP_STR(" = slop_arena_new("), size_c, SLOP_STR("); ")); ({ result = context_ctx_str5(ctx, result, SLOP_STR("slop_arena* "), arena_name, SLOP_STR(" = &"), context_ctx_str(ctx, c_local, SLOP_STR("; "))); (void)0; }); context_ctx_bind_var(ctx, (context_VarEntry){arena_name, arena_name, SLOP_STR("slop_arena*"), SLOP_STR(""), 1, 0, 0, SLOP_STR(""), SLOP_STR("")}); ({ __auto_type i = body_start; ({ while ((i < (len - 1))) { ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); if (_mv.has_value) { __auto_type body_expr = _mv.value; ({ __auto_type body_c = expr_transpile_expr(ctx, body_expr); ({ result = context_ctx_str3(ctx, result, body_c, SLOP_STR("; ")); (void)0; }); }); } else { ({ (void)0; }); } (void)0; }); ({ i = (i + 1); (void)0; }); } (void)0; }); }); ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)(len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); if (_mv.has_value) { __auto_type last_expr = _mv.value; ({ __auto_type last_c = expr_transpile_expr(ctx, last_expr); __auto_type free_part = context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), arena_name, SLOP_STR("); ")); ({ result = context_ctx_str5(ctx, result, SLOP_STR("__auto_type _wa_result = "), last_c, SLOP_STR("; "), free_part); (void)0; }); ({ result = context_ctx_str(ctx, result, SLOP_STR("_wa_result; })")); (void)0; }); }); } else { ({ __auto_type free_part = context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), arena_name, SLOP_STR("); ")); ({ result = context_ctx_str3(ctx, result, free_part, SLOP_STR("0; })")); (void)0; }); }); } (void)0; }); result; }); }) : (({ context_ctx_add_error_at(ctx, SLOP_STR("with-arena: missing size"), context_ctx_list_first_line(items), context_ctx_list_first_col(items)); SLOP_STR("({ (void)0; })"); })); });
+                        __auto_type result_str = ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type size_expr = _mv.value; ({ __auto_type size_c = expr_transpile_expr(ctx, size_expr); __auto_type result = context_ctx_str5(ctx, SLOP_STR("({ slop_arena "), c_local, SLOP_STR(" = slop_arena_new("), size_c, SLOP_STR("); ")); ({ result = context_ctx_str5(ctx, result, SLOP_STR("slop_arena* "), c_arena_name, SLOP_STR(" = &"), context_ctx_str(ctx, c_local, SLOP_STR("; "))); (void)0; }); context_ctx_bind_var(ctx, (context_VarEntry){arena_name, c_arena_name, SLOP_STR("slop_arena*"), SLOP_STR(""), 1, 0, 0, SLOP_STR(""), SLOP_STR("")}); ({ __auto_type i = body_start; ({ while ((i < (len - 1))) { ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); if (_mv.has_value) { __auto_type body_expr = _mv.value; ({ __auto_type body_c = expr_transpile_expr(ctx, body_expr); ({ result = context_ctx_str3(ctx, result, body_c, SLOP_STR("; ")); (void)0; }); }); } else { ({ (void)0; }); } (void)0; }); ({ i = (i + 1); (void)0; }); } (void)0; }); }); ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)(len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); if (_mv.has_value) { __auto_type last_expr = _mv.value; ({ __auto_type last_c = expr_transpile_expr(ctx, last_expr); __auto_type free_part = context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), c_arena_name, SLOP_STR("); ")); ({ result = context_ctx_str5(ctx, result, SLOP_STR("__auto_type _wa_result = "), last_c, SLOP_STR("; "), free_part); (void)0; }); ({ result = context_ctx_str(ctx, result, SLOP_STR("_wa_result; })")); (void)0; }); }); } else { ({ __auto_type free_part = context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), c_arena_name, SLOP_STR("); ")); ({ result = context_ctx_str3(ctx, result, free_part, SLOP_STR("0; })")); (void)0; }); }); } (void)0; }); result; }); }) : (({ context_ctx_add_error_at(ctx, SLOP_STR("with-arena: missing size"), context_ctx_list_first_line(items), context_ctx_list_first_col(items)); SLOP_STR("({ (void)0; })"); })); });
                         context_ctx_pop_scope(ctx);
                         return result_str;
                     }
@@ -8938,7 +8939,14 @@ slop_string expr_find_arena_ptr_expr(context_TranspileContext* ctx) {
             __auto_type entry = _mv_542.value;
             return entry.c_name;
         } else if (!_mv_542.has_value) {
-            return SLOP_STR("");
+            __auto_type _mv_543 = context_ctx_find_arena_var(ctx);
+            if (_mv_543.has_value) {
+                __auto_type entry = _mv_543.value;
+                return entry.c_name;
+            } else if (!_mv_543.has_value) {
+                return SLOP_STR("");
+            }
+            SLOP_UNREACHABLE();
         }
         SLOP_UNREACHABLE();
     }
@@ -8969,9 +8977,9 @@ slop_string expr_build_env_initializer(context_TranspileContext* ctx, slop_list_
         __auto_type result = SLOP_STR("{ ");
         int64_t i = 0;
         while (i < count) {
-            __auto_type _mv_543 = ({ __auto_type _lst = free_vars; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_543.has_value) {
-                __auto_type var_name = _mv_543.value;
+            __auto_type _mv_544 = ({ __auto_type _lst = free_vars; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_544.has_value) {
+                __auto_type var_name = _mv_544.value;
                 {
                     __auto_type c_name = ctype_to_c_name(arena, var_name);
                     __auto_type access_expr = ({ __auto_type _mv = ({ __auto_type _lst = captured_accesses; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type acc = _mv.value; acc; }) : (c_name); });
@@ -8981,7 +8989,7 @@ slop_string expr_build_env_initializer(context_TranspileContext* ctx, slop_list_
                         result = context_ctx_str(ctx, result, context_ctx_str5(ctx, SLOP_STR("."), c_name, SLOP_STR(" = "), access_expr, SLOP_STR("")));
                     }
                 }
-            } else if (!_mv_543.has_value) {
+            } else if (!_mv_544.has_value) {
             }
             i = (i + 1);
         }
@@ -9001,28 +9009,28 @@ slop_string expr_build_lambda_params(context_TranspileContext* ctx, slop_list_ty
                 __auto_type result = SLOP_STR("(");
                 int64_t i = 0;
                 while (i < param_count) {
-                    __auto_type _mv_544 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_544.has_value) {
-                        __auto_type param_expr = _mv_544.value;
-                        __auto_type _mv_545 = (*param_expr);
-                        switch (_mv_545.tag) {
+                    __auto_type _mv_545 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_545.has_value) {
+                        __auto_type param_expr = _mv_545.value;
+                        __auto_type _mv_546 = (*param_expr);
+                        switch (_mv_546.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type param_lst = _mv_545.data.lst;
+                                __auto_type param_lst = _mv_546.data.lst;
                                 {
                                     __auto_type param_items = param_lst.items;
                                     if (((int64_t)((param_items).len)) >= 2) {
-                                        __auto_type _mv_546 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_546.has_value) {
-                                            __auto_type name_expr = _mv_546.value;
-                                            __auto_type _mv_547 = (*name_expr);
-                                            switch (_mv_547.tag) {
+                                        __auto_type _mv_547 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_547.has_value) {
+                                            __auto_type name_expr = _mv_547.value;
+                                            __auto_type _mv_548 = (*name_expr);
+                                            switch (_mv_548.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type name_sym = _mv_547.data.sym;
-                                                    __auto_type _mv_548 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_548.has_value) {
-                                                        __auto_type type_expr = _mv_548.value;
+                                                    __auto_type name_sym = _mv_548.data.sym;
+                                                    __auto_type _mv_549 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_549.has_value) {
+                                                        __auto_type type_expr = _mv_549.value;
                                                         {
                                                             __auto_type param_name = ctype_to_c_name(arena, name_sym.name);
                                                             __auto_type param_type = context_to_c_type_prefixed(ctx, type_expr);
@@ -9032,7 +9040,7 @@ slop_string expr_build_lambda_params(context_TranspileContext* ctx, slop_list_ty
                                                                 result = context_ctx_str(ctx, result, context_ctx_str4(ctx, param_type, SLOP_STR(" "), param_name, SLOP_STR("")));
                                                             }
                                                         }
-                                                    } else if (!_mv_548.has_value) {
+                                                    } else if (!_mv_549.has_value) {
                                                     }
                                                     break;
                                                 }
@@ -9040,7 +9048,7 @@ slop_string expr_build_lambda_params(context_TranspileContext* ctx, slop_list_ty
                                                     break;
                                                 }
                                             }
-                                        } else if (!_mv_546.has_value) {
+                                        } else if (!_mv_547.has_value) {
                                         }
                                     }
                                 }
@@ -9050,7 +9058,7 @@ slop_string expr_build_lambda_params(context_TranspileContext* ctx, slop_list_ty
                                 break;
                             }
                         }
-                    } else if (!_mv_544.has_value) {
+                    } else if (!_mv_545.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -9067,28 +9075,28 @@ void expr_bind_lambda_params(context_TranspileContext* ctx, slop_list_types_SExp
         __auto_type param_count = ((int64_t)((params).len));
         int64_t i = 0;
         while (i < param_count) {
-            __auto_type _mv_549 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_549.has_value) {
-                __auto_type param_expr = _mv_549.value;
-                __auto_type _mv_550 = (*param_expr);
-                switch (_mv_550.tag) {
+            __auto_type _mv_550 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_550.has_value) {
+                __auto_type param_expr = _mv_550.value;
+                __auto_type _mv_551 = (*param_expr);
+                switch (_mv_551.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type param_lst = _mv_550.data.lst;
+                        __auto_type param_lst = _mv_551.data.lst;
                         {
                             __auto_type param_items = param_lst.items;
                             if (((int64_t)((param_items).len)) >= 2) {
-                                __auto_type _mv_551 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_551.has_value) {
-                                    __auto_type name_expr = _mv_551.value;
-                                    __auto_type _mv_552 = (*name_expr);
-                                    switch (_mv_552.tag) {
+                                __auto_type _mv_552 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_552.has_value) {
+                                    __auto_type name_expr = _mv_552.value;
+                                    __auto_type _mv_553 = (*name_expr);
+                                    switch (_mv_553.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type name_sym = _mv_552.data.sym;
-                                            __auto_type _mv_553 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_553.has_value) {
-                                                __auto_type type_expr = _mv_553.value;
+                                            __auto_type name_sym = _mv_553.data.sym;
+                                            __auto_type _mv_554 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_554.has_value) {
+                                                __auto_type type_expr = _mv_554.value;
                                                 {
                                                     __auto_type param_name = name_sym.name;
                                                     __auto_type c_name = ctype_to_c_name(arena, param_name);
@@ -9096,7 +9104,7 @@ void expr_bind_lambda_params(context_TranspileContext* ctx, slop_list_types_SExp
                                                     __auto_type is_ptr = expr_is_pointer_type_sexpr(type_expr);
                                                     context_ctx_bind_var(ctx, (context_VarEntry){param_name, c_name, c_type, SLOP_STR(""), is_ptr, 0, 0, SLOP_STR(""), SLOP_STR("")});
                                                 }
-                                            } else if (!_mv_553.has_value) {
+                                            } else if (!_mv_554.has_value) {
                                             }
                                             break;
                                         }
@@ -9104,7 +9112,7 @@ void expr_bind_lambda_params(context_TranspileContext* ctx, slop_list_types_SExp
                                             break;
                                         }
                                     }
-                                } else if (!_mv_551.has_value) {
+                                } else if (!_mv_552.has_value) {
                                 }
                             }
                         }
@@ -9114,7 +9122,7 @@ void expr_bind_lambda_params(context_TranspileContext* ctx, slop_list_types_SExp
                         break;
                     }
                 }
-            } else if (!_mv_549.has_value) {
+            } else if (!_mv_550.has_value) {
             }
             i = (i + 1);
         }
@@ -9122,31 +9130,31 @@ void expr_bind_lambda_params(context_TranspileContext* ctx, slop_list_types_SExp
 }
 
 uint8_t expr_is_pointer_type_sexpr(types_SExpr* type_expr) {
-    __auto_type _mv_554 = (*type_expr);
-    switch (_mv_554.tag) {
+    __auto_type _mv_555 = (*type_expr);
+    switch (_mv_555.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_554.data.lst;
+            __auto_type lst = _mv_555.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_555 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_555.has_value) {
-                        __auto_type head = _mv_555.value;
-                        __auto_type _mv_556 = (*head);
-                        switch (_mv_556.tag) {
+                    __auto_type _mv_556 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_556.has_value) {
+                        __auto_type head = _mv_556.value;
+                        __auto_type _mv_557 = (*head);
+                        switch (_mv_557.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_556.data.sym;
+                                __auto_type sym = _mv_557.data.sym;
                                 return (string_eq(sym.name, SLOP_STR("Ptr")) || string_eq(sym.name, SLOP_STR("ScopedPtr")));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_555.has_value) {
+                    } else if (!_mv_556.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -9175,9 +9183,9 @@ slop_string expr_transpile_lambda_body(context_TranspileContext* ctx, slop_list_
             }
         } else {
             while (i < len) {
-                __auto_type _mv_557 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_557.has_value) {
-                    __auto_type expr = _mv_557.value;
+                __auto_type _mv_558 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_558.has_value) {
+                    __auto_type expr = _mv_558.value;
                     {
                         __auto_type expr_c = expr_transpile_expr(ctx, expr);
                         __auto_type is_last = (i == (len - 1));
@@ -9191,7 +9199,7 @@ slop_string expr_transpile_lambda_body(context_TranspileContext* ctx, slop_list_
                             result = context_ctx_str(ctx, result, context_ctx_str3(ctx, expr_c, SLOP_STR("; "), SLOP_STR("")));
                         }
                     }
-                } else if (!_mv_557.has_value) {
+                } else if (!_mv_558.has_value) {
                 }
                 i = (i + 1);
             }
@@ -9213,42 +9221,42 @@ slop_string expr_build_lambda_function(context_TranspileContext* ctx, slop_strin
 
 uint8_t expr_is_capturing_lambda(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_558 = (*expr);
-    switch (_mv_558.tag) {
+    __auto_type _mv_559 = (*expr);
+    switch (_mv_559.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_558.data.lst;
+            __auto_type lst = _mv_559.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return 0;
                 } else {
-                    __auto_type _mv_559 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_559.has_value) {
-                        __auto_type head = _mv_559.value;
-                        __auto_type _mv_560 = (*head);
-                        switch (_mv_560.tag) {
+                    __auto_type _mv_560 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_560.has_value) {
+                        __auto_type head = _mv_560.value;
+                        __auto_type _mv_561 = (*head);
+                        switch (_mv_561.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_560.data.sym;
+                                __auto_type sym = _mv_561.data.sym;
                                 if (!(string_eq(sym.name, SLOP_STR("fn")))) {
                                     return 0;
                                 } else {
-                                    __auto_type _mv_561 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_561.has_value) {
-                                        __auto_type second = _mv_561.value;
-                                        __auto_type _mv_562 = (*second);
-                                        switch (_mv_562.tag) {
+                                    __auto_type _mv_562 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_562.has_value) {
+                                        __auto_type second = _mv_562.value;
+                                        __auto_type _mv_563 = (*second);
+                                        switch (_mv_563.tag) {
                                             case types_SExpr_lst:
                                             {
-                                                __auto_type _ = _mv_562.data.lst;
+                                                __auto_type _ = _mv_563.data.lst;
                                                 return 1;
                                             }
                                             default: {
                                                 return 0;
                                             }
                                         }
-                                    } else if (!_mv_561.has_value) {
+                                    } else if (!_mv_562.has_value) {
                                         return 0;
                                     }
                                     SLOP_UNREACHABLE();
@@ -9258,7 +9266,7 @@ uint8_t expr_is_capturing_lambda(types_SExpr* expr) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_559.has_value) {
+                    } else if (!_mv_560.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -9276,9 +9284,9 @@ slop_string expr_transpile_spawn_closure(context_TranspileContext* ctx, slop_lis
     SLOP_PRE(((fn_expr != NULL)), "(!= fn-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_563 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_563.has_value) {
-            __auto_type arena_expr = _mv_563.value;
+        __auto_type _mv_564 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_564.has_value) {
+            __auto_type arena_expr = _mv_564.value;
             {
                 __auto_type arena_c = expr_transpile_expr(ctx, arena_expr);
                 __auto_type has_captures = expr_lambda_has_captures(ctx, fn_expr);
@@ -9291,7 +9299,7 @@ slop_string expr_transpile_spawn_closure(context_TranspileContext* ctx, slop_lis
                     return expr_transpile_regular_fn_call(ctx, SLOP_STR("spawn"), items);
                 }
             }
-        } else if (!_mv_563.has_value) {
+        } else if (!_mv_564.has_value) {
             context_ctx_add_error_at(ctx, SLOP_STR("spawn: missing arena argument"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             return SLOP_STR("NULL");
         }
@@ -9302,25 +9310,25 @@ slop_string expr_transpile_spawn_closure(context_TranspileContext* ctx, slop_lis
 uint8_t expr_lambda_has_captures(context_TranspileContext* ctx, types_SExpr* fn_expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((fn_expr != NULL)), "(!= fn-expr nil)");
-    __auto_type _mv_564 = (*fn_expr);
-    switch (_mv_564.tag) {
+    __auto_type _mv_565 = (*fn_expr);
+    switch (_mv_565.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_564.data.lst;
+            __auto_type lst = _mv_565.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type arena = (*ctx).arena;
                 if (((int64_t)((items).len)) < 2) {
                     return 0;
                 } else {
-                    __auto_type _mv_565 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_565.has_value) {
-                        __auto_type params_expr = _mv_565.value;
-                        __auto_type _mv_566 = (*params_expr);
-                        switch (_mv_566.tag) {
+                    __auto_type _mv_566 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_566.has_value) {
+                        __auto_type params_expr = _mv_566.value;
+                        __auto_type _mv_567 = (*params_expr);
+                        switch (_mv_567.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type params_lst = _mv_566.data.lst;
+                                __auto_type params_lst = _mv_567.data.lst;
                                 {
                                     __auto_type params = params_lst.items;
                                     __auto_type param_names = expr_extract_param_names(arena, params);
@@ -9333,7 +9341,7 @@ uint8_t expr_lambda_has_captures(context_TranspileContext* ctx, types_SExpr* fn_
                                 return 0;
                             }
                         }
-                    } else if (!_mv_565.has_value) {
+                    } else if (!_mv_566.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -9356,9 +9364,9 @@ slop_string expr_transpile_regular_fn_call(context_TranspileContext* ctx, slop_s
         int64_t i = 1;
         int64_t param_idx = 0;
         while (i < len) {
-            __auto_type _mv_567 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_567.has_value) {
-                __auto_type arg = _mv_567.value;
+            __auto_type _mv_568 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_568.has_value) {
+                __auto_type arg = _mv_568.value;
                 {
                     __auto_type arg_c = expr_transpile_expr(ctx, arg);
                     __auto_type expected_type = ({ __auto_type _mv = func_opt; _mv.has_value ? ({ __auto_type func_entry = _mv.value; ({ __auto_type _mv = ({ __auto_type _lst = func_entry.param_types; size_t _idx = (size_t)param_idx; slop_option_context_FuncParamType_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type p = _mv.value; (*p).c_type; }) : (SLOP_STR("")); }); }) : (SLOP_STR("")); });
@@ -9370,7 +9378,7 @@ slop_string expr_transpile_regular_fn_call(context_TranspileContext* ctx, slop_s
                     }
                     param_idx = (param_idx + 1);
                 }
-            } else if (!_mv_567.has_value) {
+            } else if (!_mv_568.has_value) {
             }
             i = (i + 1);
         }
@@ -9385,9 +9393,9 @@ slop_string expr_infer_generic_type_binding(context_TranspileContext* ctx, slop_
         if (((int64_t)((items).len)) < 2) {
             return SLOP_STR("");
         } else {
-            __auto_type _mv_568 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_568.has_value) {
-                __auto_type first_arg = _mv_568.value;
+            __auto_type _mv_569 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_569.has_value) {
+                __auto_type first_arg = _mv_569.value;
                 {
                     __auto_type slop_type = expr_infer_expr_slop_type(ctx, first_arg);
                     if (string_eq(slop_type, SLOP_STR(""))) {
@@ -9399,7 +9407,7 @@ slop_string expr_infer_generic_type_binding(context_TranspileContext* ctx, slop_
                         return expr_extract_type_binding_from_slop_type(arena, slop_type);
                     }
                 }
-            } else if (!_mv_568.has_value) {
+            } else if (!_mv_569.has_value) {
                 return SLOP_STR("");
             }
             SLOP_UNREACHABLE();
@@ -9538,11 +9546,11 @@ slop_list_string expr_find_free_vars(context_TranspileContext* ctx, slop_list_st
         __auto_type len = ((int64_t)((body_items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_569 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_569.has_value) {
-                __auto_type expr = _mv_569.value;
+            __auto_type _mv_570 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_570.has_value) {
+                __auto_type expr = _mv_570.value;
                 expr_collect_symbols_in_expr(ctx, (&all_symbols), pending, expr);
-            } else if (!_mv_569.has_value) {
+            } else if (!_mv_570.has_value) {
             }
             i = (i + 1);
         }
@@ -9550,15 +9558,15 @@ slop_list_string expr_find_free_vars(context_TranspileContext* ctx, slop_list_st
             __auto_type sym_count = ((int64_t)((all_symbols).len));
             int64_t j = 0;
             while (j < sym_count) {
-                __auto_type _mv_570 = ({ __auto_type _lst = all_symbols; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_570.has_value) {
-                    __auto_type sym_name = _mv_570.value;
+                __auto_type _mv_571 = ({ __auto_type _lst = all_symbols; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_571.has_value) {
+                    __auto_type sym_name = _mv_571.value;
                     if (expr_is_free_var(ctx, param_names, pending, sym_name)) {
                         if (!(expr_list_contains_string(free_vars, sym_name))) {
                             ({ __auto_type _lst_p = &(free_vars); __auto_type _item = (sym_name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                         }
                     }
-                } else if (!_mv_570.has_value) {
+                } else if (!_mv_571.has_value) {
                 }
                 j = (j + 1);
             }
@@ -9570,11 +9578,11 @@ slop_list_string expr_find_free_vars(context_TranspileContext* ctx, slop_list_st
 void expr_collect_symbols_in_expr(context_TranspileContext* ctx, slop_list_string* symbols, slop_list_string pending, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_571 = (*expr);
-    switch (_mv_571.tag) {
+    __auto_type _mv_572 = (*expr);
+    switch (_mv_572.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_571.data.sym;
+            __auto_type sym = _mv_572.data.sym;
             {
                 __auto_type name = sym.name;
                 if (!(expr_is_special_keyword(name)) && !(expr_list_contains_string(pending, name))) {
@@ -9585,19 +9593,19 @@ void expr_collect_symbols_in_expr(context_TranspileContext* ctx, slop_list_strin
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_571.data.lst;
+            __auto_type lst = _mv_572.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 if (len > 0) {
-                    __auto_type _mv_572 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_572.has_value) {
-                        __auto_type head = _mv_572.value;
-                        __auto_type _mv_573 = (*head);
-                        switch (_mv_573.tag) {
+                    __auto_type _mv_573 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_573.has_value) {
+                        __auto_type head = _mv_573.value;
+                        __auto_type _mv_574 = (*head);
+                        switch (_mv_574.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type head_sym = _mv_573.data.sym;
+                                __auto_type head_sym = _mv_574.data.sym;
                                 {
                                     __auto_type op = head_sym.name;
                                     if (string_eq(op, SLOP_STR("let"))) {
@@ -9621,7 +9629,7 @@ void expr_collect_symbols_in_expr(context_TranspileContext* ctx, slop_list_strin
                                 break;
                             }
                         }
-                    } else if (!_mv_572.has_value) {
+                    } else if (!_mv_573.has_value) {
                     }
                 }
             }
@@ -9639,11 +9647,11 @@ void expr_collect_symbols_in_list(context_TranspileContext* ctx, slop_list_strin
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_574 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_574.has_value) {
-                __auto_type item = _mv_574.value;
+            __auto_type _mv_575 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_575.has_value) {
+                __auto_type item = _mv_575.value;
                 expr_collect_symbols_in_expr(ctx, symbols, pending, item);
-            } else if (!_mv_574.has_value) {
+            } else if (!_mv_575.has_value) {
             }
             i = (i + 1);
         }
@@ -9656,40 +9664,40 @@ void expr_collect_symbols_in_let(context_TranspileContext* ctx, slop_list_string
         __auto_type arena = (*ctx).arena;
         __auto_type len = ((int64_t)((items).len));
         if (len >= 2) {
-            __auto_type _mv_575 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_575.has_value) {
-                __auto_type bindings_expr = _mv_575.value;
+            __auto_type _mv_576 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_576.has_value) {
+                __auto_type bindings_expr = _mv_576.value;
                 {
                     __auto_type new_names = expr_extract_let_binding_names(arena, bindings_expr);
                     __auto_type updated_pending = expr_list_concat(arena, pending, new_names);
-                    __auto_type _mv_576 = (*bindings_expr);
-                    switch (_mv_576.tag) {
+                    __auto_type _mv_577 = (*bindings_expr);
+                    switch (_mv_577.tag) {
                         case types_SExpr_lst:
                         {
-                            __auto_type bindings_lst = _mv_576.data.lst;
+                            __auto_type bindings_lst = _mv_577.data.lst;
                             {
                                 __auto_type bindings = bindings_lst.items;
                                 __auto_type binding_count = ((int64_t)((bindings).len));
                                 __auto_type i = 0;
                                 while (i < binding_count) {
-                                    __auto_type _mv_577 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_577.has_value) {
-                                        __auto_type binding = _mv_577.value;
-                                        __auto_type _mv_578 = (*binding);
-                                        switch (_mv_578.tag) {
+                                    __auto_type _mv_578 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_578.has_value) {
+                                        __auto_type binding = _mv_578.value;
+                                        __auto_type _mv_579 = (*binding);
+                                        switch (_mv_579.tag) {
                                             case types_SExpr_lst:
                                             {
-                                                __auto_type bind_lst = _mv_578.data.lst;
+                                                __auto_type bind_lst = _mv_579.data.lst;
                                                 {
                                                     __auto_type bind_items = bind_lst.items;
                                                     if (((int64_t)((bind_items).len)) >= 2) {
                                                         {
                                                             __auto_type val_idx = ((expr_is_mut_binding(bind_items)) ? 2 : 1);
-                                                            __auto_type _mv_579 = ({ __auto_type _lst = bind_items; size_t _idx = (size_t)val_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                            if (_mv_579.has_value) {
-                                                                __auto_type val_expr = _mv_579.value;
+                                                            __auto_type _mv_580 = ({ __auto_type _lst = bind_items; size_t _idx = (size_t)val_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                            if (_mv_580.has_value) {
+                                                                __auto_type val_expr = _mv_580.value;
                                                                 expr_collect_symbols_in_expr(ctx, symbols, pending, val_expr);
-                                                            } else if (!_mv_579.has_value) {
+                                                            } else if (!_mv_580.has_value) {
                                                             }
                                                         }
                                                     }
@@ -9700,7 +9708,7 @@ void expr_collect_symbols_in_let(context_TranspileContext* ctx, slop_list_string
                                                 break;
                                             }
                                         }
-                                    } else if (!_mv_577.has_value) {
+                                    } else if (!_mv_578.has_value) {
                                     }
                                     i = (i + 1);
                                 }
@@ -9713,7 +9721,7 @@ void expr_collect_symbols_in_let(context_TranspileContext* ctx, slop_list_string
                     }
                     expr_collect_symbols_in_list(ctx, symbols, updated_pending, items, 2);
                 }
-            } else if (!_mv_575.has_value) {
+            } else if (!_mv_576.has_value) {
             }
         }
     }
@@ -9723,21 +9731,21 @@ uint8_t expr_is_mut_binding(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_580 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_580.has_value) {
-            __auto_type first = _mv_580.value;
-            __auto_type _mv_581 = (*first);
-            switch (_mv_581.tag) {
+        __auto_type _mv_581 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_581.has_value) {
+            __auto_type first = _mv_581.value;
+            __auto_type _mv_582 = (*first);
+            switch (_mv_582.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_581.data.sym;
+                    __auto_type sym = _mv_582.data.sym;
                     return string_eq(sym.name, SLOP_STR("mut"));
                 }
                 default: {
                     return 0;
                 }
             }
-        } else if (!_mv_580.has_value) {
+        } else if (!_mv_581.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -9748,37 +9756,37 @@ slop_list_string expr_extract_let_binding_names(slop_arena* arena, types_SExpr* 
     SLOP_PRE(((bindings_expr != NULL)), "(!= bindings-expr nil)");
     {
         __auto_type names = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
-        __auto_type _mv_582 = (*bindings_expr);
-        switch (_mv_582.tag) {
+        __auto_type _mv_583 = (*bindings_expr);
+        switch (_mv_583.tag) {
             case types_SExpr_lst:
             {
-                __auto_type bindings_lst = _mv_582.data.lst;
+                __auto_type bindings_lst = _mv_583.data.lst;
                 {
                     __auto_type bindings = bindings_lst.items;
                     __auto_type binding_count = ((int64_t)((bindings).len));
                     __auto_type i = 0;
                     while (i < binding_count) {
-                        __auto_type _mv_583 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_583.has_value) {
-                            __auto_type binding = _mv_583.value;
-                            __auto_type _mv_584 = (*binding);
-                            switch (_mv_584.tag) {
+                        __auto_type _mv_584 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_584.has_value) {
+                            __auto_type binding = _mv_584.value;
+                            __auto_type _mv_585 = (*binding);
+                            switch (_mv_585.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type bind_lst = _mv_584.data.lst;
+                                    __auto_type bind_lst = _mv_585.data.lst;
                                     {
                                         __auto_type bind_items = bind_lst.items;
                                         if (((int64_t)((bind_items).len)) >= 1) {
                                             {
                                                 __auto_type name_idx = ((expr_is_mut_binding(bind_items)) ? 1 : 0);
-                                                __auto_type _mv_585 = ({ __auto_type _lst = bind_items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_585.has_value) {
-                                                    __auto_type name_expr = _mv_585.value;
-                                                    __auto_type _mv_586 = (*name_expr);
-                                                    switch (_mv_586.tag) {
+                                                __auto_type _mv_586 = ({ __auto_type _lst = bind_items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_586.has_value) {
+                                                    __auto_type name_expr = _mv_586.value;
+                                                    __auto_type _mv_587 = (*name_expr);
+                                                    switch (_mv_587.tag) {
                                                         case types_SExpr_sym:
                                                         {
-                                                            __auto_type sym = _mv_586.data.sym;
+                                                            __auto_type sym = _mv_587.data.sym;
                                                             ({ __auto_type _lst_p = &(names); __auto_type _item = (sym.name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                             break;
                                                         }
@@ -9786,7 +9794,7 @@ slop_list_string expr_extract_let_binding_names(slop_arena* arena, types_SExpr* 
                                                             break;
                                                         }
                                                     }
-                                                } else if (!_mv_585.has_value) {
+                                                } else if (!_mv_586.has_value) {
                                                 }
                                             }
                                         }
@@ -9797,7 +9805,7 @@ slop_list_string expr_extract_let_binding_names(slop_arena* arena, types_SExpr* 
                                     break;
                                 }
                             }
-                        } else if (!_mv_583.has_value) {
+                        } else if (!_mv_584.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -9817,23 +9825,23 @@ void expr_collect_symbols_in_match(context_TranspileContext* ctx, slop_list_stri
     {
         __auto_type len = ((int64_t)((items).len));
         if (len >= 2) {
-            __auto_type _mv_587 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_587.has_value) {
-                __auto_type scrutinee = _mv_587.value;
+            __auto_type _mv_588 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_588.has_value) {
+                __auto_type scrutinee = _mv_588.value;
                 expr_collect_symbols_in_expr(ctx, symbols, pending, scrutinee);
-            } else if (!_mv_587.has_value) {
+            } else if (!_mv_588.has_value) {
             }
             {
                 int64_t i = 2;
                 while (i < len) {
-                    __auto_type _mv_588 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_588.has_value) {
-                        __auto_type clause = _mv_588.value;
-                        __auto_type _mv_589 = (*clause);
-                        switch (_mv_589.tag) {
+                    __auto_type _mv_589 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_589.has_value) {
+                        __auto_type clause = _mv_589.value;
+                        __auto_type _mv_590 = (*clause);
+                        switch (_mv_590.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type clause_lst = _mv_589.data.lst;
+                                __auto_type clause_lst = _mv_590.data.lst;
                                 {
                                     __auto_type clause_items = clause_lst.items;
                                     expr_collect_symbols_in_list(ctx, symbols, pending, clause_items, 1);
@@ -9844,7 +9852,7 @@ void expr_collect_symbols_in_match(context_TranspileContext* ctx, slop_list_stri
                                 break;
                             }
                         }
-                    } else if (!_mv_588.has_value) {
+                    } else if (!_mv_589.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -9859,14 +9867,14 @@ void expr_collect_symbols_in_for(context_TranspileContext* ctx, slop_list_string
         __auto_type arena = (*ctx).arena;
         __auto_type len = ((int64_t)((items).len));
         if (len >= 2) {
-            __auto_type _mv_590 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_590.has_value) {
-                __auto_type binding = _mv_590.value;
-                __auto_type _mv_591 = (*binding);
-                switch (_mv_591.tag) {
+            __auto_type _mv_591 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_591.has_value) {
+                __auto_type binding = _mv_591.value;
+                __auto_type _mv_592 = (*binding);
+                switch (_mv_592.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type bind_lst = _mv_591.data.lst;
+                        __auto_type bind_lst = _mv_592.data.lst;
                         {
                             __auto_type bind_items = bind_lst.items;
                             expr_collect_symbols_in_list(ctx, symbols, pending, bind_items, 1);
@@ -9881,7 +9889,7 @@ void expr_collect_symbols_in_for(context_TranspileContext* ctx, slop_list_string
                         break;
                     }
                 }
-            } else if (!_mv_590.has_value) {
+            } else if (!_mv_591.has_value) {
             }
         }
     }
@@ -9891,25 +9899,25 @@ slop_list_string expr_extract_for_loop_var_pending(slop_arena* arena, slop_list_
     if (((int64_t)((bind_items).len)) < 1) {
         return pending;
     } else {
-        __auto_type _mv_592 = ({ __auto_type _lst = bind_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_592.has_value) {
-            __auto_type var_expr = _mv_592.value;
-            __auto_type _mv_593 = (*var_expr);
-            switch (_mv_593.tag) {
+        __auto_type _mv_593 = ({ __auto_type _lst = bind_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_593.has_value) {
+            __auto_type var_expr = _mv_593.value;
+            __auto_type _mv_594 = (*var_expr);
+            switch (_mv_594.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type var_sym = _mv_593.data.sym;
+                    __auto_type var_sym = _mv_594.data.sym;
                     {
                         __auto_type result = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
                         __auto_type var_name = var_sym.name;
                         __auto_type plen = ((int64_t)((pending).len));
                         __auto_type i = 0;
                         while (i < plen) {
-                            __auto_type _mv_594 = ({ __auto_type _lst = pending; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_594.has_value) {
-                                __auto_type s = _mv_594.value;
+                            __auto_type _mv_595 = ({ __auto_type _lst = pending; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_595.has_value) {
+                                __auto_type s = _mv_595.value;
                                 ({ __auto_type _lst_p = &(result); __auto_type _item = (s); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                            } else if (!_mv_594.has_value) {
+                            } else if (!_mv_595.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -9921,7 +9929,7 @@ slop_list_string expr_extract_for_loop_var_pending(slop_arena* arena, slop_list_
                     return pending;
                 }
             }
-        } else if (!_mv_592.has_value) {
+        } else if (!_mv_593.has_value) {
             return pending;
         }
         SLOP_UNREACHABLE();
@@ -9939,11 +9947,11 @@ void expr_collect_symbols_in_with_arena(context_TranspileContext* ctx, slop_list
                 __auto_type arena_name = ((is_named) ? ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type name_expr = _mv.value; ({ __auto_type _mv = (*name_expr); slop_string _mr = {0}; switch (_mv.tag) { case types_SExpr_sym: { __auto_type s2 = _mv.data.sym; _mr = s2.name; break; } default: { _mr = SLOP_STR("arena"); break; }  } _mr; }); }) : (SLOP_STR("arena")); }) : SLOP_STR("arena"));
                 __auto_type size_idx = ((is_named) ? 3 : 1);
                 __auto_type body_start = ((is_named) ? 4 : 2);
-                __auto_type _mv_595 = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_595.has_value) {
-                    __auto_type size_expr = _mv_595.value;
+                __auto_type _mv_596 = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_596.has_value) {
+                    __auto_type size_expr = _mv_596.value;
                     expr_collect_symbols_in_expr(ctx, symbols, pending, size_expr);
-                } else if (!_mv_595.has_value) {
+                } else if (!_mv_596.has_value) {
                 }
                 {
                     __auto_type updated_pending = expr_list_concat(arena, pending, ({ __auto_type tmp = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 }); ({ __auto_type _lst_p = &(tmp); __auto_type _item = (arena_name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; }); tmp; }));
@@ -9960,14 +9968,14 @@ void expr_collect_nested_lambda_free_vars(context_TranspileContext* ctx, slop_li
         __auto_type arena = (*ctx).arena;
         __auto_type len = ((int64_t)((items).len));
         if (len >= 2) {
-            __auto_type _mv_596 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_596.has_value) {
-                __auto_type params_expr = _mv_596.value;
-                __auto_type _mv_597 = (*params_expr);
-                switch (_mv_597.tag) {
+            __auto_type _mv_597 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_597.has_value) {
+                __auto_type params_expr = _mv_597.value;
+                __auto_type _mv_598 = (*params_expr);
+                switch (_mv_598.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type params_lst = _mv_597.data.lst;
+                        __auto_type params_lst = _mv_598.data.lst;
                         {
                             __auto_type params = params_lst.items;
                             __auto_type param_names = expr_extract_param_names(arena, params);
@@ -9980,7 +9988,7 @@ void expr_collect_nested_lambda_free_vars(context_TranspileContext* ctx, slop_li
                         break;
                     }
                 }
-            } else if (!_mv_596.has_value) {
+            } else if (!_mv_597.has_value) {
             }
         }
     }
@@ -10001,21 +10009,21 @@ uint8_t expr_is_free_var(context_TranspileContext* ctx, slop_list_string param_n
             if (expr_is_builtin_op(sym_name)) {
                 return 0;
             } else {
-                __auto_type _mv_598 = context_ctx_lookup_func(ctx, sym_name);
-                if (_mv_598.has_value) {
-                    __auto_type _ = _mv_598.value;
+                __auto_type _mv_599 = context_ctx_lookup_func(ctx, sym_name);
+                if (_mv_599.has_value) {
+                    __auto_type _ = _mv_599.value;
                     return 0;
-                } else if (!_mv_598.has_value) {
-                    __auto_type _mv_599 = context_ctx_lookup_type(ctx, sym_name);
-                    if (_mv_599.has_value) {
-                        __auto_type _ = _mv_599.value;
+                } else if (!_mv_599.has_value) {
+                    __auto_type _mv_600 = context_ctx_lookup_type(ctx, sym_name);
+                    if (_mv_600.has_value) {
+                        __auto_type _ = _mv_600.value;
                         return 0;
-                    } else if (!_mv_599.has_value) {
-                        __auto_type _mv_600 = context_ctx_lookup_var(ctx, sym_name);
-                        if (_mv_600.has_value) {
-                            __auto_type _ = _mv_600.value;
+                    } else if (!_mv_600.has_value) {
+                        __auto_type _mv_601 = context_ctx_lookup_var(ctx, sym_name);
+                        if (_mv_601.has_value) {
+                            __auto_type _ = _mv_601.value;
                             return 1;
-                        } else if (!_mv_600.has_value) {
+                        } else if (!_mv_601.has_value) {
                             return 0;
                         }
                         SLOP_UNREACHABLE();
@@ -10038,13 +10046,13 @@ uint8_t expr_list_contains_string(slop_list_string lst, slop_string needle) {
         int64_t i = 0;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_601 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_601.has_value) {
-                __auto_type s = _mv_601.value;
+            __auto_type _mv_602 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_602.has_value) {
+                __auto_type s = _mv_602.value;
                 if (string_eq(s, needle)) {
                     found = 1;
                 }
-            } else if (!_mv_601.has_value) {
+            } else if (!_mv_602.has_value) {
             }
             i = (i + 1);
         }
@@ -10059,21 +10067,21 @@ slop_list_string expr_list_concat(slop_arena* arena, slop_list_string a, slop_li
         __auto_type len_b = ((int64_t)((b).len));
         int64_t i = 0;
         while (i < len_a) {
-            __auto_type _mv_602 = ({ __auto_type _lst = a; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_602.has_value) {
-                __auto_type s = _mv_602.value;
+            __auto_type _mv_603 = ({ __auto_type _lst = a; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_603.has_value) {
+                __auto_type s = _mv_603.value;
                 ({ __auto_type _lst_p = &(result); __auto_type _item = (s); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-            } else if (!_mv_602.has_value) {
+            } else if (!_mv_603.has_value) {
             }
             i = (i + 1);
         }
         i = 0;
         while (i < len_b) {
-            __auto_type _mv_603 = ({ __auto_type _lst = b; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_603.has_value) {
-                __auto_type s = _mv_603.value;
+            __auto_type _mv_604 = ({ __auto_type _lst = b; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_604.has_value) {
+                __auto_type s = _mv_604.value;
                 ({ __auto_type _lst_p = &(result); __auto_type _item = (s); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-            } else if (!_mv_603.has_value) {
+            } else if (!_mv_604.has_value) {
             }
             i = (i + 1);
         }
@@ -10166,33 +10174,33 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
     SLOP_PRE(((coll_expr != NULL)), "(!= coll-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_604 = (*coll_expr);
-        switch (_mv_604.tag) {
+        __auto_type _mv_605 = (*coll_expr);
+        switch (_mv_605.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_604.data.lst;
+                __auto_type lst = _mv_605.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 1) {
                         return SLOP_STR("");
                     } else {
-                        __auto_type _mv_605 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_605.has_value) {
-                            __auto_type head = _mv_605.value;
-                            __auto_type _mv_606 = (*head);
-                            switch (_mv_606.tag) {
+                        __auto_type _mv_606 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_606.has_value) {
+                            __auto_type head = _mv_606.value;
+                            __auto_type _mv_607 = (*head);
+                            switch (_mv_607.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_606.data.sym;
+                                    __auto_type sym = _mv_607.data.sym;
                                     {
                                         __auto_type op = sym.name;
                                         if (string_eq(op, SLOP_STR("map-keys"))) {
                                             if (((int64_t)((items).len)) < 2) {
                                                 return SLOP_STR("");
                                             } else {
-                                                __auto_type _mv_607 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_607.has_value) {
-                                                    __auto_type map_expr = _mv_607.value;
+                                                __auto_type _mv_608 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_608.has_value) {
+                                                    __auto_type map_expr = _mv_608.value;
                                                     {
                                                         __auto_type map_slop_type = expr_infer_expr_slop_type(ctx, map_expr);
                                                         if (string_len(map_slop_type) > 0) {
@@ -10204,7 +10212,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                                             return SLOP_STR("");
                                                         }
                                                     }
-                                                } else if (!_mv_607.has_value) {
+                                                } else if (!_mv_608.has_value) {
                                                     return SLOP_STR("");
                                                 }
                                                 SLOP_UNREACHABLE();
@@ -10213,9 +10221,9 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                             if (((int64_t)((items).len)) < 2) {
                                                 return SLOP_STR("");
                                             } else {
-                                                __auto_type _mv_608 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_608.has_value) {
-                                                    __auto_type set_expr = _mv_608.value;
+                                                __auto_type _mv_609 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_609.has_value) {
+                                                    __auto_type set_expr = _mv_609.value;
                                                     {
                                                         __auto_type set_slop_type = expr_infer_expr_slop_type(ctx, set_expr);
                                                         if (string_len(set_slop_type) > 0) {
@@ -10227,7 +10235,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                                             return SLOP_STR("");
                                                         }
                                                     }
-                                                } else if (!_mv_608.has_value) {
+                                                } else if (!_mv_609.has_value) {
                                                     return SLOP_STR("");
                                                 }
                                                 SLOP_UNREACHABLE();
@@ -10236,9 +10244,9 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                             if (((int64_t)((items).len)) < 2) {
                                                 return SLOP_STR("");
                                             } else {
-                                                __auto_type _mv_609 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_609.has_value) {
-                                                    __auto_type map_expr = _mv_609.value;
+                                                __auto_type _mv_610 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_610.has_value) {
+                                                    __auto_type map_expr = _mv_610.value;
                                                     {
                                                         __auto_type map_slop_type = expr_infer_expr_slop_type(ctx, map_expr);
                                                         if (string_len(map_slop_type) > 0) {
@@ -10250,7 +10258,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                                             return SLOP_STR("");
                                                         }
                                                     }
-                                                } else if (!_mv_609.has_value) {
+                                                } else if (!_mv_610.has_value) {
                                                     return SLOP_STR("");
                                                 }
                                                 SLOP_UNREACHABLE();
@@ -10264,7 +10272,7 @@ slop_string expr_infer_collection_element_slop_type(context_TranspileContext* ct
                                     return expr_infer_elem_from_type(ctx, coll_expr);
                                 }
                             }
-                        } else if (!_mv_605.has_value) {
+                        } else if (!_mv_606.has_value) {
                             return SLOP_STR("");
                         }
                         SLOP_UNREACHABLE();

--- a/bootstrap/transpiler/slop_match.c
+++ b/bootstrap/transpiler/slop_match.c
@@ -74,9 +74,9 @@ uint8_t match_is_option_match(slop_list_types_SExpr_ptr patterns) {
         uint8_t has_none = 0;
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_646 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_646.has_value) {
-                __auto_type pat_expr = _mv_646.value;
+            __auto_type _mv_647 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_647.has_value) {
+                __auto_type pat_expr = _mv_647.value;
                 {
                     __auto_type tag = match_get_pattern_tag(pat_expr);
                     if (string_eq(tag, SLOP_STR("some"))) {
@@ -86,7 +86,7 @@ uint8_t match_is_option_match(slop_list_types_SExpr_ptr patterns) {
                     } else {
                     }
                 }
-            } else if (!_mv_646.has_value) {
+            } else if (!_mv_647.has_value) {
             }
             i = (i + 1);
         }
@@ -101,9 +101,9 @@ uint8_t match_is_result_match(slop_list_types_SExpr_ptr patterns) {
         uint8_t has_error = 0;
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_647 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_647.has_value) {
-                __auto_type pat_expr = _mv_647.value;
+            __auto_type _mv_648 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_648.has_value) {
+                __auto_type pat_expr = _mv_648.value;
                 {
                     __auto_type tag = match_get_pattern_tag(pat_expr);
                     if (string_eq(tag, SLOP_STR("ok"))) {
@@ -113,7 +113,7 @@ uint8_t match_is_result_match(slop_list_types_SExpr_ptr patterns) {
                     } else {
                     }
                 }
-            } else if (!_mv_647.has_value) {
+            } else if (!_mv_648.has_value) {
             }
             i = (i + 1);
         }
@@ -127,14 +127,14 @@ uint8_t match_is_enum_match(slop_list_types_SExpr_ptr patterns) {
         uint8_t all_symbols = 1;
         int64_t i = 0;
         while ((i < len) && all_symbols) {
-            __auto_type _mv_648 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_648.has_value) {
-                __auto_type pat_expr = _mv_648.value;
-                __auto_type _mv_649 = (*pat_expr);
-                switch (_mv_649.tag) {
+            __auto_type _mv_649 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_649.has_value) {
+                __auto_type pat_expr = _mv_649.value;
+                __auto_type _mv_650 = (*pat_expr);
+                switch (_mv_650.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type _ = _mv_649.data.sym;
+                        __auto_type _ = _mv_650.data.sym;
                         break;
                     }
                     default: {
@@ -142,7 +142,7 @@ uint8_t match_is_enum_match(slop_list_types_SExpr_ptr patterns) {
                         break;
                     }
                 }
-            } else if (!_mv_648.has_value) {
+            } else if (!_mv_649.has_value) {
             }
             i = (i + 1);
         }
@@ -156,20 +156,20 @@ uint8_t match_is_literal_match(slop_list_types_SExpr_ptr patterns) {
         uint8_t has_literal = 0;
         int64_t i = 0;
         while ((i < len) && !(has_literal)) {
-            __auto_type _mv_650 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_650.has_value) {
-                __auto_type pat_expr = _mv_650.value;
-                __auto_type _mv_651 = (*pat_expr);
-                switch (_mv_651.tag) {
+            __auto_type _mv_651 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_651.has_value) {
+                __auto_type pat_expr = _mv_651.value;
+                __auto_type _mv_652 = (*pat_expr);
+                switch (_mv_652.tag) {
                     case types_SExpr_num:
                     {
-                        __auto_type _ = _mv_651.data.num;
+                        __auto_type _ = _mv_652.data.num;
                         has_literal = 1;
                         break;
                     }
                     case types_SExpr_str:
                     {
-                        __auto_type _ = _mv_651.data.str;
+                        __auto_type _ = _mv_652.data.str;
                         has_literal = 1;
                         break;
                     }
@@ -177,7 +177,7 @@ uint8_t match_is_literal_match(slop_list_types_SExpr_ptr patterns) {
                         break;
                     }
                 }
-            } else if (!_mv_650.has_value) {
+            } else if (!_mv_651.has_value) {
             }
             i = (i + 1);
         }
@@ -192,21 +192,21 @@ uint8_t match_is_union_match(context_TranspileContext* ctx, slop_list_types_SExp
         uint8_t has_union_variant = 0;
         int64_t i = 0;
         while ((i < len) && !(has_union_variant)) {
-            __auto_type _mv_652 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_652.has_value) {
-                __auto_type pat_expr = _mv_652.value;
+            __auto_type _mv_653 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_653.has_value) {
+                __auto_type pat_expr = _mv_653.value;
                 {
                     __auto_type tag = match_get_pattern_tag(pat_expr);
                     if ((!(string_eq(tag, SLOP_STR("")))) && (!(string_eq(tag, SLOP_STR("some")))) && (!(string_eq(tag, SLOP_STR("none")))) && (!(string_eq(tag, SLOP_STR("ok")))) && (!(string_eq(tag, SLOP_STR("error")))) && (!(string_eq(tag, SLOP_STR("else")))) && (!(string_eq(tag, SLOP_STR("_"))))) {
-                        __auto_type _mv_653 = context_ctx_lookup_enum_variant(ctx, tag);
-                        if (_mv_653.has_value) {
-                            __auto_type _ = _mv_653.value;
+                        __auto_type _mv_654 = context_ctx_lookup_enum_variant(ctx, tag);
+                        if (_mv_654.has_value) {
+                            __auto_type _ = _mv_654.value;
                             has_union_variant = 1;
-                        } else if (!_mv_653.has_value) {
+                        } else if (!_mv_654.has_value) {
                         }
                     }
                 }
-            } else if (!_mv_652.has_value) {
+            } else if (!_mv_653.has_value) {
             }
             i = (i + 1);
         }
@@ -216,31 +216,31 @@ uint8_t match_is_union_match(context_TranspileContext* ctx, slop_list_types_SExp
 
 slop_string match_get_pattern_tag(types_SExpr* pat_expr) {
     SLOP_PRE(((pat_expr != NULL)), "(!= pat-expr nil)");
-    __auto_type _mv_654 = (*pat_expr);
-    switch (_mv_654.tag) {
+    __auto_type _mv_655 = (*pat_expr);
+    switch (_mv_655.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_654.data.lst;
+            __auto_type lst = _mv_655.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return SLOP_STR("");
                 } else {
-                    __auto_type _mv_655 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_655.has_value) {
-                        __auto_type head = _mv_655.value;
-                        __auto_type _mv_656 = (*head);
-                        switch (_mv_656.tag) {
+                    __auto_type _mv_656 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_656.has_value) {
+                        __auto_type head = _mv_656.value;
+                        __auto_type _mv_657 = (*head);
+                        switch (_mv_657.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_656.data.sym;
+                                __auto_type sym = _mv_657.data.sym;
                                 return sym.name;
                             }
                             default: {
                                 return SLOP_STR("");
                             }
                         }
-                    } else if (!_mv_655.has_value) {
+                    } else if (!_mv_656.has_value) {
                         return SLOP_STR("");
                     }
                     SLOP_UNREACHABLE();
@@ -249,7 +249,7 @@ slop_string match_get_pattern_tag(types_SExpr* pat_expr) {
         }
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_654.data.sym;
+            __auto_type sym = _mv_655.data.sym;
             return sym.name;
         }
         default: {
@@ -260,31 +260,31 @@ slop_string match_get_pattern_tag(types_SExpr* pat_expr) {
 
 slop_option_string match_extract_binding_name(types_SExpr* pat_expr) {
     SLOP_PRE(((pat_expr != NULL)), "(!= pat-expr nil)");
-    __auto_type _mv_657 = (*pat_expr);
-    switch (_mv_657.tag) {
+    __auto_type _mv_658 = (*pat_expr);
+    switch (_mv_658.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_657.data.lst;
+            __auto_type lst = _mv_658.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return (slop_option_string){.has_value = false};
                 } else {
-                    __auto_type _mv_658 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_658.has_value) {
-                        __auto_type binding = _mv_658.value;
-                        __auto_type _mv_659 = (*binding);
-                        switch (_mv_659.tag) {
+                    __auto_type _mv_659 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_659.has_value) {
+                        __auto_type binding = _mv_659.value;
+                        __auto_type _mv_660 = (*binding);
+                        switch (_mv_660.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_659.data.sym;
+                                __auto_type sym = _mv_660.data.sym;
                                 return (slop_option_string){.has_value = 1, .value = sym.name};
                             }
                             default: {
                                 return (slop_option_string){.has_value = false};
                             }
                         }
-                    } else if (!_mv_658.has_value) {
+                    } else if (!_mv_659.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
                     SLOP_UNREACHABLE();
@@ -299,11 +299,11 @@ slop_option_string match_extract_binding_name(types_SExpr* pat_expr) {
 
 int64_t match_count_pattern_bindings(types_SExpr* pat_expr) {
     SLOP_PRE(((pat_expr != NULL)), "(!= pat-expr nil)");
-    __auto_type _mv_660 = (*pat_expr);
-    switch (_mv_660.tag) {
+    __auto_type _mv_661 = (*pat_expr);
+    switch (_mv_661.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_660.data.lst;
+            __auto_type lst = _mv_661.data.lst;
             {
                 __auto_type len = ((int64_t)((lst.items).len));
                 if (len > 1) {
@@ -324,20 +324,20 @@ void match_transpile_match(context_TranspileContext* ctx, types_SExpr* expr, uin
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_661 = (*expr);
-        switch (_mv_661.tag) {
+        __auto_type _mv_662 = (*expr);
+        switch (_mv_662.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_661.data.lst;
+                __auto_type lst = _mv_662.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 3) {
                         context_ctx_add_error_at(ctx, SLOP_STR("invalid match: need value and at least one branch"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     } else {
-                        __auto_type _mv_662 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_662.has_value) {
-                            __auto_type scrutinee = _mv_662.value;
+                        __auto_type _mv_663 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_663.has_value) {
+                            __auto_type scrutinee = _mv_663.value;
                             {
                                 __auto_type scrutinee_c = expr_transpile_expr(ctx, scrutinee);
                                 __auto_type patterns = match_collect_patterns(ctx, items);
@@ -371,7 +371,7 @@ void match_transpile_match(context_TranspileContext* ctx, types_SExpr* expr, uin
                                     match_transpile_generic_match(ctx, scrutinee_var, items, is_return);
                                 }
                             }
-                        } else if (!_mv_662.has_value) {
+                        } else if (!_mv_663.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing match scrutinee"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                     }
@@ -394,22 +394,22 @@ slop_list_types_SExpr_ptr match_collect_patterns(context_TranspileContext* ctx, 
         __auto_type result = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
         int64_t i = 2;
         while (i < len) {
-            __auto_type _mv_663 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_663.has_value) {
-                __auto_type branch = _mv_663.value;
-                __auto_type _mv_664 = (*branch);
-                switch (_mv_664.tag) {
+            __auto_type _mv_664 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_664.has_value) {
+                __auto_type branch = _mv_664.value;
+                __auto_type _mv_665 = (*branch);
+                switch (_mv_665.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type branch_lst = _mv_664.data.lst;
+                        __auto_type branch_lst = _mv_665.data.lst;
                         {
                             __auto_type branch_items = branch_lst.items;
                             if (((int64_t)((branch_items).len)) >= 1) {
-                                __auto_type _mv_665 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_665.has_value) {
-                                    __auto_type pattern = _mv_665.value;
+                                __auto_type _mv_666 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_666.has_value) {
+                                    __auto_type pattern = _mv_666.value;
                                     ({ __auto_type _lst_p = &(result); __auto_type _item = (pattern); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                                } else if (!_mv_665.has_value) {
+                                } else if (!_mv_666.has_value) {
                                 }
                             }
                         }
@@ -419,7 +419,7 @@ slop_list_types_SExpr_ptr match_collect_patterns(context_TranspileContext* ctx, 
                         break;
                     }
                 }
-            } else if (!_mv_663.has_value) {
+            } else if (!_mv_664.has_value) {
             }
             i = (i + 1);
         }
@@ -436,20 +436,20 @@ void match_transpile_option_match(context_TranspileContext* ctx, slop_string scr
         uint8_t first = 1;
         uint8_t has_else = 0;
         while (i < len) {
-            __auto_type _mv_666 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_666.has_value) {
-                __auto_type branch = _mv_666.value;
-                __auto_type _mv_667 = (*branch);
-                switch (_mv_667.tag) {
+            __auto_type _mv_667 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_667.has_value) {
+                __auto_type branch = _mv_667.value;
+                __auto_type _mv_668 = (*branch);
+                switch (_mv_668.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type branch_lst = _mv_667.data.lst;
+                        __auto_type branch_lst = _mv_668.data.lst;
                         {
                             __auto_type branch_items = branch_lst.items;
                             if (((int64_t)((branch_items).len)) >= 2) {
-                                __auto_type _mv_668 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_668.has_value) {
-                                    __auto_type pattern = _mv_668.value;
+                                __auto_type _mv_669 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_669.has_value) {
+                                    __auto_type pattern = _mv_669.value;
                                     {
                                         __auto_type tag = match_get_pattern_tag(pattern);
                                         if (string_eq(tag, SLOP_STR("some"))) {
@@ -465,7 +465,7 @@ void match_transpile_option_match(context_TranspileContext* ctx, slop_string scr
                                         } else {
                                         }
                                     }
-                                } else if (!_mv_668.has_value) {
+                                } else if (!_mv_669.has_value) {
                                 }
                             }
                         }
@@ -475,7 +475,7 @@ void match_transpile_option_match(context_TranspileContext* ctx, slop_string scr
                         break;
                     }
                 }
-            } else if (!_mv_666.has_value) {
+            } else if (!_mv_667.has_value) {
             }
             i = (i + 1);
         }
@@ -498,9 +498,9 @@ void match_emit_option_some_branch(context_TranspileContext* ctx, slop_string sc
         }
         context_ctx_indent(ctx);
         context_ctx_push_scope(ctx);
-        __auto_type _mv_669 = match_extract_binding_name(pattern);
-        if (_mv_669.has_value) {
-            __auto_type binding_name = _mv_669.value;
+        __auto_type _mv_670 = match_extract_binding_name(pattern);
+        if (_mv_670.has_value) {
+            __auto_type binding_name = _mv_670.value;
             {
                 __auto_type c_name = ctype_to_c_name(arena, binding_name);
                 __auto_type inner_slop_type = expr_infer_option_inner_slop_type(ctx, scrutinee_expr);
@@ -509,7 +509,7 @@ void match_emit_option_some_branch(context_TranspileContext* ctx, slop_string sc
                 context_ctx_emit(ctx, context_ctx_str4(ctx, SLOP_STR("__auto_type "), c_name, SLOP_STR(" = "), context_ctx_str(ctx, scrutinee_c, SLOP_STR(".value;"))));
                 context_ctx_bind_var(ctx, (context_VarEntry){binding_name, c_name, inner_c_type, inner_slop_type, is_ptr, 0, 0, SLOP_STR(""), SLOP_STR("")});
             }
-        } else if (!_mv_669.has_value) {
+        } else if (!_mv_670.has_value) {
         }
         match_emit_branch_body(ctx, branch_items, is_return);
         context_ctx_pop_scope(ctx);
@@ -539,20 +539,20 @@ void match_transpile_result_match(context_TranspileContext* ctx, slop_string scr
         uint8_t first = 1;
         uint8_t has_else = 0;
         while (i < len) {
-            __auto_type _mv_670 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_670.has_value) {
-                __auto_type branch = _mv_670.value;
-                __auto_type _mv_671 = (*branch);
-                switch (_mv_671.tag) {
+            __auto_type _mv_671 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_671.has_value) {
+                __auto_type branch = _mv_671.value;
+                __auto_type _mv_672 = (*branch);
+                switch (_mv_672.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type branch_lst = _mv_671.data.lst;
+                        __auto_type branch_lst = _mv_672.data.lst;
                         {
                             __auto_type branch_items = branch_lst.items;
                             if (((int64_t)((branch_items).len)) >= 2) {
-                                __auto_type _mv_672 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_672.has_value) {
-                                    __auto_type pattern = _mv_672.value;
+                                __auto_type _mv_673 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_673.has_value) {
+                                    __auto_type pattern = _mv_673.value;
                                     {
                                         __auto_type tag = match_get_pattern_tag(pattern);
                                         if (string_eq(tag, SLOP_STR("ok"))) {
@@ -568,7 +568,7 @@ void match_transpile_result_match(context_TranspileContext* ctx, slop_string scr
                                         } else {
                                         }
                                     }
-                                } else if (!_mv_672.has_value) {
+                                } else if (!_mv_673.has_value) {
                                 }
                             }
                         }
@@ -578,7 +578,7 @@ void match_transpile_result_match(context_TranspileContext* ctx, slop_string scr
                         break;
                     }
                 }
-            } else if (!_mv_670.has_value) {
+            } else if (!_mv_671.has_value) {
             }
             i = (i + 1);
         }
@@ -602,9 +602,9 @@ void match_emit_result_ok_branch(context_TranspileContext* ctx, slop_string scru
         }
         context_ctx_indent(ctx);
         context_ctx_push_scope(ctx);
-        __auto_type _mv_673 = match_extract_binding_name(pattern);
-        if (_mv_673.has_value) {
-            __auto_type binding_name = _mv_673.value;
+        __auto_type _mv_674 = match_extract_binding_name(pattern);
+        if (_mv_674.has_value) {
+            __auto_type binding_name = _mv_674.value;
             {
                 __auto_type c_name = ctype_to_c_name(arena, binding_name);
                 __auto_type ok_slop_type = expr_infer_result_ok_slop_type(ctx, scrutinee_expr);
@@ -613,7 +613,7 @@ void match_emit_result_ok_branch(context_TranspileContext* ctx, slop_string scru
                 context_ctx_emit(ctx, context_ctx_str4(ctx, SLOP_STR("__auto_type "), c_name, SLOP_STR(" = "), context_ctx_str(ctx, scrutinee_c, SLOP_STR(".data.ok;"))));
                 context_ctx_bind_var(ctx, (context_VarEntry){binding_name, c_name, ok_c_type, ok_slop_type, is_ptr, 0, 0, SLOP_STR(""), SLOP_STR("")});
             }
-        } else if (!_mv_673.has_value) {
+        } else if (!_mv_674.has_value) {
         }
         match_emit_branch_body(ctx, branch_items, is_return);
         context_ctx_pop_scope(ctx);
@@ -634,9 +634,9 @@ void match_emit_result_error_branch(context_TranspileContext* ctx, slop_string s
         }
         context_ctx_indent(ctx);
         context_ctx_push_scope(ctx);
-        __auto_type _mv_674 = match_extract_binding_name(pattern);
-        if (_mv_674.has_value) {
-            __auto_type binding_name = _mv_674.value;
+        __auto_type _mv_675 = match_extract_binding_name(pattern);
+        if (_mv_675.has_value) {
+            __auto_type binding_name = _mv_675.value;
             {
                 __auto_type c_name = ctype_to_c_name(arena, binding_name);
                 __auto_type err_slop_type = expr_infer_result_err_slop_type(ctx, scrutinee_expr);
@@ -645,7 +645,7 @@ void match_emit_result_error_branch(context_TranspileContext* ctx, slop_string s
                 context_ctx_emit(ctx, context_ctx_str4(ctx, SLOP_STR("__auto_type "), c_name, SLOP_STR(" = "), context_ctx_str(ctx, scrutinee_c, SLOP_STR(".data.err;"))));
                 context_ctx_bind_var(ctx, (context_VarEntry){binding_name, c_name, err_c_type, err_slop_type, is_ptr, 0, 0, SLOP_STR(""), SLOP_STR("")});
             }
-        } else if (!_mv_674.has_value) {
+        } else if (!_mv_675.has_value) {
         }
         match_emit_branch_body(ctx, branch_items, is_return);
         context_ctx_pop_scope(ctx);
@@ -663,20 +663,20 @@ void match_transpile_enum_match(context_TranspileContext* ctx, slop_string scrut
         context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("switch ("), scrutinee_c, SLOP_STR(") {")));
         context_ctx_indent(ctx);
         while (i < len) {
-            __auto_type _mv_675 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_675.has_value) {
-                __auto_type branch = _mv_675.value;
-                __auto_type _mv_676 = (*branch);
-                switch (_mv_676.tag) {
+            __auto_type _mv_676 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_676.has_value) {
+                __auto_type branch = _mv_676.value;
+                __auto_type _mv_677 = (*branch);
+                switch (_mv_677.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type branch_lst = _mv_676.data.lst;
+                        __auto_type branch_lst = _mv_677.data.lst;
                         {
                             __auto_type branch_items = branch_lst.items;
                             if (((int64_t)((branch_items).len)) >= 2) {
-                                __auto_type _mv_677 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_677.has_value) {
-                                    __auto_type pattern = _mv_677.value;
+                                __auto_type _mv_678 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_678.has_value) {
+                                    __auto_type pattern = _mv_678.value;
                                     {
                                         __auto_type tag = match_get_pattern_tag(pattern);
                                         if (string_eq(tag, SLOP_STR("else")) || string_eq(tag, SLOP_STR("_"))) {
@@ -684,7 +684,7 @@ void match_transpile_enum_match(context_TranspileContext* ctx, slop_string scrut
                                         }
                                     }
                                     match_emit_enum_case(ctx, pattern, branch_items, is_return);
-                                } else if (!_mv_677.has_value) {
+                                } else if (!_mv_678.has_value) {
                                 }
                             }
                         }
@@ -694,7 +694,7 @@ void match_transpile_enum_match(context_TranspileContext* ctx, slop_string scrut
                         break;
                     }
                 }
-            } else if (!_mv_675.has_value) {
+            } else if (!_mv_676.has_value) {
             }
             i = (i + 1);
         }
@@ -718,9 +718,9 @@ void match_emit_enum_case(context_TranspileContext* ctx, types_SExpr* pattern, s
             context_ctx_dedent(ctx);
             context_ctx_emit(ctx, SLOP_STR("}"));
         } else {
-            __auto_type _mv_678 = context_ctx_lookup_enum_variant(ctx, tag);
-            if (_mv_678.has_value) {
-                __auto_type type_name = _mv_678.value;
+            __auto_type _mv_679 = context_ctx_lookup_enum_variant(ctx, tag);
+            if (_mv_679.has_value) {
+                __auto_type type_name = _mv_679.value;
                 {
                     __auto_type c_case = context_ctx_str3(ctx, type_name, SLOP_STR("_"), ctype_to_c_name(arena, tag));
                     context_ctx_emit(ctx, context_ctx_str(ctx, SLOP_STR("case "), context_ctx_str(ctx, c_case, SLOP_STR(": {"))));
@@ -730,7 +730,7 @@ void match_emit_enum_case(context_TranspileContext* ctx, types_SExpr* pattern, s
                     context_ctx_dedent(ctx);
                     context_ctx_emit(ctx, SLOP_STR("}"));
                 }
-            } else if (!_mv_678.has_value) {
+            } else if (!_mv_679.has_value) {
                 context_ctx_add_error_at(ctx, context_ctx_str3(ctx, SLOP_STR("unknown enum variant '"), tag, SLOP_STR("' in match")), context_ctx_sexpr_line(pattern), context_ctx_sexpr_col(pattern));
                 context_ctx_emit(ctx, context_ctx_str(ctx, SLOP_STR("/* unknown enum variant: "), context_ctx_str(ctx, tag, SLOP_STR(" */"))));
             }
@@ -747,26 +747,26 @@ void match_transpile_literal_match(context_TranspileContext* ctx, slop_string sc
         uint8_t first = 1;
         uint8_t has_else = 0;
         while (i < len) {
-            __auto_type _mv_679 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_679.has_value) {
-                __auto_type branch = _mv_679.value;
-                __auto_type _mv_680 = (*branch);
-                switch (_mv_680.tag) {
+            __auto_type _mv_680 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_680.has_value) {
+                __auto_type branch = _mv_680.value;
+                __auto_type _mv_681 = (*branch);
+                switch (_mv_681.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type branch_lst = _mv_680.data.lst;
+                        __auto_type branch_lst = _mv_681.data.lst;
                         {
                             __auto_type branch_items = branch_lst.items;
                             if (((int64_t)((branch_items).len)) >= 2) {
-                                __auto_type _mv_681 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_681.has_value) {
-                                    __auto_type pattern = _mv_681.value;
+                                __auto_type _mv_682 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_682.has_value) {
+                                    __auto_type pattern = _mv_682.value;
                                     if (string_eq(match_get_pattern_tag(pattern), SLOP_STR("else"))) {
                                         has_else = 1;
                                     }
                                     match_emit_literal_case(ctx, scrutinee_c, pattern, branch_items, is_return, first);
                                     first = 0;
-                                } else if (!_mv_681.has_value) {
+                                } else if (!_mv_682.has_value) {
                                 }
                             }
                         }
@@ -776,7 +776,7 @@ void match_transpile_literal_match(context_TranspileContext* ctx, slop_string sc
                         break;
                     }
                 }
-            } else if (!_mv_679.has_value) {
+            } else if (!_mv_680.has_value) {
             }
             i = (i + 1);
         }
@@ -832,20 +832,20 @@ void match_transpile_union_match(context_TranspileContext* ctx, slop_string scru
             context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("switch ("), scrutinee_c, SLOP_STR(".tag) {")));
             context_ctx_indent(ctx);
             while (i < len) {
-                __auto_type _mv_682 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_682.has_value) {
-                    __auto_type branch = _mv_682.value;
-                    __auto_type _mv_683 = (*branch);
-                    switch (_mv_683.tag) {
+                __auto_type _mv_683 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_683.has_value) {
+                    __auto_type branch = _mv_683.value;
+                    __auto_type _mv_684 = (*branch);
+                    switch (_mv_684.tag) {
                         case types_SExpr_lst:
                         {
-                            __auto_type branch_lst = _mv_683.data.lst;
+                            __auto_type branch_lst = _mv_684.data.lst;
                             {
                                 __auto_type branch_items = branch_lst.items;
                                 if (((int64_t)((branch_items).len)) >= 2) {
-                                    __auto_type _mv_684 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_684.has_value) {
-                                        __auto_type pattern = _mv_684.value;
+                                    __auto_type _mv_685 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_685.has_value) {
+                                        __auto_type pattern = _mv_685.value;
                                         {
                                             __auto_type tag = match_get_pattern_tag(pattern);
                                             if (string_eq(tag, SLOP_STR("else")) || string_eq(tag, SLOP_STR("_"))) {
@@ -859,16 +859,16 @@ void match_transpile_union_match(context_TranspileContext* ctx, slop_string scru
                                                 context_ctx_dedent(ctx);
                                                 context_ctx_emit(ctx, SLOP_STR("}"));
                                             } else {
-                                                __auto_type _mv_685 = context_ctx_lookup_enum_variant(ctx, tag);
-                                                if (_mv_685.has_value) {
-                                                    __auto_type union_type_name = _mv_685.value;
+                                                __auto_type _mv_686 = context_ctx_lookup_enum_variant(ctx, tag);
+                                                if (_mv_686.has_value) {
+                                                    __auto_type union_type_name = _mv_686.value;
                                                     match_emit_union_case(ctx, scrutinee_c, pattern, tag, union_type_name, branch_items, is_return);
-                                                } else if (!_mv_685.has_value) {
+                                                } else if (!_mv_686.has_value) {
                                                     context_ctx_add_error(ctx, context_ctx_str3(ctx, SLOP_STR("unknown union variant in match: "), tag, SLOP_STR(" (not registered as enum variant)")));
                                                 }
                                             }
                                         }
-                                    } else if (!_mv_684.has_value) {
+                                    } else if (!_mv_685.has_value) {
                                     }
                                 }
                             }
@@ -878,7 +878,7 @@ void match_transpile_union_match(context_TranspileContext* ctx, slop_string scru
                             break;
                         }
                     }
-                } else if (!_mv_682.has_value) {
+                } else if (!_mv_683.has_value) {
                 }
                 i = (i + 1);
             }
@@ -905,18 +905,18 @@ void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_
             __auto_type count_key = context_ctx_str3(ctx, tag, SLOP_STR("__count"), SLOP_STR(""));
             __auto_type multi_field_count = ({ __auto_type _mv = context_ctx_lookup_field_type(ctx, union_type_name, count_key); _mv.has_value ? ({ __auto_type ct = _mv.value; ct; }) : (SLOP_STR("")); });
             if (!(string_eq(multi_field_count, SLOP_STR("")))) {
-                __auto_type _mv_686 = (*pattern);
-                switch (_mv_686.tag) {
+                __auto_type _mv_687 = (*pattern);
+                switch (_mv_687.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type pat_lst = _mv_686.data.lst;
+                        __auto_type pat_lst = _mv_687.data.lst;
                         {
                             __auto_type pat_items = pat_lst.items;
                             __auto_type pat_len = ((int64_t)((pat_items).len));
                             for (int64_t bi = 1; bi < pat_len; bi++) {
-                                __auto_type _mv_687 = ({ __auto_type _lst = pat_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_687.has_value) {
-                                    __auto_type binding_expr = _mv_687.value;
+                                __auto_type _mv_688 = ({ __auto_type _lst = pat_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_688.has_value) {
+                                    __auto_type binding_expr = _mv_688.value;
                                     {
                                         __auto_type binding_name = parser_sexpr_get_symbol_name(binding_expr);
                                         if (!(string_eq(binding_name, SLOP_STR(""))) && !(string_eq(binding_name, SLOP_STR("_")))) {
@@ -932,7 +932,7 @@ void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_
                                             }
                                         }
                                     }
-                                } else if (!_mv_687.has_value) {
+                                } else if (!_mv_688.has_value) {
                                 }
                             }
                         }
@@ -943,9 +943,9 @@ void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_
                     }
                 }
             } else {
-                __auto_type _mv_688 = match_extract_binding_name(pattern);
-                if (_mv_688.has_value) {
-                    __auto_type binding_name = _mv_688.value;
+                __auto_type _mv_689 = match_extract_binding_name(pattern);
+                if (_mv_689.has_value) {
+                    __auto_type binding_name = _mv_689.value;
                     {
                         __auto_type c_binding = ctype_to_c_name(arena, binding_name);
                         __auto_type payload_c_type = ({ __auto_type _mv = context_ctx_lookup_field_type(ctx, union_type_name, tag); _mv.has_value ? ({ __auto_type ct = _mv.value; ct; }) : (SLOP_STR("auto")); });
@@ -953,7 +953,7 @@ void match_emit_union_case(context_TranspileContext* ctx, slop_string scrutinee_
                         context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("__auto_type "), c_binding, SLOP_STR(" = "), scrutinee_c, context_ctx_str3(ctx, SLOP_STR(".data."), c_tag, SLOP_STR(";"))));
                         context_ctx_bind_var(ctx, (context_VarEntry){binding_name, c_binding, payload_c_type, payload_slop_type, 0, 0, 0, SLOP_STR(""), SLOP_STR("")});
                     }
-                } else if (!_mv_688.has_value) {
+                } else if (!_mv_689.has_value) {
                 }
             }
         }
@@ -997,14 +997,14 @@ void match_emit_branch_body(context_TranspileContext* ctx, slop_list_types_SExpr
         __auto_type len = ((int64_t)((branch_items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_689 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_689.has_value) {
-                __auto_type body_expr = _mv_689.value;
+            __auto_type _mv_690 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_690.has_value) {
+                __auto_type body_expr = _mv_690.value;
                 {
                     __auto_type is_last = (i == (len - 1));
                     match_emit_branch_body_item(ctx, body_expr, is_return, is_last);
                 }
-            } else if (!_mv_689.has_value) {
+            } else if (!_mv_690.has_value) {
             }
             i = (i + 1);
         }
@@ -1016,24 +1016,24 @@ void match_emit_branch_body_item(context_TranspileContext* ctx, types_SExpr* bod
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_690 = (*body_expr);
-        switch (_mv_690.tag) {
+        __auto_type _mv_691 = (*body_expr);
+        switch (_mv_691.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_690.data.lst;
+                __auto_type lst = _mv_691.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 1) {
                         context_ctx_emit(ctx, SLOP_STR("/* empty list */;"));
                     } else {
-                        __auto_type _mv_691 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_691.has_value) {
-                            __auto_type head_expr = _mv_691.value;
-                            __auto_type _mv_692 = (*head_expr);
-                            switch (_mv_692.tag) {
+                        __auto_type _mv_692 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_692.has_value) {
+                            __auto_type head_expr = _mv_692.value;
+                            __auto_type _mv_693 = (*head_expr);
+                            switch (_mv_693.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_692.data.sym;
+                                    __auto_type sym = _mv_693.data.sym;
                                     {
                                         __auto_type op = sym.name;
                                         if (string_eq(op, SLOP_STR("let"))) {
@@ -1080,7 +1080,7 @@ void match_emit_branch_body_item(context_TranspileContext* ctx, types_SExpr* bod
                                     break;
                                 }
                             }
-                        } else if (!_mv_691.has_value) {
+                        } else if (!_mv_692.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("empty"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         }
                     }
@@ -1112,23 +1112,23 @@ void match_emit_inline_let(context_TranspileContext* ctx, slop_list_types_SExpr_
             context_ctx_emit(ctx, SLOP_STR("{"));
             context_ctx_indent(ctx);
             context_ctx_push_scope(ctx);
-            __auto_type _mv_693 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_693.has_value) {
-                __auto_type bindings_expr = _mv_693.value;
+            __auto_type _mv_694 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_694.has_value) {
+                __auto_type bindings_expr = _mv_694.value;
                 match_emit_inline_bindings(ctx, bindings_expr);
-            } else if (!_mv_693.has_value) {
+            } else if (!_mv_694.has_value) {
             }
             {
                 int64_t i = 2;
                 while (i < len) {
-                    __auto_type _mv_694 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_694.has_value) {
-                        __auto_type body_item = _mv_694.value;
+                    __auto_type _mv_695 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_695.has_value) {
+                        __auto_type body_item = _mv_695.value;
                         {
                             __auto_type body_last = (i == (len - 1));
                             match_emit_branch_body_item(ctx, body_item, is_return, (is_last && body_last));
                         }
-                    } else if (!_mv_694.has_value) {
+                    } else if (!_mv_695.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -1145,21 +1145,21 @@ void match_emit_inline_bindings(context_TranspileContext* ctx, types_SExpr* bind
     SLOP_PRE(((bindings_expr != NULL)), "(!= bindings-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_695 = (*bindings_expr);
-        switch (_mv_695.tag) {
+        __auto_type _mv_696 = (*bindings_expr);
+        switch (_mv_696.tag) {
             case types_SExpr_lst:
             {
-                __auto_type bindings_lst = _mv_695.data.lst;
+                __auto_type bindings_lst = _mv_696.data.lst;
                 {
                     __auto_type bindings = bindings_lst.items;
                     __auto_type len = ((int64_t)((bindings).len));
                     __auto_type i = 0;
                     while (i < len) {
-                        __auto_type _mv_696 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_696.has_value) {
-                            __auto_type binding = _mv_696.value;
+                        __auto_type _mv_697 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_697.has_value) {
+                            __auto_type binding = _mv_697.value;
                             match_emit_single_inline_binding(ctx, binding);
-                        } else if (!_mv_696.has_value) {
+                        } else if (!_mv_697.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -1178,11 +1178,11 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
     SLOP_PRE(((binding != NULL)), "(!= binding nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_697 = (*binding);
-        switch (_mv_697.tag) {
+        __auto_type _mv_698 = (*binding);
+        switch (_mv_698.tag) {
             case types_SExpr_lst:
             {
-                __auto_type binding_lst = _mv_697.data.lst;
+                __auto_type binding_lst = _mv_698.data.lst;
                 {
                     __auto_type items = binding_lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -1192,14 +1192,14 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
                         if ((len - start_idx) < 2) {
                             context_ctx_add_error_at(ctx, SLOP_STR("invalid binding"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                         } else {
-                            __auto_type _mv_698 = ({ __auto_type _lst = items; size_t _idx = (size_t)start_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_698.has_value) {
-                                __auto_type name_expr = _mv_698.value;
-                                __auto_type _mv_699 = (*name_expr);
-                                switch (_mv_699.tag) {
+                            __auto_type _mv_699 = ({ __auto_type _lst = items; size_t _idx = (size_t)start_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_699.has_value) {
+                                __auto_type name_expr = _mv_699.value;
+                                __auto_type _mv_700 = (*name_expr);
+                                switch (_mv_700.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type name_sym = _mv_699.data.sym;
+                                        __auto_type name_sym = _mv_700.data.sym;
                                         {
                                             __auto_type raw_name = name_sym.name;
                                             __auto_type c_name = ctype_to_c_name(arena, raw_name);
@@ -1207,13 +1207,13 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
                                                 {
                                                     __auto_type type_idx = (start_idx + 1);
                                                     __auto_type val_idx = (start_idx + 2);
-                                                    __auto_type _mv_700 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_700.has_value) {
-                                                        __auto_type type_expr = _mv_700.value;
+                                                    __auto_type _mv_701 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_701.has_value) {
+                                                        __auto_type type_expr = _mv_701.value;
                                                         if (match_is_type_expr(type_expr)) {
-                                                            __auto_type _mv_701 = ({ __auto_type _lst = items; size_t _idx = (size_t)val_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                            if (_mv_701.has_value) {
-                                                                __auto_type val_expr = _mv_701.value;
+                                                            __auto_type _mv_702 = ({ __auto_type _lst = items; size_t _idx = (size_t)val_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                            if (_mv_702.has_value) {
+                                                                __auto_type val_expr = _mv_702.value;
                                                                 {
                                                                     __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                                     __auto_type is_ptr = strlib_ends_with(c_type, SLOP_STR("*"));
@@ -1224,23 +1224,23 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
                                                                         context_ctx_bind_var(ctx, (context_VarEntry){raw_name, c_name, c_type, slop_type_str, is_ptr, has_mut, 0, SLOP_STR(""), SLOP_STR("")});
                                                                     }
                                                                 }
-                                                            } else if (!_mv_701.has_value) {
+                                                            } else if (!_mv_702.has_value) {
                                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing value"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                             }
                                                         } else {
-                                                            __auto_type _mv_702 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                            if (_mv_702.has_value) {
-                                                                __auto_type val_expr = _mv_702.value;
+                                                            __auto_type _mv_703 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                            if (_mv_703.has_value) {
+                                                                __auto_type val_expr = _mv_703.value;
                                                                 {
                                                                     __auto_type val_c = expr_transpile_expr(ctx, val_expr);
                                                                     __auto_type inferred_slop_type = expr_infer_expr_slop_type(ctx, val_expr);
                                                                     __auto_type ptr_type_opt = match_get_arena_alloc_ptr_type_inline(ctx, val_expr);
-                                                                    __auto_type _mv_703 = ptr_type_opt;
-                                                                    if (_mv_703.has_value) {
-                                                                        __auto_type ptr_type = _mv_703.value;
+                                                                    __auto_type _mv_704 = ptr_type_opt;
+                                                                    if (_mv_704.has_value) {
+                                                                        __auto_type ptr_type = _mv_704.value;
                                                                         context_ctx_emit(ctx, context_ctx_str4(ctx, SLOP_STR("__auto_type "), c_name, SLOP_STR(" = "), context_ctx_str(ctx, val_c, SLOP_STR(";"))));
                                                                         context_ctx_bind_var(ctx, (context_VarEntry){raw_name, c_name, ptr_type, inferred_slop_type, 1, has_mut, 0, SLOP_STR(""), SLOP_STR("")});
-                                                                    } else if (!_mv_703.has_value) {
+                                                                    } else if (!_mv_704.has_value) {
                                                                         {
                                                                             __auto_type inferred_type = expr_infer_expr_c_type(ctx, val_expr);
                                                                             __auto_type is_ptr = strlib_ends_with(inferred_type, SLOP_STR("*"));
@@ -1249,30 +1249,30 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
                                                                         }
                                                                     }
                                                                 }
-                                                            } else if (!_mv_702.has_value) {
+                                                            } else if (!_mv_703.has_value) {
                                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing value"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                             }
                                                         }
-                                                    } else if (!_mv_700.has_value) {
+                                                    } else if (!_mv_701.has_value) {
                                                         context_ctx_add_error_at(ctx, SLOP_STR("missing type/value"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                     }
                                                 }
                                             } else {
                                                 {
                                                     __auto_type val_idx = (start_idx + 1);
-                                                    __auto_type _mv_704 = ({ __auto_type _lst = items; size_t _idx = (size_t)val_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_704.has_value) {
-                                                        __auto_type val_expr = _mv_704.value;
+                                                    __auto_type _mv_705 = ({ __auto_type _lst = items; size_t _idx = (size_t)val_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_705.has_value) {
+                                                        __auto_type val_expr = _mv_705.value;
                                                         {
                                                             __auto_type val_c = expr_transpile_expr(ctx, val_expr);
                                                             __auto_type inferred_slop_type = expr_infer_expr_slop_type(ctx, val_expr);
                                                             __auto_type ptr_type_opt = match_get_arena_alloc_ptr_type_inline(ctx, val_expr);
-                                                            __auto_type _mv_705 = ptr_type_opt;
-                                                            if (_mv_705.has_value) {
-                                                                __auto_type ptr_type = _mv_705.value;
+                                                            __auto_type _mv_706 = ptr_type_opt;
+                                                            if (_mv_706.has_value) {
+                                                                __auto_type ptr_type = _mv_706.value;
                                                                 context_ctx_emit(ctx, context_ctx_str4(ctx, SLOP_STR("__auto_type "), c_name, SLOP_STR(" = "), context_ctx_str(ctx, val_c, SLOP_STR(";"))));
                                                                 context_ctx_bind_var(ctx, (context_VarEntry){raw_name, c_name, ptr_type, inferred_slop_type, 1, has_mut, 0, SLOP_STR(""), SLOP_STR("")});
-                                                            } else if (!_mv_705.has_value) {
+                                                            } else if (!_mv_706.has_value) {
                                                                 {
                                                                     __auto_type inferred_type = expr_infer_expr_c_type(ctx, val_expr);
                                                                     __auto_type is_ptr = strlib_ends_with(inferred_type, SLOP_STR("*"));
@@ -1281,7 +1281,7 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
                                                                 }
                                                             }
                                                         }
-                                                    } else if (!_mv_704.has_value) {
+                                                    } else if (!_mv_705.has_value) {
                                                         context_ctx_add_error_at(ctx, SLOP_STR("missing value"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                     }
                                                 }
@@ -1294,7 +1294,7 @@ void match_emit_single_inline_binding(context_TranspileContext* ctx, types_SExpr
                                         break;
                                     }
                                 }
-                            } else if (!_mv_698.has_value) {
+                            } else if (!_mv_699.has_value) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("missing binding name"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                             }
                         }
@@ -1314,21 +1314,21 @@ uint8_t match_binding_starts_with_mut(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_706 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_706.has_value) {
-            __auto_type first = _mv_706.value;
-            __auto_type _mv_707 = (*first);
-            switch (_mv_707.tag) {
+        __auto_type _mv_707 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_707.has_value) {
+            __auto_type first = _mv_707.value;
+            __auto_type _mv_708 = (*first);
+            switch (_mv_708.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_707.data.sym;
+                    __auto_type sym = _mv_708.data.sym;
                     return string_eq(sym.name, SLOP_STR("mut"));
                 }
                 default: {
                     return 0;
                 }
             }
-        } else if (!_mv_706.has_value) {
+        } else if (!_mv_707.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -1337,11 +1337,11 @@ uint8_t match_binding_starts_with_mut(slop_list_types_SExpr_ptr items) {
 
 uint8_t match_is_type_expr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_708 = (*expr);
-    switch (_mv_708.tag) {
+    __auto_type _mv_709 = (*expr);
+    switch (_mv_709.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_708.data.sym;
+            __auto_type sym = _mv_709.data.sym;
             {
                 __auto_type name = sym.name;
                 if (string_len(name) == 0) {
@@ -1356,7 +1356,7 @@ uint8_t match_is_type_expr(types_SExpr* expr) {
         }
         case types_SExpr_lst:
         {
-            __auto_type _ = _mv_708.data.lst;
+            __auto_type _ = _mv_709.data.lst;
             return 1;
         }
         default: {
@@ -1367,34 +1367,34 @@ uint8_t match_is_type_expr(types_SExpr* expr) {
 
 uint8_t match_is_none_form_inline(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_709 = (*expr);
-    switch (_mv_709.tag) {
+    __auto_type _mv_710 = (*expr);
+    switch (_mv_710.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_709.data.sym;
+            __auto_type sym = _mv_710.data.sym;
             return string_eq(sym.name, SLOP_STR("none"));
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_709.data.lst;
+            __auto_type lst = _mv_710.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) == 1) {
-                    __auto_type _mv_710 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_710.has_value) {
-                        __auto_type head = _mv_710.value;
-                        __auto_type _mv_711 = (*head);
-                        switch (_mv_711.tag) {
+                    __auto_type _mv_711 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_711.has_value) {
+                        __auto_type head = _mv_711.value;
+                        __auto_type _mv_712 = (*head);
+                        switch (_mv_712.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_711.data.sym;
+                                __auto_type sym = _mv_712.data.sym;
                                 return string_eq(sym.name, SLOP_STR("none"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_710.has_value) {
+                    } else if (!_mv_711.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1419,28 +1419,28 @@ slop_option_string match_get_arena_alloc_ptr_type_inline(context_TranspileContex
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_712 = (*expr);
-        switch (_mv_712.tag) {
+        __auto_type _mv_713 = (*expr);
+        switch (_mv_713.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_712.data.lst;
+                __auto_type lst = _mv_713.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_713 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_713.has_value) {
-                            __auto_type head_ptr = _mv_713.value;
-                            __auto_type _mv_714 = (*head_ptr);
-                            switch (_mv_714.tag) {
+                        __auto_type _mv_714 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_714.has_value) {
+                            __auto_type head_ptr = _mv_714.value;
+                            __auto_type _mv_715 = (*head_ptr);
+                            switch (_mv_715.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type head_sym = _mv_714.data.sym;
+                                    __auto_type head_sym = _mv_715.data.sym;
                                     if (string_eq(head_sym.name, SLOP_STR("arena-alloc"))) {
-                                        __auto_type _mv_715 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_715.has_value) {
-                                            __auto_type size_expr = _mv_715.value;
+                                        __auto_type _mv_716 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_716.has_value) {
+                                            __auto_type size_expr = _mv_716.value;
                                             return match_extract_sizeof_type_inline(ctx, size_expr);
-                                        } else if (!_mv_715.has_value) {
+                                        } else if (!_mv_716.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
                                         SLOP_UNREACHABLE();
@@ -1452,7 +1452,7 @@ slop_option_string match_get_arena_alloc_ptr_type_inline(context_TranspileContex
                                     return (slop_option_string){.has_value = false};
                                 }
                             }
-                        } else if (!_mv_713.has_value) {
+                        } else if (!_mv_714.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -1473,18 +1473,18 @@ slop_option_string match_extract_sizeof_type_inline(context_TranspileContext* ct
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_716 = (*expr);
-        switch (_mv_716.tag) {
+        __auto_type _mv_717 = (*expr);
+        switch (_mv_717.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_716.data.sym;
+                __auto_type sym = _mv_717.data.sym;
                 {
                     __auto_type type_name = sym.name;
-                    __auto_type _mv_717 = context_ctx_lookup_type(ctx, type_name);
-                    if (_mv_717.has_value) {
-                        __auto_type entry = _mv_717.value;
+                    __auto_type _mv_718 = context_ctx_lookup_type(ctx, type_name);
+                    if (_mv_718.has_value) {
+                        __auto_type entry = _mv_718.value;
                         return (slop_option_string){.has_value = 1, .value = context_ctx_str(ctx, entry.c_name, SLOP_STR("*"))};
-                    } else if (!_mv_717.has_value) {
+                    } else if (!_mv_718.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
                     SLOP_UNREACHABLE();
@@ -1492,27 +1492,27 @@ slop_option_string match_extract_sizeof_type_inline(context_TranspileContext* ct
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_716.data.lst;
+                __auto_type lst = _mv_717.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_718 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_718.has_value) {
-                            __auto_type head_ptr = _mv_718.value;
-                            __auto_type _mv_719 = (*head_ptr);
-                            switch (_mv_719.tag) {
+                        __auto_type _mv_719 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_719.has_value) {
+                            __auto_type head_ptr = _mv_719.value;
+                            __auto_type _mv_720 = (*head_ptr);
+                            switch (_mv_720.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type head_sym = _mv_719.data.sym;
+                                    __auto_type head_sym = _mv_720.data.sym;
                                     if (string_eq(head_sym.name, SLOP_STR("sizeof"))) {
-                                        __auto_type _mv_720 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_720.has_value) {
-                                            __auto_type type_expr = _mv_720.value;
+                                        __auto_type _mv_721 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_721.has_value) {
+                                            __auto_type type_expr = _mv_721.value;
                                             {
                                                 __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                 return (slop_option_string){.has_value = 1, .value = context_ctx_str(ctx, c_type, SLOP_STR("*"))};
                                             }
-                                        } else if (!_mv_720.has_value) {
+                                        } else if (!_mv_721.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
                                         SLOP_UNREACHABLE();
@@ -1524,7 +1524,7 @@ slop_option_string match_extract_sizeof_type_inline(context_TranspileContext* ct
                                     return (slop_option_string){.has_value = false};
                                 }
                             }
-                        } else if (!_mv_718.has_value) {
+                        } else if (!_mv_719.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -1546,14 +1546,14 @@ void match_emit_inline_do(context_TranspileContext* ctx, slop_list_types_SExpr_p
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_721 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_721.has_value) {
-                __auto_type item = _mv_721.value;
+            __auto_type _mv_722 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_722.has_value) {
+                __auto_type item = _mv_722.value;
                 {
                     __auto_type item_last = (i == (len - 1));
                     match_emit_branch_body_item(ctx, item, is_return, (is_last && item_last));
                 }
-            } else if (!_mv_721.has_value) {
+            } else if (!_mv_722.has_value) {
             }
             i = (i + 1);
         }
@@ -1568,32 +1568,32 @@ void match_emit_inline_if(context_TranspileContext* ctx, slop_list_types_SExpr_p
         if (len < 3) {
             context_ctx_add_error_at(ctx, SLOP_STR("invalid if"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         } else {
-            __auto_type _mv_722 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_722.has_value) {
-                __auto_type cond_expr = _mv_722.value;
+            __auto_type _mv_723 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_723.has_value) {
+                __auto_type cond_expr = _mv_723.value;
                 {
                     __auto_type cond_c = context_ctx_strip_cond_parens(ctx, expr_transpile_expr(ctx, cond_expr));
                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("if ("), cond_c, SLOP_STR(") {")));
                 }
-            } else if (!_mv_722.has_value) {
+            } else if (!_mv_723.has_value) {
                 context_ctx_emit(ctx, SLOP_STR("if (/* missing */) {"));
             }
             context_ctx_indent(ctx);
-            __auto_type _mv_723 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_723.has_value) {
-                __auto_type then_expr = _mv_723.value;
+            __auto_type _mv_724 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_724.has_value) {
+                __auto_type then_expr = _mv_724.value;
                 match_emit_branch_body_item(ctx, then_expr, is_return, 1);
-            } else if (!_mv_723.has_value) {
+            } else if (!_mv_724.has_value) {
             }
             context_ctx_dedent(ctx);
             if (len >= 4) {
                 context_ctx_emit(ctx, SLOP_STR("} else {"));
                 context_ctx_indent(ctx);
-                __auto_type _mv_724 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_724.has_value) {
-                    __auto_type else_expr = _mv_724.value;
+                __auto_type _mv_725 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_725.has_value) {
+                    __auto_type else_expr = _mv_725.value;
                     match_emit_branch_body_item(ctx, else_expr, is_return, 1);
-                } else if (!_mv_724.has_value) {
+                } else if (!_mv_725.has_value) {
                 }
                 context_ctx_dedent(ctx);
                 context_ctx_emit(ctx, SLOP_STR("}"));
@@ -1612,14 +1612,14 @@ void match_emit_inline_while(context_TranspileContext* ctx, slop_list_types_SExp
         if (len < 3) {
             context_ctx_add_error_at(ctx, SLOP_STR("invalid while"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         } else {
-            __auto_type _mv_725 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_725.has_value) {
-                __auto_type cond_expr = _mv_725.value;
+            __auto_type _mv_726 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_726.has_value) {
+                __auto_type cond_expr = _mv_726.value;
                 {
                     __auto_type cond_c = context_ctx_strip_cond_parens(ctx, expr_transpile_expr(ctx, cond_expr));
                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("while ("), cond_c, SLOP_STR(") {")));
                 }
-            } else if (!_mv_725.has_value) {
+            } else if (!_mv_726.has_value) {
                 context_ctx_emit(ctx, SLOP_STR("while (/* missing */) {"));
             }
             context_ctx_indent(ctx);
@@ -1632,18 +1632,18 @@ void match_emit_inline_while(context_TranspileContext* ctx, slop_list_types_SExp
 
 slop_option_string match_get_var_c_type_inline(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
-    __auto_type _mv_726 = (*expr);
-    switch (_mv_726.tag) {
+    __auto_type _mv_727 = (*expr);
+    switch (_mv_727.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_726.data.sym;
+            __auto_type sym = _mv_727.data.sym;
             {
                 __auto_type name = sym.name;
-                __auto_type _mv_727 = context_ctx_lookup_var(ctx, name);
-                if (_mv_727.has_value) {
-                    __auto_type var_entry = _mv_727.value;
+                __auto_type _mv_728 = context_ctx_lookup_var(ctx, name);
+                if (_mv_728.has_value) {
+                    __auto_type var_entry = _mv_728.value;
                     return (slop_option_string){.has_value = 1, .value = var_entry.c_type};
-                } else if (!_mv_727.has_value) {
+                } else if (!_mv_728.has_value) {
                     return (slop_option_string){.has_value = false};
                 }
                 SLOP_UNREACHABLE();
@@ -1659,28 +1659,28 @@ slop_option_types_SExpr_ptr match_get_some_value_inline(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         slop_option_types_SExpr_ptr result = (slop_option_types_SExpr_ptr){.has_value = false};
-        __auto_type _mv_728 = (*expr);
-        switch (_mv_728.tag) {
+        __auto_type _mv_729 = (*expr);
+        switch (_mv_729.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_728.data.lst;
+                __auto_type lst = _mv_729.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_729 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_729.has_value) {
-                            __auto_type head = _mv_729.value;
-                            __auto_type _mv_730 = (*head);
-                            switch (_mv_730.tag) {
+                        __auto_type _mv_730 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_730.has_value) {
+                            __auto_type head = _mv_730.value;
+                            __auto_type _mv_731 = (*head);
+                            switch (_mv_731.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_730.data.sym;
+                                    __auto_type sym = _mv_731.data.sym;
                                     if (string_eq(sym.name, SLOP_STR("some"))) {
-                                        __auto_type _mv_731 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_731.has_value) {
-                                            __auto_type val = _mv_731.value;
+                                        __auto_type _mv_732 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_732.has_value) {
+                                            __auto_type val = _mv_732.value;
                                             result = (slop_option_types_SExpr_ptr){.has_value = 1, .value = val};
-                                        } else if (!_mv_731.has_value) {
+                                        } else if (!_mv_732.has_value) {
                                         }
                                     }
                                     break;
@@ -1689,7 +1689,7 @@ slop_option_types_SExpr_ptr match_get_some_value_inline(types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_729.has_value) {
+                        } else if (!_mv_730.has_value) {
                         }
                     }
                 }
@@ -1710,18 +1710,18 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
         __auto_type len = ((int64_t)((items).len));
         if (expr_set_is_self_assign(items)) {
         } else if (len == 5) {
-            __auto_type _mv_732 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_732.has_value) {
-                __auto_type target_expr = _mv_732.value;
-                __auto_type _mv_733 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_733.has_value) {
-                    __auto_type field_expr = _mv_733.value;
-                    __auto_type _mv_734 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_734.has_value) {
-                        __auto_type type_expr = _mv_734.value;
-                        __auto_type _mv_735 = ({ __auto_type _lst = items; size_t _idx = (size_t)4; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_735.has_value) {
-                            __auto_type value_expr = _mv_735.value;
+            __auto_type _mv_733 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_733.has_value) {
+                __auto_type target_expr = _mv_733.value;
+                __auto_type _mv_734 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_734.has_value) {
+                    __auto_type field_expr = _mv_734.value;
+                    __auto_type _mv_735 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_735.has_value) {
+                        __auto_type type_expr = _mv_735.value;
+                        __auto_type _mv_736 = ({ __auto_type _lst = items; size_t _idx = (size_t)4; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_736.has_value) {
+                            __auto_type value_expr = _mv_736.value;
                             {
                                 __auto_type field_name = match_get_field_name_inline(ctx, field_expr);
                                 __auto_type c_type = ctype_to_c_type(arena, type_expr);
@@ -1731,14 +1731,14 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
                                         if (match_is_none_form_inline(value_expr)) {
                                             context_ctx_emit(ctx, context_ctx_str(ctx, target_access, context_ctx_str(ctx, field_name, context_ctx_str3(ctx, SLOP_STR(" = ("), c_type, SLOP_STR("){.has_value = false};")))));
                                         } else {
-                                            __auto_type _mv_736 = match_get_some_value_inline(value_expr);
-                                            if (_mv_736.has_value) {
-                                                __auto_type inner_val = _mv_736.value;
+                                            __auto_type _mv_737 = match_get_some_value_inline(value_expr);
+                                            if (_mv_737.has_value) {
+                                                __auto_type inner_val = _mv_737.value;
                                                 {
                                                     __auto_type val_c = expr_transpile_expr(ctx, inner_val);
                                                     context_ctx_emit(ctx, context_ctx_str(ctx, target_access, context_ctx_str(ctx, field_name, context_ctx_str5(ctx, SLOP_STR(" = ("), c_type, SLOP_STR("){.has_value = 1, .value = "), val_c, SLOP_STR("};")))));
                                                 }
-                                            } else if (!_mv_736.has_value) {
+                                            } else if (!_mv_737.has_value) {
                                                 {
                                                     __auto_type val_c = expr_transpile_expr(ctx, value_expr);
                                                     context_ctx_emit(ctx, context_ctx_str(ctx, target_access, context_ctx_str(ctx, field_name, context_ctx_str(ctx, SLOP_STR(" = "), context_ctx_str(ctx, val_c, SLOP_STR(";"))))));
@@ -1753,28 +1753,28 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
                                     }
                                 }
                             }
-                        } else if (!_mv_735.has_value) {
+                        } else if (!_mv_736.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing set! value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                         }
-                    } else if (!_mv_734.has_value) {
+                    } else if (!_mv_735.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing set! type"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     }
-                } else if (!_mv_733.has_value) {
+                } else if (!_mv_734.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("missing set! field"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 }
-            } else if (!_mv_732.has_value) {
+            } else if (!_mv_733.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing set! target"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             }
         } else if (len == 4) {
-            __auto_type _mv_737 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_737.has_value) {
-                __auto_type target_expr = _mv_737.value;
-                __auto_type _mv_738 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_738.has_value) {
-                    __auto_type field_expr = _mv_738.value;
-                    __auto_type _mv_739 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_739.has_value) {
-                        __auto_type value_expr = _mv_739.value;
+            __auto_type _mv_738 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_738.has_value) {
+                __auto_type target_expr = _mv_738.value;
+                __auto_type _mv_739 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_739.has_value) {
+                    __auto_type field_expr = _mv_739.value;
+                    __auto_type _mv_740 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_740.has_value) {
+                        __auto_type value_expr = _mv_740.value;
                         {
                             __auto_type field_name = match_get_field_name_inline(ctx, field_expr);
                             __auto_type value_c = expr_transpile_expr(ctx, value_expr);
@@ -1790,39 +1790,39 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
                                 }
                             }
                         }
-                    } else if (!_mv_739.has_value) {
+                    } else if (!_mv_740.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing set! value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     }
-                } else if (!_mv_738.has_value) {
+                } else if (!_mv_739.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("missing set! field"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 }
-            } else if (!_mv_737.has_value) {
+            } else if (!_mv_738.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing set! target"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             }
         } else if (len >= 3) {
-            __auto_type _mv_740 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_740.has_value) {
-                __auto_type target_expr = _mv_740.value;
-                __auto_type _mv_741 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_741.has_value) {
-                    __auto_type val_expr = _mv_741.value;
+            __auto_type _mv_741 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_741.has_value) {
+                __auto_type target_expr = _mv_741.value;
+                __auto_type _mv_742 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_742.has_value) {
+                    __auto_type val_expr = _mv_742.value;
                     {
                         __auto_type target_c = expr_transpile_expr(ctx, target_expr);
                         __auto_type target_type_opt = match_get_var_c_type_inline(ctx, target_expr);
-                        __auto_type _mv_742 = target_type_opt;
-                        if (_mv_742.has_value) {
-                            __auto_type target_type = _mv_742.value;
+                        __auto_type _mv_743 = target_type_opt;
+                        if (_mv_743.has_value) {
+                            __auto_type target_type = _mv_743.value;
                             if (strlib_starts_with(target_type, SLOP_STR("slop_option_"))) {
                                 {
                                     __auto_type some_val_opt = match_get_some_value_inline(val_expr);
-                                    __auto_type _mv_743 = some_val_opt;
-                                    if (_mv_743.has_value) {
-                                        __auto_type inner_expr = _mv_743.value;
+                                    __auto_type _mv_744 = some_val_opt;
+                                    if (_mv_744.has_value) {
+                                        __auto_type inner_expr = _mv_744.value;
                                         {
                                             __auto_type inner_c = expr_transpile_expr(ctx, inner_expr);
                                             context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str5(ctx, SLOP_STR(" = ("), target_type, SLOP_STR("){.has_value = 1, .value = "), inner_c, SLOP_STR("};"))));
                                         }
-                                    } else if (!_mv_743.has_value) {
+                                    } else if (!_mv_744.has_value) {
                                         {
                                             __auto_type val_c = expr_transpile_expr(ctx, val_expr);
                                             if (string_eq(val_c, SLOP_STR("none"))) {
@@ -1839,23 +1839,23 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
                                     context_ctx_emit(ctx, context_ctx_str4(ctx, target_c, SLOP_STR(" = "), val_c, SLOP_STR(";")));
                                 }
                             }
-                        } else if (!_mv_742.has_value) {
+                        } else if (!_mv_743.has_value) {
                             {
                                 __auto_type some_val_opt = match_get_some_value_inline(val_expr);
-                                __auto_type _mv_744 = some_val_opt;
-                                if (_mv_744.has_value) {
-                                    __auto_type inner_expr = _mv_744.value;
+                                __auto_type _mv_745 = some_val_opt;
+                                if (_mv_745.has_value) {
+                                    __auto_type inner_expr = _mv_745.value;
                                     {
                                         __auto_type inner_c = expr_transpile_expr(ctx, inner_expr);
                                         __auto_type inner_type = expr_infer_expr_c_type(ctx, inner_expr);
                                         __auto_type option_type = expr_c_type_to_option_type_name(ctx, inner_type);
                                         context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str5(ctx, SLOP_STR(" = ("), option_type, SLOP_STR("){.has_value = 1, .value = "), inner_c, SLOP_STR("};"))));
                                     }
-                                } else if (!_mv_744.has_value) {
+                                } else if (!_mv_745.has_value) {
                                     if (match_is_none_form_inline(val_expr)) {
-                                        __auto_type _mv_745 = context_ctx_get_current_return_type(ctx);
-                                        if (_mv_745.has_value) {
-                                            __auto_type ret_type = _mv_745.value;
+                                        __auto_type _mv_746 = context_ctx_get_current_return_type(ctx);
+                                        if (_mv_746.has_value) {
+                                            __auto_type ret_type = _mv_746.value;
                                             if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
                                                 context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str3(ctx, SLOP_STR(" = ("), ret_type, SLOP_STR("){.has_value = false};"))));
                                             } else {
@@ -1864,7 +1864,7 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
                                                     context_ctx_emit(ctx, context_ctx_str4(ctx, target_c, SLOP_STR(" = "), val_c, SLOP_STR(";")));
                                                 }
                                             }
-                                        } else if (!_mv_745.has_value) {
+                                        } else if (!_mv_746.has_value) {
                                             {
                                                 __auto_type val_c = expr_transpile_expr(ctx, val_expr);
                                                 context_ctx_emit(ctx, context_ctx_str4(ctx, target_c, SLOP_STR(" = "), val_c, SLOP_STR(";")));
@@ -1880,10 +1880,10 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
                             }
                         }
                     }
-                } else if (!_mv_741.has_value) {
+                } else if (!_mv_742.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("missing set! value"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 }
-            } else if (!_mv_740.has_value) {
+            } else if (!_mv_741.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing set! target"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             }
         } else {
@@ -1894,31 +1894,31 @@ void match_emit_inline_set(context_TranspileContext* ctx, slop_list_types_SExpr_
 
 uint8_t match_is_deref_inline(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_746 = (*expr);
-    switch (_mv_746.tag) {
+    __auto_type _mv_747 = (*expr);
+    switch (_mv_747.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_746.data.lst;
+            __auto_type lst = _mv_747.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return 0;
                 } else {
-                    __auto_type _mv_747 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_747.has_value) {
-                        __auto_type head = _mv_747.value;
-                        __auto_type _mv_748 = (*head);
-                        switch (_mv_748.tag) {
+                    __auto_type _mv_748 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_748.has_value) {
+                        __auto_type head = _mv_748.value;
+                        __auto_type _mv_749 = (*head);
+                        switch (_mv_749.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_748.data.sym;
+                                __auto_type sym = _mv_749.data.sym;
                                 return string_eq(sym.name, SLOP_STR("deref"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_747.has_value) {
+                    } else if (!_mv_748.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1933,18 +1933,18 @@ uint8_t match_is_deref_inline(types_SExpr* expr) {
 
 slop_string match_get_deref_inner_inline(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_749 = (*expr);
-    switch (_mv_749.tag) {
+    __auto_type _mv_750 = (*expr);
+    switch (_mv_750.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_749.data.lst;
+            __auto_type lst = _mv_750.data.lst;
             {
                 __auto_type items = lst.items;
-                __auto_type _mv_750 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_750.has_value) {
-                    __auto_type inner = _mv_750.value;
+                __auto_type _mv_751 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_751.has_value) {
+                    __auto_type inner = _mv_751.value;
                     return expr_transpile_expr(ctx, inner);
-                } else if (!_mv_750.has_value) {
+                } else if (!_mv_751.has_value) {
                     return SLOP_STR("/* missing deref arg */");
                 }
                 SLOP_UNREACHABLE();
@@ -1961,11 +1961,11 @@ slop_string match_get_field_name_inline(context_TranspileContext* ctx, types_SEx
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_751 = (*expr);
-        switch (_mv_751.tag) {
+        __auto_type _mv_752 = (*expr);
+        switch (_mv_752.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_751.data.sym;
+                __auto_type sym = _mv_752.data.sym;
                 return ctype_to_c_name(arena, sym.name);
             }
             default: {
@@ -1983,14 +1983,14 @@ void match_emit_inline_when(context_TranspileContext* ctx, slop_list_types_SExpr
         if (len < 2) {
             context_ctx_add_error_at(ctx, SLOP_STR("invalid when"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         } else {
-            __auto_type _mv_752 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_752.has_value) {
-                __auto_type cond_expr = _mv_752.value;
+            __auto_type _mv_753 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_753.has_value) {
+                __auto_type cond_expr = _mv_753.value;
                 {
                     __auto_type cond_c = context_ctx_strip_cond_parens(ctx, expr_transpile_expr(ctx, cond_expr));
                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("if ("), cond_c, SLOP_STR(") {")));
                 }
-            } else if (!_mv_752.has_value) {
+            } else if (!_mv_753.has_value) {
                 context_ctx_emit(ctx, SLOP_STR("if (/* missing */) {"));
             }
             context_ctx_indent(ctx);
@@ -2010,28 +2010,28 @@ void match_emit_inline_cond(context_TranspileContext* ctx, slop_list_types_SExpr
         uint8_t first = 1;
         uint8_t has_else = 0;
         while (i < len) {
-            __auto_type _mv_753 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_753.has_value) {
-                __auto_type clause_expr = _mv_753.value;
-                __auto_type _mv_754 = (*clause_expr);
-                switch (_mv_754.tag) {
+            __auto_type _mv_754 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_754.has_value) {
+                __auto_type clause_expr = _mv_754.value;
+                __auto_type _mv_755 = (*clause_expr);
+                switch (_mv_755.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type clause_lst = _mv_754.data.lst;
+                        __auto_type clause_lst = _mv_755.data.lst;
                         {
                             __auto_type clause_items = clause_lst.items;
                             __auto_type clause_len = ((int64_t)((clause_items).len));
                             if (clause_len < 1) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("invalid cond clause"), context_ctx_sexpr_line(clause_expr), context_ctx_sexpr_col(clause_expr));
                             } else {
-                                __auto_type _mv_755 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_755.has_value) {
-                                    __auto_type test_expr = _mv_755.value;
-                                    __auto_type _mv_756 = (*test_expr);
-                                    switch (_mv_756.tag) {
+                                __auto_type _mv_756 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_756.has_value) {
+                                    __auto_type test_expr = _mv_756.value;
+                                    __auto_type _mv_757 = (*test_expr);
+                                    switch (_mv_757.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_756.data.sym;
+                                            __auto_type sym = _mv_757.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("else"))) {
                                                 has_else = 1;
                                                 context_ctx_emit(ctx, SLOP_STR("} else {"));
@@ -2070,7 +2070,7 @@ void match_emit_inline_cond(context_TranspileContext* ctx, slop_list_types_SExpr
                                             break;
                                         }
                                     }
-                                } else if (!_mv_755.has_value) {
+                                } else if (!_mv_756.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing test"), context_ctx_sexpr_line(clause_expr), context_ctx_sexpr_col(clause_expr));
                                 }
                             }
@@ -2082,7 +2082,7 @@ void match_emit_inline_cond(context_TranspileContext* ctx, slop_list_types_SExpr
                         break;
                     }
                 }
-            } else if (!_mv_753.has_value) {
+            } else if (!_mv_754.has_value) {
             }
             i = (i + 1);
         }
@@ -2099,14 +2099,14 @@ void match_emit_inline_cond_body(context_TranspileContext* ctx, slop_list_types_
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_757 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_757.has_value) {
-                __auto_type body_expr = _mv_757.value;
+            __auto_type _mv_758 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_758.has_value) {
+                __auto_type body_expr = _mv_758.value;
                 {
                     __auto_type body_is_last = (i == (len - 1));
                     match_emit_branch_body_item(ctx, body_expr, is_return, (is_last && body_is_last));
                 }
-            } else if (!_mv_757.has_value) {
+            } else if (!_mv_758.has_value) {
             }
             i = (i + 1);
         }
@@ -2126,41 +2126,42 @@ void match_emit_inline_with_arena(context_TranspileContext* ctx, slop_list_types
                 __auto_type arena_name = ((is_named) ? ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type name_expr = _mv.value; parser_sexpr_get_symbol_name(name_expr); }) : (SLOP_STR("arena")); }) : SLOP_STR("arena"));
                 __auto_type size_idx = ((is_named) ? 3 : 1);
                 __auto_type body_start = ((is_named) ? 4 : 2);
-                __auto_type c_local = ((is_named) ? string_concat(ctx_arena, SLOP_STR("_arena_"), arena_name) : SLOP_STR("_arena"));
+                __auto_type c_arena_name = ctype_to_c_name(ctx_arena, arena_name);
+                __auto_type c_local = ((is_named) ? string_concat(ctx_arena, SLOP_STR("_arena_"), c_arena_name) : SLOP_STR("_arena"));
                 if (is_named && (len < 4)) {
                     context_ctx_add_error_at(ctx, SLOP_STR("with-arena :as requires name and size"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                 } else {
                     context_ctx_emit(ctx, SLOP_STR("{"));
                     context_ctx_indent(ctx);
                     context_ctx_push_scope(ctx);
-                    __auto_type _mv_758 = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_758.has_value) {
-                        __auto_type size_expr = _mv_758.value;
+                    __auto_type _mv_759 = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_759.has_value) {
+                        __auto_type size_expr = _mv_759.value;
                         {
                             __auto_type size_c = expr_transpile_expr(ctx, size_expr);
                             context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("slop_arena "), c_local, SLOP_STR(" = slop_arena_new("), size_c, SLOP_STR(");")));
-                            context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("slop_arena* "), arena_name, SLOP_STR(" = &"), c_local, SLOP_STR(";")));
+                            context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("slop_arena* "), c_arena_name, SLOP_STR(" = &"), c_local, SLOP_STR(";")));
                         }
-                    } else if (!_mv_758.has_value) {
+                    } else if (!_mv_759.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing size"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     }
-                    context_ctx_bind_var(ctx, (context_VarEntry){arena_name, arena_name, SLOP_STR("slop_arena*"), SLOP_STR(""), 1, 0, 0, SLOP_STR(""), SLOP_STR("")});
+                    context_ctx_bind_var(ctx, (context_VarEntry){arena_name, c_arena_name, SLOP_STR("slop_arena*"), SLOP_STR(""), 1, 0, 0, SLOP_STR(""), SLOP_STR("")});
                     {
                         int64_t i = body_start;
                         while (i < len) {
-                            __auto_type _mv_759 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_759.has_value) {
-                                __auto_type body_expr = _mv_759.value;
+                            __auto_type _mv_760 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_760.has_value) {
+                                __auto_type body_expr = _mv_760.value;
                                 {
                                     __auto_type is_last = (i == (len - 1));
                                     match_emit_branch_body_item(ctx, body_expr, (is_return && is_last), is_last);
                                 }
-                            } else if (!_mv_759.has_value) {
+                            } else if (!_mv_760.has_value) {
                             }
                             i = (i + 1);
                         }
                     }
-                    context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), arena_name, SLOP_STR(");")));
+                    context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), c_arena_name, SLOP_STR(");")));
                     context_ctx_pop_scope(ctx);
                     context_ctx_dedent(ctx);
                     context_ctx_emit(ctx, SLOP_STR("}"));
@@ -2176,11 +2177,11 @@ void match_emit_inline_body_items(context_TranspileContext* ctx, slop_list_types
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_760 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_760.has_value) {
-                __auto_type body_expr = _mv_760.value;
+            __auto_type _mv_761 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_761.has_value) {
+                __auto_type body_expr = _mv_761.value;
                 match_emit_branch_body_item(ctx, body_expr, 0, 0);
-            } else if (!_mv_760.has_value) {
+            } else if (!_mv_761.has_value) {
             }
             i = (i + 1);
         }
@@ -2195,36 +2196,36 @@ void match_emit_inline_for(context_TranspileContext* ctx, slop_list_types_SExpr_
         if (len < 2) {
             context_ctx_add_error_at(ctx, SLOP_STR("invalid for: need binding"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         } else {
-            __auto_type _mv_761 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_761.has_value) {
-                __auto_type binding_expr = _mv_761.value;
-                __auto_type _mv_762 = (*binding_expr);
-                switch (_mv_762.tag) {
+            __auto_type _mv_762 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_762.has_value) {
+                __auto_type binding_expr = _mv_762.value;
+                __auto_type _mv_763 = (*binding_expr);
+                switch (_mv_763.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type binding_lst = _mv_762.data.lst;
+                        __auto_type binding_lst = _mv_763.data.lst;
                         {
                             __auto_type binding_items = binding_lst.items;
                             __auto_type binding_len = ((int64_t)((binding_items).len));
                             if (binding_len < 3) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("for binding needs (var start end)"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                             } else {
-                                __auto_type _mv_763 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_763.has_value) {
-                                    __auto_type var_expr = _mv_763.value;
-                                    __auto_type _mv_764 = (*var_expr);
-                                    switch (_mv_764.tag) {
+                                __auto_type _mv_764 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_764.has_value) {
+                                    __auto_type var_expr = _mv_764.value;
+                                    __auto_type _mv_765 = (*var_expr);
+                                    switch (_mv_765.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type var_sym = _mv_764.data.sym;
+                                            __auto_type var_sym = _mv_765.data.sym;
                                             {
                                                 __auto_type var_name = ctype_to_c_name(arena, var_sym.name);
-                                                __auto_type _mv_765 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_765.has_value) {
-                                                    __auto_type start_expr = _mv_765.value;
-                                                    __auto_type _mv_766 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_766.has_value) {
-                                                        __auto_type end_expr = _mv_766.value;
+                                                __auto_type _mv_766 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_766.has_value) {
+                                                    __auto_type start_expr = _mv_766.value;
+                                                    __auto_type _mv_767 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_767.has_value) {
+                                                        __auto_type end_expr = _mv_767.value;
                                                         {
                                                             __auto_type start_c = expr_transpile_expr(ctx, start_expr);
                                                             __auto_type end_c = expr_transpile_expr(ctx, end_expr);
@@ -2237,10 +2238,10 @@ void match_emit_inline_for(context_TranspileContext* ctx, slop_list_types_SExpr_
                                                             context_ctx_dedent(ctx);
                                                             context_ctx_emit(ctx, SLOP_STR("}"));
                                                         }
-                                                    } else if (!_mv_766.has_value) {
+                                                    } else if (!_mv_767.has_value) {
                                                         context_ctx_add_error_at(ctx, SLOP_STR("missing end"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                                     }
-                                                } else if (!_mv_765.has_value) {
+                                                } else if (!_mv_766.has_value) {
                                                     context_ctx_add_error_at(ctx, SLOP_STR("missing start"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                                 }
                                             }
@@ -2251,7 +2252,7 @@ void match_emit_inline_for(context_TranspileContext* ctx, slop_list_types_SExpr_
                                             break;
                                         }
                                     }
-                                } else if (!_mv_763.has_value) {
+                                } else if (!_mv_764.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing var"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                 }
                             }
@@ -2263,7 +2264,7 @@ void match_emit_inline_for(context_TranspileContext* ctx, slop_list_types_SExpr_
                         break;
                     }
                 }
-            } else if (!_mv_761.has_value) {
+            } else if (!_mv_762.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing binding"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             }
         }
@@ -2338,38 +2339,38 @@ void match_emit_inline_for_each_map_kv(context_TranspileContext* ctx, slop_list_
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_767 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_767.has_value) {
-            __auto_type kv_list_expr = _mv_767.value;
-            __auto_type _mv_768 = (*kv_list_expr);
-            switch (_mv_768.tag) {
+        __auto_type _mv_768 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_768.has_value) {
+            __auto_type kv_list_expr = _mv_768.value;
+            __auto_type _mv_769 = (*kv_list_expr);
+            switch (_mv_769.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type kv_lst = _mv_768.data.lst;
+                    __auto_type kv_lst = _mv_769.data.lst;
                     {
                         __auto_type kv_items = kv_lst.items;
                         if (((int64_t)((kv_items).len)) < 2) {
                             context_ctx_add_error(ctx, SLOP_STR("Map for-each needs ((k v) map)"));
                         } else {
-                            __auto_type _mv_769 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_769.has_value) {
-                                __auto_type k_expr = _mv_769.value;
-                                __auto_type _mv_770 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_770.has_value) {
-                                    __auto_type v_expr = _mv_770.value;
-                                    __auto_type _mv_771 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_771.has_value) {
-                                        __auto_type map_expr = _mv_771.value;
-                                        __auto_type _mv_772 = (*k_expr);
-                                        switch (_mv_772.tag) {
+                            __auto_type _mv_770 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_770.has_value) {
+                                __auto_type k_expr = _mv_770.value;
+                                __auto_type _mv_771 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_771.has_value) {
+                                    __auto_type v_expr = _mv_771.value;
+                                    __auto_type _mv_772 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_772.has_value) {
+                                        __auto_type map_expr = _mv_772.value;
+                                        __auto_type _mv_773 = (*k_expr);
+                                        switch (_mv_773.tag) {
                                             case types_SExpr_sym:
                                             {
-                                                __auto_type k_sym = _mv_772.data.sym;
-                                                __auto_type _mv_773 = (*v_expr);
-                                                switch (_mv_773.tag) {
+                                                __auto_type k_sym = _mv_773.data.sym;
+                                                __auto_type _mv_774 = (*v_expr);
+                                                switch (_mv_774.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type v_sym = _mv_773.data.sym;
+                                                        __auto_type v_sym = _mv_774.data.sym;
                                                         {
                                                             __auto_type k_name = ctype_to_c_name(arena, k_sym.name);
                                                             __auto_type v_name = ctype_to_c_name(arena, v_sym.name);
@@ -2425,13 +2426,13 @@ void match_emit_inline_for_each_map_kv(context_TranspileContext* ctx, slop_list_
                                                 break;
                                             }
                                         }
-                                    } else if (!_mv_771.has_value) {
+                                    } else if (!_mv_772.has_value) {
                                         context_ctx_add_error(ctx, SLOP_STR("Missing map expression"));
                                     }
-                                } else if (!_mv_770.has_value) {
+                                } else if (!_mv_771.has_value) {
                                     context_ctx_add_error(ctx, SLOP_STR("Missing value binding"));
                                 }
-                            } else if (!_mv_769.has_value) {
+                            } else if (!_mv_770.has_value) {
                                 context_ctx_add_error(ctx, SLOP_STR("Missing key binding"));
                             }
                         }
@@ -2443,7 +2444,7 @@ void match_emit_inline_for_each_map_kv(context_TranspileContext* ctx, slop_list_
                     break;
                 }
             }
-        } else if (!_mv_767.has_value) {
+        } else if (!_mv_768.has_value) {
             context_ctx_add_error(ctx, SLOP_STR("Missing binding"));
         }
     }
@@ -2457,39 +2458,39 @@ void match_emit_inline_for_each(context_TranspileContext* ctx, slop_list_types_S
         if (len < 2) {
             context_ctx_add_error_at(ctx, SLOP_STR("invalid for-each: need binding"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         } else {
-            __auto_type _mv_774 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_774.has_value) {
-                __auto_type binding_expr = _mv_774.value;
-                __auto_type _mv_775 = (*binding_expr);
-                switch (_mv_775.tag) {
+            __auto_type _mv_775 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_775.has_value) {
+                __auto_type binding_expr = _mv_775.value;
+                __auto_type _mv_776 = (*binding_expr);
+                switch (_mv_776.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type binding_lst = _mv_775.data.lst;
+                        __auto_type binding_lst = _mv_776.data.lst;
                         {
                             __auto_type binding_items = binding_lst.items;
                             __auto_type binding_len = ((int64_t)((binding_items).len));
                             if (binding_len < 2) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("for-each binding needs (var coll)"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                             } else {
-                                __auto_type _mv_776 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_776.has_value) {
-                                    __auto_type first_elem = _mv_776.value;
-                                    __auto_type _mv_777 = (*first_elem);
-                                    switch (_mv_777.tag) {
+                                __auto_type _mv_777 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_777.has_value) {
+                                    __auto_type first_elem = _mv_777.value;
+                                    __auto_type _mv_778 = (*first_elem);
+                                    switch (_mv_778.tag) {
                                         case types_SExpr_lst:
                                         {
-                                            __auto_type _ = _mv_777.data.lst;
+                                            __auto_type _ = _mv_778.data.lst;
                                             match_emit_inline_for_each_map_kv(ctx, binding_items, items, len);
                                             break;
                                         }
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type var_sym = _mv_777.data.sym;
+                                            __auto_type var_sym = _mv_778.data.sym;
                                             {
                                                 __auto_type var_name = ctype_to_c_name(arena, var_sym.name);
-                                                __auto_type _mv_778 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_778.has_value) {
-                                                    __auto_type coll_expr = _mv_778.value;
+                                                __auto_type _mv_779 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_779.has_value) {
+                                                    __auto_type coll_expr = _mv_779.value;
                                                     {
                                                         __auto_type coll_slop_type = expr_infer_expr_slop_type(ctx, coll_expr);
                                                         __auto_type resolved_type = expr_resolve_type_alias(ctx, coll_slop_type);
@@ -2528,7 +2529,7 @@ void match_emit_inline_for_each(context_TranspileContext* ctx, slop_list_types_S
                                                             }
                                                         }
                                                     }
-                                                } else if (!_mv_778.has_value) {
+                                                } else if (!_mv_779.has_value) {
                                                     context_ctx_add_error_at(ctx, SLOP_STR("missing collection"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                                 }
                                             }
@@ -2539,7 +2540,7 @@ void match_emit_inline_for_each(context_TranspileContext* ctx, slop_list_types_S
                                             break;
                                         }
                                     }
-                                } else if (!_mv_776.has_value) {
+                                } else if (!_mv_777.has_value) {
                                     context_ctx_add_error_at(ctx, SLOP_STR("missing var"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                 }
                             }
@@ -2551,7 +2552,7 @@ void match_emit_inline_for_each(context_TranspileContext* ctx, slop_list_types_S
                         break;
                     }
                 }
-            } else if (!_mv_774.has_value) {
+            } else if (!_mv_775.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing binding"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
             }
         }
@@ -2565,11 +2566,11 @@ void match_emit_inline_return(context_TranspileContext* ctx, slop_list_types_SEx
         if (len < 2) {
             context_ctx_emit(ctx, SLOP_STR("return;"));
         } else {
-            __auto_type _mv_779 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_779.has_value) {
-                __auto_type val_expr = _mv_779.value;
+            __auto_type _mv_780 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_780.has_value) {
+                __auto_type val_expr = _mv_780.value;
                 match_emit_typed_return_expr(ctx, val_expr);
-            } else if (!_mv_779.has_value) {
+            } else if (!_mv_780.has_value) {
                 context_ctx_emit(ctx, SLOP_STR("return;"));
             }
         }
@@ -2587,61 +2588,61 @@ void match_emit_return_typed(context_TranspileContext* ctx, slop_string code) {
 void match_emit_typed_return_expr(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_780 = (*expr);
-    switch (_mv_780.tag) {
+    __auto_type _mv_781 = (*expr);
+    switch (_mv_781.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_780.data.lst;
+            __auto_type lst = _mv_781.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                 } else {
-                    __auto_type _mv_781 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_781.has_value) {
-                        __auto_type head = _mv_781.value;
-                        __auto_type _mv_782 = (*head);
-                        switch (_mv_782.tag) {
+                    __auto_type _mv_782 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_782.has_value) {
+                        __auto_type head = _mv_782.value;
+                        __auto_type _mv_783 = (*head);
+                        switch (_mv_783.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_782.data.sym;
+                                __auto_type sym = _mv_783.data.sym;
                                 {
                                     __auto_type op = sym.name;
                                     if (string_eq(op, SLOP_STR("some"))) {
-                                        __auto_type _mv_783 = context_ctx_get_current_return_type(ctx);
-                                        if (_mv_783.has_value) {
-                                            __auto_type ret_type = _mv_783.value;
+                                        __auto_type _mv_784 = context_ctx_get_current_return_type(ctx);
+                                        if (_mv_784.has_value) {
+                                            __auto_type ret_type = _mv_784.value;
                                             if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
                                                 if (((int64_t)((items).len)) < 2) {
                                                     match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                                                 } else {
-                                                    __auto_type _mv_784 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_784.has_value) {
-                                                        __auto_type inner_expr = _mv_784.value;
+                                                    __auto_type _mv_785 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_785.has_value) {
+                                                        __auto_type inner_expr = _mv_785.value;
                                                         {
                                                             __auto_type inner_c = expr_transpile_expr(ctx, inner_expr);
                                                             context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("return ("), ret_type, SLOP_STR("){.has_value = 1, .value = "), inner_c, SLOP_STR("};")));
                                                         }
-                                                    } else if (!_mv_784.has_value) {
+                                                    } else if (!_mv_785.has_value) {
                                                         match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                                                     }
                                                 }
                                             } else {
                                                 match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                                             }
-                                        } else if (!_mv_783.has_value) {
+                                        } else if (!_mv_784.has_value) {
                                             match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                                         }
                                     } else if (string_eq(op, SLOP_STR("none"))) {
-                                        __auto_type _mv_785 = context_ctx_get_current_return_type(ctx);
-                                        if (_mv_785.has_value) {
-                                            __auto_type ret_type = _mv_785.value;
+                                        __auto_type _mv_786 = context_ctx_get_current_return_type(ctx);
+                                        if (_mv_786.has_value) {
+                                            __auto_type ret_type = _mv_786.value;
                                             if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
                                                 context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("return ("), ret_type, SLOP_STR("){.has_value = false};")));
                                             } else {
                                                 match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                                             }
-                                        } else if (!_mv_785.has_value) {
+                                        } else if (!_mv_786.has_value) {
                                             match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                                         }
                                     } else {
@@ -2655,7 +2656,7 @@ void match_emit_typed_return_expr(context_TranspileContext* ctx, types_SExpr* ex
                                 break;
                             }
                         }
-                    } else if (!_mv_781.has_value) {
+                    } else if (!_mv_782.has_value) {
                         match_emit_return_typed(ctx, expr_transpile_expr(ctx, expr));
                     }
                 }
@@ -2671,11 +2672,11 @@ void match_emit_typed_return_expr(context_TranspileContext* ctx, types_SExpr* ex
 
 uint8_t match_is_pattern_literal(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_786 = (*expr);
-    switch (_mv_786.tag) {
+    __auto_type _mv_787 = (*expr);
+    switch (_mv_787.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_786.data.sym;
+            __auto_type sym = _mv_787.data.sym;
             {
                 __auto_type name = sym.name;
                 return (string_eq(name, SLOP_STR("true")) || string_eq(name, SLOP_STR("false")));
@@ -2683,7 +2684,7 @@ uint8_t match_is_pattern_literal(types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type _ = _mv_786.data.num;
+            __auto_type _ = _mv_787.data.num;
             return 1;
         }
         default: {
@@ -2694,11 +2695,11 @@ uint8_t match_is_pattern_literal(types_SExpr* expr) {
 
 slop_string match_pattern_literal_to_c(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_787 = (*expr);
-    switch (_mv_787.tag) {
+    __auto_type _mv_788 = (*expr);
+    switch (_mv_788.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_787.data.sym;
+            __auto_type sym = _mv_788.data.sym;
             {
                 __auto_type name = sym.name;
                 if (string_eq(name, SLOP_STR("true"))) {
@@ -2712,7 +2713,7 @@ slop_string match_pattern_literal_to_c(types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type n = _mv_787.data.num;
+            __auto_type n = _mv_788.data.num;
             return n.raw;
         }
         default: {
@@ -2723,24 +2724,24 @@ slop_string match_pattern_literal_to_c(types_SExpr* expr) {
 
 uint8_t match_has_literal_in_union_arm(types_SExpr* pat_expr) {
     SLOP_PRE(((pat_expr != NULL)), "(!= pat-expr nil)");
-    __auto_type _mv_788 = (*pat_expr);
-    switch (_mv_788.tag) {
+    __auto_type _mv_789 = (*pat_expr);
+    switch (_mv_789.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_788.data.lst;
+            __auto_type lst = _mv_789.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type found = 0;
                 for (int64_t i = 1; i < len; i++) {
                     if (!(found)) {
-                        __auto_type _mv_789 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_789.has_value) {
-                            __auto_type item = _mv_789.value;
+                        __auto_type _mv_790 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_790.has_value) {
+                            __auto_type item = _mv_790.value;
                             if (match_is_pattern_literal(item)) {
                                 found = 1;
                             }
-                        } else if (!_mv_789.has_value) {
+                        } else if (!_mv_790.has_value) {
                         }
                     }
                 }
@@ -2759,13 +2760,13 @@ uint8_t match_has_literal_in_patterns(slop_list_types_SExpr_ptr patterns) {
         uint8_t found = 0;
         int64_t i = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_790 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_790.has_value) {
-                __auto_type pat_expr = _mv_790.value;
+            __auto_type _mv_791 = ({ __auto_type _lst = patterns; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_791.has_value) {
+                __auto_type pat_expr = _mv_791.value;
                 if (match_has_literal_in_union_arm(pat_expr)) {
                     found = 1;
                 }
-            } else if (!_mv_790.has_value) {
+            } else if (!_mv_791.has_value) {
             }
             i = (i + 1);
         }
@@ -2778,19 +2779,19 @@ slop_string match_build_literal_guard_cond(context_TranspileContext* ctx, slop_s
     SLOP_PRE(((pattern != NULL)), "(!= pattern nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_791 = (*pattern);
-        switch (_mv_791.tag) {
+        __auto_type _mv_792 = (*pattern);
+        switch (_mv_792.tag) {
             case types_SExpr_lst:
             {
-                __auto_type pat_lst = _mv_791.data.lst;
+                __auto_type pat_lst = _mv_792.data.lst;
                 {
                     __auto_type pat_items = pat_lst.items;
                     __auto_type pat_len = ((int64_t)((pat_items).len));
                     __auto_type cond = tag_cond;
                     for (int64_t bi = 1; bi < pat_len; bi++) {
-                        __auto_type _mv_792 = ({ __auto_type _lst = pat_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_792.has_value) {
-                            __auto_type item = _mv_792.value;
+                        __auto_type _mv_793 = ({ __auto_type _lst = pat_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_793.has_value) {
+                            __auto_type item = _mv_793.value;
                             if (match_is_pattern_literal(item)) {
                                 {
                                     __auto_type lit_c = match_pattern_literal_to_c(item);
@@ -2809,7 +2810,7 @@ slop_string match_build_literal_guard_cond(context_TranspileContext* ctx, slop_s
                                     }
                                 }
                             }
-                        } else if (!_mv_792.has_value) {
+                        } else if (!_mv_793.has_value) {
                         }
                     }
                     return cond;
@@ -2828,18 +2829,18 @@ void match_emit_union_literal_bindings(context_TranspileContext* ctx, slop_strin
     {
         __auto_type arena = (*ctx).arena;
         if (is_multi) {
-            __auto_type _mv_793 = (*pattern);
-            switch (_mv_793.tag) {
+            __auto_type _mv_794 = (*pattern);
+            switch (_mv_794.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type pat_lst = _mv_793.data.lst;
+                    __auto_type pat_lst = _mv_794.data.lst;
                     {
                         __auto_type pat_items = pat_lst.items;
                         __auto_type pat_len = ((int64_t)((pat_items).len));
                         for (int64_t bi = 1; bi < pat_len; bi++) {
-                            __auto_type _mv_794 = ({ __auto_type _lst = pat_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_794.has_value) {
-                                __auto_type binding_expr = _mv_794.value;
+                            __auto_type _mv_795 = ({ __auto_type _lst = pat_items; size_t _idx = (size_t)bi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_795.has_value) {
+                                __auto_type binding_expr = _mv_795.value;
                                 if (!(match_is_pattern_literal(binding_expr))) {
                                     {
                                         __auto_type binding_name = parser_sexpr_get_symbol_name(binding_expr);
@@ -2857,7 +2858,7 @@ void match_emit_union_literal_bindings(context_TranspileContext* ctx, slop_strin
                                         }
                                     }
                                 }
-                            } else if (!_mv_794.has_value) {
+                            } else if (!_mv_795.has_value) {
                             }
                         }
                     }
@@ -2868,9 +2869,9 @@ void match_emit_union_literal_bindings(context_TranspileContext* ctx, slop_strin
                 }
             }
         } else {
-            __auto_type _mv_795 = match_extract_binding_name(pattern);
-            if (_mv_795.has_value) {
-                __auto_type binding_name = _mv_795.value;
+            __auto_type _mv_796 = match_extract_binding_name(pattern);
+            if (_mv_796.has_value) {
+                __auto_type binding_name = _mv_796.value;
                 if ((!(string_eq(binding_name, SLOP_STR("true")))) && (!(string_eq(binding_name, SLOP_STR("false")))) && (!(string_eq(binding_name, SLOP_STR("_"))))) {
                     {
                         __auto_type c_binding = ctype_to_c_name(arena, binding_name);
@@ -2880,7 +2881,7 @@ void match_emit_union_literal_bindings(context_TranspileContext* ctx, slop_strin
                         context_ctx_bind_var(ctx, (context_VarEntry){binding_name, c_binding, payload_c_type, payload_slop_type, 0, 0, 0, SLOP_STR(""), SLOP_STR("")});
                     }
                 }
-            } else if (!_mv_795.has_value) {
+            } else if (!_mv_796.has_value) {
             }
         }
     }
@@ -2895,20 +2896,20 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
         uint8_t first = 1;
         uint8_t has_else = 0;
         while (i < len) {
-            __auto_type _mv_796 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_796.has_value) {
-                __auto_type branch = _mv_796.value;
-                __auto_type _mv_797 = (*branch);
-                switch (_mv_797.tag) {
+            __auto_type _mv_797 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_797.has_value) {
+                __auto_type branch = _mv_797.value;
+                __auto_type _mv_798 = (*branch);
+                switch (_mv_798.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type branch_lst = _mv_797.data.lst;
+                        __auto_type branch_lst = _mv_798.data.lst;
                         {
                             __auto_type branch_items = branch_lst.items;
                             if (((int64_t)((branch_items).len)) >= 2) {
-                                __auto_type _mv_798 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_798.has_value) {
-                                    __auto_type pattern = _mv_798.value;
+                                __auto_type _mv_799 = ({ __auto_type _lst = branch_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_799.has_value) {
+                                    __auto_type pattern = _mv_799.value;
                                     {
                                         __auto_type tag = match_get_pattern_tag(pattern);
                                         if (string_eq(tag, SLOP_STR("else")) || string_eq(tag, SLOP_STR("_"))) {
@@ -2923,9 +2924,9 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
                                             context_ctx_dedent(ctx);
                                             first = 0;
                                         } else {
-                                            __auto_type _mv_799 = context_ctx_lookup_enum_variant(ctx, tag);
-                                            if (_mv_799.has_value) {
-                                                __auto_type union_type_name = _mv_799.value;
+                                            __auto_type _mv_800 = context_ctx_lookup_enum_variant(ctx, tag);
+                                            if (_mv_800.has_value) {
+                                                __auto_type union_type_name = _mv_800.value;
                                                 {
                                                     __auto_type c_tag = ctype_to_c_name(arena, tag);
                                                     __auto_type tag_cond = context_ctx_str5(ctx, scrutinee_c, SLOP_STR(".tag == "), union_type_name, SLOP_STR("_"), c_tag);
@@ -2946,12 +2947,12 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
                                                     context_ctx_dedent(ctx);
                                                     first = 0;
                                                 }
-                                            } else if (!_mv_799.has_value) {
+                                            } else if (!_mv_800.has_value) {
                                                 context_ctx_add_error(ctx, context_ctx_str3(ctx, SLOP_STR("unknown union variant in match: "), tag, SLOP_STR(" (not registered as enum variant)")));
                                             }
                                         }
                                     }
-                                } else if (!_mv_798.has_value) {
+                                } else if (!_mv_799.has_value) {
                                 }
                             }
                         }
@@ -2961,7 +2962,7 @@ void match_transpile_union_match_with_literals(context_TranspileContext* ctx, sl
                         break;
                     }
                 }
-            } else if (!_mv_796.has_value) {
+            } else if (!_mv_797.has_value) {
             }
             i = (i + 1);
         }

--- a/bootstrap/transpiler/slop_parser.c
+++ b/bootstrap/transpiler/slop_parser.c
@@ -346,15 +346,15 @@ slop_result_list_parser_Token_parser_ParseError parser_tokenize(slop_arena* aren
         uint8_t has_error = 0;
         __auto_type error_val = (parser_ParseError){SLOP_STR(""), 0, 0};
         while (!(done) && !(has_error)) {
-            __auto_type _mv_610 = parser_lexer_next_token(arena, (&state));
-            if (_mv_610.is_ok) {
-                __auto_type tok = _mv_610.data.ok;
+            __auto_type _mv_611 = parser_lexer_next_token(arena, (&state));
+            if (_mv_611.is_ok) {
+                __auto_type tok = _mv_611.data.ok;
                 ({ __auto_type _lst_p = &(tokens); __auto_type _item = (tok); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                 if (tok.kind == parser_TokenType_tok_eof) {
                     done = 1;
                 }
-            } else if (!_mv_610.is_ok) {
-                __auto_type e = _mv_610.data.err;
+            } else if (!_mv_611.is_ok) {
+                __auto_type e = _mv_611.data.err;
                 has_error = 1;
                 error_val = e;
             }
@@ -376,11 +376,11 @@ uint8_t parser_parser_at_end(parser_ParserState* state) {
 }
 
 parser_Token parser_parser_peek(parser_ParserState* state) {
-    __auto_type _mv_611 = ({ __auto_type _lst = (*state).tokens; size_t _idx = (size_t)(*state).pos; slop_option_parser_Token _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-    if (_mv_611.has_value) {
-        __auto_type tok = _mv_611.value;
+    __auto_type _mv_612 = ({ __auto_type _lst = (*state).tokens; size_t _idx = (size_t)(*state).pos; slop_option_parser_Token _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+    if (_mv_612.has_value) {
+        __auto_type tok = _mv_612.value;
         return tok;
-    } else if (!_mv_611.has_value) {
+    } else if (!_mv_612.has_value) {
         return (parser_Token){parser_TokenType_tok_eof, SLOP_STR(""), 1, 1};
     }
     SLOP_UNREACHABLE();
@@ -431,9 +431,9 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_expr(slop_arena* aren
             }
         } else if (tok.kind == parser_TokenType_tok_quote) {
             parser_parser_advance(state);
-            __auto_type _mv_612 = parser_parse_expr(arena, state);
-            if (_mv_612.is_ok) {
-                __auto_type quoted_expr = _mv_612.data.ok;
+            __auto_type _mv_613 = parser_parse_expr(arena, state);
+            if (_mv_613.is_ok) {
+                __auto_type quoted_expr = _mv_613.data.ok;
                 {
                     __auto_type node = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                     __auto_type quote_sym = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
@@ -444,8 +444,8 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_expr(slop_arena* aren
                     (*node) = ((types_SExpr){ .tag = types_SExpr_lst, .data.lst = (types_SExprList){items, tok.line, tok.col, ((slop_option_types_ResolvedType_ptr){.has_value = false})} });
                     return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = node });
                 }
-            } else if (!_mv_612.is_ok) {
-                __auto_type e = _mv_612.data.err;
+            } else if (!_mv_613.is_ok) {
+                __auto_type e = _mv_613.data.err;
                 return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
             }
             SLOP_UNREACHABLE();
@@ -521,12 +521,12 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_list(slop_arena* aren
                         has_error = 1;
                         error_val = (parser_ParseError){SLOP_STR("Unterminated list"), start_tok.line, start_tok.col};
                     } else {
-                        __auto_type _mv_613 = parser_parse_expr(arena, state);
-                        if (_mv_613.is_ok) {
-                            __auto_type expr = _mv_613.data.ok;
+                        __auto_type _mv_614 = parser_parse_expr(arena, state);
+                        if (_mv_614.is_ok) {
+                            __auto_type expr = _mv_614.data.ok;
                             ({ __auto_type _lst_p = &(items); __auto_type _item = (expr); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                        } else if (!_mv_613.is_ok) {
-                            __auto_type e = _mv_613.data.err;
+                        } else if (!_mv_614.is_ok) {
+                            __auto_type e = _mv_614.data.err;
                             has_error = 1;
                             error_val = e;
                         }
@@ -580,18 +580,18 @@ int64_t parser_get_precedence(slop_string op) {
 
 slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_paren_group(slop_arena* arena, parser_ParserState* state) {
     parser_parser_advance(state);
-    __auto_type _mv_614 = parser_parse_infix_prec(arena, state, 0);
-    if (!_mv_614.is_ok) {
-        __auto_type e = _mv_614.data.err;
+    __auto_type _mv_615 = parser_parse_infix_prec(arena, state, 0);
+    if (!_mv_615.is_ok) {
+        __auto_type e = _mv_615.data.err;
         return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-    } else if (_mv_614.is_ok) {
-        __auto_type expr = _mv_614.data.ok;
-        __auto_type _mv_615 = parser_parser_expect(state, parser_TokenType_tok_rparen);
-        if (!_mv_615.is_ok) {
-            __auto_type e = _mv_615.data.err;
+    } else if (_mv_615.is_ok) {
+        __auto_type expr = _mv_615.data.ok;
+        __auto_type _mv_616 = parser_parser_expect(state, parser_TokenType_tok_rparen);
+        if (!_mv_616.is_ok) {
+            __auto_type e = _mv_616.data.err;
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-        } else if (_mv_615.is_ok) {
-            __auto_type _ = _mv_615.data.ok;
+        } else if (_mv_616.is_ok) {
+            __auto_type _ = _mv_616.data.ok;
             return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = expr });
         }
         SLOP_UNREACHABLE();
@@ -616,12 +616,12 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
         } else if (tok.kind == parser_TokenType_tok_symbol) {
             if (string_eq(tok.value, SLOP_STR("not"))) {
                 parser_parser_advance(state);
-                __auto_type _mv_616 = parser_parse_infix_primary(arena, state);
-                if (!_mv_616.is_ok) {
-                    __auto_type e = _mv_616.data.err;
+                __auto_type _mv_617 = parser_parse_infix_primary(arena, state);
+                if (!_mv_617.is_ok) {
+                    __auto_type e = _mv_617.data.err;
                     return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-                } else if (_mv_616.is_ok) {
-                    __auto_type operand = _mv_616.data.ok;
+                } else if (_mv_617.is_ok) {
+                    __auto_type operand = _mv_617.data.ok;
                     {
                         __auto_type node = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                         __auto_type not_sym = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
@@ -644,12 +644,12 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
             }
         } else if ((tok.kind == parser_TokenType_tok_operator) && string_eq(tok.value, SLOP_STR("-"))) {
             parser_parser_advance(state);
-            __auto_type _mv_617 = parser_parse_infix_primary(arena, state);
-            if (!_mv_617.is_ok) {
-                __auto_type e = _mv_617.data.err;
+            __auto_type _mv_618 = parser_parse_infix_primary(arena, state);
+            if (!_mv_618.is_ok) {
+                __auto_type e = _mv_618.data.err;
                 return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-            } else if (_mv_617.is_ok) {
-                __auto_type operand = _mv_617.data.ok;
+            } else if (_mv_618.is_ok) {
+                __auto_type operand = _mv_618.data.ok;
                 {
                     __auto_type node = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                     __auto_type minus_sym = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
@@ -671,13 +671,13 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
             {
                 __auto_type saved_pos = (*state).pos;
                 parser_parser_advance(state);
-                __auto_type _mv_618 = parser_parse_infix_primary(arena, state);
-                if (!_mv_618.is_ok) {
-                    __auto_type _ = _mv_618.data.err;
+                __auto_type _mv_619 = parser_parse_infix_primary(arena, state);
+                if (!_mv_619.is_ok) {
+                    __auto_type _ = _mv_619.data.err;
                     (*state).pos = saved_pos;
                     return parser_parse_list(arena, state);
-                } else if (_mv_618.is_ok) {
-                    __auto_type _ = _mv_618.data.ok;
+                } else if (_mv_619.is_ok) {
+                    __auto_type _ = _mv_619.data.ok;
                     {
                         __auto_type next_tok = parser_parser_peek(state);
                         if ((next_tok.kind == parser_TokenType_tok_operator) || ((next_tok.kind == parser_TokenType_tok_symbol) && (string_eq(next_tok.value, SLOP_STR("and")) || string_eq(next_tok.value, SLOP_STR("or"))))) {
@@ -693,12 +693,12 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
             }
         } else if (tok.kind == parser_TokenType_tok_quote) {
             parser_parser_advance(state);
-            __auto_type _mv_619 = parser_parse_infix_primary(arena, state);
-            if (!_mv_619.is_ok) {
-                __auto_type e = _mv_619.data.err;
+            __auto_type _mv_620 = parser_parse_infix_primary(arena, state);
+            if (!_mv_620.is_ok) {
+                __auto_type e = _mv_620.data.err;
                 return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-            } else if (_mv_619.is_ok) {
-                __auto_type quoted_expr = _mv_619.data.ok;
+            } else if (_mv_620.is_ok) {
+                __auto_type quoted_expr = _mv_620.data.ok;
                 {
                     __auto_type node = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                     __auto_type quote_sym = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
@@ -718,12 +718,12 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_primary(slop_ar
 }
 
 slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_prec(slop_arena* arena, parser_ParserState* state, int64_t min_prec) {
-    __auto_type _mv_620 = parser_parse_infix_primary(arena, state);
-    if (!_mv_620.is_ok) {
-        __auto_type e = _mv_620.data.err;
+    __auto_type _mv_621 = parser_parse_infix_primary(arena, state);
+    if (!_mv_621.is_ok) {
+        __auto_type e = _mv_621.data.err;
         return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-    } else if (_mv_620.is_ok) {
-        __auto_type left = _mv_620.data.ok;
+    } else if (_mv_621.is_ok) {
+        __auto_type left = _mv_621.data.ok;
         {
             __auto_type result = left;
             __auto_type done = 0;
@@ -741,13 +741,13 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix_prec(slop_arena
                                 {
                                     __auto_type op_tok = tok;
                                     parser_parser_advance(state);
-                                    __auto_type _mv_621 = parser_parse_infix_prec(arena, state, (op_prec + 1));
-                                    if (!_mv_621.is_ok) {
-                                        __auto_type e = _mv_621.data.err;
+                                    __auto_type _mv_622 = parser_parse_infix_prec(arena, state, (op_prec + 1));
+                                    if (!_mv_622.is_ok) {
+                                        __auto_type e = _mv_622.data.err;
                                         has_error = 1;
                                         error_val = e;
-                                    } else if (_mv_621.is_ok) {
-                                        __auto_type right = _mv_621.data.ok;
+                                    } else if (_mv_622.is_ok) {
+                                        __auto_type right = _mv_622.data.ok;
                                         {
                                             __auto_type node = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                                             __auto_type op_sym = ((types_SExpr*)(({ __auto_type _alloc = (types_SExpr*)slop_arena_alloc(arena, sizeof(types_SExpr)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
@@ -787,12 +787,12 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix(slop_arena* are
         {
             __auto_type result = parser_parse_infix_prec(arena, state, 0);
             (*state).in_infix = 0;
-            __auto_type _mv_622 = result;
-            if (!_mv_622.is_ok) {
-                __auto_type e = _mv_622.data.err;
+            __auto_type _mv_623 = result;
+            if (!_mv_623.is_ok) {
+                __auto_type e = _mv_623.data.err;
                 return ((slop_result_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
-            } else if (_mv_622.is_ok) {
-                __auto_type expr = _mv_622.data.ok;
+            } else if (_mv_623.is_ok) {
+                __auto_type expr = _mv_623.data.ok;
                 {
                     __auto_type tok = parser_parser_peek(state);
                     if (tok.kind == parser_TokenType_tok_rbrace) {
@@ -809,9 +809,9 @@ slop_result_types_SExpr_ptr_parser_ParseError parser_parse_infix(slop_arena* are
 }
 
 slop_result_list_types_SExpr_ptr_parser_ParseError parser_parse(slop_arena* arena, slop_string source) {
-    __auto_type _mv_623 = parser_tokenize(arena, source);
-    if (_mv_623.is_ok) {
-        __auto_type tokens = _mv_623.data.ok;
+    __auto_type _mv_624 = parser_tokenize(arena, source);
+    if (_mv_624.is_ok) {
+        __auto_type tokens = _mv_624.data.ok;
         {
             __auto_type state = parser_parser_new(tokens);
             __auto_type result = ((slop_list_types_SExpr_ptr){ .data = (types_SExpr**)slop_arena_alloc(arena, 16 * sizeof(types_SExpr*)), .len = 0, .cap = 16 });
@@ -824,12 +824,12 @@ slop_result_list_types_SExpr_ptr_parser_ParseError parser_parse(slop_arena* aren
                     if (tok.kind == parser_TokenType_tok_eof) {
                         done = 1;
                     } else {
-                        __auto_type _mv_624 = parser_parse_expr(arena, (&state));
-                        if (_mv_624.is_ok) {
-                            __auto_type expr = _mv_624.data.ok;
+                        __auto_type _mv_625 = parser_parse_expr(arena, (&state));
+                        if (_mv_625.is_ok) {
+                            __auto_type expr = _mv_625.data.ok;
                             ({ __auto_type _lst_p = &(result); __auto_type _item = (expr); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                        } else if (!_mv_624.is_ok) {
-                            __auto_type e = _mv_624.data.err;
+                        } else if (!_mv_625.is_ok) {
+                            __auto_type e = _mv_625.data.err;
                             has_error = 1;
                             error_val = e;
                         }
@@ -842,34 +842,34 @@ slop_result_list_types_SExpr_ptr_parser_ParseError parser_parse(slop_arena* aren
                 return ((slop_result_list_types_SExpr_ptr_parser_ParseError){ .is_ok = true, .data.ok = result });
             }
         }
-    } else if (!_mv_623.is_ok) {
-        __auto_type e = _mv_623.data.err;
+    } else if (!_mv_624.is_ok) {
+        __auto_type e = _mv_624.data.err;
         return ((slop_result_list_types_SExpr_ptr_parser_ParseError){ .is_ok = false, .data.err = e });
     }
     SLOP_UNREACHABLE();
 }
 
 int64_t parser_sexpr_line(types_SExpr* expr) {
-    __auto_type _mv_625 = (*expr);
-    switch (_mv_625.tag) {
+    __auto_type _mv_626 = (*expr);
+    switch (_mv_626.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_625.data.sym;
+            __auto_type s = _mv_626.data.sym;
             return s.line;
         }
         case types_SExpr_str:
         {
-            __auto_type s = _mv_625.data.str;
+            __auto_type s = _mv_626.data.str;
             return s.line;
         }
         case types_SExpr_num:
         {
-            __auto_type n = _mv_625.data.num;
+            __auto_type n = _mv_626.data.num;
             return n.line;
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_625.data.lst;
+            __auto_type l = _mv_626.data.lst;
             return l.line;
         }
     }
@@ -877,26 +877,26 @@ int64_t parser_sexpr_line(types_SExpr* expr) {
 }
 
 int64_t parser_sexpr_col(types_SExpr* expr) {
-    __auto_type _mv_626 = (*expr);
-    switch (_mv_626.tag) {
+    __auto_type _mv_627 = (*expr);
+    switch (_mv_627.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_626.data.sym;
+            __auto_type s = _mv_627.data.sym;
             return s.col;
         }
         case types_SExpr_str:
         {
-            __auto_type s = _mv_626.data.str;
+            __auto_type s = _mv_627.data.str;
             return s.col;
         }
         case types_SExpr_num:
         {
-            __auto_type n = _mv_626.data.num;
+            __auto_type n = _mv_627.data.num;
             return n.col;
         }
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_626.data.lst;
+            __auto_type l = _mv_627.data.lst;
             return l.col;
         }
     }
@@ -904,11 +904,11 @@ int64_t parser_sexpr_col(types_SExpr* expr) {
 }
 
 uint8_t parser_sexpr_is_symbol_with_name(types_SExpr* expr, slop_string name) {
-    __auto_type _mv_627 = (*expr);
-    switch (_mv_627.tag) {
+    __auto_type _mv_628 = (*expr);
+    switch (_mv_628.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_627.data.sym;
+            __auto_type sym = _mv_628.data.sym;
             return string_eq(sym.name, name);
         }
         default: {
@@ -918,19 +918,19 @@ uint8_t parser_sexpr_is_symbol_with_name(types_SExpr* expr, slop_string name) {
 }
 
 uint8_t parser_is_form(types_SExpr* expr, slop_string keyword) {
-    __auto_type _mv_628 = (*expr);
-    switch (_mv_628.tag) {
+    __auto_type _mv_629 = (*expr);
+    switch (_mv_629.tag) {
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_628.data.lst;
+            __auto_type l = _mv_629.data.lst;
             if (((int64_t)((l.items).len)) == 0) {
                 return 0;
             } else {
-                __auto_type _mv_629 = ({ __auto_type _lst = l.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_629.has_value) {
-                    __auto_type first = _mv_629.value;
+                __auto_type _mv_630 = ({ __auto_type _lst = l.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_630.has_value) {
+                    __auto_type first = _mv_630.value;
                     return parser_sexpr_is_symbol_with_name(first, keyword);
-                } else if (!_mv_629.has_value) {
+                } else if (!_mv_630.has_value) {
                     return 0;
                 }
                 SLOP_UNREACHABLE();
@@ -943,11 +943,11 @@ uint8_t parser_is_form(types_SExpr* expr, slop_string keyword) {
 }
 
 int64_t parser_sexpr_list_len(types_SExpr* expr) {
-    __auto_type _mv_630 = (*expr);
-    switch (_mv_630.tag) {
+    __auto_type _mv_631 = (*expr);
+    switch (_mv_631.tag) {
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_630.data.lst;
+            __auto_type l = _mv_631.data.lst;
             return ((int64_t)((l.items).len));
         }
         default: {
@@ -957,11 +957,11 @@ int64_t parser_sexpr_list_len(types_SExpr* expr) {
 }
 
 slop_option_types_SExpr_ptr parser_sexpr_list_get(types_SExpr* expr, int64_t index) {
-    __auto_type _mv_631 = (*expr);
-    switch (_mv_631.tag) {
+    __auto_type _mv_632 = (*expr);
+    switch (_mv_632.tag) {
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_631.data.lst;
+            __auto_type l = _mv_632.data.lst;
             return ({ __auto_type _lst = l.items; size_t _idx = (size_t)index; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
         }
         default: {
@@ -971,11 +971,11 @@ slop_option_types_SExpr_ptr parser_sexpr_list_get(types_SExpr* expr, int64_t ind
 }
 
 uint8_t parser_sexpr_is_list(types_SExpr* expr) {
-    __auto_type _mv_632 = (*expr);
-    switch (_mv_632.tag) {
+    __auto_type _mv_633 = (*expr);
+    switch (_mv_633.tag) {
         case types_SExpr_lst:
         {
-            __auto_type l = _mv_632.data.lst;
+            __auto_type l = _mv_633.data.lst;
             return 1;
         }
         default: {
@@ -985,11 +985,11 @@ uint8_t parser_sexpr_is_list(types_SExpr* expr) {
 }
 
 slop_string parser_sexpr_get_symbol_name(types_SExpr* expr) {
-    __auto_type _mv_633 = (*expr);
-    switch (_mv_633.tag) {
+    __auto_type _mv_634 = (*expr);
+    switch (_mv_634.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_633.data.sym;
+            __auto_type sym = _mv_634.data.sym;
             return sym.name;
         }
         default: {
@@ -1003,11 +1003,11 @@ slop_string parser_sexpr_symbol_name(types_SExpr* expr) {
 }
 
 uint8_t parser_sexpr_is_symbol(types_SExpr* expr) {
-    __auto_type _mv_634 = (*expr);
-    switch (_mv_634.tag) {
+    __auto_type _mv_635 = (*expr);
+    switch (_mv_635.tag) {
         case types_SExpr_sym:
         {
-            __auto_type s = _mv_634.data.sym;
+            __auto_type s = _mv_635.data.sym;
             return 1;
         }
         default: {
@@ -1017,11 +1017,11 @@ uint8_t parser_sexpr_is_symbol(types_SExpr* expr) {
 }
 
 uint8_t parser_sexpr_is_number(types_SExpr* expr) {
-    __auto_type _mv_635 = (*expr);
-    switch (_mv_635.tag) {
+    __auto_type _mv_636 = (*expr);
+    switch (_mv_636.tag) {
         case types_SExpr_num:
         {
-            __auto_type n = _mv_635.data.num;
+            __auto_type n = _mv_636.data.num;
             return 1;
         }
         default: {
@@ -1031,11 +1031,11 @@ uint8_t parser_sexpr_is_number(types_SExpr* expr) {
 }
 
 uint8_t parser_sexpr_is_string(types_SExpr* expr) {
-    __auto_type _mv_636 = (*expr);
-    switch (_mv_636.tag) {
+    __auto_type _mv_637 = (*expr);
+    switch (_mv_637.tag) {
         case types_SExpr_str:
         {
-            __auto_type s = _mv_636.data.str;
+            __auto_type s = _mv_637.data.str;
             return 1;
         }
         default: {
@@ -1045,11 +1045,11 @@ uint8_t parser_sexpr_is_string(types_SExpr* expr) {
 }
 
 slop_string parser_sexpr_number_string(types_SExpr* expr) {
-    __auto_type _mv_637 = (*expr);
-    switch (_mv_637.tag) {
+    __auto_type _mv_638 = (*expr);
+    switch (_mv_638.tag) {
         case types_SExpr_num:
         {
-            __auto_type n = _mv_637.data.num;
+            __auto_type n = _mv_638.data.num;
             return n.raw;
         }
         default: {
@@ -1059,11 +1059,11 @@ slop_string parser_sexpr_number_string(types_SExpr* expr) {
 }
 
 slop_string parser_sexpr_string_value(types_SExpr* expr) {
-    __auto_type _mv_638 = (*expr);
-    switch (_mv_638.tag) {
+    __auto_type _mv_639 = (*expr);
+    switch (_mv_639.tag) {
         case types_SExpr_str:
         {
-            __auto_type s = _mv_638.data.str;
+            __auto_type s = _mv_639.data.str;
             return s.value;
         }
         default: {
@@ -1078,34 +1078,34 @@ slop_list_types_SExpr_ptr parser_find_holes(slop_arena* arena, types_SExpr* expr
         if (parser_is_form(expr, SLOP_STR("hole"))) {
             ({ __auto_type _lst_p = &(result); __auto_type _item = (expr); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
         }
-        __auto_type _mv_639 = (*expr);
-        switch (_mv_639.tag) {
+        __auto_type _mv_640 = (*expr);
+        switch (_mv_640.tag) {
             case types_SExpr_lst:
             {
-                __auto_type l = _mv_639.data.lst;
+                __auto_type l = _mv_640.data.lst;
                 {
                     __auto_type items = l.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type i = 0;
                     while (i < len) {
-                        __auto_type _mv_640 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_640.has_value) {
-                            __auto_type child = _mv_640.value;
+                        __auto_type _mv_641 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_641.has_value) {
+                            __auto_type child = _mv_641.value;
                             {
                                 __auto_type child_holes = parser_find_holes(arena, child);
                                 __auto_type child_len = ((int64_t)((child_holes).len));
                                 __auto_type j = 0;
                                 while (j < child_len) {
-                                    __auto_type _mv_641 = ({ __auto_type _lst = child_holes; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_641.has_value) {
-                                        __auto_type h = _mv_641.value;
+                                    __auto_type _mv_642 = ({ __auto_type _lst = child_holes; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_642.has_value) {
+                                        __auto_type h = _mv_642.value;
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (h); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
-                                    } else if (!_mv_641.has_value) {
+                                    } else if (!_mv_642.has_value) {
                                     }
                                     j = (j + 1);
                                 }
                             }
-                        } else if (!_mv_640.has_value) {
+                        } else if (!_mv_641.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -1121,16 +1121,16 @@ slop_list_types_SExpr_ptr parser_find_holes(slop_arena* arena, types_SExpr* expr
 }
 
 slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
-    __auto_type _mv_642 = (*expr);
-    switch (_mv_642.tag) {
+    __auto_type _mv_643 = (*expr);
+    switch (_mv_643.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_642.data.sym;
+            __auto_type sym = _mv_643.data.sym;
             return parser_string_copy(arena, sym.name);
         }
         case types_SExpr_str:
         {
-            __auto_type str = _mv_642.data.str;
+            __auto_type str = _mv_643.data.str;
             {
                 __auto_type val = str.value;
                 __auto_type slen = ((int64_t)(val.len));
@@ -1171,7 +1171,7 @@ slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type num = _mv_642.data.num;
+            __auto_type num = _mv_643.data.num;
             if (num.is_float) {
                 return parser_string_copy(arena, SLOP_STR("<float>"));
             } else {
@@ -1180,7 +1180,7 @@ slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_642.data.lst;
+            __auto_type lst = _mv_643.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
@@ -1191,9 +1191,9 @@ slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
                         __auto_type result = parser_string_copy(arena, SLOP_STR("("));
                         __auto_type i = 0;
                         while (i < len) {
-                            __auto_type _mv_643 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_643.has_value) {
-                                __auto_type child = _mv_643.value;
+                            __auto_type _mv_644 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_644.has_value) {
+                                __auto_type child = _mv_644.value;
                                 {
                                     __auto_type child_str = parser_pretty_print(arena, child);
                                     if (i > 0) {
@@ -1201,7 +1201,7 @@ slop_string parser_pretty_print(slop_arena* arena, types_SExpr* expr) {
                                     }
                                     result = string_concat(arena, result, child_str);
                                 }
-                            } else if (!_mv_643.has_value) {
+                            } else if (!_mv_644.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -1266,9 +1266,9 @@ slop_string parser_json_print_list(slop_arena* arena, slop_list_types_SExpr_ptr 
                 __auto_type result = parser_string_copy(arena, SLOP_STR("["));
                 int64_t i = 0;
                 while (i < len) {
-                    __auto_type _mv_644 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_644.has_value) {
-                        __auto_type child = _mv_644.value;
+                    __auto_type _mv_645 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_645.has_value) {
+                        __auto_type child = _mv_645.value;
                         {
                             __auto_type child_json = parser_json_print(arena, child);
                             if (i > 0) {
@@ -1276,7 +1276,7 @@ slop_string parser_json_print_list(slop_arena* arena, slop_list_types_SExpr_ptr 
                             }
                             result = string_concat(arena, result, child_json);
                         }
-                    } else if (!_mv_644.has_value) {
+                    } else if (!_mv_645.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -1287,11 +1287,11 @@ slop_string parser_json_print_list(slop_arena* arena, slop_list_types_SExpr_ptr 
 }
 
 slop_string parser_json_print(slop_arena* arena, types_SExpr* expr) {
-    __auto_type _mv_645 = (*expr);
-    switch (_mv_645.tag) {
+    __auto_type _mv_646 = (*expr);
+    switch (_mv_646.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_645.data.sym;
+            __auto_type sym = _mv_646.data.sym;
             {
                 __auto_type escaped = parser_json_escape_string(arena, sym.name);
                 __auto_type line_str = int_to_string(arena, sym.line);
@@ -1301,7 +1301,7 @@ slop_string parser_json_print(slop_arena* arena, types_SExpr* expr) {
         }
         case types_SExpr_str:
         {
-            __auto_type str = _mv_645.data.str;
+            __auto_type str = _mv_646.data.str;
             {
                 __auto_type escaped = parser_json_escape_string(arena, str.value);
                 __auto_type line_str = int_to_string(arena, str.line);
@@ -1311,7 +1311,7 @@ slop_string parser_json_print(slop_arena* arena, types_SExpr* expr) {
         }
         case types_SExpr_num:
         {
-            __auto_type num = _mv_645.data.num;
+            __auto_type num = _mv_646.data.num;
             {
                 __auto_type line_str = int_to_string(arena, num.line);
                 __auto_type col_str = int_to_string(arena, num.col);
@@ -1330,7 +1330,7 @@ slop_string parser_json_print(slop_arena* arena, types_SExpr* expr) {
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_645.data.lst;
+            __auto_type lst = _mv_646.data.lst;
             {
                 __auto_type items_json = parser_json_print_list(arena, lst.items);
                 __auto_type line_str = int_to_string(arena, lst.line);

--- a/bootstrap/transpiler/slop_stmt.c
+++ b/bootstrap/transpiler/slop_stmt.c
@@ -38,25 +38,25 @@ void stmt_emit_return_with_typed_none(context_TranspileContext* ctx, slop_string
 
 slop_string stmt_sexpr_to_type_string(slop_arena* arena, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_800 = (*expr);
-    switch (_mv_800.tag) {
+    __auto_type _mv_801 = (*expr);
+    switch (_mv_801.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_800.data.sym;
+            __auto_type sym = _mv_801.data.sym;
             return sym.name;
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_800.data.lst;
+            __auto_type lst = _mv_801.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type result = SLOP_STR("(");
                 __auto_type i = 0;
                 while (i < len) {
-                    __auto_type _mv_801 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_801.has_value) {
-                        __auto_type item_expr = _mv_801.value;
+                    __auto_type _mv_802 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_802.has_value) {
+                        __auto_type item_expr = _mv_802.value;
                         {
                             __auto_type item_str = ctype_sexpr_to_type_string(arena, item_expr);
                             if (i > 0) {
@@ -65,7 +65,7 @@ slop_string stmt_sexpr_to_type_string(slop_arena* arena, types_SExpr* expr) {
                                 result = string_concat(arena, result, item_str);
                             }
                         }
-                    } else if (!_mv_801.has_value) {
+                    } else if (!_mv_802.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -83,39 +83,39 @@ slop_option_string stmt_get_arena_alloc_ptr_type(context_TranspileContext* ctx, 
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_802 = (*expr);
-        switch (_mv_802.tag) {
+        __auto_type _mv_803 = (*expr);
+        switch (_mv_803.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_802.data.lst;
+                __auto_type lst = _mv_803.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_803 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_803.has_value) {
-                            __auto_type head_ptr = _mv_803.value;
-                            __auto_type _mv_804 = (*head_ptr);
-                            switch (_mv_804.tag) {
+                        __auto_type _mv_804 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_804.has_value) {
+                            __auto_type head_ptr = _mv_804.value;
+                            __auto_type _mv_805 = (*head_ptr);
+                            switch (_mv_805.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type head_sym = _mv_804.data.sym;
+                                    __auto_type head_sym = _mv_805.data.sym;
                                     {
                                         __auto_type op = head_sym.name;
                                         if (string_eq(op, SLOP_STR("arena-alloc"))) {
-                                            __auto_type _mv_805 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_805.has_value) {
-                                                __auto_type size_expr = _mv_805.value;
+                                            __auto_type _mv_806 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_806.has_value) {
+                                                __auto_type size_expr = _mv_806.value;
                                                 return stmt_extract_sizeof_type_opt(ctx, size_expr);
-                                            } else if (!_mv_805.has_value) {
+                                            } else if (!_mv_806.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
                                             SLOP_UNREACHABLE();
                                         } else if (string_eq(op, SLOP_STR("cast")) && (((int64_t)((items).len)) >= 3)) {
-                                            __auto_type _mv_806 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_806.has_value) {
-                                                __auto_type inner_expr = _mv_806.value;
+                                            __auto_type _mv_807 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_807.has_value) {
+                                                __auto_type inner_expr = _mv_807.value;
                                                 return stmt_get_arena_alloc_ptr_type(ctx, inner_expr);
-                                            } else if (!_mv_806.has_value) {
+                                            } else if (!_mv_807.has_value) {
                                                 return (slop_option_string){.has_value = false};
                                             }
                                             SLOP_UNREACHABLE();
@@ -128,7 +128,7 @@ slop_option_string stmt_get_arena_alloc_ptr_type(context_TranspileContext* ctx, 
                                     return (slop_option_string){.has_value = false};
                                 }
                             }
-                        } else if (!_mv_803.has_value) {
+                        } else if (!_mv_804.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -149,18 +149,18 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_807 = (*expr);
-        switch (_mv_807.tag) {
+        __auto_type _mv_808 = (*expr);
+        switch (_mv_808.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_807.data.sym;
+                __auto_type sym = _mv_808.data.sym;
                 {
                     __auto_type type_name = sym.name;
-                    __auto_type _mv_808 = context_ctx_lookup_type(ctx, type_name);
-                    if (_mv_808.has_value) {
-                        __auto_type entry = _mv_808.value;
+                    __auto_type _mv_809 = context_ctx_lookup_type(ctx, type_name);
+                    if (_mv_809.has_value) {
+                        __auto_type entry = _mv_809.value;
                         return (slop_option_string){.has_value = 1, .value = context_ctx_str(ctx, entry.c_name, SLOP_STR("*"))};
-                    } else if (!_mv_808.has_value) {
+                    } else if (!_mv_809.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
                     SLOP_UNREACHABLE();
@@ -168,27 +168,27 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_807.data.lst;
+                __auto_type lst = _mv_808.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_809 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_809.has_value) {
-                            __auto_type head_ptr = _mv_809.value;
-                            __auto_type _mv_810 = (*head_ptr);
-                            switch (_mv_810.tag) {
+                        __auto_type _mv_810 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_810.has_value) {
+                            __auto_type head_ptr = _mv_810.value;
+                            __auto_type _mv_811 = (*head_ptr);
+                            switch (_mv_811.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type head_sym = _mv_810.data.sym;
+                                    __auto_type head_sym = _mv_811.data.sym;
                                     if (string_eq(head_sym.name, SLOP_STR("sizeof"))) {
-                                        __auto_type _mv_811 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_811.has_value) {
-                                            __auto_type type_expr = _mv_811.value;
+                                        __auto_type _mv_812 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_812.has_value) {
+                                            __auto_type type_expr = _mv_812.value;
                                             {
                                                 __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                 return (slop_option_string){.has_value = 1, .value = context_ctx_str(ctx, c_type, SLOP_STR("*"))};
                                             }
-                                        } else if (!_mv_811.has_value) {
+                                        } else if (!_mv_812.has_value) {
                                             return (slop_option_string){.has_value = false};
                                         }
                                         SLOP_UNREACHABLE();
@@ -200,7 +200,7 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
                                     return (slop_option_string){.has_value = false};
                                 }
                             }
-                        } else if (!_mv_809.has_value) {
+                        } else if (!_mv_810.has_value) {
                             return (slop_option_string){.has_value = false};
                         }
                         SLOP_UNREACHABLE();
@@ -218,24 +218,24 @@ slop_option_string stmt_extract_sizeof_type_opt(context_TranspileContext* ctx, t
 
 uint8_t stmt_is_stmt_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_812 = (*expr);
-    switch (_mv_812.tag) {
+    __auto_type _mv_813 = (*expr);
+    switch (_mv_813.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_812.data.lst;
+            __auto_type lst = _mv_813.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_813 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_813.has_value) {
-                        __auto_type head_expr = _mv_813.value;
-                        __auto_type _mv_814 = (*head_expr);
-                        switch (_mv_814.tag) {
+                    __auto_type _mv_814 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_814.has_value) {
+                        __auto_type head_expr = _mv_814.value;
+                        __auto_type _mv_815 = (*head_expr);
+                        switch (_mv_815.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_814.data.sym;
+                                __auto_type sym = _mv_815.data.sym;
                                 {
                                     __auto_type name = sym.name;
                                     return ((string_eq(name, SLOP_STR("let"))) || (string_eq(name, SLOP_STR("let*"))) || (string_eq(name, SLOP_STR("if"))) || (string_eq(name, SLOP_STR("when"))) || (string_eq(name, SLOP_STR("while"))) || (string_eq(name, SLOP_STR("for"))) || (string_eq(name, SLOP_STR("for-each"))) || (string_eq(name, SLOP_STR("set!"))) || (string_eq(name, SLOP_STR("do"))) || (string_eq(name, SLOP_STR("match"))) || (string_eq(name, SLOP_STR("cond"))) || (string_eq(name, SLOP_STR("with-arena"))));
@@ -245,7 +245,7 @@ uint8_t stmt_is_stmt_form(types_SExpr* expr) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_813.has_value) {
+                    } else if (!_mv_814.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -263,11 +263,11 @@ void stmt_transpile_let(context_TranspileContext* ctx, types_SExpr* expr, uint8_
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_815 = (*expr);
-        switch (_mv_815.tag) {
+        __auto_type _mv_816 = (*expr);
+        switch (_mv_816.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_815.data.lst;
+                __auto_type lst = _mv_816.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -277,14 +277,14 @@ void stmt_transpile_let(context_TranspileContext* ctx, types_SExpr* expr, uint8_
                         context_ctx_emit(ctx, SLOP_STR("{"));
                         context_ctx_indent(ctx);
                         context_ctx_push_scope(ctx);
-                        __auto_type _mv_816 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_816.has_value) {
-                            __auto_type bindings_expr = _mv_816.value;
-                            __auto_type _mv_817 = (*bindings_expr);
-                            switch (_mv_817.tag) {
+                        __auto_type _mv_817 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_817.has_value) {
+                            __auto_type bindings_expr = _mv_817.value;
+                            __auto_type _mv_818 = (*bindings_expr);
+                            switch (_mv_818.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type bindings_lst = _mv_817.data.lst;
+                                    __auto_type bindings_lst = _mv_818.data.lst;
                                     stmt_transpile_bindings(ctx, bindings_lst.items);
                                     break;
                                 }
@@ -293,20 +293,20 @@ void stmt_transpile_let(context_TranspileContext* ctx, types_SExpr* expr, uint8_
                                     break;
                                 }
                             }
-                        } else if (!_mv_816.has_value) {
+                        } else if (!_mv_817.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing bindings"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                         {
                             __auto_type i = 2;
                             while (i < len) {
-                                __auto_type _mv_818 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_818.has_value) {
-                                    __auto_type body_expr = _mv_818.value;
+                                __auto_type _mv_819 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_819.has_value) {
+                                    __auto_type body_expr = _mv_819.value;
                                     {
                                         __auto_type is_last = (i == (len - 1));
                                         stmt_transpile_stmt(ctx, body_expr, (is_return && is_last));
                                     }
-                                } else if (!_mv_818.has_value) {
+                                } else if (!_mv_819.has_value) {
                                 }
                                 i = (i + 1);
                             }
@@ -333,11 +333,11 @@ void stmt_transpile_bindings(context_TranspileContext* ctx, slop_list_types_SExp
         __auto_type len = ((int64_t)((bindings).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_819 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_819.has_value) {
-                __auto_type binding_expr = _mv_819.value;
+            __auto_type _mv_820 = ({ __auto_type _lst = bindings; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_820.has_value) {
+                __auto_type binding_expr = _mv_820.value;
                 stmt_transpile_single_binding(ctx, binding_expr);
-            } else if (!_mv_819.has_value) {
+            } else if (!_mv_820.has_value) {
             }
             i = (i + 1);
         }
@@ -349,11 +349,11 @@ void stmt_transpile_single_binding(context_TranspileContext* ctx, types_SExpr* b
     SLOP_PRE(((binding != NULL)), "(!= binding nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_820 = (*binding);
-        switch (_mv_820.tag) {
+        __auto_type _mv_821 = (*binding);
+        switch (_mv_821.tag) {
             case types_SExpr_lst:
             {
-                __auto_type binding_lst = _mv_820.data.lst;
+                __auto_type binding_lst = _mv_821.data.lst;
                 {
                     __auto_type items = binding_lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -363,24 +363,24 @@ void stmt_transpile_single_binding(context_TranspileContext* ctx, types_SExpr* b
                         if ((len - start_idx) < 2) {
                             context_ctx_add_error_at(ctx, SLOP_STR("invalid binding: need name and value"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                         } else {
-                            __auto_type _mv_821 = ({ __auto_type _lst = items; size_t _idx = (size_t)start_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_821.has_value) {
-                                __auto_type name_expr = _mv_821.value;
-                                __auto_type _mv_822 = (*name_expr);
-                                switch (_mv_822.tag) {
+                            __auto_type _mv_822 = ({ __auto_type _lst = items; size_t _idx = (size_t)start_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_822.has_value) {
+                                __auto_type name_expr = _mv_822.value;
+                                __auto_type _mv_823 = (*name_expr);
+                                switch (_mv_823.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type name_sym = _mv_822.data.sym;
+                                        __auto_type name_sym = _mv_823.data.sym;
                                         {
                                             __auto_type raw_name = name_sym.name;
                                             __auto_type var_name = ctype_to_c_name(arena, raw_name);
                                             if ((len - start_idx) >= 3) {
-                                                __auto_type _mv_823 = ({ __auto_type _lst = items; size_t _idx = (size_t)(start_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_823.has_value) {
-                                                    __auto_type type_expr = _mv_823.value;
-                                                    __auto_type _mv_824 = ({ __auto_type _lst = items; size_t _idx = (size_t)(start_idx + 2); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_824.has_value) {
-                                                        __auto_type init_expr = _mv_824.value;
+                                                __auto_type _mv_824 = ({ __auto_type _lst = items; size_t _idx = (size_t)(start_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_824.has_value) {
+                                                    __auto_type type_expr = _mv_824.value;
+                                                    __auto_type _mv_825 = ({ __auto_type _lst = items; size_t _idx = (size_t)(start_idx + 2); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_825.has_value) {
+                                                        __auto_type init_expr = _mv_825.value;
                                                         {
                                                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                             {
@@ -392,26 +392,26 @@ void stmt_transpile_single_binding(context_TranspileContext* ctx, types_SExpr* b
                                                                 }
                                                             }
                                                         }
-                                                    } else if (!_mv_824.has_value) {
+                                                    } else if (!_mv_825.has_value) {
                                                         context_ctx_add_error_at(ctx, SLOP_STR("missing init"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                     }
-                                                } else if (!_mv_823.has_value) {
+                                                } else if (!_mv_824.has_value) {
                                                     context_ctx_add_error_at(ctx, SLOP_STR("missing type"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                 }
                                             } else {
-                                                __auto_type _mv_825 = ({ __auto_type _lst = items; size_t _idx = (size_t)(start_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_825.has_value) {
-                                                    __auto_type init_expr = _mv_825.value;
+                                                __auto_type _mv_826 = ({ __auto_type _lst = items; size_t _idx = (size_t)(start_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_826.has_value) {
+                                                    __auto_type init_expr = _mv_826.value;
                                                     {
                                                         __auto_type init_c = expr_transpile_expr(ctx, init_expr);
                                                         __auto_type inferred_slop_type = expr_infer_expr_slop_type(ctx, init_expr);
                                                         __auto_type ptr_type_opt = stmt_get_arena_alloc_ptr_type(ctx, init_expr);
-                                                        __auto_type _mv_826 = ptr_type_opt;
-                                                        if (_mv_826.has_value) {
-                                                            __auto_type ptr_type = _mv_826.value;
+                                                        __auto_type _mv_827 = ptr_type_opt;
+                                                        if (_mv_827.has_value) {
+                                                            __auto_type ptr_type = _mv_827.value;
                                                             context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("__auto_type "), var_name, SLOP_STR(" = "), init_c, SLOP_STR(";")));
                                                             context_ctx_bind_var(ctx, (context_VarEntry){raw_name, var_name, ptr_type, inferred_slop_type, 1, has_mut, 0, SLOP_STR(""), SLOP_STR("")});
-                                                        } else if (!_mv_826.has_value) {
+                                                        } else if (!_mv_827.has_value) {
                                                             {
                                                                 __auto_type inferred_type = expr_infer_expr_c_type(ctx, init_expr);
                                                                 __auto_type lambda_info = context_ctx_get_last_lambda_info(ctx);
@@ -428,7 +428,7 @@ void stmt_transpile_single_binding(context_TranspileContext* ctx, types_SExpr* b
                                                             }
                                                         }
                                                     }
-                                                } else if (!_mv_825.has_value) {
+                                                } else if (!_mv_826.has_value) {
                                                     context_ctx_add_error_at(ctx, SLOP_STR("missing init"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                                                 }
                                             }
@@ -440,7 +440,7 @@ void stmt_transpile_single_binding(context_TranspileContext* ctx, types_SExpr* b
                                         break;
                                     }
                                 }
-                            } else if (!_mv_821.has_value) {
+                            } else if (!_mv_822.has_value) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("missing binding name"), context_ctx_sexpr_line(binding), context_ctx_sexpr_col(binding));
                             }
                         }
@@ -460,21 +460,21 @@ uint8_t stmt_binding_has_mut(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_827 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_827.has_value) {
-            __auto_type first = _mv_827.value;
-            __auto_type _mv_828 = (*first);
-            switch (_mv_828.tag) {
+        __auto_type _mv_828 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_828.has_value) {
+            __auto_type first = _mv_828.value;
+            __auto_type _mv_829 = (*first);
+            switch (_mv_829.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_828.data.sym;
+                    __auto_type sym = _mv_829.data.sym;
                     return string_eq(sym.name, SLOP_STR("mut"));
                 }
                 default: {
                     return 0;
                 }
             }
-        } else if (!_mv_827.has_value) {
+        } else if (!_mv_828.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -517,28 +517,28 @@ slop_option_types_SExpr_ptr stmt_get_some_value(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         slop_option_types_SExpr_ptr result = (slop_option_types_SExpr_ptr){.has_value = false};
-        __auto_type _mv_829 = (*expr);
-        switch (_mv_829.tag) {
+        __auto_type _mv_830 = (*expr);
+        switch (_mv_830.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_829.data.lst;
+                __auto_type lst = _mv_830.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_830 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_830.has_value) {
-                            __auto_type head_expr = _mv_830.value;
-                            __auto_type _mv_831 = (*head_expr);
-                            switch (_mv_831.tag) {
+                        __auto_type _mv_831 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_831.has_value) {
+                            __auto_type head_expr = _mv_831.value;
+                            __auto_type _mv_832 = (*head_expr);
+                            switch (_mv_832.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_831.data.sym;
+                                    __auto_type sym = _mv_832.data.sym;
                                     if (string_eq(sym.name, SLOP_STR("some"))) {
-                                        __auto_type _mv_832 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_832.has_value) {
-                                            __auto_type val = _mv_832.value;
+                                        __auto_type _mv_833 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_833.has_value) {
+                                            __auto_type val = _mv_833.value;
                                             result = (slop_option_types_SExpr_ptr){.has_value = 1, .value = val};
-                                        } else if (!_mv_832.has_value) {
+                                        } else if (!_mv_833.has_value) {
                                         }
                                     }
                                     break;
@@ -547,7 +547,7 @@ slop_option_types_SExpr_ptr stmt_get_some_value(types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_830.has_value) {
+                        } else if (!_mv_831.has_value) {
                         }
                     }
                 }
@@ -563,34 +563,34 @@ slop_option_types_SExpr_ptr stmt_get_some_value(types_SExpr* expr) {
 
 uint8_t stmt_is_none_form(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_833 = (*expr);
-    switch (_mv_833.tag) {
+    __auto_type _mv_834 = (*expr);
+    switch (_mv_834.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_833.data.sym;
+            __auto_type sym = _mv_834.data.sym;
             return string_eq(sym.name, SLOP_STR("none"));
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_833.data.lst;
+            __auto_type lst = _mv_834.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) == 1) {
-                    __auto_type _mv_834 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_834.has_value) {
-                        __auto_type head = _mv_834.value;
-                        __auto_type _mv_835 = (*head);
-                        switch (_mv_835.tag) {
+                    __auto_type _mv_835 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_835.has_value) {
+                        __auto_type head = _mv_835.value;
+                        __auto_type _mv_836 = (*head);
+                        switch (_mv_836.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_835.data.sym;
+                                __auto_type sym = _mv_836.data.sym;
                                 return string_eq(sym.name, SLOP_STR("none"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_834.has_value) {
+                    } else if (!_mv_835.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -608,39 +608,39 @@ uint8_t stmt_is_none_form(types_SExpr* expr) {
 void stmt_transpile_if(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_836 = (*expr);
-    switch (_mv_836.tag) {
+    __auto_type _mv_837 = (*expr);
+    switch (_mv_837.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_836.data.lst;
+            __auto_type lst = _mv_837.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 if (len < 3) {
                     context_ctx_add_error_at(ctx, SLOP_STR("invalid if: need condition and then-branch"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                 } else {
-                    __auto_type _mv_837 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_837.has_value) {
-                        __auto_type cond_expr = _mv_837.value;
+                    __auto_type _mv_838 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_838.has_value) {
+                        __auto_type cond_expr = _mv_838.value;
                         {
                             __auto_type cond_c = context_ctx_strip_cond_parens(ctx, expr_transpile_expr(ctx, cond_expr));
                             context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("if ("), cond_c, SLOP_STR(") {")));
                             context_ctx_indent(ctx);
-                            __auto_type _mv_838 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_838.has_value) {
-                                __auto_type then_expr = _mv_838.value;
+                            __auto_type _mv_839 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_839.has_value) {
+                                __auto_type then_expr = _mv_839.value;
                                 stmt_transpile_stmt(ctx, then_expr, is_return);
-                            } else if (!_mv_838.has_value) {
+                            } else if (!_mv_839.has_value) {
                             }
                             context_ctx_dedent(ctx);
                             if (len >= 4) {
                                 context_ctx_emit(ctx, SLOP_STR("} else {"));
                                 context_ctx_indent(ctx);
-                                __auto_type _mv_839 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_839.has_value) {
-                                    __auto_type else_expr = _mv_839.value;
+                                __auto_type _mv_840 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_840.has_value) {
+                                    __auto_type else_expr = _mv_840.value;
                                     stmt_transpile_stmt(ctx, else_expr, is_return);
-                                } else if (!_mv_839.has_value) {
+                                } else if (!_mv_840.has_value) {
                                 }
                                 context_ctx_dedent(ctx);
                                 context_ctx_emit(ctx, SLOP_STR("}"));
@@ -648,7 +648,7 @@ void stmt_transpile_if(context_TranspileContext* ctx, types_SExpr* expr, uint8_t
                                 context_ctx_emit(ctx, SLOP_STR("}"));
                             }
                         }
-                    } else if (!_mv_837.has_value) {
+                    } else if (!_mv_838.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing if condition"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     }
                 }
@@ -665,20 +665,20 @@ void stmt_transpile_if(context_TranspileContext* ctx, types_SExpr* expr, uint8_t
 void stmt_transpile_when(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_840 = (*expr);
-    switch (_mv_840.tag) {
+    __auto_type _mv_841 = (*expr);
+    switch (_mv_841.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_840.data.lst;
+            __auto_type lst = _mv_841.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 if (len < 3) {
                     context_ctx_add_error_at(ctx, SLOP_STR("invalid when: need condition and body"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                 } else {
-                    __auto_type _mv_841 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_841.has_value) {
-                        __auto_type cond_expr = _mv_841.value;
+                    __auto_type _mv_842 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_842.has_value) {
+                        __auto_type cond_expr = _mv_842.value;
                         {
                             __auto_type cond_c = context_ctx_strip_cond_parens(ctx, expr_transpile_expr(ctx, cond_expr));
                             context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("if ("), cond_c, SLOP_STR(") {")));
@@ -686,11 +686,11 @@ void stmt_transpile_when(context_TranspileContext* ctx, types_SExpr* expr) {
                             {
                                 __auto_type i = 2;
                                 while (i < len) {
-                                    __auto_type _mv_842 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_842.has_value) {
-                                        __auto_type body_expr = _mv_842.value;
+                                    __auto_type _mv_843 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_843.has_value) {
+                                        __auto_type body_expr = _mv_843.value;
                                         stmt_transpile_stmt(ctx, body_expr, 0);
-                                    } else if (!_mv_842.has_value) {
+                                    } else if (!_mv_843.has_value) {
                                     }
                                     i = (i + 1);
                                 }
@@ -698,7 +698,7 @@ void stmt_transpile_when(context_TranspileContext* ctx, types_SExpr* expr) {
                             context_ctx_dedent(ctx);
                             context_ctx_emit(ctx, SLOP_STR("}"));
                         }
-                    } else if (!_mv_841.has_value) {
+                    } else if (!_mv_842.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing when condition"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     }
                 }
@@ -715,20 +715,20 @@ void stmt_transpile_when(context_TranspileContext* ctx, types_SExpr* expr) {
 void stmt_transpile_while(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_843 = (*expr);
-    switch (_mv_843.tag) {
+    __auto_type _mv_844 = (*expr);
+    switch (_mv_844.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_843.data.lst;
+            __auto_type lst = _mv_844.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 if (len < 3) {
                     context_ctx_add_error_at(ctx, SLOP_STR("invalid while: need condition and body"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                 } else {
-                    __auto_type _mv_844 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_844.has_value) {
-                        __auto_type cond_expr = _mv_844.value;
+                    __auto_type _mv_845 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_845.has_value) {
+                        __auto_type cond_expr = _mv_845.value;
                         {
                             __auto_type cond_c = context_ctx_strip_cond_parens(ctx, expr_transpile_expr(ctx, cond_expr));
                             context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("while ("), cond_c, SLOP_STR(") {")));
@@ -736,11 +736,11 @@ void stmt_transpile_while(context_TranspileContext* ctx, types_SExpr* expr) {
                             {
                                 __auto_type i = 2;
                                 while (i < len) {
-                                    __auto_type _mv_845 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_845.has_value) {
-                                        __auto_type body_expr = _mv_845.value;
+                                    __auto_type _mv_846 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_846.has_value) {
+                                        __auto_type body_expr = _mv_846.value;
                                         stmt_transpile_stmt(ctx, body_expr, 0);
-                                    } else if (!_mv_845.has_value) {
+                                    } else if (!_mv_846.has_value) {
                                     }
                                     i = (i + 1);
                                 }
@@ -748,7 +748,7 @@ void stmt_transpile_while(context_TranspileContext* ctx, types_SExpr* expr) {
                             context_ctx_dedent(ctx);
                             context_ctx_emit(ctx, SLOP_STR("}"));
                         }
-                    } else if (!_mv_844.has_value) {
+                    } else if (!_mv_845.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing while condition"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     }
                 }
@@ -767,11 +767,11 @@ void stmt_transpile_set(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_846 = (*expr);
-        switch (_mv_846.tag) {
+        __auto_type _mv_847 = (*expr);
+        switch (_mv_847.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_846.data.lst;
+                __auto_type lst = _mv_847.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -781,29 +781,29 @@ void stmt_transpile_set(context_TranspileContext* ctx, types_SExpr* expr) {
                     } else if (len == 4) {
                         stmt_transpile_field_set(ctx, items);
                     } else if (len == 3) {
-                        __auto_type _mv_847 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_847.has_value) {
-                            __auto_type target_expr = _mv_847.value;
-                            __auto_type _mv_848 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_848.has_value) {
-                                __auto_type value_expr = _mv_848.value;
+                        __auto_type _mv_848 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_848.has_value) {
+                            __auto_type target_expr = _mv_848.value;
+                            __auto_type _mv_849 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_849.has_value) {
+                                __auto_type value_expr = _mv_849.value;
                                 {
                                     __auto_type target_c = expr_transpile_expr(ctx, target_expr);
                                     __auto_type target_type_opt = stmt_get_var_c_type(ctx, target_expr);
-                                    __auto_type _mv_849 = target_type_opt;
-                                    if (_mv_849.has_value) {
-                                        __auto_type target_type = _mv_849.value;
+                                    __auto_type _mv_850 = target_type_opt;
+                                    if (_mv_850.has_value) {
+                                        __auto_type target_type = _mv_850.value;
                                         if (strlib_starts_with(target_type, SLOP_STR("slop_option_"))) {
                                             {
                                                 __auto_type some_val_opt = stmt_get_some_value(value_expr);
-                                                __auto_type _mv_850 = some_val_opt;
-                                                if (_mv_850.has_value) {
-                                                    __auto_type val_expr = _mv_850.value;
+                                                __auto_type _mv_851 = some_val_opt;
+                                                if (_mv_851.has_value) {
+                                                    __auto_type val_expr = _mv_851.value;
                                                     {
                                                         __auto_type val_c = expr_transpile_expr(ctx, val_expr);
                                                         context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str5(ctx, SLOP_STR(" = ("), target_type, SLOP_STR("){.has_value = 1, .value = "), val_c, SLOP_STR("};"))));
                                                     }
-                                                } else if (!_mv_850.has_value) {
+                                                } else if (!_mv_851.has_value) {
                                                     if (stmt_is_none_form(value_expr)) {
                                                         context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str3(ctx, SLOP_STR(" = ("), target_type, SLOP_STR("){.has_value = false};"))));
                                                     } else {
@@ -820,23 +820,23 @@ void stmt_transpile_set(context_TranspileContext* ctx, types_SExpr* expr) {
                                                 context_ctx_emit(ctx, context_ctx_str4(ctx, target_c, SLOP_STR(" = "), value_c, SLOP_STR(";")));
                                             }
                                         }
-                                    } else if (!_mv_849.has_value) {
+                                    } else if (!_mv_850.has_value) {
                                         {
                                             __auto_type some_val_opt = stmt_get_some_value(value_expr);
-                                            __auto_type _mv_851 = some_val_opt;
-                                            if (_mv_851.has_value) {
-                                                __auto_type inner_expr = _mv_851.value;
+                                            __auto_type _mv_852 = some_val_opt;
+                                            if (_mv_852.has_value) {
+                                                __auto_type inner_expr = _mv_852.value;
                                                 {
                                                     __auto_type inner_c = expr_transpile_expr(ctx, inner_expr);
                                                     __auto_type inner_type = expr_infer_expr_c_type(ctx, inner_expr);
                                                     __auto_type option_type = expr_c_type_to_option_type_name(ctx, inner_type);
                                                     context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str5(ctx, SLOP_STR(" = ("), option_type, SLOP_STR("){.has_value = 1, .value = "), inner_c, SLOP_STR("};"))));
                                                 }
-                                            } else if (!_mv_851.has_value) {
+                                            } else if (!_mv_852.has_value) {
                                                 if (stmt_is_none_form(value_expr)) {
-                                                    __auto_type _mv_852 = context_ctx_get_current_return_type(ctx);
-                                                    if (_mv_852.has_value) {
-                                                        __auto_type ret_type = _mv_852.value;
+                                                    __auto_type _mv_853 = context_ctx_get_current_return_type(ctx);
+                                                    if (_mv_853.has_value) {
+                                                        __auto_type ret_type = _mv_853.value;
                                                         if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
                                                             context_ctx_emit(ctx, context_ctx_str(ctx, target_c, context_ctx_str3(ctx, SLOP_STR(" = ("), ret_type, SLOP_STR("){.has_value = false};"))));
                                                         } else {
@@ -845,7 +845,7 @@ void stmt_transpile_set(context_TranspileContext* ctx, types_SExpr* expr) {
                                                                 context_ctx_emit(ctx, context_ctx_str4(ctx, target_c, SLOP_STR(" = "), value_c, SLOP_STR(";")));
                                                             }
                                                         }
-                                                    } else if (!_mv_852.has_value) {
+                                                    } else if (!_mv_853.has_value) {
                                                         {
                                                             __auto_type value_c = expr_transpile_expr(ctx, value_expr);
                                                             context_ctx_emit(ctx, context_ctx_str4(ctx, target_c, SLOP_STR(" = "), value_c, SLOP_STR(";")));
@@ -861,10 +861,10 @@ void stmt_transpile_set(context_TranspileContext* ctx, types_SExpr* expr) {
                                         }
                                     }
                                 }
-                            } else if (!_mv_848.has_value) {
+                            } else if (!_mv_849.has_value) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("missing set! value"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                             }
-                        } else if (!_mv_847.has_value) {
+                        } else if (!_mv_848.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing set! target"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                     } else {
@@ -883,18 +883,18 @@ void stmt_transpile_set(context_TranspileContext* ctx, types_SExpr* expr) {
 
 slop_option_string stmt_get_var_c_type(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
-    __auto_type _mv_853 = (*expr);
-    switch (_mv_853.tag) {
+    __auto_type _mv_854 = (*expr);
+    switch (_mv_854.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_853.data.sym;
+            __auto_type sym = _mv_854.data.sym;
             {
                 __auto_type name = sym.name;
-                __auto_type _mv_854 = context_ctx_lookup_var(ctx, name);
-                if (_mv_854.has_value) {
-                    __auto_type var_entry = _mv_854.value;
+                __auto_type _mv_855 = context_ctx_lookup_var(ctx, name);
+                if (_mv_855.has_value) {
+                    __auto_type var_entry = _mv_855.value;
                     return (slop_option_string){.has_value = 1, .value = var_entry.c_type};
-                } else if (!_mv_854.has_value) {
+                } else if (!_mv_855.has_value) {
                     return (slop_option_string){.has_value = false};
                 }
                 SLOP_UNREACHABLE();
@@ -909,18 +909,18 @@ slop_option_string stmt_get_var_c_type(context_TranspileContext* ctx, types_SExp
 uint8_t stmt_is_pointer_target(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_855 = (*expr);
-    switch (_mv_855.tag) {
+    __auto_type _mv_856 = (*expr);
+    switch (_mv_856.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_855.data.sym;
+            __auto_type sym = _mv_856.data.sym;
             {
                 __auto_type name = sym.name;
-                __auto_type _mv_856 = context_ctx_lookup_var(ctx, name);
-                if (_mv_856.has_value) {
-                    __auto_type var_entry = _mv_856.value;
+                __auto_type _mv_857 = context_ctx_lookup_var(ctx, name);
+                if (_mv_857.has_value) {
+                    __auto_type var_entry = _mv_857.value;
                     return (var_entry.is_pointer || ({ __auto_type c_type = var_entry.c_type; strlib_ends_with(c_type, SLOP_STR("*")); }));
-                } else if (!_mv_856.has_value) {
+                } else if (!_mv_857.has_value) {
                     return 0;
                 }
                 SLOP_UNREACHABLE();
@@ -936,15 +936,15 @@ void stmt_transpile_field_set(context_TranspileContext* ctx, slop_list_types_SEx
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_857 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_857.has_value) {
-            __auto_type target_expr = _mv_857.value;
-            __auto_type _mv_858 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_858.has_value) {
-                __auto_type field_expr = _mv_858.value;
-                __auto_type _mv_859 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_859.has_value) {
-                    __auto_type value_expr = _mv_859.value;
+        __auto_type _mv_858 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_858.has_value) {
+            __auto_type target_expr = _mv_858.value;
+            __auto_type _mv_859 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_859.has_value) {
+                __auto_type field_expr = _mv_859.value;
+                __auto_type _mv_860 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_860.has_value) {
+                    __auto_type value_expr = _mv_860.value;
                     {
                         __auto_type field_name = stmt_get_symbol_name(arena, field_expr);
                         __auto_type value_c = expr_transpile_expr(ctx, value_expr);
@@ -966,13 +966,13 @@ void stmt_transpile_field_set(context_TranspileContext* ctx, slop_list_types_SEx
                             }
                         }
                     }
-                } else if (!_mv_859.has_value) {
+                } else if (!_mv_860.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("missing set! value"), context_ctx_sexpr_line(target_expr), context_ctx_sexpr_col(target_expr));
                 }
-            } else if (!_mv_858.has_value) {
+            } else if (!_mv_859.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing set! field"), context_ctx_sexpr_line(target_expr), context_ctx_sexpr_col(target_expr));
             }
-        } else if (!_mv_857.has_value) {
+        } else if (!_mv_858.has_value) {
             context_ctx_add_error_at(ctx, SLOP_STR("missing set! target"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         }
     }
@@ -982,18 +982,18 @@ void stmt_transpile_typed_field_set(context_TranspileContext* ctx, slop_list_typ
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_860 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_860.has_value) {
-            __auto_type target_expr = _mv_860.value;
-            __auto_type _mv_861 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_861.has_value) {
-                __auto_type field_expr = _mv_861.value;
-                __auto_type _mv_862 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_862.has_value) {
-                    __auto_type type_expr = _mv_862.value;
-                    __auto_type _mv_863 = ({ __auto_type _lst = items; size_t _idx = (size_t)4; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_863.has_value) {
-                        __auto_type value_expr = _mv_863.value;
+        __auto_type _mv_861 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_861.has_value) {
+            __auto_type target_expr = _mv_861.value;
+            __auto_type _mv_862 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_862.has_value) {
+                __auto_type field_expr = _mv_862.value;
+                __auto_type _mv_863 = ({ __auto_type _lst = items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_863.has_value) {
+                    __auto_type type_expr = _mv_863.value;
+                    __auto_type _mv_864 = ({ __auto_type _lst = items; size_t _idx = (size_t)4; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_864.has_value) {
+                        __auto_type value_expr = _mv_864.value;
                         {
                             __auto_type field_name = stmt_get_symbol_name(arena, field_expr);
                             __auto_type c_type = ctype_to_c_type(arena, type_expr);
@@ -1003,14 +1003,14 @@ void stmt_transpile_typed_field_set(context_TranspileContext* ctx, slop_list_typ
                                     if (stmt_is_none_form(value_expr)) {
                                         context_ctx_emit(ctx, context_ctx_str(ctx, target_access, context_ctx_str(ctx, field_name, context_ctx_str3(ctx, SLOP_STR(" = ("), c_type, SLOP_STR("){.has_value = false};")))));
                                     } else {
-                                        __auto_type _mv_864 = stmt_get_some_value(value_expr);
-                                        if (_mv_864.has_value) {
-                                            __auto_type inner_val = _mv_864.value;
+                                        __auto_type _mv_865 = stmt_get_some_value(value_expr);
+                                        if (_mv_865.has_value) {
+                                            __auto_type inner_val = _mv_865.value;
                                             {
                                                 __auto_type val_c = expr_transpile_expr(ctx, inner_val);
                                                 context_ctx_emit(ctx, context_ctx_str(ctx, target_access, context_ctx_str(ctx, field_name, context_ctx_str5(ctx, SLOP_STR(" = ("), c_type, SLOP_STR("){.has_value = 1, .value = "), val_c, SLOP_STR("};")))));
                                             }
-                                        } else if (!_mv_864.has_value) {
+                                        } else if (!_mv_865.has_value) {
                                             {
                                                 __auto_type val_c = expr_transpile_expr(ctx, value_expr);
                                                 context_ctx_emit(ctx, context_ctx_str(ctx, target_access, context_ctx_str(ctx, field_name, context_ctx_str(ctx, SLOP_STR(" = "), context_ctx_str(ctx, val_c, SLOP_STR(";"))))));
@@ -1025,16 +1025,16 @@ void stmt_transpile_typed_field_set(context_TranspileContext* ctx, slop_list_typ
                                 }
                             }
                         }
-                    } else if (!_mv_863.has_value) {
+                    } else if (!_mv_864.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("missing set! value"), context_ctx_sexpr_line(type_expr), context_ctx_sexpr_col(type_expr));
                     }
-                } else if (!_mv_862.has_value) {
+                } else if (!_mv_863.has_value) {
                     context_ctx_add_error_at(ctx, SLOP_STR("missing set! type"), context_ctx_sexpr_line(field_expr), context_ctx_sexpr_col(field_expr));
                 }
-            } else if (!_mv_861.has_value) {
+            } else if (!_mv_862.has_value) {
                 context_ctx_add_error_at(ctx, SLOP_STR("missing set! field"), context_ctx_sexpr_line(target_expr), context_ctx_sexpr_col(target_expr));
             }
-        } else if (!_mv_860.has_value) {
+        } else if (!_mv_861.has_value) {
             context_ctx_add_error_at(ctx, SLOP_STR("missing set! target"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
         }
     }
@@ -1042,31 +1042,31 @@ void stmt_transpile_typed_field_set(context_TranspileContext* ctx, slop_list_typ
 
 uint8_t stmt_is_deref_expr(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_865 = (*expr);
-    switch (_mv_865.tag) {
+    __auto_type _mv_866 = (*expr);
+    switch (_mv_866.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_865.data.lst;
+            __auto_type lst = _mv_866.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_866 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_866.has_value) {
-                        __auto_type head = _mv_866.value;
-                        __auto_type _mv_867 = (*head);
-                        switch (_mv_867.tag) {
+                    __auto_type _mv_867 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_867.has_value) {
+                        __auto_type head = _mv_867.value;
+                        __auto_type _mv_868 = (*head);
+                        switch (_mv_868.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_867.data.sym;
+                                __auto_type sym = _mv_868.data.sym;
                                 return string_eq(sym.name, SLOP_STR("deref"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_866.has_value) {
+                    } else if (!_mv_867.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1081,18 +1081,18 @@ uint8_t stmt_is_deref_expr(types_SExpr* expr) {
 
 types_SExpr* stmt_get_deref_inner(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_868 = (*expr);
-    switch (_mv_868.tag) {
+    __auto_type _mv_869 = (*expr);
+    switch (_mv_869.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_868.data.lst;
+            __auto_type lst = _mv_869.data.lst;
             {
                 __auto_type items = lst.items;
-                __auto_type _mv_869 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_869.has_value) {
-                    __auto_type inner = _mv_869.value;
+                __auto_type _mv_870 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_870.has_value) {
+                    __auto_type inner = _mv_870.value;
                     return inner;
-                } else if (!_mv_869.has_value) {
+                } else if (!_mv_870.has_value) {
                     return expr;
                 }
                 SLOP_UNREACHABLE();
@@ -1106,11 +1106,11 @@ types_SExpr* stmt_get_deref_inner(types_SExpr* expr) {
 
 slop_string stmt_get_symbol_name(slop_arena* arena, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_870 = (*expr);
-    switch (_mv_870.tag) {
+    __auto_type _mv_871 = (*expr);
+    switch (_mv_871.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_870.data.sym;
+            __auto_type sym = _mv_871.data.sym;
             return ctype_to_c_name(arena, sym.name);
         }
         default: {
@@ -1122,24 +1122,24 @@ slop_string stmt_get_symbol_name(slop_arena* arena, types_SExpr* expr) {
 void stmt_transpile_do(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_871 = (*expr);
-    switch (_mv_871.tag) {
+    __auto_type _mv_872 = (*expr);
+    switch (_mv_872.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_871.data.lst;
+            __auto_type lst = _mv_872.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type i = 1;
                 while (i < len) {
-                    __auto_type _mv_872 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_872.has_value) {
-                        __auto_type body_expr = _mv_872.value;
+                    __auto_type _mv_873 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_873.has_value) {
+                        __auto_type body_expr = _mv_873.value;
                         {
                             __auto_type is_last = (i == (len - 1));
                             stmt_transpile_stmt(ctx, body_expr, (is_return && is_last));
                         }
-                    } else if (!_mv_872.has_value) {
+                    } else if (!_mv_873.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -1155,11 +1155,11 @@ void stmt_transpile_do(context_TranspileContext* ctx, types_SExpr* expr, uint8_t
 void stmt_transpile_with_arena(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_873 = (*expr);
-    switch (_mv_873.tag) {
+    __auto_type _mv_874 = (*expr);
+    switch (_mv_874.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_873.data.lst;
+            __auto_type lst = _mv_874.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
@@ -1171,16 +1171,17 @@ void stmt_transpile_with_arena(context_TranspileContext* ctx, types_SExpr* expr,
                         __auto_type arena_name = ((is_named) ? ({ __auto_type _mv = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type name_expr = _mv.value; parser_sexpr_get_symbol_name(name_expr); }) : (SLOP_STR("arena")); }) : SLOP_STR("arena"));
                         __auto_type size_idx = ((is_named) ? 3 : 1);
                         __auto_type body_start = ((is_named) ? 4 : 2);
-                        __auto_type c_local = ((is_named) ? string_concat((*ctx).arena, SLOP_STR("_arena_"), arena_name) : SLOP_STR("_arena"));
+                        __auto_type c_arena_name = ctype_to_c_name((*ctx).arena, arena_name);
+                        __auto_type c_local = ((is_named) ? string_concat((*ctx).arena, SLOP_STR("_arena_"), c_arena_name) : SLOP_STR("_arena"));
                         if (is_named && (len < 4)) {
                             context_ctx_add_error_at(ctx, SLOP_STR("with-arena :as requires name and size"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         } else {
                             context_ctx_emit(ctx, SLOP_STR("{"));
                             context_ctx_indent(ctx);
                             context_ctx_push_scope(ctx);
-                            __auto_type _mv_874 = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_874.has_value) {
-                                __auto_type size_expr = _mv_874.value;
+                            __auto_type _mv_875 = ({ __auto_type _lst = items; size_t _idx = (size_t)size_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_875.has_value) {
+                                __auto_type size_expr = _mv_875.value;
                                 {
                                     __auto_type size_c = expr_transpile_expr(ctx, size_expr);
                                     context_ctx_emit(ctx, SLOP_STR("#ifdef SLOP_DEBUG"));
@@ -1190,28 +1191,28 @@ void stmt_transpile_with_arena(context_TranspileContext* ctx, types_SExpr* expr,
                                     context_ctx_emit(ctx, SLOP_STR("#ifdef SLOP_DEBUG"));
                                     context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("SLOP_PRE("), c_local, SLOP_STR(".base != NULL, \"arena allocation failed\");")));
                                     context_ctx_emit(ctx, SLOP_STR("#endif"));
-                                    context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("slop_arena* "), arena_name, SLOP_STR(" = &"), c_local, SLOP_STR(";")));
+                                    context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("slop_arena* "), c_arena_name, SLOP_STR(" = &"), c_local, SLOP_STR(";")));
                                 }
-                            } else if (!_mv_874.has_value) {
+                            } else if (!_mv_875.has_value) {
                                 context_ctx_add_error_at(ctx, SLOP_STR("missing size"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                             }
-                            context_ctx_bind_var(ctx, (context_VarEntry){arena_name, arena_name, SLOP_STR("slop_arena*"), SLOP_STR(""), 1, 0, 0, SLOP_STR(""), SLOP_STR("")});
+                            context_ctx_bind_var(ctx, (context_VarEntry){arena_name, c_arena_name, SLOP_STR("slop_arena*"), SLOP_STR(""), 1, 0, 0, SLOP_STR(""), SLOP_STR("")});
                             {
                                 __auto_type i = body_start;
                                 while (i < len) {
-                                    __auto_type _mv_875 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_875.has_value) {
-                                        __auto_type body_expr = _mv_875.value;
+                                    __auto_type _mv_876 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_876.has_value) {
+                                        __auto_type body_expr = _mv_876.value;
                                         {
                                             __auto_type is_last = (i == (len - 1));
                                             stmt_transpile_stmt(ctx, body_expr, (is_return && is_last));
                                         }
-                                    } else if (!_mv_875.has_value) {
+                                    } else if (!_mv_876.has_value) {
                                     }
                                     i = (i + 1);
                                 }
                             }
-                            context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), arena_name, SLOP_STR(");")));
+                            context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("slop_arena_free("), c_arena_name, SLOP_STR(");")));
                             context_ctx_pop_scope(ctx);
                             context_ctx_dedent(ctx);
                             context_ctx_emit(ctx, SLOP_STR("}"));
@@ -1231,39 +1232,39 @@ void stmt_transpile_with_arena(context_TranspileContext* ctx, types_SExpr* expr,
 void stmt_transpile_cond(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_876 = (*expr);
-    switch (_mv_876.tag) {
+    __auto_type _mv_877 = (*expr);
+    switch (_mv_877.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_876.data.lst;
+            __auto_type lst = _mv_877.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type i = 1;
                 __auto_type first = 1;
                 while (i < len) {
-                    __auto_type _mv_877 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_877.has_value) {
-                        __auto_type clause_expr = _mv_877.value;
-                        __auto_type _mv_878 = (*clause_expr);
-                        switch (_mv_878.tag) {
+                    __auto_type _mv_878 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_878.has_value) {
+                        __auto_type clause_expr = _mv_878.value;
+                        __auto_type _mv_879 = (*clause_expr);
+                        switch (_mv_879.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type clause_lst = _mv_878.data.lst;
+                                __auto_type clause_lst = _mv_879.data.lst;
                                 {
                                     __auto_type clause_items = clause_lst.items;
                                     __auto_type clause_len = ((int64_t)((clause_items).len));
                                     if (clause_len < 1) {
                                         context_ctx_add_error_at(ctx, SLOP_STR("invalid cond clause"), context_ctx_sexpr_line(clause_expr), context_ctx_sexpr_col(clause_expr));
                                     } else {
-                                        __auto_type _mv_879 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_879.has_value) {
-                                            __auto_type test_expr = _mv_879.value;
-                                            __auto_type _mv_880 = (*test_expr);
-                                            switch (_mv_880.tag) {
+                                        __auto_type _mv_880 = ({ __auto_type _lst = clause_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_880.has_value) {
+                                            __auto_type test_expr = _mv_880.value;
+                                            __auto_type _mv_881 = (*test_expr);
+                                            switch (_mv_881.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_880.data.sym;
+                                                    __auto_type sym = _mv_881.data.sym;
                                                     if (string_eq(sym.name, SLOP_STR("else"))) {
                                                         context_ctx_emit(ctx, SLOP_STR("} else {"));
                                                         context_ctx_indent(ctx);
@@ -1301,7 +1302,7 @@ void stmt_transpile_cond(context_TranspileContext* ctx, types_SExpr* expr, uint8
                                                     break;
                                                 }
                                             }
-                                        } else if (!_mv_879.has_value) {
+                                        } else if (!_mv_880.has_value) {
                                             context_ctx_add_error_at(ctx, SLOP_STR("missing test"), context_ctx_sexpr_line(clause_expr), context_ctx_sexpr_col(clause_expr));
                                         }
                                     }
@@ -1313,7 +1314,7 @@ void stmt_transpile_cond(context_TranspileContext* ctx, types_SExpr* expr, uint8
                                 break;
                             }
                         }
-                    } else if (!_mv_877.has_value) {
+                    } else if (!_mv_878.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -1336,14 +1337,14 @@ void stmt_transpile_cond_body(context_TranspileContext* ctx, slop_list_types_SEx
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_881 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_881.has_value) {
-                __auto_type body_expr = _mv_881.value;
+            __auto_type _mv_882 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_882.has_value) {
+                __auto_type body_expr = _mv_882.value;
                 {
                     __auto_type is_last = (i == (len - 1));
                     stmt_transpile_stmt(ctx, body_expr, (is_return && is_last));
                 }
-            } else if (!_mv_881.has_value) {
+            } else if (!_mv_882.has_value) {
             }
             i = (i + 1);
         }
@@ -1355,47 +1356,47 @@ void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_882 = (*expr);
-        switch (_mv_882.tag) {
+        __auto_type _mv_883 = (*expr);
+        switch (_mv_883.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_882.data.lst;
+                __auto_type lst = _mv_883.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 2) {
                         context_ctx_add_error_at(ctx, SLOP_STR("invalid for: need binding"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     } else {
-                        __auto_type _mv_883 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_883.has_value) {
-                            __auto_type binding_expr = _mv_883.value;
-                            __auto_type _mv_884 = (*binding_expr);
-                            switch (_mv_884.tag) {
+                        __auto_type _mv_884 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_884.has_value) {
+                            __auto_type binding_expr = _mv_884.value;
+                            __auto_type _mv_885 = (*binding_expr);
+                            switch (_mv_885.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type binding_lst = _mv_884.data.lst;
+                                    __auto_type binding_lst = _mv_885.data.lst;
                                     {
                                         __auto_type binding_items = binding_lst.items;
                                         __auto_type binding_len = ((int64_t)((binding_items).len));
                                         if (binding_len < 3) {
                                             context_ctx_add_error_at(ctx, SLOP_STR("for binding needs (var start end)"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                         } else {
-                                            __auto_type _mv_885 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_885.has_value) {
-                                                __auto_type var_expr = _mv_885.value;
-                                                __auto_type _mv_886 = (*var_expr);
-                                                switch (_mv_886.tag) {
+                                            __auto_type _mv_886 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_886.has_value) {
+                                                __auto_type var_expr = _mv_886.value;
+                                                __auto_type _mv_887 = (*var_expr);
+                                                switch (_mv_887.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type var_sym = _mv_886.data.sym;
+                                                        __auto_type var_sym = _mv_887.data.sym;
                                                         {
                                                             __auto_type var_name = ctype_to_c_name(arena, var_sym.name);
-                                                            __auto_type _mv_887 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                            if (_mv_887.has_value) {
-                                                                __auto_type start_expr = _mv_887.value;
-                                                                __auto_type _mv_888 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                if (_mv_888.has_value) {
-                                                                    __auto_type end_expr = _mv_888.value;
+                                                            __auto_type _mv_888 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                            if (_mv_888.has_value) {
+                                                                __auto_type start_expr = _mv_888.value;
+                                                                __auto_type _mv_889 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                if (_mv_889.has_value) {
+                                                                    __auto_type end_expr = _mv_889.value;
                                                                     {
                                                                         __auto_type start_c = expr_transpile_expr(ctx, start_expr);
                                                                         __auto_type end_c = expr_transpile_expr(ctx, end_expr);
@@ -1406,11 +1407,11 @@ void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr) {
                                                                         {
                                                                             __auto_type i = 2;
                                                                             while (i < len) {
-                                                                                __auto_type _mv_889 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                                if (_mv_889.has_value) {
-                                                                                    __auto_type body_expr = _mv_889.value;
+                                                                                __auto_type _mv_890 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                                if (_mv_890.has_value) {
+                                                                                    __auto_type body_expr = _mv_890.value;
                                                                                     stmt_transpile_stmt(ctx, body_expr, 0);
-                                                                                } else if (!_mv_889.has_value) {
+                                                                                } else if (!_mv_890.has_value) {
                                                                                 }
                                                                                 i = (i + 1);
                                                                             }
@@ -1419,10 +1420,10 @@ void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr) {
                                                                         context_ctx_dedent(ctx);
                                                                         context_ctx_emit(ctx, SLOP_STR("}"));
                                                                     }
-                                                                } else if (!_mv_888.has_value) {
+                                                                } else if (!_mv_889.has_value) {
                                                                     context_ctx_add_error_at(ctx, SLOP_STR("missing end"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                                                 }
-                                                            } else if (!_mv_887.has_value) {
+                                                            } else if (!_mv_888.has_value) {
                                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing start"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                                             }
                                                         }
@@ -1433,7 +1434,7 @@ void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr) {
                                                         break;
                                                     }
                                                 }
-                                            } else if (!_mv_885.has_value) {
+                                            } else if (!_mv_886.has_value) {
                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing var"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                             }
                                         }
@@ -1445,7 +1446,7 @@ void stmt_transpile_for(context_TranspileContext* ctx, types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_883.has_value) {
+                        } else if (!_mv_884.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing binding"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                     }
@@ -1484,11 +1485,11 @@ void stmt_transpile_for_each_set(context_TranspileContext* ctx, slop_string var_
         {
             int64_t i = 2;
             while (i < len) {
-                __auto_type _mv_890 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_890.has_value) {
-                    __auto_type body_expr = _mv_890.value;
+                __auto_type _mv_891 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_891.has_value) {
+                    __auto_type body_expr = _mv_891.value;
                     stmt_transpile_stmt(ctx, body_expr, 0);
-                } else if (!_mv_890.has_value) {
+                } else if (!_mv_891.has_value) {
                 }
                 i = (i + 1);
             }
@@ -1527,11 +1528,11 @@ void stmt_transpile_for_each_map_keys(context_TranspileContext* ctx, slop_string
         {
             int64_t i = 2;
             while (i < len) {
-                __auto_type _mv_891 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_891.has_value) {
-                    __auto_type body_expr = _mv_891.value;
+                __auto_type _mv_892 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_892.has_value) {
+                    __auto_type body_expr = _mv_892.value;
                     stmt_transpile_stmt(ctx, body_expr, 0);
-                } else if (!_mv_891.has_value) {
+                } else if (!_mv_892.has_value) {
                 }
                 i = (i + 1);
             }
@@ -1550,38 +1551,38 @@ void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_typ
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_892 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_892.has_value) {
-            __auto_type kv_list_expr = _mv_892.value;
-            __auto_type _mv_893 = (*kv_list_expr);
-            switch (_mv_893.tag) {
+        __auto_type _mv_893 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_893.has_value) {
+            __auto_type kv_list_expr = _mv_893.value;
+            __auto_type _mv_894 = (*kv_list_expr);
+            switch (_mv_894.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type kv_lst = _mv_893.data.lst;
+                    __auto_type kv_lst = _mv_894.data.lst;
                     {
                         __auto_type kv_items = kv_lst.items;
                         if (((int64_t)((kv_items).len)) < 2) {
                             context_ctx_add_error(ctx, SLOP_STR("Map for-each needs ((k v) map)"));
                         } else {
-                            __auto_type _mv_894 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_894.has_value) {
-                                __auto_type k_expr = _mv_894.value;
-                                __auto_type _mv_895 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_895.has_value) {
-                                    __auto_type v_expr = _mv_895.value;
-                                    __auto_type _mv_896 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_896.has_value) {
-                                        __auto_type map_expr = _mv_896.value;
-                                        __auto_type _mv_897 = (*k_expr);
-                                        switch (_mv_897.tag) {
+                            __auto_type _mv_895 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_895.has_value) {
+                                __auto_type k_expr = _mv_895.value;
+                                __auto_type _mv_896 = ({ __auto_type _lst = kv_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_896.has_value) {
+                                    __auto_type v_expr = _mv_896.value;
+                                    __auto_type _mv_897 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_897.has_value) {
+                                        __auto_type map_expr = _mv_897.value;
+                                        __auto_type _mv_898 = (*k_expr);
+                                        switch (_mv_898.tag) {
                                             case types_SExpr_sym:
                                             {
-                                                __auto_type k_sym = _mv_897.data.sym;
-                                                __auto_type _mv_898 = (*v_expr);
-                                                switch (_mv_898.tag) {
+                                                __auto_type k_sym = _mv_898.data.sym;
+                                                __auto_type _mv_899 = (*v_expr);
+                                                switch (_mv_899.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type v_sym = _mv_898.data.sym;
+                                                        __auto_type v_sym = _mv_899.data.sym;
                                                         {
                                                             __auto_type k_name = ctype_to_c_name(arena, k_sym.name);
                                                             __auto_type v_name = ctype_to_c_name(arena, v_sym.name);
@@ -1617,11 +1618,11 @@ void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_typ
                                                             {
                                                                 __auto_type i = 2;
                                                                 while (i < len) {
-                                                                    __auto_type _mv_899 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                    if (_mv_899.has_value) {
-                                                                        __auto_type body_expr = _mv_899.value;
+                                                                    __auto_type _mv_900 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                    if (_mv_900.has_value) {
+                                                                        __auto_type body_expr = _mv_900.value;
                                                                         stmt_transpile_stmt(ctx, body_expr, 0);
-                                                                    } else if (!_mv_899.has_value) {
+                                                                    } else if (!_mv_900.has_value) {
                                                                     }
                                                                     i = (i + 1);
                                                                 }
@@ -1648,13 +1649,13 @@ void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_typ
                                                 break;
                                             }
                                         }
-                                    } else if (!_mv_896.has_value) {
+                                    } else if (!_mv_897.has_value) {
                                         context_ctx_add_error(ctx, SLOP_STR("Missing map expression"));
                                     }
-                                } else if (!_mv_895.has_value) {
+                                } else if (!_mv_896.has_value) {
                                     context_ctx_add_error(ctx, SLOP_STR("Missing value binding"));
                                 }
-                            } else if (!_mv_894.has_value) {
+                            } else if (!_mv_895.has_value) {
                                 context_ctx_add_error(ctx, SLOP_STR("Missing key binding"));
                             }
                         }
@@ -1666,7 +1667,7 @@ void stmt_transpile_for_each_map_kv(context_TranspileContext* ctx, slop_list_typ
                     break;
                 }
             }
-        } else if (!_mv_892.has_value) {
+        } else if (!_mv_893.has_value) {
             context_ctx_add_error(ctx, SLOP_STR("Missing binding"));
         }
     }
@@ -1677,50 +1678,50 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_900 = (*expr);
-        switch (_mv_900.tag) {
+        __auto_type _mv_901 = (*expr);
+        switch (_mv_901.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_900.data.lst;
+                __auto_type lst = _mv_901.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 2) {
                         context_ctx_add_error_at(ctx, SLOP_STR("invalid for-each: need binding"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                     } else {
-                        __auto_type _mv_901 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_901.has_value) {
-                            __auto_type binding_expr = _mv_901.value;
-                            __auto_type _mv_902 = (*binding_expr);
-                            switch (_mv_902.tag) {
+                        __auto_type _mv_902 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_902.has_value) {
+                            __auto_type binding_expr = _mv_902.value;
+                            __auto_type _mv_903 = (*binding_expr);
+                            switch (_mv_903.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type binding_lst = _mv_902.data.lst;
+                                    __auto_type binding_lst = _mv_903.data.lst;
                                     {
                                         __auto_type binding_items = binding_lst.items;
                                         __auto_type binding_len = ((int64_t)((binding_items).len));
                                         if (binding_len < 2) {
                                             context_ctx_add_error_at(ctx, SLOP_STR("for-each binding needs (var coll)"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                         } else {
-                                            __auto_type _mv_903 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_903.has_value) {
-                                                __auto_type first_elem = _mv_903.value;
-                                                __auto_type _mv_904 = (*first_elem);
-                                                switch (_mv_904.tag) {
+                                            __auto_type _mv_904 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_904.has_value) {
+                                                __auto_type first_elem = _mv_904.value;
+                                                __auto_type _mv_905 = (*first_elem);
+                                                switch (_mv_905.tag) {
                                                     case types_SExpr_lst:
                                                     {
-                                                        __auto_type _ = _mv_904.data.lst;
+                                                        __auto_type _ = _mv_905.data.lst;
                                                         stmt_transpile_for_each_map_kv(ctx, binding_items, items, len);
                                                         break;
                                                     }
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type var_sym = _mv_904.data.sym;
+                                                        __auto_type var_sym = _mv_905.data.sym;
                                                         {
                                                             __auto_type var_name = ctype_to_c_name(arena, var_sym.name);
-                                                            __auto_type _mv_905 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                            if (_mv_905.has_value) {
-                                                                __auto_type coll_expr = _mv_905.value;
+                                                            __auto_type _mv_906 = ({ __auto_type _lst = binding_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                            if (_mv_906.has_value) {
+                                                                __auto_type coll_expr = _mv_906.value;
                                                                 {
                                                                     __auto_type coll_slop_type = expr_infer_expr_slop_type(ctx, coll_expr);
                                                                     __auto_type resolved_type = expr_resolve_type_alias(ctx, coll_slop_type);
@@ -1753,11 +1754,11 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
                                                                             {
                                                                                 __auto_type i = 2;
                                                                                 while (i < len) {
-                                                                                    __auto_type _mv_906 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                                    if (_mv_906.has_value) {
-                                                                                        __auto_type body_expr = _mv_906.value;
+                                                                                    __auto_type _mv_907 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                                    if (_mv_907.has_value) {
+                                                                                        __auto_type body_expr = _mv_907.value;
                                                                                         stmt_transpile_stmt(ctx, body_expr, 0);
-                                                                                    } else if (!_mv_906.has_value) {
+                                                                                    } else if (!_mv_907.has_value) {
                                                                                     }
                                                                                     i = (i + 1);
                                                                                 }
@@ -1770,7 +1771,7 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
                                                                         }
                                                                     }
                                                                 }
-                                                            } else if (!_mv_905.has_value) {
+                                                            } else if (!_mv_906.has_value) {
                                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing collection"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                                             }
                                                         }
@@ -1781,7 +1782,7 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
                                                         break;
                                                     }
                                                 }
-                                            } else if (!_mv_903.has_value) {
+                                            } else if (!_mv_904.has_value) {
                                                 context_ctx_add_error_at(ctx, SLOP_STR("missing var"), context_ctx_sexpr_line(binding_expr), context_ctx_sexpr_col(binding_expr));
                                             }
                                         }
@@ -1793,7 +1794,7 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
                                     break;
                                 }
                             }
-                        } else if (!_mv_901.has_value) {
+                        } else if (!_mv_902.has_value) {
                             context_ctx_add_error_at(ctx, SLOP_STR("missing binding"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                         }
                     }
@@ -1811,24 +1812,24 @@ void stmt_transpile_for_each(context_TranspileContext* ctx, types_SExpr* expr) {
 void stmt_transpile_stmt(context_TranspileContext* ctx, types_SExpr* expr, uint8_t is_return) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_907 = (*expr);
-    switch (_mv_907.tag) {
+    __auto_type _mv_908 = (*expr);
+    switch (_mv_908.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_907.data.lst;
+            __auto_type lst = _mv_908.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     context_ctx_add_error_at(ctx, SLOP_STR("empty list"), context_ctx_sexpr_line(expr), context_ctx_sexpr_col(expr));
                 } else {
-                    __auto_type _mv_908 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_908.has_value) {
-                        __auto_type head_expr = _mv_908.value;
-                        __auto_type _mv_909 = (*head_expr);
-                        switch (_mv_909.tag) {
+                    __auto_type _mv_909 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_909.has_value) {
+                        __auto_type head_expr = _mv_909.value;
+                        __auto_type _mv_910 = (*head_expr);
+                        switch (_mv_910.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_909.data.sym;
+                                __auto_type sym = _mv_910.data.sym;
                                 {
                                     __auto_type op = sym.name;
                                     if (string_eq(op, SLOP_STR("let")) || string_eq(op, SLOP_STR("let*"))) {
@@ -1857,11 +1858,11 @@ void stmt_transpile_stmt(context_TranspileContext* ctx, types_SExpr* expr, uint8
                                         if (((int64_t)((items).len)) < 2) {
                                             context_ctx_emit(ctx, SLOP_STR("return;"));
                                         } else {
-                                            __auto_type _mv_910 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_910.has_value) {
-                                                __auto_type val_expr = _mv_910.value;
+                                            __auto_type _mv_911 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_911.has_value) {
+                                                __auto_type val_expr = _mv_911.value;
                                                 stmt_emit_typed_return_expr(ctx, val_expr);
-                                            } else if (!_mv_910.has_value) {
+                                            } else if (!_mv_911.has_value) {
                                                 context_ctx_emit(ctx, SLOP_STR("return;"));
                                             }
                                         }
@@ -1893,7 +1894,7 @@ void stmt_transpile_stmt(context_TranspileContext* ctx, types_SExpr* expr, uint8
                                 break;
                             }
                         }
-                    } else if (!_mv_908.has_value) {
+                    } else if (!_mv_909.has_value) {
                         context_ctx_add_error_at(ctx, SLOP_STR("empty"), context_ctx_list_first_line(items), context_ctx_list_first_col(items));
                     }
                 }
@@ -1916,61 +1917,61 @@ void stmt_transpile_stmt(context_TranspileContext* ctx, types_SExpr* expr, uint8
 void stmt_emit_typed_return_expr(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_911 = (*expr);
-    switch (_mv_911.tag) {
+    __auto_type _mv_912 = (*expr);
+    switch (_mv_912.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_911.data.lst;
+            __auto_type lst = _mv_912.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                 } else {
-                    __auto_type _mv_912 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_912.has_value) {
-                        __auto_type head = _mv_912.value;
-                        __auto_type _mv_913 = (*head);
-                        switch (_mv_913.tag) {
+                    __auto_type _mv_913 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_913.has_value) {
+                        __auto_type head = _mv_913.value;
+                        __auto_type _mv_914 = (*head);
+                        switch (_mv_914.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_913.data.sym;
+                                __auto_type sym = _mv_914.data.sym;
                                 {
                                     __auto_type op = sym.name;
                                     if (string_eq(op, SLOP_STR("some"))) {
-                                        __auto_type _mv_914 = context_ctx_get_current_return_type(ctx);
-                                        if (_mv_914.has_value) {
-                                            __auto_type ret_type = _mv_914.value;
+                                        __auto_type _mv_915 = context_ctx_get_current_return_type(ctx);
+                                        if (_mv_915.has_value) {
+                                            __auto_type ret_type = _mv_915.value;
                                             if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
                                                 if (((int64_t)((items).len)) < 2) {
                                                     stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                                                 } else {
-                                                    __auto_type _mv_915 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_915.has_value) {
-                                                        __auto_type inner_expr = _mv_915.value;
+                                                    __auto_type _mv_916 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_916.has_value) {
+                                                        __auto_type inner_expr = _mv_916.value;
                                                         {
                                                             __auto_type inner_c = expr_transpile_expr(ctx, inner_expr);
                                                             context_ctx_emit(ctx, context_ctx_str5(ctx, SLOP_STR("return ("), ret_type, SLOP_STR("){.has_value = 1, .value = "), inner_c, SLOP_STR("};")));
                                                         }
-                                                    } else if (!_mv_915.has_value) {
+                                                    } else if (!_mv_916.has_value) {
                                                         stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                                                     }
                                                 }
                                             } else {
                                                 stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                                             }
-                                        } else if (!_mv_914.has_value) {
+                                        } else if (!_mv_915.has_value) {
                                             stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                                         }
                                     } else if (string_eq(op, SLOP_STR("none"))) {
-                                        __auto_type _mv_916 = context_ctx_get_current_return_type(ctx);
-                                        if (_mv_916.has_value) {
-                                            __auto_type ret_type = _mv_916.value;
+                                        __auto_type _mv_917 = context_ctx_get_current_return_type(ctx);
+                                        if (_mv_917.has_value) {
+                                            __auto_type ret_type = _mv_917.value;
                                             if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
                                                 context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("return ("), ret_type, SLOP_STR("){.has_value = false};")));
                                             } else {
                                                 stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                                             }
-                                        } else if (!_mv_916.has_value) {
+                                        } else if (!_mv_917.has_value) {
                                             stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                                         }
                                     } else {
@@ -1984,7 +1985,7 @@ void stmt_emit_typed_return_expr(context_TranspileContext* ctx, types_SExpr* exp
                                 break;
                             }
                         }
-                    } else if (!_mv_912.has_value) {
+                    } else if (!_mv_913.has_value) {
                         stmt_emit_return_with_typed_none(ctx, expr_transpile_expr(ctx, expr));
                     }
                 }
@@ -2003,22 +2004,22 @@ void stmt_emit_return_with_typed_none(context_TranspileContext* ctx, slop_string
     {
         __auto_type final_code = code;
         if (string_eq(code, SLOP_STR("none"))) {
-            __auto_type _mv_917 = context_ctx_get_current_return_type(ctx);
-            if (_mv_917.has_value) {
-                __auto_type ret_type = _mv_917.value;
-                if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
-                    final_code = context_ctx_str3(ctx, SLOP_STR("("), ret_type, SLOP_STR("){.has_value = false}"));
-                }
-            } else if (!_mv_917.has_value) {
-            }
-        } else {
             __auto_type _mv_918 = context_ctx_get_current_return_type(ctx);
             if (_mv_918.has_value) {
                 __auto_type ret_type = _mv_918.value;
                 if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
-                    __auto_type _mv_919 = context_ctx_lookup_var(ctx, code);
-                    if (_mv_919.has_value) {
-                        __auto_type var_entry = _mv_919.value;
+                    final_code = context_ctx_str3(ctx, SLOP_STR("("), ret_type, SLOP_STR("){.has_value = false}"));
+                }
+            } else if (!_mv_918.has_value) {
+            }
+        } else {
+            __auto_type _mv_919 = context_ctx_get_current_return_type(ctx);
+            if (_mv_919.has_value) {
+                __auto_type ret_type = _mv_919.value;
+                if (strlib_starts_with(ret_type, SLOP_STR("slop_option_"))) {
+                    __auto_type _mv_920 = context_ctx_lookup_var(ctx, code);
+                    if (_mv_920.has_value) {
+                        __auto_type var_entry = _mv_920.value;
                         {
                             __auto_type var_type = var_entry.c_type;
                             if (string_eq(var_type, SLOP_STR("_slop_option_generic")) || string_eq(var_type, SLOP_STR("auto"))) {
@@ -2033,10 +2034,10 @@ void stmt_emit_return_with_typed_none(context_TranspileContext* ctx, slop_string
                                 }
                             }
                         }
-                    } else if (!_mv_919.has_value) {
+                    } else if (!_mv_920.has_value) {
                     }
                 }
-            } else if (!_mv_918.has_value) {
+            } else if (!_mv_919.has_value) {
             }
         }
         if (context_ctx_is_capture_retval(ctx)) {

--- a/bootstrap/transpiler/slop_transpiler.c
+++ b/bootstrap/transpiler/slop_transpiler.c
@@ -212,48 +212,48 @@ transpiler_GenericInfo transpiler_extract_generic_info(slop_arena* arena, slop_l
         __auto_type result_is_generic = 0;
         __auto_type result_type_params = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
         while (i < len) {
-            __auto_type _mv_1107 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1107.has_value) {
-                __auto_type item = _mv_1107.value;
-                __auto_type _mv_1108 = (*item);
-                switch (_mv_1108.tag) {
+            __auto_type _mv_1108 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1108.has_value) {
+                __auto_type item = _mv_1108.value;
+                __auto_type _mv_1109 = (*item);
+                switch (_mv_1109.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type lst = _mv_1108.data.lst;
+                        __auto_type lst = _mv_1109.data.lst;
                         {
                             __auto_type sub_items = lst.items;
                             if (((int64_t)((sub_items).len)) >= 1) {
-                                __auto_type _mv_1109 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1109.has_value) {
-                                    __auto_type head = _mv_1109.value;
-                                    __auto_type _mv_1110 = (*head);
-                                    switch (_mv_1110.tag) {
+                                __auto_type _mv_1110 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1110.has_value) {
+                                    __auto_type head = _mv_1110.value;
+                                    __auto_type _mv_1111 = (*head);
+                                    switch (_mv_1111.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_1110.data.sym;
+                                            __auto_type sym = _mv_1111.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("@generic"))) {
                                                 if (((int64_t)((sub_items).len)) >= 2) {
-                                                    __auto_type _mv_1111 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1111.has_value) {
-                                                        __auto_type params_expr = _mv_1111.value;
-                                                        __auto_type _mv_1112 = (*params_expr);
-                                                        switch (_mv_1112.tag) {
+                                                    __auto_type _mv_1112 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1112.has_value) {
+                                                        __auto_type params_expr = _mv_1112.value;
+                                                        __auto_type _mv_1113 = (*params_expr);
+                                                        switch (_mv_1113.tag) {
                                                             case types_SExpr_lst:
                                                             {
-                                                                __auto_type params_lst = _mv_1112.data.lst;
+                                                                __auto_type params_lst = _mv_1113.data.lst;
                                                                 {
                                                                     __auto_type param_items = params_lst.items;
                                                                     __auto_type param_len = ((int64_t)((param_items).len));
                                                                     __auto_type j = 0;
                                                                     while (j < param_len) {
-                                                                        __auto_type _mv_1113 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                        if (_mv_1113.has_value) {
-                                                                            __auto_type param = _mv_1113.value;
-                                                                            __auto_type _mv_1114 = (*param);
-                                                                            switch (_mv_1114.tag) {
+                                                                        __auto_type _mv_1114 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                        if (_mv_1114.has_value) {
+                                                                            __auto_type param = _mv_1114.value;
+                                                                            __auto_type _mv_1115 = (*param);
+                                                                            switch (_mv_1115.tag) {
                                                                                 case types_SExpr_sym:
                                                                                 {
-                                                                                    __auto_type param_sym = _mv_1114.data.sym;
+                                                                                    __auto_type param_sym = _mv_1115.data.sym;
                                                                                     ({ __auto_type _lst_p = &(result_type_params); __auto_type _item = (param_sym.name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                                                     break;
                                                                                 }
@@ -261,7 +261,7 @@ transpiler_GenericInfo transpiler_extract_generic_info(slop_arena* arena, slop_l
                                                                                     break;
                                                                                 }
                                                                             }
-                                                                        } else if (!_mv_1113.has_value) {
+                                                                        } else if (!_mv_1114.has_value) {
                                                                         }
                                                                         j = (j + 1);
                                                                     }
@@ -270,7 +270,7 @@ transpiler_GenericInfo transpiler_extract_generic_info(slop_arena* arena, slop_l
                                                             }
                                                             case types_SExpr_sym:
                                                             {
-                                                                __auto_type single_sym = _mv_1112.data.sym;
+                                                                __auto_type single_sym = _mv_1113.data.sym;
                                                                 ({ __auto_type _lst_p = &(result_type_params); __auto_type _item = (single_sym.name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                                 break;
                                                             }
@@ -278,7 +278,7 @@ transpiler_GenericInfo transpiler_extract_generic_info(slop_arena* arena, slop_l
                                                                 break;
                                                             }
                                                         }
-                                                    } else if (!_mv_1111.has_value) {
+                                                    } else if (!_mv_1112.has_value) {
                                                     }
                                                 }
                                             }
@@ -288,7 +288,7 @@ transpiler_GenericInfo transpiler_extract_generic_info(slop_arena* arena, slop_l
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1109.has_value) {
+                                } else if (!_mv_1110.has_value) {
                                 }
                             }
                         }
@@ -298,7 +298,7 @@ transpiler_GenericInfo transpiler_extract_generic_info(slop_arena* arena, slop_l
                         break;
                     }
                 }
-            } else if (!_mv_1107.has_value) {
+            } else if (!_mv_1108.has_value) {
             }
             i = (i + 1);
         }
@@ -312,11 +312,11 @@ void transpiler_prescan_module(context_TranspileContext* ctx, slop_list_types_SE
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1115 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1115.has_value) {
-                __auto_type item = _mv_1115.value;
+            __auto_type _mv_1116 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1116.has_value) {
+                __auto_type item = _mv_1116.value;
                 transpiler_prescan_top_level(ctx, item);
-            } else if (!_mv_1115.has_value) {
+            } else if (!_mv_1116.has_value) {
             }
             i = (i + 1);
         }
@@ -326,22 +326,22 @@ void transpiler_prescan_module(context_TranspileContext* ctx, slop_list_types_SE
 void transpiler_prescan_top_level(context_TranspileContext* ctx, types_SExpr* item) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1116 = (*item);
-    switch (_mv_1116.tag) {
+    __auto_type _mv_1117 = (*item);
+    switch (_mv_1117.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1116.data.lst;
+            __auto_type lst = _mv_1117.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) >= 1) {
-                    __auto_type _mv_1117 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1117.has_value) {
-                        __auto_type head = _mv_1117.value;
-                        __auto_type _mv_1118 = (*head);
-                        switch (_mv_1118.tag) {
+                    __auto_type _mv_1118 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1118.has_value) {
+                        __auto_type head = _mv_1118.value;
+                        __auto_type _mv_1119 = (*head);
+                        switch (_mv_1119.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1118.data.sym;
+                                __auto_type sym = _mv_1119.data.sym;
                                 {
                                     __auto_type name = sym.name;
                                     if (string_eq(name, SLOP_STR("type"))) {
@@ -365,7 +365,7 @@ void transpiler_prescan_top_level(context_TranspileContext* ctx, types_SExpr* it
                                 break;
                             }
                         }
-                    } else if (!_mv_1117.has_value) {
+                    } else if (!_mv_1118.has_value) {
                     }
                 }
             }
@@ -382,14 +382,14 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
     {
         __auto_type arena = (*ctx).arena;
         if (((int64_t)((items).len)) >= 2) {
-            __auto_type _mv_1119 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1119.has_value) {
-                __auto_type name_expr = _mv_1119.value;
-                __auto_type _mv_1120 = (*name_expr);
-                switch (_mv_1120.tag) {
+            __auto_type _mv_1120 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1120.has_value) {
+                __auto_type name_expr = _mv_1120.value;
+                __auto_type _mv_1121 = (*name_expr);
+                switch (_mv_1121.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_1120.data.sym;
+                        __auto_type sym = _mv_1121.data.sym;
                         {
                             __auto_type type_name = sym.name;
                             __auto_type base_c_name = ctype_to_c_name(arena, type_name);
@@ -408,14 +408,14 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
                                 }
                                 if (is_record || is_union) {
                                     if (((int64_t)((items).len)) >= 3) {
-                                        __auto_type _mv_1121 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1121.has_value) {
-                                            __auto_type def_expr = _mv_1121.value;
-                                            __auto_type _mv_1122 = (*def_expr);
-                                            switch (_mv_1122.tag) {
+                                        __auto_type _mv_1122 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1122.has_value) {
+                                            __auto_type def_expr = _mv_1122.value;
+                                            __auto_type _mv_1123 = (*def_expr);
+                                            switch (_mv_1123.tag) {
                                                 case types_SExpr_lst:
                                                 {
-                                                    __auto_type def_lst = _mv_1122.data.lst;
+                                                    __auto_type def_lst = _mv_1123.data.lst;
                                                     transpiler_scan_record_fields_for_generics(ctx, def_lst.items);
                                                     break;
                                                 }
@@ -423,7 +423,7 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
                                                     break;
                                                 }
                                             }
-                                        } else if (!_mv_1121.has_value) {
+                                        } else if (!_mv_1122.has_value) {
                                         }
                                     }
                                     {
@@ -433,9 +433,9 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
                                     }
                                 }
                                 if (((int64_t)((items).len)) >= 3) {
-                                    __auto_type _mv_1123 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                    if (_mv_1123.has_value) {
-                                        __auto_type body_expr = _mv_1123.value;
+                                    __auto_type _mv_1124 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                    if (_mv_1124.has_value) {
+                                        __auto_type body_expr = _mv_1124.value;
                                         transpiler_check_and_register_result_alias(ctx, type_name, body_expr);
                                         {
                                             __auto_type slop_type_str = parser_pretty_print(arena, body_expr);
@@ -446,7 +446,7 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
                                                 transpiler_scan_type_for_generics(ctx, body_expr);
                                             }
                                         }
-                                    } else if (!_mv_1123.has_value) {
+                                    } else if (!_mv_1124.has_value) {
                                     }
                                 }
                             }
@@ -457,7 +457,7 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
                         break;
                     }
                 }
-            } else if (!_mv_1119.has_value) {
+            } else if (!_mv_1120.has_value) {
             }
         }
     }
@@ -466,42 +466,42 @@ void transpiler_prescan_type(context_TranspileContext* ctx, slop_list_types_SExp
 void transpiler_register_enum_variants(context_TranspileContext* ctx, slop_string enum_name, slop_list_types_SExpr_ptr items) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     if (((int64_t)((items).len)) >= 3) {
-        __auto_type _mv_1124 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1124.has_value) {
-            __auto_type def_expr = _mv_1124.value;
-            __auto_type _mv_1125 = (*def_expr);
-            switch (_mv_1125.tag) {
+        __auto_type _mv_1125 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1125.has_value) {
+            __auto_type def_expr = _mv_1125.value;
+            __auto_type _mv_1126 = (*def_expr);
+            switch (_mv_1126.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type def_lst = _mv_1125.data.lst;
+                    __auto_type def_lst = _mv_1126.data.lst;
                     {
                         __auto_type def_items = def_lst.items;
                         __auto_type len = ((int64_t)((def_items).len));
                         __auto_type i = 1;
                         while (i < len) {
-                            __auto_type _mv_1126 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1126.has_value) {
-                                __auto_type variant_expr = _mv_1126.value;
-                                __auto_type _mv_1127 = (*variant_expr);
-                                switch (_mv_1127.tag) {
+                            __auto_type _mv_1127 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1127.has_value) {
+                                __auto_type variant_expr = _mv_1127.value;
+                                __auto_type _mv_1128 = (*variant_expr);
+                                switch (_mv_1128.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1127.data.sym;
+                                        __auto_type sym = _mv_1128.data.sym;
                                         context_ctx_register_enum_variant(ctx, sym.name, enum_name);
                                         break;
                                     }
                                     case types_SExpr_lst:
                                     {
-                                        __auto_type variant_lst = _mv_1127.data.lst;
+                                        __auto_type variant_lst = _mv_1128.data.lst;
                                         if (((int64_t)((variant_lst.items).len)) > 0) {
-                                            __auto_type _mv_1128 = ({ __auto_type _lst = variant_lst.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1128.has_value) {
-                                                __auto_type name_expr = _mv_1128.value;
-                                                __auto_type _mv_1129 = (*name_expr);
-                                                switch (_mv_1129.tag) {
+                                            __auto_type _mv_1129 = ({ __auto_type _lst = variant_lst.items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1129.has_value) {
+                                                __auto_type name_expr = _mv_1129.value;
+                                                __auto_type _mv_1130 = (*name_expr);
+                                                switch (_mv_1130.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type name_sym = _mv_1129.data.sym;
+                                                        __auto_type name_sym = _mv_1130.data.sym;
                                                         context_ctx_register_enum_variant(ctx, name_sym.name, enum_name);
                                                         break;
                                                     }
@@ -509,7 +509,7 @@ void transpiler_register_enum_variants(context_TranspileContext* ctx, slop_strin
                                                         break;
                                                     }
                                                 }
-                                            } else if (!_mv_1128.has_value) {
+                                            } else if (!_mv_1129.has_value) {
                                             }
                                         }
                                         break;
@@ -518,7 +518,7 @@ void transpiler_register_enum_variants(context_TranspileContext* ctx, slop_strin
                                         break;
                                     }
                                 }
-                            } else if (!_mv_1126.has_value) {
+                            } else if (!_mv_1127.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -529,7 +529,7 @@ void transpiler_register_enum_variants(context_TranspileContext* ctx, slop_strin
                     break;
                 }
             }
-        } else if (!_mv_1124.has_value) {
+        } else if (!_mv_1125.has_value) {
         }
     }
 }
@@ -539,27 +539,27 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
     {
         __auto_type arena = (*ctx).arena;
         if (((int64_t)((items).len)) >= 3) {
-            __auto_type _mv_1130 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1130.has_value) {
-                __auto_type def_expr = _mv_1130.value;
-                __auto_type _mv_1131 = (*def_expr);
-                switch (_mv_1131.tag) {
+            __auto_type _mv_1131 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1131.has_value) {
+                __auto_type def_expr = _mv_1131.value;
+                __auto_type _mv_1132 = (*def_expr);
+                switch (_mv_1132.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type def_lst = _mv_1131.data.lst;
+                        __auto_type def_lst = _mv_1132.data.lst;
                         {
                             __auto_type def_items = def_lst.items;
                             __auto_type len = ((int64_t)((def_items).len));
                             __auto_type i = 1;
                             while (i < len) {
-                                __auto_type _mv_1132 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1132.has_value) {
-                                    __auto_type variant_expr = _mv_1132.value;
-                                    __auto_type _mv_1133 = (*variant_expr);
-                                    switch (_mv_1133.tag) {
+                                __auto_type _mv_1133 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1133.has_value) {
+                                    __auto_type variant_expr = _mv_1133.value;
+                                    __auto_type _mv_1134 = (*variant_expr);
+                                    switch (_mv_1134.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_1133.data.sym;
+                                            __auto_type sym = _mv_1134.data.sym;
                                             {
                                                 __auto_type variant_name = sym.name;
                                                 context_ctx_register_enum_variant(ctx, variant_name, union_name);
@@ -569,26 +569,26 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                         }
                                         case types_SExpr_lst:
                                         {
-                                            __auto_type variant_lst = _mv_1133.data.lst;
+                                            __auto_type variant_lst = _mv_1134.data.lst;
                                             {
                                                 __auto_type vl_items = variant_lst.items;
                                                 __auto_type vl_len = ((int64_t)((vl_items).len));
                                                 if (vl_len >= 2) {
-                                                    __auto_type _mv_1134 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1134.has_value) {
-                                                        __auto_type name_expr = _mv_1134.value;
-                                                        __auto_type _mv_1135 = (*name_expr);
-                                                        switch (_mv_1135.tag) {
+                                                    __auto_type _mv_1135 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1135.has_value) {
+                                                        __auto_type name_expr = _mv_1135.value;
+                                                        __auto_type _mv_1136 = (*name_expr);
+                                                        switch (_mv_1136.tag) {
                                                             case types_SExpr_sym:
                                                             {
-                                                                __auto_type name_sym = _mv_1135.data.sym;
+                                                                __auto_type name_sym = _mv_1136.data.sym;
                                                                 {
                                                                     __auto_type variant_name = name_sym.name;
                                                                     __auto_type c_variant_name = ctype_to_c_name(arena, variant_name);
                                                                     context_ctx_register_enum_variant(ctx, variant_name, union_name);
-                                                                    __auto_type _mv_1136 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                    if (_mv_1136.has_value) {
-                                                                        __auto_type type_expr = _mv_1136.value;
+                                                                    __auto_type _mv_1137 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                    if (_mv_1137.has_value) {
+                                                                        __auto_type type_expr = _mv_1137.value;
                                                                         {
                                                                             __auto_type slop_type = parser_pretty_print(arena, type_expr);
                                                                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
@@ -596,7 +596,7 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                                                             context_ctx_register_union_variant(ctx, variant_name, union_name, c_variant_name, slop_type, c_type);
                                                                             context_ctx_register_field_type(ctx, union_name, variant_name, c_type, slop_type, is_ptr);
                                                                         }
-                                                                    } else if (!_mv_1136.has_value) {
+                                                                    } else if (!_mv_1137.has_value) {
                                                                         context_ctx_register_union_variant(ctx, variant_name, union_name, c_variant_name, SLOP_STR(""), SLOP_STR(""));
                                                                     }
                                                                     if (vl_len >= 3) {
@@ -606,9 +606,9 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                                                             context_ctx_register_field_type(ctx, union_name, count_key, count_str, SLOP_STR(""), 0);
                                                                         }
                                                                         for (int64_t fi = 1; fi < vl_len; fi++) {
-                                                                            __auto_type _mv_1137 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                            if (_mv_1137.has_value) {
-                                                                                __auto_type type_expr = _mv_1137.value;
+                                                                            __auto_type _mv_1138 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                            if (_mv_1138.has_value) {
+                                                                                __auto_type type_expr = _mv_1138.value;
                                                                                 {
                                                                                     __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                                                     __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
@@ -616,7 +616,7 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                                                                     __auto_type field_key = context_ctx_str3(ctx, variant_name, SLOP_STR("__"), int_to_string(arena, (fi - 1)));
                                                                                     context_ctx_register_field_type(ctx, union_name, field_key, c_type, slop_type_str, is_ptr);
                                                                                 }
-                                                                            } else if (!_mv_1137.has_value) {
+                                                                            } else if (!_mv_1138.has_value) {
                                                                             }
                                                                         }
                                                                     }
@@ -627,18 +627,18 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                                                 break;
                                                             }
                                                         }
-                                                    } else if (!_mv_1134.has_value) {
+                                                    } else if (!_mv_1135.has_value) {
                                                     }
                                                 } else {
                                                     if (((int64_t)((vl_items).len)) == 1) {
-                                                        __auto_type _mv_1138 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                        if (_mv_1138.has_value) {
-                                                            __auto_type name_expr = _mv_1138.value;
-                                                            __auto_type _mv_1139 = (*name_expr);
-                                                            switch (_mv_1139.tag) {
+                                                        __auto_type _mv_1139 = ({ __auto_type _lst = vl_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                        if (_mv_1139.has_value) {
+                                                            __auto_type name_expr = _mv_1139.value;
+                                                            __auto_type _mv_1140 = (*name_expr);
+                                                            switch (_mv_1140.tag) {
                                                                 case types_SExpr_sym:
                                                                 {
-                                                                    __auto_type name_sym = _mv_1139.data.sym;
+                                                                    __auto_type name_sym = _mv_1140.data.sym;
                                                                     {
                                                                         __auto_type variant_name = name_sym.name;
                                                                         context_ctx_register_enum_variant(ctx, variant_name, union_name);
@@ -650,7 +650,7 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                                                     break;
                                                                 }
                                                             }
-                                                        } else if (!_mv_1138.has_value) {
+                                                        } else if (!_mv_1139.has_value) {
                                                         }
                                                     }
                                                 }
@@ -661,7 +661,7 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1132.has_value) {
+                                } else if (!_mv_1133.has_value) {
                                 }
                                 i = (i + 1);
                             }
@@ -672,7 +672,7 @@ void transpiler_register_union_variants(context_TranspileContext* ctx, slop_stri
                         break;
                     }
                 }
-            } else if (!_mv_1130.has_value) {
+            } else if (!_mv_1131.has_value) {
             }
         }
     }
@@ -683,14 +683,14 @@ void transpiler_prescan_fn(context_TranspileContext* ctx, slop_list_types_SExpr_
     {
         __auto_type arena = (*ctx).arena;
         if (((int64_t)((items).len)) >= 2) {
-            __auto_type _mv_1140 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1140.has_value) {
-                __auto_type name_expr = _mv_1140.value;
-                __auto_type _mv_1141 = (*name_expr);
-                switch (_mv_1141.tag) {
+            __auto_type _mv_1141 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1141.has_value) {
+                __auto_type name_expr = _mv_1141.value;
+                __auto_type _mv_1142 = (*name_expr);
+                switch (_mv_1142.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_1141.data.sym;
+                        __auto_type sym = _mv_1142.data.sym;
                         {
                             __auto_type fn_name = sym.name;
                             __auto_type base_name = ctype_to_c_name(arena, fn_name);
@@ -720,7 +720,7 @@ void transpiler_prescan_fn(context_TranspileContext* ctx, slop_list_types_SExpr_
                         break;
                     }
                 }
-            } else if (!_mv_1140.has_value) {
+            } else if (!_mv_1141.has_value) {
             }
         }
     }
@@ -732,46 +732,46 @@ uint8_t transpiler_fn_returns_string(slop_list_types_SExpr_ptr items) {
         int64_t i = 3;
         uint8_t result = 0;
         while ((i < len) && !(result)) {
-            __auto_type _mv_1142 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1142.has_value) {
-                __auto_type item = _mv_1142.value;
-                __auto_type _mv_1143 = (*item);
-                switch (_mv_1143.tag) {
+            __auto_type _mv_1143 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1143.has_value) {
+                __auto_type item = _mv_1143.value;
+                __auto_type _mv_1144 = (*item);
+                switch (_mv_1144.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type lst = _mv_1143.data.lst;
+                        __auto_type lst = _mv_1144.data.lst;
                         {
                             __auto_type sub_items = lst.items;
                             if (((int64_t)((sub_items).len)) >= 2) {
-                                __auto_type _mv_1144 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1144.has_value) {
-                                    __auto_type head = _mv_1144.value;
-                                    __auto_type _mv_1145 = (*head);
-                                    switch (_mv_1145.tag) {
+                                __auto_type _mv_1145 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1145.has_value) {
+                                    __auto_type head = _mv_1145.value;
+                                    __auto_type _mv_1146 = (*head);
+                                    switch (_mv_1146.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_1145.data.sym;
+                                            __auto_type sym = _mv_1146.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("@spec"))) {
-                                                __auto_type _mv_1146 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1146.has_value) {
-                                                    __auto_type spec_body = _mv_1146.value;
-                                                    __auto_type _mv_1147 = (*spec_body);
-                                                    switch (_mv_1147.tag) {
+                                                __auto_type _mv_1147 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1147.has_value) {
+                                                    __auto_type spec_body = _mv_1147.value;
+                                                    __auto_type _mv_1148 = (*spec_body);
+                                                    switch (_mv_1148.tag) {
                                                         case types_SExpr_lst:
                                                         {
-                                                            __auto_type body_lst = _mv_1147.data.lst;
+                                                            __auto_type body_lst = _mv_1148.data.lst;
                                                             {
                                                                 __auto_type body_items = body_lst.items;
                                                                 __auto_type body_len = ((int64_t)((body_items).len));
                                                                 if (body_len >= 1) {
-                                                                    __auto_type _mv_1148 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                    if (_mv_1148.has_value) {
-                                                                        __auto_type ret_type = _mv_1148.value;
-                                                                        __auto_type _mv_1149 = (*ret_type);
-                                                                        switch (_mv_1149.tag) {
+                                                                    __auto_type _mv_1149 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                    if (_mv_1149.has_value) {
+                                                                        __auto_type ret_type = _mv_1149.value;
+                                                                        __auto_type _mv_1150 = (*ret_type);
+                                                                        switch (_mv_1150.tag) {
                                                                             case types_SExpr_sym:
                                                                             {
-                                                                                __auto_type ret_sym = _mv_1149.data.sym;
+                                                                                __auto_type ret_sym = _mv_1150.data.sym;
                                                                                 result = string_eq(ret_sym.name, SLOP_STR("String"));
                                                                                 break;
                                                                             }
@@ -779,7 +779,7 @@ uint8_t transpiler_fn_returns_string(slop_list_types_SExpr_ptr items) {
                                                                                 break;
                                                                             }
                                                                         }
-                                                                    } else if (!_mv_1148.has_value) {
+                                                                    } else if (!_mv_1149.has_value) {
                                                                     }
                                                                 }
                                                             }
@@ -789,7 +789,7 @@ uint8_t transpiler_fn_returns_string(slop_list_types_SExpr_ptr items) {
                                                             break;
                                                         }
                                                     }
-                                                } else if (!_mv_1146.has_value) {
+                                                } else if (!_mv_1147.has_value) {
                                                 }
                                             }
                                             break;
@@ -798,7 +798,7 @@ uint8_t transpiler_fn_returns_string(slop_list_types_SExpr_ptr items) {
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1144.has_value) {
+                                } else if (!_mv_1145.has_value) {
                                 }
                             }
                         }
@@ -808,7 +808,7 @@ uint8_t transpiler_fn_returns_string(slop_list_types_SExpr_ptr items) {
                         break;
                     }
                 }
-            } else if (!_mv_1142.has_value) {
+            } else if (!_mv_1143.has_value) {
             }
             i = (i + 1);
         }
@@ -823,43 +823,43 @@ slop_string transpiler_fn_return_type(context_TranspileContext* ctx, slop_list_t
         int64_t i = 3;
         __auto_type result = SLOP_STR("");
         while ((i < len) && string_eq(result, SLOP_STR(""))) {
-            __auto_type _mv_1150 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1150.has_value) {
-                __auto_type item = _mv_1150.value;
-                __auto_type _mv_1151 = (*item);
-                switch (_mv_1151.tag) {
+            __auto_type _mv_1151 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1151.has_value) {
+                __auto_type item = _mv_1151.value;
+                __auto_type _mv_1152 = (*item);
+                switch (_mv_1152.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type lst = _mv_1151.data.lst;
+                        __auto_type lst = _mv_1152.data.lst;
                         {
                             __auto_type sub_items = lst.items;
                             if (((int64_t)((sub_items).len)) >= 2) {
-                                __auto_type _mv_1152 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1152.has_value) {
-                                    __auto_type head = _mv_1152.value;
-                                    __auto_type _mv_1153 = (*head);
-                                    switch (_mv_1153.tag) {
+                                __auto_type _mv_1153 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1153.has_value) {
+                                    __auto_type head = _mv_1153.value;
+                                    __auto_type _mv_1154 = (*head);
+                                    switch (_mv_1154.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_1153.data.sym;
+                                            __auto_type sym = _mv_1154.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("@spec"))) {
-                                                __auto_type _mv_1154 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1154.has_value) {
-                                                    __auto_type spec_body = _mv_1154.value;
-                                                    __auto_type _mv_1155 = (*spec_body);
-                                                    switch (_mv_1155.tag) {
+                                                __auto_type _mv_1155 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1155.has_value) {
+                                                    __auto_type spec_body = _mv_1155.value;
+                                                    __auto_type _mv_1156 = (*spec_body);
+                                                    switch (_mv_1156.tag) {
                                                         case types_SExpr_lst:
                                                         {
-                                                            __auto_type body_lst = _mv_1155.data.lst;
+                                                            __auto_type body_lst = _mv_1156.data.lst;
                                                             {
                                                                 __auto_type body_items = body_lst.items;
                                                                 __auto_type body_len = ((int64_t)((body_items).len));
                                                                 if (body_len >= 1) {
-                                                                    __auto_type _mv_1156 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                                    if (_mv_1156.has_value) {
-                                                                        __auto_type ret_type = _mv_1156.value;
+                                                                    __auto_type _mv_1157 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                                    if (_mv_1157.has_value) {
+                                                                        __auto_type ret_type = _mv_1157.value;
                                                                         result = context_to_c_type_prefixed(ctx, ret_type);
-                                                                    } else if (!_mv_1156.has_value) {
+                                                                    } else if (!_mv_1157.has_value) {
                                                                     }
                                                                 }
                                                             }
@@ -869,7 +869,7 @@ slop_string transpiler_fn_return_type(context_TranspileContext* ctx, slop_list_t
                                                             break;
                                                         }
                                                     }
-                                                } else if (!_mv_1154.has_value) {
+                                                } else if (!_mv_1155.has_value) {
                                                 }
                                             }
                                             break;
@@ -878,7 +878,7 @@ slop_string transpiler_fn_return_type(context_TranspileContext* ctx, slop_list_t
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1152.has_value) {
+                                } else if (!_mv_1153.has_value) {
                                 }
                             }
                         }
@@ -888,7 +888,7 @@ slop_string transpiler_fn_return_type(context_TranspileContext* ctx, slop_list_t
                         break;
                     }
                 }
-            } else if (!_mv_1150.has_value) {
+            } else if (!_mv_1151.has_value) {
             }
             i = (i + 1);
         }
@@ -899,35 +899,35 @@ slop_string transpiler_fn_return_type(context_TranspileContext* ctx, slop_list_t
 void transpiler_prescan_fn_params(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     if (((int64_t)((items).len)) >= 3) {
-        __auto_type _mv_1157 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1157.has_value) {
-            __auto_type params_expr = _mv_1157.value;
-            __auto_type _mv_1158 = (*params_expr);
-            switch (_mv_1158.tag) {
+        __auto_type _mv_1158 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1158.has_value) {
+            __auto_type params_expr = _mv_1158.value;
+            __auto_type _mv_1159 = (*params_expr);
+            switch (_mv_1159.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type params_lst = _mv_1158.data.lst;
+                    __auto_type params_lst = _mv_1159.data.lst;
                     {
                         __auto_type params = params_lst.items;
                         __auto_type param_count = ((int64_t)((params).len));
                         __auto_type i = 0;
                         while (i < param_count) {
-                            __auto_type _mv_1159 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1159.has_value) {
-                                __auto_type param_expr = _mv_1159.value;
-                                __auto_type _mv_1160 = (*param_expr);
-                                switch (_mv_1160.tag) {
+                            __auto_type _mv_1160 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1160.has_value) {
+                                __auto_type param_expr = _mv_1160.value;
+                                __auto_type _mv_1161 = (*param_expr);
+                                switch (_mv_1161.tag) {
                                     case types_SExpr_lst:
                                     {
-                                        __auto_type param_lst = _mv_1160.data.lst;
+                                        __auto_type param_lst = _mv_1161.data.lst;
                                         {
                                             __auto_type param_items = param_lst.items;
                                             if (((int64_t)((param_items).len)) >= 2) {
-                                                __auto_type _mv_1161 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1161.has_value) {
-                                                    __auto_type type_expr = _mv_1161.value;
+                                                __auto_type _mv_1162 = ({ __auto_type _lst = param_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1162.has_value) {
+                                                    __auto_type type_expr = _mv_1162.value;
                                                     transpiler_scan_type_for_generics(ctx, type_expr);
-                                                } else if (!_mv_1161.has_value) {
+                                                } else if (!_mv_1162.has_value) {
                                                 }
                                             }
                                         }
@@ -937,7 +937,7 @@ void transpiler_prescan_fn_params(context_TranspileContext* ctx, slop_list_types
                                         break;
                                     }
                                 }
-                            } else if (!_mv_1159.has_value) {
+                            } else if (!_mv_1160.has_value) {
                             }
                             i = (i + 1);
                         }
@@ -948,7 +948,7 @@ void transpiler_prescan_fn_params(context_TranspileContext* ctx, slop_list_types
                     break;
                 }
             }
-        } else if (!_mv_1157.has_value) {
+        } else if (!_mv_1158.has_value) {
         }
     }
 }
@@ -959,29 +959,29 @@ slop_list_context_FuncParamType_ptr transpiler_prescan_collect_param_types(conte
         __auto_type arena = (*ctx).arena;
         __auto_type result = ((slop_list_context_FuncParamType_ptr){ .data = (context_FuncParamType**)slop_arena_alloc(arena, 16 * sizeof(context_FuncParamType*)), .len = 0, .cap = 16 });
         if (((int64_t)((items).len)) >= 3) {
-            __auto_type _mv_1162 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1162.has_value) {
-                __auto_type params_expr = _mv_1162.value;
-                __auto_type _mv_1163 = (*params_expr);
-                switch (_mv_1163.tag) {
+            __auto_type _mv_1163 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1163.has_value) {
+                __auto_type params_expr = _mv_1163.value;
+                __auto_type _mv_1164 = (*params_expr);
+                switch (_mv_1164.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type params_lst = _mv_1163.data.lst;
+                        __auto_type params_lst = _mv_1164.data.lst;
                         {
                             __auto_type params = params_lst.items;
                             __auto_type param_count = ((int64_t)((params).len));
                             __auto_type i = 0;
                             while (i < param_count) {
-                                __auto_type _mv_1164 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1164.has_value) {
-                                    __auto_type param_expr = _mv_1164.value;
+                                __auto_type _mv_1165 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1165.has_value) {
+                                    __auto_type param_expr = _mv_1165.value;
                                     {
                                         __auto_type c_type = transpiler_prescan_get_param_c_type(ctx, param_expr);
                                         __auto_type param_info = ((context_FuncParamType*)(({ __auto_type _alloc = (context_FuncParamType*)slop_arena_alloc(arena, sizeof(context_FuncParamType)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                                         (*param_info).c_type = c_type;
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (param_info); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
-                                } else if (!_mv_1164.has_value) {
+                                } else if (!_mv_1165.has_value) {
                                 }
                                 i = (i + 1);
                             }
@@ -992,7 +992,7 @@ slop_list_context_FuncParamType_ptr transpiler_prescan_collect_param_types(conte
                         break;
                     }
                 }
-            } else if (!_mv_1162.has_value) {
+            } else if (!_mv_1163.has_value) {
             }
         }
         return result;
@@ -1004,11 +1004,11 @@ slop_string transpiler_prescan_get_param_c_type(context_TranspileContext* ctx, t
     SLOP_PRE(((param != NULL)), "(!= param nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1165 = (*param);
-        switch (_mv_1165.tag) {
+        __auto_type _mv_1166 = (*param);
+        switch (_mv_1166.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1165.data.lst;
+                __auto_type lst = _mv_1166.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
@@ -1018,11 +1018,11 @@ slop_string transpiler_prescan_get_param_c_type(context_TranspileContext* ctx, t
                         {
                             __auto_type has_mode = ((len >= 3) && transpiler_prescan_is_param_mode(items));
                             __auto_type type_idx = ((has_mode) ? 2 : 1);
-                            __auto_type _mv_1166 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1166.has_value) {
-                                __auto_type type_expr = _mv_1166.value;
+                            __auto_type _mv_1167 = ({ __auto_type _lst = items; size_t _idx = (size_t)type_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1167.has_value) {
+                                __auto_type type_expr = _mv_1167.value;
                                 return context_to_c_type_prefixed(ctx, type_expr);
-                            } else if (!_mv_1166.has_value) {
+                            } else if (!_mv_1167.has_value) {
                                 return SLOP_STR("void*");
                             }
                             SLOP_UNREACHABLE();
@@ -1041,14 +1041,14 @@ uint8_t transpiler_prescan_is_param_mode(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_1167 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1167.has_value) {
-            __auto_type first = _mv_1167.value;
-            __auto_type _mv_1168 = (*first);
-            switch (_mv_1168.tag) {
+        __auto_type _mv_1168 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1168.has_value) {
+            __auto_type first = _mv_1168.value;
+            __auto_type _mv_1169 = (*first);
+            switch (_mv_1169.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type sym = _mv_1168.data.sym;
+                    __auto_type sym = _mv_1169.data.sym;
                     {
                         __auto_type name = sym.name;
                         if (string_eq(name, SLOP_STR("in"))) {
@@ -1068,7 +1068,7 @@ uint8_t transpiler_prescan_is_param_mode(slop_list_types_SExpr_ptr items) {
                     return 0;
                 }
             }
-        } else if (!_mv_1167.has_value) {
+        } else if (!_mv_1168.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -1082,13 +1082,13 @@ void transpiler_prescan_fn_result_type(context_TranspileContext* ctx, slop_list_
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 3;
         while (i < len) {
-            __auto_type _mv_1169 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1169.has_value) {
-                __auto_type item = _mv_1169.value;
+            __auto_type _mv_1170 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1170.has_value) {
+                __auto_type item = _mv_1170.value;
                 if (transpiler_is_spec_annotation(item)) {
                     transpiler_extract_result_type(ctx, item);
                 }
-            } else if (!_mv_1169.has_value) {
+            } else if (!_mv_1170.has_value) {
             }
             i = (i + 1);
         }
@@ -1097,31 +1097,31 @@ void transpiler_prescan_fn_result_type(context_TranspileContext* ctx, slop_list_
 
 uint8_t transpiler_is_spec_annotation(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1170 = (*expr);
-    switch (_mv_1170.tag) {
+    __auto_type _mv_1171 = (*expr);
+    switch (_mv_1171.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1170.data.lst;
+            __auto_type lst = _mv_1171.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1171 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1171.has_value) {
-                        __auto_type head = _mv_1171.value;
-                        __auto_type _mv_1172 = (*head);
-                        switch (_mv_1172.tag) {
+                    __auto_type _mv_1172 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1172.has_value) {
+                        __auto_type head = _mv_1172.value;
+                        __auto_type _mv_1173 = (*head);
+                        switch (_mv_1173.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1172.data.sym;
+                                __auto_type sym = _mv_1173.data.sym;
                                 return string_eq(sym.name, SLOP_STR("@spec"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1171.has_value) {
+                    } else if (!_mv_1172.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -1139,32 +1139,32 @@ void transpiler_extract_result_type(context_TranspileContext* ctx, types_SExpr* 
     SLOP_PRE(((spec_expr != NULL)), "(!= spec-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1173 = (*spec_expr);
-        switch (_mv_1173.tag) {
+        __auto_type _mv_1174 = (*spec_expr);
+        switch (_mv_1174.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1173.data.lst;
+                __auto_type lst = _mv_1174.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_1174 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1174.has_value) {
-                            __auto_type spec_body = _mv_1174.value;
-                            __auto_type _mv_1175 = (*spec_body);
-                            switch (_mv_1175.tag) {
+                        __auto_type _mv_1175 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1175.has_value) {
+                            __auto_type spec_body = _mv_1175.value;
+                            __auto_type _mv_1176 = (*spec_body);
+                            switch (_mv_1176.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type body_lst = _mv_1175.data.lst;
+                                    __auto_type body_lst = _mv_1176.data.lst;
                                     {
                                         __auto_type body_items = body_lst.items;
                                         __auto_type body_len = ((int64_t)((body_items).len));
                                         if (body_len >= 1) {
-                                            __auto_type _mv_1176 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1176.has_value) {
-                                                __auto_type ret_type = _mv_1176.value;
+                                            __auto_type _mv_1177 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)(body_len - 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1177.has_value) {
+                                                __auto_type ret_type = _mv_1177.value;
                                                 transpiler_scan_type_for_generics(ctx, ret_type);
                                                 transpiler_check_and_register_result_type(ctx, ret_type);
-                                            } else if (!_mv_1176.has_value) {
+                                            } else if (!_mv_1177.has_value) {
                                             }
                                         }
                                     }
@@ -1174,7 +1174,7 @@ void transpiler_extract_result_type(context_TranspileContext* ctx, types_SExpr* 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1174.has_value) {
+                        } else if (!_mv_1175.has_value) {
                         }
                     }
                 }
@@ -1192,38 +1192,38 @@ void transpiler_check_and_register_result_type(context_TranspileContext* ctx, ty
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1177 = (*type_expr);
-        switch (_mv_1177.tag) {
+        __auto_type _mv_1178 = (*type_expr);
+        switch (_mv_1178.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1177.data.lst;
+                __auto_type lst = _mv_1178.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_1178 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1178.has_value) {
-                            __auto_type head = _mv_1178.value;
-                            __auto_type _mv_1179 = (*head);
-                            switch (_mv_1179.tag) {
+                        __auto_type _mv_1179 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1179.has_value) {
+                            __auto_type head = _mv_1179.value;
+                            __auto_type _mv_1180 = (*head);
+                            switch (_mv_1180.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1179.data.sym;
+                                    __auto_type sym = _mv_1180.data.sym;
                                     if (string_eq(sym.name, SLOP_STR("Result"))) {
-                                        __auto_type _mv_1180 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1180.has_value) {
-                                            __auto_type ok_type_expr = _mv_1180.value;
-                                            __auto_type _mv_1181 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1181.has_value) {
-                                                __auto_type err_type_expr = _mv_1181.value;
+                                        __auto_type _mv_1181 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1181.has_value) {
+                                            __auto_type ok_type_expr = _mv_1181.value;
+                                            __auto_type _mv_1182 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1182.has_value) {
+                                                __auto_type err_type_expr = _mv_1182.value;
                                                 {
                                                     __auto_type ok_c_type = context_to_c_type_prefixed(ctx, ok_type_expr);
                                                     __auto_type err_c_type = context_to_c_type_prefixed(ctx, err_type_expr);
                                                     __auto_type result_name = transpiler_build_result_type_name(ctx, ok_c_type, err_c_type);
                                                     context_ctx_register_result_type(ctx, ok_c_type, err_c_type, result_name);
                                                 }
-                                            } else if (!_mv_1181.has_value) {
+                                            } else if (!_mv_1182.has_value) {
                                             }
-                                        } else if (!_mv_1180.has_value) {
+                                        } else if (!_mv_1181.has_value) {
                                         }
                                     }
                                     break;
@@ -1232,7 +1232,7 @@ void transpiler_check_and_register_result_type(context_TranspileContext* ctx, ty
                                     break;
                                 }
                             }
-                        } else if (!_mv_1178.has_value) {
+                        } else if (!_mv_1179.has_value) {
                         }
                     }
                 }
@@ -1261,11 +1261,11 @@ void transpiler_prescan_fn_for_struct_keys(context_TranspileContext* ctx, slop_l
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 3;
         while (i < len) {
-            __auto_type _mv_1182 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1182.has_value) {
-                __auto_type item = _mv_1182.value;
+            __auto_type _mv_1183 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1183.has_value) {
+                __auto_type item = _mv_1183.value;
                 transpiler_prescan_expr_for_struct_keys(ctx, item);
-            } else if (!_mv_1182.has_value) {
+            } else if (!_mv_1183.has_value) {
             }
             i = (i + 1);
         }
@@ -1275,59 +1275,45 @@ void transpiler_prescan_fn_for_struct_keys(context_TranspileContext* ctx, slop_l
 void transpiler_prescan_expr_for_struct_keys(context_TranspileContext* ctx, types_SExpr* expr) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1183 = (*expr);
-    switch (_mv_1183.tag) {
+    __auto_type _mv_1184 = (*expr);
+    switch (_mv_1184.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1183.data.lst;
+            __auto_type lst = _mv_1184.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 if (len >= 1) {
-                    __auto_type _mv_1184 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1184.has_value) {
-                        __auto_type head = _mv_1184.value;
-                        __auto_type _mv_1185 = (*head);
-                        switch (_mv_1185.tag) {
+                    __auto_type _mv_1185 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1185.has_value) {
+                        __auto_type head = _mv_1185.value;
+                        __auto_type _mv_1186 = (*head);
+                        switch (_mv_1186.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1185.data.sym;
+                                __auto_type sym = _mv_1186.data.sym;
                                 {
                                     __auto_type name = sym.name;
                                     if (string_eq(name, SLOP_STR("map-new"))) {
                                         if (len >= 3) {
-                                            __auto_type _mv_1186 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1186.has_value) {
-                                                __auto_type key_type_expr = _mv_1186.value;
+                                            __auto_type _mv_1187 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1187.has_value) {
+                                                __auto_type key_type_expr = _mv_1187.value;
                                                 transpiler_prescan_register_struct_key_type(ctx, key_type_expr);
-                                            } else if (!_mv_1186.has_value) {
+                                            } else if (!_mv_1187.has_value) {
                                             }
                                         }
                                     } else if (string_eq(name, SLOP_STR("set-new"))) {
                                         if (len >= 3) {
-                                            __auto_type _mv_1187 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1187.has_value) {
-                                                __auto_type elem_type_expr = _mv_1187.value;
+                                            __auto_type _mv_1188 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1188.has_value) {
+                                                __auto_type elem_type_expr = _mv_1188.value;
                                                 transpiler_prescan_register_struct_key_type(ctx, elem_type_expr);
-                                            } else if (!_mv_1187.has_value) {
+                                            } else if (!_mv_1188.has_value) {
                                             }
                                         }
                                     } else if (string_eq(name, SLOP_STR("chan-buffered"))) {
                                         if (len >= 4) {
-                                            __auto_type _mv_1188 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1188.has_value) {
-                                                __auto_type type_expr = _mv_1188.value;
-                                                {
-                                                    __auto_type elem_c = context_to_c_type_prefixed(ctx, type_expr);
-                                                    __auto_type elem_id = ctype_type_to_identifier((*ctx).arena, elem_c);
-                                                    __auto_type c_name = context_ctx_str(ctx, SLOP_STR("slop_chan_"), elem_id);
-                                                    context_ctx_register_chan_type(ctx, elem_c, c_name);
-                                                }
-                                            } else if (!_mv_1188.has_value) {
-                                            }
-                                        }
-                                    } else if (string_eq(name, SLOP_STR("chan"))) {
-                                        if (len >= 3) {
                                             __auto_type _mv_1189 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                             if (_mv_1189.has_value) {
                                                 __auto_type type_expr = _mv_1189.value;
@@ -1340,15 +1326,29 @@ void transpiler_prescan_expr_for_struct_keys(context_TranspileContext* ctx, type
                                             } else if (!_mv_1189.has_value) {
                                             }
                                         }
+                                    } else if (string_eq(name, SLOP_STR("chan"))) {
+                                        if (len >= 3) {
+                                            __auto_type _mv_1190 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1190.has_value) {
+                                                __auto_type type_expr = _mv_1190.value;
+                                                {
+                                                    __auto_type elem_c = context_to_c_type_prefixed(ctx, type_expr);
+                                                    __auto_type elem_id = ctype_type_to_identifier((*ctx).arena, elem_c);
+                                                    __auto_type c_name = context_ctx_str(ctx, SLOP_STR("slop_chan_"), elem_id);
+                                                    context_ctx_register_chan_type(ctx, elem_c, c_name);
+                                                }
+                                            } else if (!_mv_1190.has_value) {
+                                            }
+                                        }
                                     } else {
                                         {
                                             __auto_type i = 0;
                                             while (i < len) {
-                                                __auto_type _mv_1190 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1190.has_value) {
-                                                    __auto_type child = _mv_1190.value;
+                                                __auto_type _mv_1191 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1191.has_value) {
+                                                    __auto_type child = _mv_1191.value;
                                                     transpiler_prescan_expr_for_struct_keys(ctx, child);
-                                                } else if (!_mv_1190.has_value) {
+                                                } else if (!_mv_1191.has_value) {
                                                 }
                                                 i = (i + 1);
                                             }
@@ -1361,11 +1361,11 @@ void transpiler_prescan_expr_for_struct_keys(context_TranspileContext* ctx, type
                                 {
                                     __auto_type i = 0;
                                     while (i < len) {
-                                        __auto_type _mv_1191 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1191.has_value) {
-                                            __auto_type child = _mv_1191.value;
+                                        __auto_type _mv_1192 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1192.has_value) {
+                                            __auto_type child = _mv_1192.value;
                                             transpiler_prescan_expr_for_struct_keys(ctx, child);
-                                        } else if (!_mv_1191.has_value) {
+                                        } else if (!_mv_1192.has_value) {
                                         }
                                         i = (i + 1);
                                     }
@@ -1373,7 +1373,7 @@ void transpiler_prescan_expr_for_struct_keys(context_TranspileContext* ctx, type
                                 break;
                             }
                         }
-                    } else if (!_mv_1184.has_value) {
+                    } else if (!_mv_1185.has_value) {
                     }
                 }
             }
@@ -1390,33 +1390,33 @@ void transpiler_prescan_register_struct_key_type(context_TranspileContext* ctx, 
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1192 = (*type_expr);
-        switch (_mv_1192.tag) {
+        __auto_type _mv_1193 = (*type_expr);
+        switch (_mv_1193.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1192.data.sym;
+                __auto_type sym = _mv_1193.data.sym;
                 {
                     __auto_type name = sym.name;
                     if (!(transpiler_is_builtin_map_key_type(name))) {
-                        __auto_type _mv_1193 = context_ctx_lookup_type(ctx, name);
-                        if (_mv_1193.has_value) {
-                            __auto_type type_entry = _mv_1193.value;
+                        __auto_type _mv_1194 = context_ctx_lookup_type(ctx, name);
+                        if (_mv_1194.has_value) {
+                            __auto_type type_entry = _mv_1194.value;
                             context_ctx_register_struct_key_type(ctx, type_entry.c_name);
-                        } else if (!_mv_1193.has_value) {
-                            __auto_type _mv_1194 = context_ctx_get_module(ctx);
-                            if (_mv_1194.has_value) {
-                                __auto_type mod = _mv_1194.value;
+                        } else if (!_mv_1194.has_value) {
+                            __auto_type _mv_1195 = context_ctx_get_module(ctx);
+                            if (_mv_1195.has_value) {
+                                __auto_type mod = _mv_1195.value;
                                 {
                                     __auto_type prefixed = context_ctx_str3(ctx, mod, SLOP_STR("_"), name);
-                                    __auto_type _mv_1195 = context_ctx_lookup_type(ctx, prefixed);
-                                    if (_mv_1195.has_value) {
-                                        __auto_type type_entry = _mv_1195.value;
+                                    __auto_type _mv_1196 = context_ctx_lookup_type(ctx, prefixed);
+                                    if (_mv_1196.has_value) {
+                                        __auto_type type_entry = _mv_1196.value;
                                         context_ctx_register_struct_key_type(ctx, type_entry.c_name);
-                                    } else if (!_mv_1195.has_value) {
+                                    } else if (!_mv_1196.has_value) {
                                         context_ctx_register_struct_key_type(ctx, ctype_to_c_name(arena, name));
                                     }
                                 }
-                            } else if (!_mv_1194.has_value) {
+                            } else if (!_mv_1195.has_value) {
                                 context_ctx_register_struct_key_type(ctx, ctype_to_c_name(arena, name));
                             }
                         }
@@ -1440,29 +1440,29 @@ void transpiler_check_and_register_result_alias(context_TranspileContext* ctx, s
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1196 = (*body_expr);
-        switch (_mv_1196.tag) {
+        __auto_type _mv_1197 = (*body_expr);
+        switch (_mv_1197.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1196.data.lst;
+                __auto_type lst = _mv_1197.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_1197 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1197.has_value) {
-                            __auto_type head = _mv_1197.value;
-                            __auto_type _mv_1198 = (*head);
-                            switch (_mv_1198.tag) {
+                        __auto_type _mv_1198 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1198.has_value) {
+                            __auto_type head = _mv_1198.value;
+                            __auto_type _mv_1199 = (*head);
+                            switch (_mv_1199.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1198.data.sym;
+                                    __auto_type sym = _mv_1199.data.sym;
                                     if (string_eq(sym.name, SLOP_STR("Result"))) {
-                                        __auto_type _mv_1199 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1199.has_value) {
-                                            __auto_type ok_type_expr = _mv_1199.value;
-                                            __auto_type _mv_1200 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1200.has_value) {
-                                                __auto_type err_type_expr = _mv_1200.value;
+                                        __auto_type _mv_1200 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1200.has_value) {
+                                            __auto_type ok_type_expr = _mv_1200.value;
+                                            __auto_type _mv_1201 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1201.has_value) {
+                                                __auto_type err_type_expr = _mv_1201.value;
                                                 {
                                                     __auto_type ok_c_type = context_to_c_type_prefixed(ctx, ok_type_expr);
                                                     __auto_type err_c_type = context_to_c_type_prefixed(ctx, err_type_expr);
@@ -1470,9 +1470,9 @@ void transpiler_check_and_register_result_alias(context_TranspileContext* ctx, s
                                                     context_ctx_register_result_type_alias(ctx, alias_name, result_name);
                                                     context_ctx_register_result_type(ctx, ok_c_type, err_c_type, result_name);
                                                 }
-                                            } else if (!_mv_1200.has_value) {
+                                            } else if (!_mv_1201.has_value) {
                                             }
-                                        } else if (!_mv_1199.has_value) {
+                                        } else if (!_mv_1200.has_value) {
                                         }
                                     }
                                     break;
@@ -1481,7 +1481,7 @@ void transpiler_check_and_register_result_alias(context_TranspileContext* ctx, s
                                     break;
                                 }
                             }
-                        } else if (!_mv_1197.has_value) {
+                        } else if (!_mv_1198.has_value) {
                         }
                     }
                 }
@@ -1500,14 +1500,14 @@ void transpiler_prescan_ffi(context_TranspileContext* ctx, slop_list_types_SExpr
         __auto_type arena = (*ctx).arena;
         __auto_type len = ((int64_t)((items).len));
         if (len >= 2) {
-            __auto_type _mv_1201 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1201.has_value) {
-                __auto_type header_expr = _mv_1201.value;
-                __auto_type _mv_1202 = (*header_expr);
-                switch (_mv_1202.tag) {
+            __auto_type _mv_1202 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1202.has_value) {
+                __auto_type header_expr = _mv_1202.value;
+                __auto_type _mv_1203 = (*header_expr);
+                switch (_mv_1203.tag) {
                     case types_SExpr_str:
                     {
-                        __auto_type str = _mv_1202.data.str;
+                        __auto_type str = _mv_1203.data.str;
                         context_ctx_add_include(ctx, str.value);
                         break;
                     }
@@ -1515,16 +1515,16 @@ void transpiler_prescan_ffi(context_TranspileContext* ctx, slop_list_types_SExpr
                         break;
                     }
                 }
-            } else if (!_mv_1201.has_value) {
+            } else if (!_mv_1202.has_value) {
             }
             {
                 int64_t i = 2;
                 while (i < len) {
-                    __auto_type _mv_1203 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1203.has_value) {
-                        __auto_type func_decl = _mv_1203.value;
+                    __auto_type _mv_1204 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1204.has_value) {
+                        __auto_type func_decl = _mv_1204.value;
                         transpiler_register_ffi_function(ctx, func_decl);
-                    } else if (!_mv_1203.has_value) {
+                    } else if (!_mv_1204.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -1547,14 +1547,14 @@ uint8_t transpiler_is_type_name(slop_string name) {
 void transpiler_prescan_import(context_TranspileContext* ctx, slop_list_types_SExpr_ptr items) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     if (((int64_t)((items).len)) >= 3) {
-        __auto_type _mv_1204 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1204.has_value) {
-            __auto_type mod_expr = _mv_1204.value;
-            __auto_type _mv_1205 = (*mod_expr);
-            switch (_mv_1205.tag) {
+        __auto_type _mv_1205 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1205.has_value) {
+            __auto_type mod_expr = _mv_1205.value;
+            __auto_type _mv_1206 = (*mod_expr);
+            switch (_mv_1206.tag) {
                 case types_SExpr_sym:
                 {
-                    __auto_type mod_sym = _mv_1205.data.sym;
+                    __auto_type mod_sym = _mv_1206.data.sym;
                     {
                         __auto_type mod_name = mod_sym.name;
                         __auto_type arena = (*ctx).arena;
@@ -1565,27 +1565,27 @@ void transpiler_prescan_import(context_TranspileContext* ctx, slop_list_types_SE
                         if (string_eq(mod_name, SLOP_STR("file"))) {
                             transpiler_register_file_module_variants(ctx);
                         }
-                        __auto_type _mv_1206 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1206.has_value) {
-                            __auto_type symbols_expr = _mv_1206.value;
-                            __auto_type _mv_1207 = (*symbols_expr);
-                            switch (_mv_1207.tag) {
+                        __auto_type _mv_1207 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1207.has_value) {
+                            __auto_type symbols_expr = _mv_1207.value;
+                            __auto_type _mv_1208 = (*symbols_expr);
+                            switch (_mv_1208.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type symbols_lst = _mv_1207.data.lst;
+                                    __auto_type symbols_lst = _mv_1208.data.lst;
                                     {
                                         __auto_type syms = symbols_lst.items;
                                         __auto_type sym_len = ((int64_t)((syms).len));
                                         __auto_type j = 0;
                                         while (j < sym_len) {
-                                            __auto_type _mv_1208 = ({ __auto_type _lst = syms; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1208.has_value) {
-                                                __auto_type sym_item = _mv_1208.value;
-                                                __auto_type _mv_1209 = (*sym_item);
-                                                switch (_mv_1209.tag) {
+                                            __auto_type _mv_1209 = ({ __auto_type _lst = syms; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1209.has_value) {
+                                                __auto_type sym_item = _mv_1209.value;
+                                                __auto_type _mv_1210 = (*sym_item);
+                                                switch (_mv_1210.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type s = _mv_1209.data.sym;
+                                                        __auto_type s = _mv_1210.data.sym;
                                                         {
                                                             __auto_type sym_name = s.name;
                                                             __auto_type c_mod_name = ctype_to_c_name(arena, mod_name);
@@ -1619,7 +1619,7 @@ void transpiler_prescan_import(context_TranspileContext* ctx, slop_list_types_SE
                                                         break;
                                                     }
                                                 }
-                                            } else if (!_mv_1208.has_value) {
+                                            } else if (!_mv_1209.has_value) {
                                             }
                                             j = (j + 1);
                                         }
@@ -1630,7 +1630,7 @@ void transpiler_prescan_import(context_TranspileContext* ctx, slop_list_types_SE
                                     break;
                                 }
                             }
-                        } else if (!_mv_1206.has_value) {
+                        } else if (!_mv_1207.has_value) {
                         }
                     }
                     break;
@@ -1639,7 +1639,7 @@ void transpiler_prescan_import(context_TranspileContext* ctx, slop_list_types_SE
                     break;
                 }
             }
-        } else if (!_mv_1204.has_value) {
+        } else if (!_mv_1205.has_value) {
         }
     }
 }
@@ -1685,14 +1685,14 @@ void transpiler_prescan_const(context_TranspileContext* ctx, slop_list_types_SEx
     {
         __auto_type arena = (*ctx).arena;
         if (((int64_t)((items).len)) >= 3) {
-            __auto_type _mv_1210 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1210.has_value) {
-                __auto_type name_expr = _mv_1210.value;
-                __auto_type _mv_1211 = (*name_expr);
-                switch (_mv_1211.tag) {
+            __auto_type _mv_1211 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1211.has_value) {
+                __auto_type name_expr = _mv_1211.value;
+                __auto_type _mv_1212 = (*name_expr);
+                switch (_mv_1212.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_1211.data.sym;
+                        __auto_type sym = _mv_1212.data.sym;
                         {
                             __auto_type const_name = sym.name;
                             __auto_type base_name = ctype_to_c_name(arena, const_name);
@@ -1705,7 +1705,7 @@ void transpiler_prescan_const(context_TranspileContext* ctx, slop_list_types_SEx
                         break;
                     }
                 }
-            } else if (!_mv_1210.has_value) {
+            } else if (!_mv_1211.has_value) {
             }
         }
     }
@@ -1716,23 +1716,23 @@ void transpiler_register_ffi_function(context_TranspileContext* ctx, types_SExpr
     SLOP_PRE(((func_decl != NULL)), "(!= func-decl nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1212 = (*func_decl);
-        switch (_mv_1212.tag) {
+        __auto_type _mv_1213 = (*func_decl);
+        switch (_mv_1213.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1212.data.lst;
+                __auto_type lst = _mv_1213.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 1) {
-                        __auto_type _mv_1213 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1213.has_value) {
-                            __auto_type name_expr = _mv_1213.value;
-                            __auto_type _mv_1214 = (*name_expr);
-                            switch (_mv_1214.tag) {
+                        __auto_type _mv_1214 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1214.has_value) {
+                            __auto_type name_expr = _mv_1214.value;
+                            __auto_type _mv_1215 = (*name_expr);
+                            switch (_mv_1215.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1214.data.sym;
+                                    __auto_type sym = _mv_1215.data.sym;
                                     {
                                         __auto_type fn_name = sym.name;
                                         __auto_type c_name = transpiler_extract_ffi_c_name(ctx, items, fn_name);
@@ -1749,7 +1749,7 @@ void transpiler_register_ffi_function(context_TranspileContext* ctx, types_SExpr
                                     break;
                                 }
                             }
-                        } else if (!_mv_1213.has_value) {
+                        } else if (!_mv_1214.has_value) {
                         }
                     }
                 }
@@ -1768,29 +1768,29 @@ slop_list_context_FuncParamType_ptr transpiler_extract_ffi_param_types(context_T
         __auto_type arena = (*ctx).arena;
         __auto_type result = ((slop_list_context_FuncParamType_ptr){ .data = (context_FuncParamType**)slop_arena_alloc(arena, 16 * sizeof(context_FuncParamType*)), .len = 0, .cap = 16 });
         if (((int64_t)((items).len)) >= 2) {
-            __auto_type _mv_1215 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1215.has_value) {
-                __auto_type params_expr = _mv_1215.value;
-                __auto_type _mv_1216 = (*params_expr);
-                switch (_mv_1216.tag) {
+            __auto_type _mv_1216 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1216.has_value) {
+                __auto_type params_expr = _mv_1216.value;
+                __auto_type _mv_1217 = (*params_expr);
+                switch (_mv_1217.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type params_lst = _mv_1216.data.lst;
+                        __auto_type params_lst = _mv_1217.data.lst;
                         {
                             __auto_type params = params_lst.items;
                             __auto_type param_count = ((int64_t)((params).len));
                             __auto_type i = 0;
                             while (i < param_count) {
-                                __auto_type _mv_1217 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1217.has_value) {
-                                    __auto_type param_expr = _mv_1217.value;
+                                __auto_type _mv_1218 = ({ __auto_type _lst = params; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1218.has_value) {
+                                    __auto_type param_expr = _mv_1218.value;
                                     {
                                         __auto_type c_type = transpiler_prescan_get_param_c_type(ctx, param_expr);
                                         __auto_type param_info = ((context_FuncParamType*)(({ __auto_type _alloc = (context_FuncParamType*)slop_arena_alloc(arena, sizeof(context_FuncParamType)); if (_alloc == NULL) { fprintf(stderr, "SLOP: arena alloc failed at %s:%d\n", __FILE__, __LINE__); abort(); } _alloc; })));
                                         (*param_info).c_type = c_type;
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (param_info); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
-                                } else if (!_mv_1217.has_value) {
+                                } else if (!_mv_1218.has_value) {
                                 }
                                 i = (i + 1);
                             }
@@ -1801,7 +1801,7 @@ slop_list_context_FuncParamType_ptr transpiler_extract_ffi_param_types(context_T
                         break;
                     }
                 }
-            } else if (!_mv_1215.has_value) {
+            } else if (!_mv_1216.has_value) {
             }
         }
         return result;
@@ -1817,23 +1817,23 @@ slop_string transpiler_extract_ffi_c_name(context_TranspileContext* ctx, slop_li
         uint8_t found_c_name = 0;
         __auto_type c_name = SLOP_STR("");
         while (i < len) {
-            __auto_type _mv_1218 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1218.has_value) {
-                __auto_type item_expr = _mv_1218.value;
-                __auto_type _mv_1219 = (*item_expr);
-                switch (_mv_1219.tag) {
+            __auto_type _mv_1219 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1219.has_value) {
+                __auto_type item_expr = _mv_1219.value;
+                __auto_type _mv_1220 = (*item_expr);
+                switch (_mv_1220.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_1219.data.sym;
+                        __auto_type sym = _mv_1220.data.sym;
                         if (string_eq(sym.name, SLOP_STR(":c-name"))) {
-                            __auto_type _mv_1220 = ({ __auto_type _lst = items; size_t _idx = (size_t)(i + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1220.has_value) {
-                                __auto_type c_name_expr = _mv_1220.value;
-                                __auto_type _mv_1221 = (*c_name_expr);
-                                switch (_mv_1221.tag) {
+                            __auto_type _mv_1221 = ({ __auto_type _lst = items; size_t _idx = (size_t)(i + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1221.has_value) {
+                                __auto_type c_name_expr = _mv_1221.value;
+                                __auto_type _mv_1222 = (*c_name_expr);
+                                switch (_mv_1222.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type c_sym = _mv_1221.data.sym;
+                                        __auto_type c_sym = _mv_1222.data.sym;
                                         c_name = c_sym.name;
                                         found_c_name = 1;
                                         break;
@@ -1842,7 +1842,7 @@ slop_string transpiler_extract_ffi_c_name(context_TranspileContext* ctx, slop_li
                                         break;
                                     }
                                 }
-                            } else if (!_mv_1220.has_value) {
+                            } else if (!_mv_1221.has_value) {
                             }
                         }
                         break;
@@ -1851,7 +1851,7 @@ slop_string transpiler_extract_ffi_c_name(context_TranspileContext* ctx, slop_li
                         break;
                     }
                 }
-            } else if (!_mv_1218.has_value) {
+            } else if (!_mv_1219.has_value) {
             }
             i = (i + 1);
         }
@@ -1873,14 +1873,14 @@ void transpiler_prescan_ffi_struct(context_TranspileContext* ctx, slop_list_type
                 __auto_type has_header = ((len >= 2) && transpiler_is_ffi_string_item(items, 1));
                 __auto_type name_idx = ((((len >= 2) && transpiler_is_ffi_string_item(items, 1))) ? 2 : 1);
                 if (has_header) {
-                    __auto_type _mv_1222 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1222.has_value) {
-                        __auto_type header_expr = _mv_1222.value;
-                        __auto_type _mv_1223 = (*header_expr);
-                        switch (_mv_1223.tag) {
+                    __auto_type _mv_1223 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1223.has_value) {
+                        __auto_type header_expr = _mv_1223.value;
+                        __auto_type _mv_1224 = (*header_expr);
+                        switch (_mv_1224.tag) {
                             case types_SExpr_str:
                             {
-                                __auto_type str = _mv_1223.data.str;
+                                __auto_type str = _mv_1224.data.str;
                                 context_ctx_add_include(ctx, str.value);
                                 break;
                             }
@@ -1888,18 +1888,18 @@ void transpiler_prescan_ffi_struct(context_TranspileContext* ctx, slop_list_type
                                 break;
                             }
                         }
-                    } else if (!_mv_1222.has_value) {
+                    } else if (!_mv_1223.has_value) {
                     }
                 }
                 if (len >= (name_idx + 1)) {
-                    __auto_type _mv_1224 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1224.has_value) {
-                        __auto_type name_expr = _mv_1224.value;
-                        __auto_type _mv_1225 = (*name_expr);
-                        switch (_mv_1225.tag) {
+                    __auto_type _mv_1225 = ({ __auto_type _lst = items; size_t _idx = (size_t)name_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1225.has_value) {
+                        __auto_type name_expr = _mv_1225.value;
+                        __auto_type _mv_1226 = (*name_expr);
+                        switch (_mv_1226.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1225.data.sym;
+                                __auto_type sym = _mv_1226.data.sym;
                                 {
                                     __auto_type type_name = sym.name;
                                     __auto_type c_name = transpiler_get_ffi_struct_c_name(arena, items, name_idx, type_name);
@@ -1911,7 +1911,7 @@ void transpiler_prescan_ffi_struct(context_TranspileContext* ctx, slop_list_type
                                 break;
                             }
                         }
-                    } else if (!_mv_1224.has_value) {
+                    } else if (!_mv_1225.has_value) {
                     }
                 }
             }
@@ -1924,30 +1924,30 @@ slop_string transpiler_get_ffi_struct_c_name(slop_arena* arena, slop_list_types_
         __auto_type len = ((int64_t)((items).len));
         __auto_type modifier_idx = (name_idx + 1);
         if (len >= (modifier_idx + 2)) {
-            __auto_type _mv_1226 = ({ __auto_type _lst = items; size_t _idx = (size_t)modifier_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1226.has_value) {
-                __auto_type mod_expr = _mv_1226.value;
-                __auto_type _mv_1227 = (*mod_expr);
-                switch (_mv_1227.tag) {
+            __auto_type _mv_1227 = ({ __auto_type _lst = items; size_t _idx = (size_t)modifier_idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1227.has_value) {
+                __auto_type mod_expr = _mv_1227.value;
+                __auto_type _mv_1228 = (*mod_expr);
+                switch (_mv_1228.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type sym = _mv_1227.data.sym;
+                        __auto_type sym = _mv_1228.data.sym;
                         if (string_eq(sym.name, SLOP_STR(":c-name"))) {
-                            __auto_type _mv_1228 = ({ __auto_type _lst = items; size_t _idx = (size_t)(modifier_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1228.has_value) {
-                                __auto_type cname_expr = _mv_1228.value;
-                                __auto_type _mv_1229 = (*cname_expr);
-                                switch (_mv_1229.tag) {
+                            __auto_type _mv_1229 = ({ __auto_type _lst = items; size_t _idx = (size_t)(modifier_idx + 1); slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1229.has_value) {
+                                __auto_type cname_expr = _mv_1229.value;
+                                __auto_type _mv_1230 = (*cname_expr);
+                                switch (_mv_1230.tag) {
                                     case types_SExpr_str:
                                     {
-                                        __auto_type str = _mv_1229.data.str;
+                                        __auto_type str = _mv_1230.data.str;
                                         return transpiler_apply_struct_prefix_heuristic(arena, str.value);
                                     }
                                     default: {
                                         return transpiler_apply_struct_prefix_heuristic(arena, default_name);
                                     }
                                 }
-                            } else if (!_mv_1228.has_value) {
+                            } else if (!_mv_1229.has_value) {
                                 return transpiler_apply_struct_prefix_heuristic(arena, default_name);
                             }
                             SLOP_UNREACHABLE();
@@ -1959,7 +1959,7 @@ slop_string transpiler_get_ffi_struct_c_name(slop_arena* arena, slop_list_types_
                         return transpiler_apply_struct_prefix_heuristic(arena, default_name);
                     }
                 }
-            } else if (!_mv_1226.has_value) {
+            } else if (!_mv_1227.has_value) {
                 return transpiler_apply_struct_prefix_heuristic(arena, default_name);
             }
             SLOP_UNREACHABLE();
@@ -2005,21 +2005,21 @@ uint8_t transpiler_string_ends_with(slop_string s, slop_string suffix) {
 }
 
 uint8_t transpiler_is_ffi_string_item(slop_list_types_SExpr_ptr items, int64_t idx) {
-    __auto_type _mv_1230 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-    if (_mv_1230.has_value) {
-        __auto_type item = _mv_1230.value;
-        __auto_type _mv_1231 = (*item);
-        switch (_mv_1231.tag) {
+    __auto_type _mv_1231 = ({ __auto_type _lst = items; size_t _idx = (size_t)idx; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+    if (_mv_1231.has_value) {
+        __auto_type item = _mv_1231.value;
+        __auto_type _mv_1232 = (*item);
+        switch (_mv_1232.tag) {
             case types_SExpr_str:
             {
-                __auto_type _ = _mv_1231.data.str;
+                __auto_type _ = _mv_1232.data.str;
                 return 1;
             }
             default: {
                 return 0;
             }
         }
-    } else if (!_mv_1230.has_value) {
+    } else if (!_mv_1231.has_value) {
         return 0;
     }
     SLOP_UNREACHABLE();
@@ -2029,34 +2029,34 @@ uint8_t transpiler_is_enum_def(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 3) {
         return 0;
     } else {
-        __auto_type _mv_1232 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1232.has_value) {
-            __auto_type def_expr = _mv_1232.value;
-            __auto_type _mv_1233 = (*def_expr);
-            switch (_mv_1233.tag) {
+        __auto_type _mv_1233 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1233.has_value) {
+            __auto_type def_expr = _mv_1233.value;
+            __auto_type _mv_1234 = (*def_expr);
+            switch (_mv_1234.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type def_lst = _mv_1233.data.lst;
+                    __auto_type def_lst = _mv_1234.data.lst;
                     {
                         __auto_type def_items = def_lst.items;
                         if (((int64_t)((def_items).len)) < 1) {
                             return 0;
                         } else {
-                            __auto_type _mv_1234 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1234.has_value) {
-                                __auto_type head = _mv_1234.value;
-                                __auto_type _mv_1235 = (*head);
-                                switch (_mv_1235.tag) {
+                            __auto_type _mv_1235 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1235.has_value) {
+                                __auto_type head = _mv_1235.value;
+                                __auto_type _mv_1236 = (*head);
+                                switch (_mv_1236.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1235.data.sym;
+                                        __auto_type sym = _mv_1236.data.sym;
                                         return string_eq(sym.name, SLOP_STR("enum"));
                                     }
                                     default: {
                                         return 0;
                                     }
                                 }
-                            } else if (!_mv_1234.has_value) {
+                            } else if (!_mv_1235.has_value) {
                                 return 0;
                             }
                             SLOP_UNREACHABLE();
@@ -2067,7 +2067,7 @@ uint8_t transpiler_is_enum_def(slop_list_types_SExpr_ptr items) {
                     return 0;
                 }
             }
-        } else if (!_mv_1232.has_value) {
+        } else if (!_mv_1233.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -2078,34 +2078,34 @@ uint8_t transpiler_is_record_def(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 3) {
         return 0;
     } else {
-        __auto_type _mv_1236 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1236.has_value) {
-            __auto_type def_expr = _mv_1236.value;
-            __auto_type _mv_1237 = (*def_expr);
-            switch (_mv_1237.tag) {
+        __auto_type _mv_1237 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1237.has_value) {
+            __auto_type def_expr = _mv_1237.value;
+            __auto_type _mv_1238 = (*def_expr);
+            switch (_mv_1238.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type def_lst = _mv_1237.data.lst;
+                    __auto_type def_lst = _mv_1238.data.lst;
                     {
                         __auto_type def_items = def_lst.items;
                         if (((int64_t)((def_items).len)) < 1) {
                             return 0;
                         } else {
-                            __auto_type _mv_1238 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1238.has_value) {
-                                __auto_type head = _mv_1238.value;
-                                __auto_type _mv_1239 = (*head);
-                                switch (_mv_1239.tag) {
+                            __auto_type _mv_1239 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1239.has_value) {
+                                __auto_type head = _mv_1239.value;
+                                __auto_type _mv_1240 = (*head);
+                                switch (_mv_1240.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1239.data.sym;
+                                        __auto_type sym = _mv_1240.data.sym;
                                         return string_eq(sym.name, SLOP_STR("record"));
                                     }
                                     default: {
                                         return 0;
                                     }
                                 }
-                            } else if (!_mv_1238.has_value) {
+                            } else if (!_mv_1239.has_value) {
                                 return 0;
                             }
                             SLOP_UNREACHABLE();
@@ -2116,7 +2116,7 @@ uint8_t transpiler_is_record_def(slop_list_types_SExpr_ptr items) {
                     return 0;
                 }
             }
-        } else if (!_mv_1236.has_value) {
+        } else if (!_mv_1237.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -2127,34 +2127,34 @@ uint8_t transpiler_is_union_def(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 3) {
         return 0;
     } else {
-        __auto_type _mv_1240 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1240.has_value) {
-            __auto_type def_expr = _mv_1240.value;
-            __auto_type _mv_1241 = (*def_expr);
-            switch (_mv_1241.tag) {
+        __auto_type _mv_1241 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1241.has_value) {
+            __auto_type def_expr = _mv_1241.value;
+            __auto_type _mv_1242 = (*def_expr);
+            switch (_mv_1242.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type def_lst = _mv_1241.data.lst;
+                    __auto_type def_lst = _mv_1242.data.lst;
                     {
                         __auto_type def_items = def_lst.items;
                         if (((int64_t)((def_items).len)) < 1) {
                             return 0;
                         } else {
-                            __auto_type _mv_1242 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1242.has_value) {
-                                __auto_type head = _mv_1242.value;
-                                __auto_type _mv_1243 = (*head);
-                                switch (_mv_1243.tag) {
+                            __auto_type _mv_1243 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1243.has_value) {
+                                __auto_type head = _mv_1243.value;
+                                __auto_type _mv_1244 = (*head);
+                                switch (_mv_1244.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1243.data.sym;
+                                        __auto_type sym = _mv_1244.data.sym;
                                         return string_eq(sym.name, SLOP_STR("union"));
                                     }
                                     default: {
                                         return 0;
                                     }
                                 }
-                            } else if (!_mv_1242.has_value) {
+                            } else if (!_mv_1243.has_value) {
                                 return 0;
                             }
                             SLOP_UNREACHABLE();
@@ -2165,7 +2165,7 @@ uint8_t transpiler_is_union_def(slop_list_types_SExpr_ptr items) {
                     return 0;
                 }
             }
-        } else if (!_mv_1240.has_value) {
+        } else if (!_mv_1241.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -2177,36 +2177,36 @@ slop_string transpiler_get_array_c_type(context_TranspileContext* ctx, slop_list
     if (((int64_t)((items).len)) < 3) {
         return default_c_type;
     } else {
-        __auto_type _mv_1244 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1244.has_value) {
-            __auto_type body_expr = _mv_1244.value;
-            __auto_type _mv_1245 = (*body_expr);
-            switch (_mv_1245.tag) {
+        __auto_type _mv_1245 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1245.has_value) {
+            __auto_type body_expr = _mv_1245.value;
+            __auto_type _mv_1246 = (*body_expr);
+            switch (_mv_1246.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type body_lst = _mv_1245.data.lst;
+                    __auto_type body_lst = _mv_1246.data.lst;
                     {
                         __auto_type body_items = body_lst.items;
                         if (((int64_t)((body_items).len)) < 2) {
                             return default_c_type;
                         } else {
-                            __auto_type _mv_1246 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1246.has_value) {
-                                __auto_type head = _mv_1246.value;
-                                __auto_type _mv_1247 = (*head);
-                                switch (_mv_1247.tag) {
+                            __auto_type _mv_1247 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1247.has_value) {
+                                __auto_type head = _mv_1247.value;
+                                __auto_type _mv_1248 = (*head);
+                                switch (_mv_1248.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1247.data.sym;
+                                        __auto_type sym = _mv_1248.data.sym;
                                         if (string_eq(sym.name, SLOP_STR("Array"))) {
-                                            __auto_type _mv_1248 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1248.has_value) {
-                                                __auto_type elem_expr = _mv_1248.value;
+                                            __auto_type _mv_1249 = ({ __auto_type _lst = body_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1249.has_value) {
+                                                __auto_type elem_expr = _mv_1249.value;
                                                 {
                                                     __auto_type elem_c = context_to_c_type_prefixed(ctx, elem_expr);
                                                     return context_ctx_str(ctx, elem_c, SLOP_STR("*"));
                                                 }
-                                            } else if (!_mv_1248.has_value) {
+                                            } else if (!_mv_1249.has_value) {
                                                 return default_c_type;
                                             }
                                             SLOP_UNREACHABLE();
@@ -2218,7 +2218,7 @@ slop_string transpiler_get_array_c_type(context_TranspileContext* ctx, slop_list
                                         return default_c_type;
                                     }
                                 }
-                            } else if (!_mv_1246.has_value) {
+                            } else if (!_mv_1247.has_value) {
                                 return default_c_type;
                             }
                             SLOP_UNREACHABLE();
@@ -2229,7 +2229,7 @@ slop_string transpiler_get_array_c_type(context_TranspileContext* ctx, slop_list
                     return default_c_type;
                 }
             }
-        } else if (!_mv_1244.has_value) {
+        } else if (!_mv_1245.has_value) {
             return default_c_type;
         }
         SLOP_UNREACHABLE();
@@ -2250,13 +2250,13 @@ void transpiler_emit_all_types(context_TranspileContext* ctx, slop_list_types_SE
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1249 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1249.has_value) {
-                __auto_type item = _mv_1249.value;
+            __auto_type _mv_1250 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1250.has_value) {
+                __auto_type item = _mv_1250.value;
                 if (transpiler_is_type_def(item) && !(transpiler_is_union_type_def(item))) {
                     defn_transpile_type(ctx, item);
                 }
-            } else if (!_mv_1249.has_value) {
+            } else if (!_mv_1250.has_value) {
             }
             i = (i + 1);
         }
@@ -2265,13 +2265,13 @@ void transpiler_emit_all_types(context_TranspileContext* ctx, slop_list_types_SE
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1250 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1250.has_value) {
-                __auto_type item = _mv_1250.value;
+            __auto_type _mv_1251 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1251.has_value) {
+                __auto_type item = _mv_1251.value;
                 if (transpiler_is_type_def(item) && transpiler_is_union_type_def(item)) {
                     defn_transpile_type(ctx, item);
                 }
-            } else if (!_mv_1250.has_value) {
+            } else if (!_mv_1251.has_value) {
             }
             i = (i + 1);
         }
@@ -2280,44 +2280,44 @@ void transpiler_emit_all_types(context_TranspileContext* ctx, slop_list_types_SE
 
 uint8_t transpiler_is_union_type_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1251 = (*item);
-    switch (_mv_1251.tag) {
+    __auto_type _mv_1252 = (*item);
+    switch (_mv_1252.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1251.data.lst;
+            __auto_type lst = _mv_1252.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 3) {
                     return 0;
                 } else {
-                    __auto_type _mv_1252 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1252.has_value) {
-                        __auto_type def_expr = _mv_1252.value;
-                        __auto_type _mv_1253 = (*def_expr);
-                        switch (_mv_1253.tag) {
+                    __auto_type _mv_1253 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1253.has_value) {
+                        __auto_type def_expr = _mv_1253.value;
+                        __auto_type _mv_1254 = (*def_expr);
+                        switch (_mv_1254.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type def_lst = _mv_1253.data.lst;
+                                __auto_type def_lst = _mv_1254.data.lst;
                                 {
                                     __auto_type def_items = def_lst.items;
                                     if (((int64_t)((def_items).len)) < 1) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1254 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1254.has_value) {
-                                            __auto_type head = _mv_1254.value;
-                                            __auto_type _mv_1255 = (*head);
-                                            switch (_mv_1255.tag) {
+                                        __auto_type _mv_1255 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1255.has_value) {
+                                            __auto_type head = _mv_1255.value;
+                                            __auto_type _mv_1256 = (*head);
+                                            switch (_mv_1256.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_1255.data.sym;
+                                                    __auto_type sym = _mv_1256.data.sym;
                                                     return string_eq(sym.name, SLOP_STR("union"));
                                                 }
                                                 default: {
                                                     return 0;
                                                 }
                                             }
-                                        } else if (!_mv_1254.has_value) {
+                                        } else if (!_mv_1255.has_value) {
                                             return 0;
                                         }
                                         SLOP_UNREACHABLE();
@@ -2328,7 +2328,7 @@ uint8_t transpiler_is_union_type_def(types_SExpr* item) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1252.has_value) {
+                    } else if (!_mv_1253.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2343,31 +2343,31 @@ uint8_t transpiler_is_union_type_def(types_SExpr* item) {
 
 uint8_t transpiler_is_type_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1256 = (*item);
-    switch (_mv_1256.tag) {
+    __auto_type _mv_1257 = (*item);
+    switch (_mv_1257.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1256.data.lst;
+            __auto_type lst = _mv_1257.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1257 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1257.has_value) {
-                        __auto_type head = _mv_1257.value;
-                        __auto_type _mv_1258 = (*head);
-                        switch (_mv_1258.tag) {
+                    __auto_type _mv_1258 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1258.has_value) {
+                        __auto_type head = _mv_1258.value;
+                        __auto_type _mv_1259 = (*head);
+                        switch (_mv_1259.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1258.data.sym;
+                                __auto_type sym = _mv_1259.data.sym;
                                 return string_eq(sym.name, SLOP_STR("type"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1257.has_value) {
+                    } else if (!_mv_1258.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2386,13 +2386,13 @@ void transpiler_emit_all_functions(context_TranspileContext* ctx, slop_list_type
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1259 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1259.has_value) {
-                __auto_type item = _mv_1259.value;
+            __auto_type _mv_1260 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1260.has_value) {
+                __auto_type item = _mv_1260.value;
                 if (transpiler_is_fn_def(item)) {
                     defn_transpile_function(ctx, item);
                 }
-            } else if (!_mv_1259.has_value) {
+            } else if (!_mv_1260.has_value) {
             }
             i = (i + 1);
         }
@@ -2401,31 +2401,31 @@ void transpiler_emit_all_functions(context_TranspileContext* ctx, slop_list_type
 
 uint8_t transpiler_is_fn_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1260 = (*item);
-    switch (_mv_1260.tag) {
+    __auto_type _mv_1261 = (*item);
+    switch (_mv_1261.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1260.data.lst;
+            __auto_type lst = _mv_1261.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1261 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1261.has_value) {
-                        __auto_type head = _mv_1261.value;
-                        __auto_type _mv_1262 = (*head);
-                        switch (_mv_1262.tag) {
+                    __auto_type _mv_1262 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1262.has_value) {
+                        __auto_type head = _mv_1262.value;
+                        __auto_type _mv_1263 = (*head);
+                        switch (_mv_1263.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1262.data.sym;
+                                __auto_type sym = _mv_1263.data.sym;
                                 return string_eq(sym.name, SLOP_STR("fn"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1261.has_value) {
+                    } else if (!_mv_1262.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -2443,23 +2443,23 @@ void transpiler_transpile_module(context_TranspileContext* ctx, types_SExpr* mod
     SLOP_PRE(((module_expr != NULL)), "(!= module-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1263 = (*module_expr);
-        switch (_mv_1263.tag) {
+        __auto_type _mv_1264 = (*module_expr);
+        switch (_mv_1264.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1263.data.lst;
+                __auto_type lst = _mv_1264.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 2) {
-                        __auto_type _mv_1264 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1264.has_value) {
-                            __auto_type name_expr = _mv_1264.value;
-                            __auto_type _mv_1265 = (*name_expr);
-                            switch (_mv_1265.tag) {
+                        __auto_type _mv_1265 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1265.has_value) {
+                            __auto_type name_expr = _mv_1265.value;
+                            __auto_type _mv_1266 = (*name_expr);
+                            switch (_mv_1266.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1265.data.sym;
+                                    __auto_type sym = _mv_1266.data.sym;
                                     context_ctx_set_module(ctx, (slop_option_string){.has_value = 1, .value = sym.name});
                                     break;
                                 }
@@ -2467,7 +2467,7 @@ void transpiler_transpile_module(context_TranspileContext* ctx, types_SExpr* mod
                                     break;
                                 }
                             }
-                        } else if (!_mv_1264.has_value) {
+                        } else if (!_mv_1265.has_value) {
                         }
                         {
                             __auto_type body_start = transpiler_get_body_start(items);
@@ -2524,27 +2524,27 @@ int64_t transpiler_get_body_start(slop_list_types_SExpr_ptr items) {
     if (((int64_t)((items).len)) < 3) {
         return 2;
     } else {
-        __auto_type _mv_1266 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1266.has_value) {
-            __auto_type third = _mv_1266.value;
-            __auto_type _mv_1267 = (*third);
-            switch (_mv_1267.tag) {
+        __auto_type _mv_1267 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1267.has_value) {
+            __auto_type third = _mv_1267.value;
+            __auto_type _mv_1268 = (*third);
+            switch (_mv_1268.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type lst = _mv_1267.data.lst;
+                    __auto_type lst = _mv_1268.data.lst;
                     {
                         __auto_type sub_items = lst.items;
                         if (((int64_t)((sub_items).len)) < 1) {
                             return 2;
                         } else {
-                            __auto_type _mv_1268 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1268.has_value) {
-                                __auto_type head = _mv_1268.value;
-                                __auto_type _mv_1269 = (*head);
-                                switch (_mv_1269.tag) {
+                            __auto_type _mv_1269 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1269.has_value) {
+                                __auto_type head = _mv_1269.value;
+                                __auto_type _mv_1270 = (*head);
+                                switch (_mv_1270.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1269.data.sym;
+                                        __auto_type sym = _mv_1270.data.sym;
                                         if (string_eq(sym.name, SLOP_STR("export"))) {
                                             return 3;
                                         } else {
@@ -2555,7 +2555,7 @@ int64_t transpiler_get_body_start(slop_list_types_SExpr_ptr items) {
                                         return 2;
                                     }
                                 }
-                            } else if (!_mv_1268.has_value) {
+                            } else if (!_mv_1269.has_value) {
                                 return 2;
                             }
                             SLOP_UNREACHABLE();
@@ -2566,7 +2566,7 @@ int64_t transpiler_get_body_start(slop_list_types_SExpr_ptr items) {
                     return 2;
                 }
             }
-        } else if (!_mv_1266.has_value) {
+        } else if (!_mv_1267.has_value) {
             return 2;
         }
         SLOP_UNREACHABLE();
@@ -2579,38 +2579,38 @@ slop_list_string transpiler_get_export_names(slop_arena* arena, slop_list_types_
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 2;
         while (i < len) {
-            __auto_type _mv_1270 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1270.has_value) {
-                __auto_type item = _mv_1270.value;
-                __auto_type _mv_1271 = (*item);
-                switch (_mv_1271.tag) {
+            __auto_type _mv_1271 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1271.has_value) {
+                __auto_type item = _mv_1271.value;
+                __auto_type _mv_1272 = (*item);
+                switch (_mv_1272.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type lst = _mv_1271.data.lst;
+                        __auto_type lst = _mv_1272.data.lst;
                         {
                             __auto_type sub_items = lst.items;
                             if (((int64_t)((sub_items).len)) >= 1) {
-                                __auto_type _mv_1272 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1272.has_value) {
-                                    __auto_type head = _mv_1272.value;
-                                    __auto_type _mv_1273 = (*head);
-                                    switch (_mv_1273.tag) {
+                                __auto_type _mv_1273 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1273.has_value) {
+                                    __auto_type head = _mv_1273.value;
+                                    __auto_type _mv_1274 = (*head);
+                                    switch (_mv_1274.tag) {
                                         case types_SExpr_sym:
                                         {
-                                            __auto_type sym = _mv_1273.data.sym;
+                                            __auto_type sym = _mv_1274.data.sym;
                                             if (string_eq(sym.name, SLOP_STR("export"))) {
                                                 {
                                                     __auto_type export_len = ((int64_t)((sub_items).len));
                                                     __auto_type j = 1;
                                                     while (j < export_len) {
-                                                        __auto_type _mv_1274 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                        if (_mv_1274.has_value) {
-                                                            __auto_type name_expr = _mv_1274.value;
-                                                            __auto_type _mv_1275 = (*name_expr);
-                                                            switch (_mv_1275.tag) {
+                                                        __auto_type _mv_1275 = ({ __auto_type _lst = sub_items; size_t _idx = (size_t)j; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                        if (_mv_1275.has_value) {
+                                                            __auto_type name_expr = _mv_1275.value;
+                                                            __auto_type _mv_1276 = (*name_expr);
+                                                            switch (_mv_1276.tag) {
                                                                 case types_SExpr_sym:
                                                                 {
-                                                                    __auto_type name_sym = _mv_1275.data.sym;
+                                                                    __auto_type name_sym = _mv_1276.data.sym;
                                                                     ({ __auto_type _lst_p = &(result); __auto_type _item = (name_sym.name); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                                                     break;
                                                                 }
@@ -2618,7 +2618,7 @@ slop_list_string transpiler_get_export_names(slop_arena* arena, slop_list_types_
                                                                     break;
                                                                 }
                                                             }
-                                                        } else if (!_mv_1274.has_value) {
+                                                        } else if (!_mv_1275.has_value) {
                                                         }
                                                         j = (j + 1);
                                                     }
@@ -2630,7 +2630,7 @@ slop_list_string transpiler_get_export_names(slop_arena* arena, slop_list_types_
                                             break;
                                         }
                                     }
-                                } else if (!_mv_1272.has_value) {
+                                } else if (!_mv_1273.has_value) {
                                 }
                             }
                         }
@@ -2640,7 +2640,7 @@ slop_list_string transpiler_get_export_names(slop_arena* arena, slop_list_types_
                         break;
                     }
                 }
-            } else if (!_mv_1270.has_value) {
+            } else if (!_mv_1271.has_value) {
             }
             i = (i + 1);
         }
@@ -2654,13 +2654,13 @@ uint8_t transpiler_list_contains_str(slop_list_string lst, slop_string needle) {
         int64_t i = 0;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1276 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1276.has_value) {
-                __auto_type s = _mv_1276.value;
+            __auto_type _mv_1277 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1277.has_value) {
+                __auto_type s = _mv_1277.value;
                 if (string_eq(s, needle)) {
                     found = 1;
                 }
-            } else if (!_mv_1276.has_value) {
+            } else if (!_mv_1277.has_value) {
             }
             i = (i + 1);
         }
@@ -2674,11 +2674,11 @@ void transpiler_prescan_module_body(context_TranspileContext* ctx, slop_list_typ
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1277 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1277.has_value) {
-                __auto_type item = _mv_1277.value;
+            __auto_type _mv_1278 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1278.has_value) {
+                __auto_type item = _mv_1278.value;
                 transpiler_prescan_top_level(ctx, item);
-            } else if (!_mv_1277.has_value) {
+            } else if (!_mv_1278.has_value) {
             }
             i = (i + 1);
         }
@@ -2690,30 +2690,30 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1278 = (*type_expr);
-        switch (_mv_1278.tag) {
+        __auto_type _mv_1279 = (*type_expr);
+        switch (_mv_1279.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1278.data.lst;
+                __auto_type lst = _mv_1279.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 1) {
-                        __auto_type _mv_1279 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1279.has_value) {
-                            __auto_type head = _mv_1279.value;
-                            __auto_type _mv_1280 = (*head);
-                            switch (_mv_1280.tag) {
+                        __auto_type _mv_1280 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1280.has_value) {
+                            __auto_type head = _mv_1280.value;
+                            __auto_type _mv_1281 = (*head);
+                            switch (_mv_1281.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1280.data.sym;
+                                    __auto_type sym = _mv_1281.data.sym;
                                     {
                                         __auto_type op = sym.name;
                                         if (string_eq(op, SLOP_STR("Option"))) {
                                             if (len >= 2) {
-                                                __auto_type _mv_1281 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1281.has_value) {
-                                                    __auto_type inner = _mv_1281.value;
+                                                __auto_type _mv_1282 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1282.has_value) {
+                                                    __auto_type inner = _mv_1282.value;
                                                     {
                                                         __auto_type inner_c = context_to_c_type_prefixed(ctx, inner);
                                                         __auto_type inner_id = ctype_type_to_identifier(arena, inner_c);
@@ -2721,14 +2721,14 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                         context_ctx_register_option_type(ctx, inner_c, c_name);
                                                         transpiler_scan_type_for_generics(ctx, inner);
                                                     }
-                                                } else if (!_mv_1281.has_value) {
+                                                } else if (!_mv_1282.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("List"))) {
                                             if (len >= 2) {
-                                                __auto_type _mv_1282 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1282.has_value) {
-                                                    __auto_type elem = _mv_1282.value;
+                                                __auto_type _mv_1283 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1283.has_value) {
+                                                    __auto_type elem = _mv_1283.value;
                                                     {
                                                         __auto_type elem_c = context_to_c_type_prefixed(ctx, elem);
                                                         __auto_type elem_id = ctype_type_to_identifier(arena, elem_c);
@@ -2738,26 +2738,26 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                         context_ctx_register_option_type(ctx, elem_c, option_c_name);
                                                         transpiler_scan_type_for_generics(ctx, elem);
                                                     }
-                                                } else if (!_mv_1282.has_value) {
+                                                } else if (!_mv_1283.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("Ptr"))) {
                                             if (len >= 2) {
-                                                __auto_type _mv_1283 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1283.has_value) {
-                                                    __auto_type inner = _mv_1283.value;
+                                                __auto_type _mv_1284 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1284.has_value) {
+                                                    __auto_type inner = _mv_1284.value;
                                                     transpiler_scan_type_for_generics(ctx, inner);
-                                                } else if (!_mv_1283.has_value) {
+                                                } else if (!_mv_1284.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("Result"))) {
                                             if (len >= 3) {
-                                                __auto_type _mv_1284 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1284.has_value) {
-                                                    __auto_type ok_type = _mv_1284.value;
-                                                    __auto_type _mv_1285 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                    if (_mv_1285.has_value) {
-                                                        __auto_type err_type = _mv_1285.value;
+                                                __auto_type _mv_1285 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1285.has_value) {
+                                                    __auto_type ok_type = _mv_1285.value;
+                                                    __auto_type _mv_1286 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                    if (_mv_1286.has_value) {
+                                                        __auto_type err_type = _mv_1286.value;
                                                         {
                                                             __auto_type ok_c = context_to_c_type_prefixed(ctx, ok_type);
                                                             __auto_type err_c = context_to_c_type_prefixed(ctx, err_type);
@@ -2768,16 +2768,16 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                             transpiler_scan_type_for_generics(ctx, ok_type);
                                                             transpiler_scan_type_for_generics(ctx, err_type);
                                                         }
-                                                    } else if (!_mv_1285.has_value) {
+                                                    } else if (!_mv_1286.has_value) {
                                                     }
-                                                } else if (!_mv_1284.has_value) {
+                                                } else if (!_mv_1285.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("Chan"))) {
                                             if (len >= 2) {
-                                                __auto_type _mv_1286 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1286.has_value) {
-                                                    __auto_type elem = _mv_1286.value;
+                                                __auto_type _mv_1287 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1287.has_value) {
+                                                    __auto_type elem = _mv_1287.value;
                                                     {
                                                         __auto_type elem_c = context_to_c_type_prefixed(ctx, elem);
                                                         __auto_type elem_id = ctype_type_to_identifier(arena, elem_c);
@@ -2785,14 +2785,14 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                         context_ctx_register_chan_type(ctx, elem_c, c_name);
                                                         transpiler_scan_type_for_generics(ctx, elem);
                                                     }
-                                                } else if (!_mv_1286.has_value) {
+                                                } else if (!_mv_1287.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("Thread"))) {
                                             if (len >= 2) {
-                                                __auto_type _mv_1287 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1287.has_value) {
-                                                    __auto_type result = _mv_1287.value;
+                                                __auto_type _mv_1288 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1288.has_value) {
+                                                    __auto_type result = _mv_1288.value;
                                                     {
                                                         __auto_type result_c = context_to_c_type_prefixed(ctx, result);
                                                         {
@@ -2803,14 +2803,14 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                             transpiler_scan_type_for_generics(ctx, result);
                                                         }
                                                     }
-                                                } else if (!_mv_1287.has_value) {
+                                                } else if (!_mv_1288.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("Map"))) {
                                             if (len >= 3) {
-                                                __auto_type _mv_1288 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1288.has_value) {
-                                                    __auto_type key_type = _mv_1288.value;
+                                                __auto_type _mv_1289 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1289.has_value) {
+                                                    __auto_type key_type = _mv_1289.value;
                                                     {
                                                         __auto_type key_c = context_to_c_type_prefixed(ctx, key_type);
                                                         __auto_type key_id = ctype_type_to_identifier(arena, key_c);
@@ -2819,9 +2819,9 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                         context_ctx_register_list_type(ctx, key_c, list_c_name);
                                                         context_ctx_register_option_type(ctx, key_c, option_c_name);
                                                         transpiler_scan_type_for_generics(ctx, key_type);
-                                                        __auto_type _mv_1289 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                        if (_mv_1289.has_value) {
-                                                            __auto_type val_type = _mv_1289.value;
+                                                        __auto_type _mv_1290 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                        if (_mv_1290.has_value) {
+                                                            __auto_type val_type = _mv_1290.value;
                                                             {
                                                                 __auto_type val_c = context_to_c_type_prefixed(ctx, val_type);
                                                                 __auto_type val_id = ctype_type_to_identifier(arena, val_c);
@@ -2829,17 +2829,17 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                                 context_ctx_register_option_type(ctx, val_c, val_option_c_name);
                                                                 transpiler_scan_type_for_generics(ctx, val_type);
                                                             }
-                                                        } else if (!_mv_1289.has_value) {
+                                                        } else if (!_mv_1290.has_value) {
                                                         }
                                                     }
-                                                } else if (!_mv_1288.has_value) {
+                                                } else if (!_mv_1289.has_value) {
                                                 }
                                             }
                                         } else if (string_eq(op, SLOP_STR("Set"))) {
                                             if (len >= 2) {
-                                                __auto_type _mv_1290 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1290.has_value) {
-                                                    __auto_type elem_type = _mv_1290.value;
+                                                __auto_type _mv_1291 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1291.has_value) {
+                                                    __auto_type elem_type = _mv_1291.value;
                                                     {
                                                         __auto_type elem_c = context_to_c_type_prefixed(ctx, elem_type);
                                                         __auto_type elem_id = ctype_type_to_identifier(arena, elem_c);
@@ -2849,7 +2849,7 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                                         context_ctx_register_option_type(ctx, elem_c, option_c_name);
                                                         transpiler_scan_type_for_generics(ctx, elem_type);
                                                     }
-                                                } else if (!_mv_1290.has_value) {
+                                                } else if (!_mv_1291.has_value) {
                                                 }
                                             }
                                         } else {
@@ -2861,7 +2861,7 @@ void transpiler_scan_type_for_generics(context_TranspileContext* ctx, types_SExp
                                     break;
                                 }
                             }
-                        } else if (!_mv_1279.has_value) {
+                        } else if (!_mv_1280.has_value) {
                         }
                     }
                 }
@@ -2880,22 +2880,22 @@ void transpiler_scan_record_fields_for_generics(context_TranspileContext* ctx, s
         __auto_type len = ((int64_t)((items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1291 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1291.has_value) {
-                __auto_type field_expr = _mv_1291.value;
-                __auto_type _mv_1292 = (*field_expr);
-                switch (_mv_1292.tag) {
+            __auto_type _mv_1292 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1292.has_value) {
+                __auto_type field_expr = _mv_1292.value;
+                __auto_type _mv_1293 = (*field_expr);
+                switch (_mv_1293.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type field_lst = _mv_1292.data.lst;
+                        __auto_type field_lst = _mv_1293.data.lst;
                         {
                             __auto_type field_items = field_lst.items;
                             if (((int64_t)((field_items).len)) >= 2) {
-                                __auto_type _mv_1293 = ({ __auto_type _lst = field_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1293.has_value) {
-                                    __auto_type type_expr = _mv_1293.value;
+                                __auto_type _mv_1294 = ({ __auto_type _lst = field_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1294.has_value) {
+                                    __auto_type type_expr = _mv_1294.value;
                                     transpiler_scan_type_for_generics(ctx, type_expr);
-                                } else if (!_mv_1293.has_value) {
+                                } else if (!_mv_1294.has_value) {
                                 }
                             }
                         }
@@ -2905,7 +2905,7 @@ void transpiler_scan_record_fields_for_generics(context_TranspileContext* ctx, s
                         break;
                     }
                 }
-            } else if (!_mv_1291.has_value) {
+            } else if (!_mv_1292.has_value) {
             }
             i = (i + 1);
         }
@@ -2919,11 +2919,11 @@ void transpiler_emit_ffi_includes(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((includes).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1294 = ({ __auto_type _lst = includes; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1294.has_value) {
-                __auto_type header = _mv_1294.value;
+            __auto_type _mv_1295 = ({ __auto_type _lst = includes; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1295.has_value) {
+                __auto_type header = _mv_1295.value;
                 emit_emit_include(ctx, header, 1);
-            } else if (!_mv_1294.has_value) {
+            } else if (!_mv_1295.has_value) {
             }
             i = (i + 1);
         }
@@ -2937,11 +2937,11 @@ void transpiler_emit_ffi_includes_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((includes).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1295 = ({ __auto_type _lst = includes; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1295.has_value) {
-                __auto_type header = _mv_1295.value;
+            __auto_type _mv_1296 = ({ __auto_type _lst = includes; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1296.has_value) {
+                __auto_type header = _mv_1296.value;
                 context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("#include <"), header, SLOP_STR(">")));
-            } else if (!_mv_1295.has_value) {
+            } else if (!_mv_1296.has_value) {
             }
             i = (i + 1);
         }
@@ -2952,9 +2952,9 @@ void transpiler_emit_header_guard_open(context_TranspileContext* ctx) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1296 = context_ctx_get_module(ctx);
-        if (_mv_1296.has_value) {
-            __auto_type mod_name = _mv_1296.value;
+        __auto_type _mv_1297 = context_ctx_get_module(ctx);
+        if (_mv_1297.has_value) {
+            __auto_type mod_name = _mv_1297.value;
             {
                 __auto_type c_name = ctype_to_c_name(arena, mod_name);
                 __auto_type guard = context_ctx_str3(ctx, SLOP_STR("SLOP_"), c_name, SLOP_STR("_H"));
@@ -2962,7 +2962,7 @@ void transpiler_emit_header_guard_open(context_TranspileContext* ctx) {
                 context_ctx_emit_header(ctx, context_ctx_str(ctx, SLOP_STR("#define "), guard));
                 context_ctx_emit_header(ctx, SLOP_STR(""));
             }
-        } else if (!_mv_1296.has_value) {
+        } else if (!_mv_1297.has_value) {
         }
     }
 }
@@ -2988,14 +2988,14 @@ void transpiler_emit_header_dependency_includes(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((imports).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1297 = ({ __auto_type _lst = imports; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1297.has_value) {
-                __auto_type mod_name = _mv_1297.value;
+            __auto_type _mv_1298 = ({ __auto_type _lst = imports; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1298.has_value) {
+                __auto_type mod_name = _mv_1298.value;
                 {
                     __auto_type c_name = ctype_to_c_name(arena, mod_name);
                     context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("#include \"slop_"), c_name, SLOP_STR(".h\"")));
                 }
-            } else if (!_mv_1297.has_value) {
+            } else if (!_mv_1298.has_value) {
             }
             i = (i + 1);
         }
@@ -3010,22 +3010,22 @@ void transpiler_emit_forward_decls(context_TranspileContext* ctx, slop_list_type
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1298 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1298.has_value) {
-                __auto_type item = _mv_1298.value;
+            __auto_type _mv_1299 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1299.has_value) {
+                __auto_type item = _mv_1299.value;
                 if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
-                    __auto_type _mv_1299 = transpiler_get_type_name(item);
-                    if (_mv_1299.has_value) {
-                        __auto_type type_name = _mv_1299.value;
+                    __auto_type _mv_1300 = transpiler_get_type_name(item);
+                    if (_mv_1300.has_value) {
+                        __auto_type type_name = _mv_1300.value;
                         {
                             __auto_type c_name = ctype_to_c_name(arena, type_name);
                             context_ctx_emit(ctx, context_ctx_str3(ctx, SLOP_STR("typedef struct "), c_name, context_ctx_str(ctx, SLOP_STR(" "), context_ctx_str(ctx, c_name, SLOP_STR(";")))));
                             emitted_any = 1;
                         }
-                    } else if (!_mv_1299.has_value) {
+                    } else if (!_mv_1300.has_value) {
                     }
                 }
-            } else if (!_mv_1298.has_value) {
+            } else if (!_mv_1299.has_value) {
             }
             i = (i + 1);
         }
@@ -3037,37 +3037,37 @@ void transpiler_emit_forward_decls(context_TranspileContext* ctx, slop_list_type
 
 uint8_t transpiler_is_struct_type_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1300 = (*item);
-    switch (_mv_1300.tag) {
+    __auto_type _mv_1301 = (*item);
+    switch (_mv_1301.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1300.data.lst;
+            __auto_type lst = _mv_1301.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 3) {
                     return 0;
                 } else {
-                    __auto_type _mv_1301 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1301.has_value) {
-                        __auto_type def_expr = _mv_1301.value;
-                        __auto_type _mv_1302 = (*def_expr);
-                        switch (_mv_1302.tag) {
+                    __auto_type _mv_1302 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1302.has_value) {
+                        __auto_type def_expr = _mv_1302.value;
+                        __auto_type _mv_1303 = (*def_expr);
+                        switch (_mv_1303.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type def_lst = _mv_1302.data.lst;
+                                __auto_type def_lst = _mv_1303.data.lst;
                                 {
                                     __auto_type def_items = def_lst.items;
                                     if (((int64_t)((def_items).len)) < 1) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1303 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1303.has_value) {
-                                            __auto_type head = _mv_1303.value;
-                                            __auto_type _mv_1304 = (*head);
-                                            switch (_mv_1304.tag) {
+                                        __auto_type _mv_1304 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1304.has_value) {
+                                            __auto_type head = _mv_1304.value;
+                                            __auto_type _mv_1305 = (*head);
+                                            switch (_mv_1305.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_1304.data.sym;
+                                                    __auto_type sym = _mv_1305.data.sym;
                                                     {
                                                         __auto_type kind = sym.name;
                                                         return ((string_eq(kind, SLOP_STR("record"))) || (string_eq(kind, SLOP_STR("union"))) || ((string_eq(kind, SLOP_STR("enum")) && transpiler_has_enum_payload_variants(def_items))));
@@ -3077,7 +3077,7 @@ uint8_t transpiler_is_struct_type_def(types_SExpr* item) {
                                                     return 0;
                                                 }
                                             }
-                                        } else if (!_mv_1303.has_value) {
+                                        } else if (!_mv_1304.has_value) {
                                             return 0;
                                         }
                                         SLOP_UNREACHABLE();
@@ -3088,7 +3088,7 @@ uint8_t transpiler_is_struct_type_def(types_SExpr* item) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1301.has_value) {
+                    } else if (!_mv_1302.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -3107,14 +3107,14 @@ uint8_t transpiler_has_enum_payload_variants(slop_list_types_SExpr_ptr items) {
         int64_t i = 1;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1305 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1305.has_value) {
-                __auto_type item = _mv_1305.value;
-                __auto_type _mv_1306 = (*item);
-                switch (_mv_1306.tag) {
+            __auto_type _mv_1306 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1306.has_value) {
+                __auto_type item = _mv_1306.value;
+                __auto_type _mv_1307 = (*item);
+                switch (_mv_1307.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type _ = _mv_1306.data.lst;
+                        __auto_type _ = _mv_1307.data.lst;
                         found = 1;
                         break;
                     }
@@ -3122,7 +3122,7 @@ uint8_t transpiler_has_enum_payload_variants(slop_list_types_SExpr_ptr items) {
                         break;
                     }
                 }
-            } else if (!_mv_1305.has_value) {
+            } else if (!_mv_1306.has_value) {
             }
             i = (i + 1);
         }
@@ -3132,42 +3132,42 @@ uint8_t transpiler_has_enum_payload_variants(slop_list_types_SExpr_ptr items) {
 
 uint8_t transpiler_is_type_alias_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1307 = (*item);
-    switch (_mv_1307.tag) {
+    __auto_type _mv_1308 = (*item);
+    switch (_mv_1308.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1307.data.lst;
+            __auto_type lst = _mv_1308.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 3) {
                     return 0;
                 } else {
-                    __auto_type _mv_1308 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1308.has_value) {
-                        __auto_type def_expr = _mv_1308.value;
-                        __auto_type _mv_1309 = (*def_expr);
-                        switch (_mv_1309.tag) {
+                    __auto_type _mv_1309 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1309.has_value) {
+                        __auto_type def_expr = _mv_1309.value;
+                        __auto_type _mv_1310 = (*def_expr);
+                        switch (_mv_1310.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type _ = _mv_1309.data.sym;
+                                __auto_type _ = _mv_1310.data.sym;
                                 return 1;
                             }
                             case types_SExpr_lst:
                             {
-                                __auto_type def_lst = _mv_1309.data.lst;
+                                __auto_type def_lst = _mv_1310.data.lst;
                                 {
                                     __auto_type def_items = def_lst.items;
                                     if (((int64_t)((def_items).len)) < 1) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1310 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1310.has_value) {
-                                            __auto_type head = _mv_1310.value;
-                                            __auto_type _mv_1311 = (*head);
-                                            switch (_mv_1311.tag) {
+                                        __auto_type _mv_1311 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1311.has_value) {
+                                            __auto_type head = _mv_1311.value;
+                                            __auto_type _mv_1312 = (*head);
+                                            switch (_mv_1312.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_1311.data.sym;
+                                                    __auto_type sym = _mv_1312.data.sym;
                                                     {
                                                         __auto_type kind = sym.name;
                                                         return ((!(string_eq(kind, SLOP_STR("record")))) && (!(string_eq(kind, SLOP_STR("enum")))) && (!(string_eq(kind, SLOP_STR("union")))));
@@ -3177,7 +3177,7 @@ uint8_t transpiler_is_type_alias_def(types_SExpr* item) {
                                                     return 0;
                                                 }
                                             }
-                                        } else if (!_mv_1310.has_value) {
+                                        } else if (!_mv_1311.has_value) {
                                             return 0;
                                         }
                                         SLOP_UNREACHABLE();
@@ -3188,7 +3188,7 @@ uint8_t transpiler_is_type_alias_def(types_SExpr* item) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1308.has_value) {
+                    } else if (!_mv_1309.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -3203,44 +3203,44 @@ uint8_t transpiler_is_type_alias_def(types_SExpr* item) {
 
 uint8_t transpiler_is_result_type_alias_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1312 = (*item);
-    switch (_mv_1312.tag) {
+    __auto_type _mv_1313 = (*item);
+    switch (_mv_1313.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1312.data.lst;
+            __auto_type lst = _mv_1313.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 3) {
                     return 0;
                 } else {
-                    __auto_type _mv_1313 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1313.has_value) {
-                        __auto_type def_expr = _mv_1313.value;
-                        __auto_type _mv_1314 = (*def_expr);
-                        switch (_mv_1314.tag) {
+                    __auto_type _mv_1314 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1314.has_value) {
+                        __auto_type def_expr = _mv_1314.value;
+                        __auto_type _mv_1315 = (*def_expr);
+                        switch (_mv_1315.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type def_lst = _mv_1314.data.lst;
+                                __auto_type def_lst = _mv_1315.data.lst;
                                 {
                                     __auto_type def_items = def_lst.items;
                                     if (((int64_t)((def_items).len)) < 1) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1315 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1315.has_value) {
-                                            __auto_type head = _mv_1315.value;
-                                            __auto_type _mv_1316 = (*head);
-                                            switch (_mv_1316.tag) {
+                                        __auto_type _mv_1316 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1316.has_value) {
+                                            __auto_type head = _mv_1316.value;
+                                            __auto_type _mv_1317 = (*head);
+                                            switch (_mv_1317.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_1316.data.sym;
+                                                    __auto_type sym = _mv_1317.data.sym;
                                                     return string_eq(sym.name, SLOP_STR("Result"));
                                                 }
                                                 default: {
                                                     return 0;
                                                 }
                                             }
-                                        } else if (!_mv_1315.has_value) {
+                                        } else if (!_mv_1316.has_value) {
                                             return 0;
                                         }
                                         SLOP_UNREACHABLE();
@@ -3251,7 +3251,7 @@ uint8_t transpiler_is_result_type_alias_def(types_SExpr* item) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1313.has_value) {
+                    } else if (!_mv_1314.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -3269,29 +3269,29 @@ void transpiler_emit_type_alias_to_header(context_TranspileContext* ctx, types_S
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1317 = (*type_def);
-        switch (_mv_1317.tag) {
+        __auto_type _mv_1318 = (*type_def);
+        switch (_mv_1318.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1317.data.lst;
+                __auto_type lst = _mv_1318.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_1318 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1318.has_value) {
-                            __auto_type name_expr = _mv_1318.value;
-                            __auto_type _mv_1319 = (*name_expr);
-                            switch (_mv_1319.tag) {
+                        __auto_type _mv_1319 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1319.has_value) {
+                            __auto_type name_expr = _mv_1319.value;
+                            __auto_type _mv_1320 = (*name_expr);
+                            switch (_mv_1320.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1319.data.sym;
+                                    __auto_type name_sym = _mv_1320.data.sym;
                                     {
                                         __auto_type type_name = name_sym.name;
                                         __auto_type base_c_name = ctype_to_c_name(arena, type_name);
                                         __auto_type c_name = context_ctx_prefix_type(ctx, base_c_name);
-                                        __auto_type _mv_1320 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1320.has_value) {
-                                            __auto_type body_expr = _mv_1320.value;
+                                        __auto_type _mv_1321 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1321.has_value) {
+                                            __auto_type body_expr = _mv_1321.value;
                                             if (transpiler_is_array_type_body(body_expr)) {
                                                 transpiler_emit_array_typedef_to_header(ctx, c_name, body_expr);
                                             } else if (transpiler_is_range_type_body(body_expr)) {
@@ -3304,7 +3304,7 @@ void transpiler_emit_type_alias_to_header(context_TranspileContext* ctx, types_S
                                                     context_ctx_mark_type_emitted(ctx, c_name);
                                                 }
                                             }
-                                        } else if (!_mv_1320.has_value) {
+                                        } else if (!_mv_1321.has_value) {
                                         }
                                     }
                                     break;
@@ -3313,7 +3313,7 @@ void transpiler_emit_type_alias_to_header(context_TranspileContext* ctx, types_S
                                     break;
                                 }
                             }
-                        } else if (!_mv_1318.has_value) {
+                        } else if (!_mv_1319.has_value) {
                         }
                     }
                 }
@@ -3328,31 +3328,31 @@ void transpiler_emit_type_alias_to_header(context_TranspileContext* ctx, types_S
 
 uint8_t transpiler_is_array_type_body(types_SExpr* body_expr) {
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
-    __auto_type _mv_1321 = (*body_expr);
-    switch (_mv_1321.tag) {
+    __auto_type _mv_1322 = (*body_expr);
+    switch (_mv_1322.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1321.data.lst;
+            __auto_type lst = _mv_1322.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1322 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1322.has_value) {
-                        __auto_type head = _mv_1322.value;
-                        __auto_type _mv_1323 = (*head);
-                        switch (_mv_1323.tag) {
+                    __auto_type _mv_1323 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1323.has_value) {
+                        __auto_type head = _mv_1323.value;
+                        __auto_type _mv_1324 = (*head);
+                        switch (_mv_1324.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1323.data.sym;
+                                __auto_type sym = _mv_1324.data.sym;
                                 return string_eq(sym.name, SLOP_STR("Array"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1322.has_value) {
+                    } else if (!_mv_1323.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -3370,33 +3370,33 @@ void transpiler_emit_array_typedef_to_header(context_TranspileContext* ctx, slop
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1324 = (*body_expr);
-        switch (_mv_1324.tag) {
+        __auto_type _mv_1325 = (*body_expr);
+        switch (_mv_1325.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1324.data.lst;
+                __auto_type lst = _mv_1325.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len < 3) {
                         context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("typedef void* "), c_name, SLOP_STR(";")));
                     } else {
-                        __auto_type _mv_1325 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1325.has_value) {
-                            __auto_type elem_type_expr = _mv_1325.value;
-                            __auto_type _mv_1326 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1326.has_value) {
-                                __auto_type size_expr = _mv_1326.value;
+                        __auto_type _mv_1326 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1326.has_value) {
+                            __auto_type elem_type_expr = _mv_1326.value;
+                            __auto_type _mv_1327 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1327.has_value) {
+                                __auto_type size_expr = _mv_1327.value;
                                 {
                                     __auto_type elem_c_type = context_to_c_type_prefixed(ctx, elem_type_expr);
                                     __auto_type size_str = transpiler_get_array_size_string(size_expr);
                                     context_ctx_emit_header(ctx, context_ctx_str5(ctx, SLOP_STR("typedef "), elem_c_type, SLOP_STR(" "), c_name, context_ctx_str3(ctx, SLOP_STR("["), size_str, SLOP_STR("];"))));
                                     context_ctx_emit_header(ctx, SLOP_STR(""));
                                 }
-                            } else if (!_mv_1326.has_value) {
+                            } else if (!_mv_1327.has_value) {
                                 context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("typedef void* "), c_name, SLOP_STR(";")));
                             }
-                        } else if (!_mv_1325.has_value) {
+                        } else if (!_mv_1326.has_value) {
                             context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("typedef void* "), c_name, SLOP_STR(";")));
                         }
                     }
@@ -3413,11 +3413,11 @@ void transpiler_emit_array_typedef_to_header(context_TranspileContext* ctx, slop
 
 slop_string transpiler_get_array_size_string(types_SExpr* expr) {
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
-    __auto_type _mv_1327 = (*expr);
-    switch (_mv_1327.tag) {
+    __auto_type _mv_1328 = (*expr);
+    switch (_mv_1328.tag) {
         case types_SExpr_num:
         {
-            __auto_type num = _mv_1327.data.num;
+            __auto_type num = _mv_1328.data.num;
             return num.raw;
         }
         default: {
@@ -3428,25 +3428,25 @@ slop_string transpiler_get_array_size_string(types_SExpr* expr) {
 
 uint8_t transpiler_is_range_type_body(types_SExpr* body_expr) {
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
-    __auto_type _mv_1328 = (*body_expr);
-    switch (_mv_1328.tag) {
+    __auto_type _mv_1329 = (*body_expr);
+    switch (_mv_1329.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1328.data.lst;
+            __auto_type lst = _mv_1329.data.lst;
             {
                 __auto_type items = lst.items;
                 __auto_type len = ((int64_t)((items).len));
                 __auto_type found_dots = 0;
                 __auto_type i = 0;
                 while ((i < len) && !(found_dots)) {
-                    __auto_type _mv_1329 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1329.has_value) {
-                        __auto_type item = _mv_1329.value;
-                        __auto_type _mv_1330 = (*item);
-                        switch (_mv_1330.tag) {
+                    __auto_type _mv_1330 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1330.has_value) {
+                        __auto_type item = _mv_1330.value;
+                        __auto_type _mv_1331 = (*item);
+                        switch (_mv_1331.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1330.data.sym;
+                                __auto_type sym = _mv_1331.data.sym;
                                 if (string_eq(sym.name, SLOP_STR(".."))) {
                                     found_dots = 1;
                                 }
@@ -3456,7 +3456,7 @@ uint8_t transpiler_is_range_type_body(types_SExpr* body_expr) {
                                 break;
                             }
                         }
-                    } else if (!_mv_1329.has_value) {
+                    } else if (!_mv_1330.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -3477,24 +3477,24 @@ transpiler_RangeBoundsHeader transpiler_parse_range_bounds_header(types_SExpr* b
         uint8_t has_min = 0;
         uint8_t has_max = 0;
         uint8_t found_dots = 0;
-        __auto_type _mv_1331 = (*body_expr);
-        switch (_mv_1331.tag) {
+        __auto_type _mv_1332 = (*body_expr);
+        switch (_mv_1332.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1331.data.lst;
+                __auto_type lst = _mv_1332.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type i = 1;
                     while (i < len) {
-                        __auto_type _mv_1332 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1332.has_value) {
-                            __auto_type item = _mv_1332.value;
-                            __auto_type _mv_1333 = (*item);
-                            switch (_mv_1333.tag) {
+                        __auto_type _mv_1333 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1333.has_value) {
+                            __auto_type item = _mv_1333.value;
+                            __auto_type _mv_1334 = (*item);
+                            switch (_mv_1334.tag) {
                                 case types_SExpr_num:
                                 {
-                                    __auto_type num = _mv_1333.data.num;
+                                    __auto_type num = _mv_1334.data.num;
                                     if (!(found_dots)) {
                                         min_val = transpiler_string_to_int_header(num.raw);
                                         has_min = 1;
@@ -3506,7 +3506,7 @@ transpiler_RangeBoundsHeader transpiler_parse_range_bounds_header(types_SExpr* b
                                 }
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1333.data.sym;
+                                    __auto_type sym = _mv_1334.data.sym;
                                     if (string_eq(sym.name, SLOP_STR(".."))) {
                                         found_dots = 1;
                                     }
@@ -3516,7 +3516,7 @@ transpiler_RangeBoundsHeader transpiler_parse_range_bounds_header(types_SExpr* b
                                     break;
                                 }
                             }
-                        } else if (!_mv_1332.has_value) {
+                        } else if (!_mv_1333.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -3626,23 +3626,23 @@ void transpiler_emit_forward_decls_header(context_TranspileContext* ctx, slop_li
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1334 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1334.has_value) {
-                __auto_type item = _mv_1334.value;
+            __auto_type _mv_1335 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1335.has_value) {
+                __auto_type item = _mv_1335.value;
                 if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
-                    __auto_type _mv_1335 = transpiler_get_type_name(item);
-                    if (_mv_1335.has_value) {
-                        __auto_type type_name = _mv_1335.value;
+                    __auto_type _mv_1336 = transpiler_get_type_name(item);
+                    if (_mv_1336.has_value) {
+                        __auto_type type_name = _mv_1336.value;
                         {
                             __auto_type base_name = ctype_to_c_name(arena, type_name);
                             __auto_type c_name = ((context_ctx_prefixing_enabled(ctx)) ? ({ __auto_type _mv = context_ctx_get_module(ctx); _mv.has_value ? ({ __auto_type mod_name = _mv.value; context_ctx_str(ctx, ctype_to_c_name(arena, mod_name), context_ctx_str(ctx, SLOP_STR("_"), base_name)); }) : (base_name); }) : base_name);
                             context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("typedef struct "), c_name, context_ctx_str(ctx, SLOP_STR(" "), context_ctx_str(ctx, c_name, SLOP_STR(";")))));
                             emitted_any = 1;
                         }
-                    } else if (!_mv_1335.has_value) {
+                    } else if (!_mv_1336.has_value) {
                     }
                 }
-            } else if (!_mv_1334.has_value) {
+            } else if (!_mv_1335.has_value) {
             }
             i = (i + 1);
         }
@@ -3659,14 +3659,14 @@ void transpiler_emit_fn_forward_decls(context_TranspileContext* ctx, slop_list_t
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1336 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1336.has_value) {
-                __auto_type item = _mv_1336.value;
+            __auto_type _mv_1337 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1337.has_value) {
+                __auto_type item = _mv_1337.value;
                 if (transpiler_is_fn_def(item)) {
                     defn_emit_forward_declaration(ctx, item);
                     emitted_any = 1;
                 }
-            } else if (!_mv_1336.has_value) {
+            } else if (!_mv_1337.has_value) {
             }
             i = (i + 1);
         }
@@ -3683,14 +3683,14 @@ void transpiler_emit_fn_forward_decls_header(context_TranspileContext* ctx, slop
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1337 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1337.has_value) {
-                __auto_type item = _mv_1337.value;
+            __auto_type _mv_1338 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1338.has_value) {
+                __auto_type item = _mv_1338.value;
                 if (transpiler_is_fn_def(item)) {
                     transpiler_emit_fn_forward_decl_header(ctx, item);
                     emitted_any = 1;
                 }
-            } else if (!_mv_1337.has_value) {
+            } else if (!_mv_1338.has_value) {
             }
             i = (i + 1);
         }
@@ -3709,11 +3709,11 @@ void transpiler_emit_c_name_aliases(context_TranspileContext* ctx) {
         if (len > 0) {
             context_ctx_emit_header(ctx, SLOP_STR("/* Function name aliases for C interop */"));
             while (i < len) {
-                __auto_type _mv_1338 = ({ __auto_type _lst = aliases; size_t _idx = (size_t)i; slop_option_context_FuncCNameAlias _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1338.has_value) {
-                    __auto_type alias = _mv_1338.value;
+                __auto_type _mv_1339 = ({ __auto_type _lst = aliases; size_t _idx = (size_t)i; slop_option_context_FuncCNameAlias _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1339.has_value) {
+                    __auto_type alias = _mv_1339.value;
                     context_ctx_emit_header(ctx, context_ctx_str(ctx, SLOP_STR("#define "), context_ctx_str(ctx, alias.mangled_name, context_ctx_str(ctx, SLOP_STR(" "), alias.clean_name))));
-                } else if (!_mv_1338.has_value) {
+                } else if (!_mv_1339.has_value) {
                 }
                 i = (i + 1);
             }
@@ -3727,31 +3727,31 @@ void transpiler_emit_fn_forward_decl_header(context_TranspileContext* ctx, types
     SLOP_PRE(((expr != NULL)), "(!= expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1339 = (*expr);
-        switch (_mv_1339.tag) {
+        __auto_type _mv_1340 = (*expr);
+        switch (_mv_1340.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1339.data.lst;
+                __auto_type lst = _mv_1340.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 3) {
-                        __auto_type _mv_1340 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1340.has_value) {
-                            __auto_type name_expr = _mv_1340.value;
-                            __auto_type _mv_1341 = (*name_expr);
-                            switch (_mv_1341.tag) {
+                        __auto_type _mv_1341 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1341.has_value) {
+                            __auto_type name_expr = _mv_1341.value;
+                            __auto_type _mv_1342 = (*name_expr);
+                            switch (_mv_1342.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1341.data.sym;
+                                    __auto_type name_sym = _mv_1342.data.sym;
                                     {
                                         __auto_type raw_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, raw_name);
                                         __auto_type mangled_name = ((string_eq(base_name, SLOP_STR("main"))) ? base_name : context_ctx_prefix_type(ctx, base_name));
                                         __auto_type fn_name = context_extract_fn_c_name(arena, items, mangled_name);
-                                        __auto_type _mv_1342 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1342.has_value) {
-                                            __auto_type params_expr = _mv_1342.value;
+                                        __auto_type _mv_1343 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1343.has_value) {
+                                            __auto_type params_expr = _mv_1343.value;
                                             {
                                                 __auto_type result_type_opt = defn_get_result_type_name(ctx, items);
                                                 __auto_type raw_return = defn_get_return_type(ctx, items);
@@ -3762,7 +3762,7 @@ void transpiler_emit_fn_forward_decl_header(context_TranspileContext* ctx, types
                                                     context_ctx_emit_header(ctx, context_ctx_str5(ctx, actual_return, SLOP_STR(" "), fn_name, SLOP_STR("("), context_ctx_str(ctx, ((string_eq(param_str, SLOP_STR(""))) ? SLOP_STR("void") : param_str), SLOP_STR(");"))));
                                                 }
                                             }
-                                        } else if (!_mv_1342.has_value) {
+                                        } else if (!_mv_1343.has_value) {
                                         }
                                     }
                                     break;
@@ -3771,7 +3771,7 @@ void transpiler_emit_fn_forward_decl_header(context_TranspileContext* ctx, types
                                     break;
                                 }
                             }
-                        } else if (!_mv_1340.has_value) {
+                        } else if (!_mv_1341.has_value) {
                         }
                     }
                 }
@@ -3786,31 +3786,31 @@ void transpiler_emit_fn_forward_decl_header(context_TranspileContext* ctx, types
 
 slop_option_string transpiler_get_type_name(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1343 = (*item);
-    switch (_mv_1343.tag) {
+    __auto_type _mv_1344 = (*item);
+    switch (_mv_1344.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1343.data.lst;
+            __auto_type lst = _mv_1344.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return (slop_option_string){.has_value = false};
                 } else {
-                    __auto_type _mv_1344 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1344.has_value) {
-                        __auto_type name_expr = _mv_1344.value;
-                        __auto_type _mv_1345 = (*name_expr);
-                        switch (_mv_1345.tag) {
+                    __auto_type _mv_1345 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1345.has_value) {
+                        __auto_type name_expr = _mv_1345.value;
+                        __auto_type _mv_1346 = (*name_expr);
+                        switch (_mv_1346.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1345.data.sym;
+                                __auto_type sym = _mv_1346.data.sym;
                                 return (slop_option_string){.has_value = 1, .value = sym.name};
                             }
                             default: {
                                 return (slop_option_string){.has_value = false};
                             }
                         }
-                    } else if (!_mv_1344.has_value) {
+                    } else if (!_mv_1345.has_value) {
                         return (slop_option_string){.has_value = false};
                     }
                     SLOP_UNREACHABLE();
@@ -3829,14 +3829,14 @@ void transpiler_emit_module_types(context_TranspileContext* ctx, slop_list_types
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1346 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1346.has_value) {
-                __auto_type item = _mv_1346.value;
+            __auto_type _mv_1347 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1347.has_value) {
+                __auto_type item = _mv_1347.value;
                 if (transpiler_is_type_def(item)) {
                     defn_transpile_type(ctx, item);
                     context_ctx_emit(ctx, SLOP_STR(""));
                 }
-            } else if (!_mv_1346.has_value) {
+            } else if (!_mv_1347.has_value) {
             }
             i = (i + 1);
         }
@@ -3850,14 +3850,14 @@ void transpiler_emit_type_aliases(context_TranspileContext* ctx, slop_list_types
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1347 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1347.has_value) {
-                __auto_type item = _mv_1347.value;
+            __auto_type _mv_1348 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1348.has_value) {
+                __auto_type item = _mv_1348.value;
                 if (transpiler_is_type_def(item) && transpiler_is_type_alias_def(item)) {
                     defn_transpile_type(ctx, item);
                     emitted_any = 1;
                 }
-            } else if (!_mv_1347.has_value) {
+            } else if (!_mv_1348.has_value) {
             }
             i = (i + 1);
         }
@@ -3874,14 +3874,14 @@ void transpiler_emit_enum_types(context_TranspileContext* ctx, slop_list_types_S
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1348 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1348.has_value) {
-                __auto_type item = _mv_1348.value;
+            __auto_type _mv_1349 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1349.has_value) {
+                __auto_type item = _mv_1349.value;
                 if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
                     defn_transpile_type(ctx, item);
                     emitted_any = 1;
                 }
-            } else if (!_mv_1348.has_value) {
+            } else if (!_mv_1349.has_value) {
             }
             i = (i + 1);
         }
@@ -3897,14 +3897,14 @@ void transpiler_emit_struct_types(context_TranspileContext* ctx, slop_list_types
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1349 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1349.has_value) {
-                __auto_type item = _mv_1349.value;
+            __auto_type _mv_1350 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1350.has_value) {
+                __auto_type item = _mv_1350.value;
                 if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                     defn_transpile_type(ctx, item);
                     context_ctx_emit(ctx, SLOP_STR(""));
                 }
-            } else if (!_mv_1349.has_value) {
+            } else if (!_mv_1350.has_value) {
             }
             i = (i + 1);
         }
@@ -3918,11 +3918,11 @@ void transpiler_emit_result_types(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((result_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1350 = ({ __auto_type _lst = result_types; size_t _idx = (size_t)i; slop_option_context_ResultType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1350.has_value) {
-                __auto_type rt = _mv_1350.value;
+            __auto_type _mv_1351 = ({ __auto_type _lst = result_types; size_t _idx = (size_t)i; slop_option_context_ResultType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1351.has_value) {
+                __auto_type rt = _mv_1351.value;
                 transpiler_emit_single_result_type(ctx, rt);
-            } else if (!_mv_1350.has_value) {
+            } else if (!_mv_1351.has_value) {
             }
             i = (i + 1);
         }
@@ -3957,11 +3957,11 @@ void transpiler_emit_result_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((result_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1351 = ({ __auto_type _lst = result_types; size_t _idx = (size_t)i; slop_option_context_ResultType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1351.has_value) {
-                __auto_type rt = _mv_1351.value;
+            __auto_type _mv_1352 = ({ __auto_type _lst = result_types; size_t _idx = (size_t)i; slop_option_context_ResultType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1352.has_value) {
+                __auto_type rt = _mv_1352.value;
                 transpiler_emit_single_result_type_header(ctx, rt);
-            } else if (!_mv_1351.has_value) {
+            } else if (!_mv_1352.has_value) {
             }
             i = (i + 1);
         }
@@ -3996,9 +3996,9 @@ void transpiler_emit_inline_records_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((inline_records).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1352 = ({ __auto_type _lst = inline_records; size_t _idx = (size_t)i; slop_option_context_InlineRecord _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1352.has_value) {
-                __auto_type ir = _mv_1352.value;
+            __auto_type _mv_1353 = ({ __auto_type _lst = inline_records; size_t _idx = (size_t)i; slop_option_context_InlineRecord _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1353.has_value) {
+                __auto_type ir = _mv_1353.value;
                 {
                     __auto_type type_name = ir.type_name;
                     __auto_type field_body = ir.field_body;
@@ -4009,7 +4009,7 @@ void transpiler_emit_inline_records_header(context_TranspileContext* ctx) {
                     context_ctx_emit_header(ctx, SLOP_STR("#endif"));
                     context_ctx_emit_header(ctx, SLOP_STR(""));
                 }
-            } else if (!_mv_1352.has_value) {
+            } else if (!_mv_1353.has_value) {
             }
             i = (i + 1);
         }
@@ -4023,13 +4023,13 @@ void transpiler_emit_option_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1353 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1353.has_value) {
-                __auto_type ot = _mv_1353.value;
+            __auto_type _mv_1354 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1354.has_value) {
+                __auto_type ot = _mv_1354.value;
                 if (transpiler_is_pointer_elem_type(ot.inner_type)) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1353.has_value) {
+            } else if (!_mv_1354.has_value) {
             }
             i = (i + 1);
         }
@@ -4043,13 +4043,13 @@ void transpiler_emit_value_option_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1354 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1354.has_value) {
-                __auto_type ot = _mv_1354.value;
+            __auto_type _mv_1355 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1355.has_value) {
+                __auto_type ot = _mv_1355.value;
                 if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_is_type_emitted_or_primitive(ctx, ot.inner_type)) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1354.has_value) {
+            } else if (!_mv_1355.has_value) {
             }
             i = (i + 1);
         }
@@ -4063,13 +4063,13 @@ void transpiler_emit_complex_value_option_types_header(context_TranspileContext*
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1355 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1355.has_value) {
-                __auto_type ot = _mv_1355.value;
+            __auto_type _mv_1356 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1356.has_value) {
+                __auto_type ot = _mv_1356.value;
                 if (!(transpiler_is_pointer_elem_type(ot.inner_type))) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1355.has_value) {
+            } else if (!_mv_1356.has_value) {
             }
             i = (i + 1);
         }
@@ -4111,14 +4111,14 @@ void transpiler_emit_list_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1356 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1356.has_value) {
-                __auto_type lt = _mv_1356.value;
+            __auto_type _mv_1357 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1357.has_value) {
+                __auto_type lt = _mv_1357.value;
                 if (transpiler_is_pointer_elem_type(lt.elem_type)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                     transpiler_emit_option_for_inner_type(ctx, lt.c_name);
                 }
-            } else if (!_mv_1356.has_value) {
+            } else if (!_mv_1357.has_value) {
             }
             i = (i + 1);
         }
@@ -4132,14 +4132,14 @@ void transpiler_emit_primitive_list_types_header(context_TranspileContext* ctx) 
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1357 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1357.has_value) {
-                __auto_type lt = _mv_1357.value;
+            __auto_type _mv_1358 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1358.has_value) {
+                __auto_type lt = _mv_1358.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_is_primitive_or_runtime_type(lt.elem_type)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                     transpiler_emit_option_for_inner_type(ctx, lt.c_name);
                 }
-            } else if (!_mv_1357.has_value) {
+            } else if (!_mv_1358.has_value) {
             }
             i = (i + 1);
         }
@@ -4153,13 +4153,13 @@ void transpiler_emit_primitive_option_types_header(context_TranspileContext* ctx
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1358 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1358.has_value) {
-                __auto_type ot = _mv_1358.value;
+            __auto_type _mv_1359 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1359.has_value) {
+                __auto_type ot = _mv_1359.value;
                 if ((!(transpiler_is_pointer_elem_type(ot.inner_type))) && (transpiler_is_primitive_or_runtime_type(ot.inner_type)) && (!(strlib_starts_with(ot.inner_type, SLOP_STR("slop_list_"))))) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1358.has_value) {
+            } else if (!_mv_1359.has_value) {
             }
             i = (i + 1);
         }
@@ -4177,14 +4177,14 @@ void transpiler_emit_imported_list_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1359 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1359.has_value) {
-                __auto_type lt = _mv_1359.value;
+            __auto_type _mv_1360 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1360.has_value) {
+                __auto_type lt = _mv_1360.value;
                 if ((!(transpiler_is_pointer_elem_type(lt.elem_type))) && (!(transpiler_is_primitive_or_runtime_type(lt.elem_type))) && (transpiler_is_imported_type(ctx, lt.elem_type))) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                     transpiler_emit_option_for_inner_type(ctx, lt.c_name);
                 }
-            } else if (!_mv_1359.has_value) {
+            } else if (!_mv_1360.has_value) {
             }
             i = (i + 1);
         }
@@ -4198,13 +4198,13 @@ void transpiler_emit_imported_option_types_header(context_TranspileContext* ctx)
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1360 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1360.has_value) {
-                __auto_type ot = _mv_1360.value;
+            __auto_type _mv_1361 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1361.has_value) {
+                __auto_type ot = _mv_1361.value;
                 if ((!(transpiler_is_pointer_elem_type(ot.inner_type))) && (!(transpiler_is_primitive_or_runtime_type(ot.inner_type))) && (!(strlib_starts_with(ot.inner_type, SLOP_STR("slop_list_")))) && (transpiler_is_imported_type(ctx, ot.inner_type))) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1360.has_value) {
+            } else if (!_mv_1361.has_value) {
             }
             i = (i + 1);
         }
@@ -4218,11 +4218,11 @@ void transpiler_emit_late_registered_list_types_header(context_TranspileContext*
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1361 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1361.has_value) {
-                __auto_type lt = _mv_1361.value;
+            __auto_type _mv_1362 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1362.has_value) {
+                __auto_type lt = _mv_1362.value;
                 transpiler_emit_single_list_type_header(ctx, lt);
-            } else if (!_mv_1361.has_value) {
+            } else if (!_mv_1362.has_value) {
             }
             i = (i + 1);
         }
@@ -4236,11 +4236,11 @@ void transpiler_emit_late_registered_option_types_header(context_TranspileContex
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1362 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1362.has_value) {
-                __auto_type ot = _mv_1362.value;
+            __auto_type _mv_1363 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1363.has_value) {
+                __auto_type ot = _mv_1363.value;
                 transpiler_emit_single_option_type_header(ctx, ot);
-            } else if (!_mv_1362.has_value) {
+            } else if (!_mv_1363.has_value) {
             }
             i = (i + 1);
         }
@@ -4254,13 +4254,13 @@ void transpiler_emit_value_list_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1363 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1363.has_value) {
-                __auto_type lt = _mv_1363.value;
+            __auto_type _mv_1364 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1364.has_value) {
+                __auto_type lt = _mv_1364.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_is_type_emitted_or_primitive(ctx, lt.elem_type)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1363.has_value) {
+            } else if (!_mv_1364.has_value) {
             }
             i = (i + 1);
         }
@@ -4274,13 +4274,13 @@ void transpiler_emit_complex_value_list_types_header(context_TranspileContext* c
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1364 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1364.has_value) {
-                __auto_type lt = _mv_1364.value;
+            __auto_type _mv_1365 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1365.has_value) {
+                __auto_type lt = _mv_1365.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && !(context_ctx_is_type_emitted(ctx, lt.c_name))) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1364.has_value) {
+            } else if (!_mv_1365.has_value) {
             }
             i = (i + 1);
         }
@@ -4316,9 +4316,9 @@ void transpiler_emit_union_payload_hash_eq(context_TranspileContext* ctx, slop_l
         __auto_type len = ((int64_t)((variants).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1365 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1365.has_value) {
-                __auto_type variant = _mv_1365.value;
+            __auto_type _mv_1366 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1366.has_value) {
+                __auto_type variant = _mv_1366.value;
                 {
                     __auto_type slop_type = variant.slop_type;
                     __auto_type c_payload_type = variant.c_type;
@@ -4338,7 +4338,7 @@ void transpiler_emit_union_payload_hash_eq(context_TranspileContext* ctx, slop_l
                         }
                     }
                 }
-            } else if (!_mv_1365.has_value) {
+            } else if (!_mv_1366.has_value) {
             }
             i = (i + 1);
         }
@@ -4351,9 +4351,9 @@ void transpiler_emit_record_field_dependencies(context_TranspileContext* ctx, sl
         __auto_type len = ((int64_t)((fields).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1366 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1366.has_value) {
-                __auto_type field = _mv_1366.value;
+            __auto_type _mv_1367 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1367.has_value) {
+                __auto_type field = _mv_1367.value;
                 {
                     __auto_type slop_type = field.slop_type;
                     __auto_type c_type = field.c_type;
@@ -4389,7 +4389,7 @@ void transpiler_emit_record_field_dependencies(context_TranspileContext* ctx, sl
                         }
                     }
                 }
-            } else if (!_mv_1366.has_value) {
+            } else if (!_mv_1367.has_value) {
             }
             i = (i + 1);
         }
@@ -4446,9 +4446,9 @@ uint8_t transpiler_is_primitive_slop_type(slop_string slop_type) {
 
 uint8_t transpiler_is_range_type_alias(context_TranspileContext* ctx, slop_string slop_type) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
-    __auto_type _mv_1367 = context_ctx_lookup_type_alias(ctx, slop_type);
-    if (_mv_1367.has_value) {
-        __auto_type underlying = _mv_1367.value;
+    __auto_type _mv_1368 = context_ctx_lookup_type_alias(ctx, slop_type);
+    if (_mv_1368.has_value) {
+        __auto_type underlying = _mv_1368.value;
         if (strlib_starts_with(underlying, SLOP_STR("(Int"))) {
             return 1;
         } else if (strlib_starts_with(underlying, SLOP_STR("(I64"))) {
@@ -4470,7 +4470,7 @@ uint8_t transpiler_is_range_type_alias(context_TranspileContext* ctx, slop_strin
         } else {
             return 0;
         }
-    } else if (!_mv_1367.has_value) {
+    } else if (!_mv_1368.has_value) {
         return 0;
     }
     SLOP_UNREACHABLE();
@@ -4487,11 +4487,11 @@ uint8_t transpiler_is_narrow_signed_payload_type(slop_string slop_type) {
 slop_string transpiler_resolve_payload_slop_type(context_TranspileContext* ctx, slop_string slop_type) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     if (transpiler_is_range_type_alias(ctx, slop_type)) {
-        __auto_type _mv_1368 = context_ctx_lookup_type_alias(ctx, slop_type);
-        if (_mv_1368.has_value) {
-            __auto_type underlying = _mv_1368.value;
+        __auto_type _mv_1369 = context_ctx_lookup_type_alias(ctx, slop_type);
+        if (_mv_1369.has_value) {
+            __auto_type underlying = _mv_1369.value;
             return underlying;
-        } else if (!_mv_1368.has_value) {
+        } else if (!_mv_1369.has_value) {
             return slop_type;
         }
         SLOP_UNREACHABLE();
@@ -4559,30 +4559,30 @@ slop_list_transpiler_PayloadSlot transpiler_union_variant_payloads(context_Trans
         __auto_type arena = (*ctx).arena;
         __auto_type slots = ((slop_list_transpiler_PayloadSlot){ .data = (transpiler_PayloadSlot*)slop_arena_alloc(arena, 16 * sizeof(transpiler_PayloadSlot)), .len = 0, .cap = 16 });
         __auto_type count_key = context_ctx_str(ctx, variant_name, SLOP_STR("__count"));
-        __auto_type _mv_1369 = context_ctx_lookup_field_type(ctx, union_name, count_key);
-        if (_mv_1369.has_value) {
-            __auto_type _ = _mv_1369.value;
+        __auto_type _mv_1370 = context_ctx_lookup_field_type(ctx, union_name, count_key);
+        if (_mv_1370.has_value) {
+            __auto_type _ = _mv_1370.value;
             {
                 __auto_type i = 0;
                 __auto_type more = 1;
                 while (more) {
                     {
                         __auto_type key = context_ctx_str3(ctx, variant_name, SLOP_STR("__"), int_to_string(arena, i));
-                        __auto_type _mv_1370 = context_ctx_lookup_field_type(ctx, union_name, key);
-                        if (_mv_1370.has_value) {
-                            __auto_type slot_c_type = _mv_1370.value;
+                        __auto_type _mv_1371 = context_ctx_lookup_field_type(ctx, union_name, key);
+                        if (_mv_1371.has_value) {
+                            __auto_type slot_c_type = _mv_1371.value;
                             {
                                 __auto_type slot_slop_type = ({ __auto_type _mv = context_ctx_lookup_field_slop_type(ctx, union_name, key); _mv.has_value ? ({ __auto_type st = _mv.value; st; }) : (SLOP_STR("")); });
                                 ({ __auto_type _lst_p = &(slots); __auto_type _item = ((transpiler_PayloadSlot){slot_slop_type, slot_c_type}); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                 i = (i + 1);
                             }
-                        } else if (!_mv_1370.has_value) {
+                        } else if (!_mv_1371.has_value) {
                             more = 0;
                         }
                     }
                 }
             }
-        } else if (!_mv_1369.has_value) {
+        } else if (!_mv_1370.has_value) {
         }
         return slots;
     }
@@ -4597,11 +4597,11 @@ void transpiler_emit_union_hash_fn(context_TranspileContext* ctx, slop_string c_
         __auto_type len = ((int64_t)((variants).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1371 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1371.has_value) {
-                __auto_type variant = _mv_1371.value;
+            __auto_type _mv_1372 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1372.has_value) {
+                __auto_type variant = _mv_1372.value;
                 transpiler_emit_union_variant_hash(ctx, c_type, variant);
-            } else if (!_mv_1371.has_value) {
+            } else if (!_mv_1372.has_value) {
             }
             i = (i + 1);
         }
@@ -4639,14 +4639,14 @@ void transpiler_emit_multi_payload_hash(context_TranspileContext* ctx, slop_stri
         context_ctx_emit_header(ctx, SLOP_STR("            {"));
         context_ctx_emit_header(ctx, SLOP_STR("                uint64_t hash = 14695981039346656037ULL;"));
         while (i < len) {
-            __auto_type _mv_1372 = ({ __auto_type _lst = payloads; size_t _idx = (size_t)i; slop_option_transpiler_PayloadSlot _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1372.has_value) {
-                __auto_type slot = _mv_1372.value;
+            __auto_type _mv_1373 = ({ __auto_type _lst = payloads; size_t _idx = (size_t)i; slop_option_transpiler_PayloadSlot _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1373.has_value) {
+                __auto_type slot = _mv_1373.value;
                 {
                     __auto_type access = context_ctx_str4(ctx, SLOP_STR("_k->data."), c_variant_name, SLOP_STR(".f"), int_to_string(arena, i));
                     context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("                hash ^= "), transpiler_payload_hash_expr(ctx, slot.slop_type, slot.c_type, access), SLOP_STR("; hash *= 1099511628211ULL;")));
                 }
-            } else if (!_mv_1372.has_value) {
+            } else if (!_mv_1373.has_value) {
             }
             i = (i + 1);
         }
@@ -4666,11 +4666,11 @@ void transpiler_emit_union_eq_fn(context_TranspileContext* ctx, slop_string c_ty
         __auto_type len = ((int64_t)((variants).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1373 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1373.has_value) {
-                __auto_type variant = _mv_1373.value;
+            __auto_type _mv_1374 = ({ __auto_type _lst = variants; size_t _idx = (size_t)i; slop_option_context_UnionVariantEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1374.has_value) {
+                __auto_type variant = _mv_1374.value;
                 transpiler_emit_union_variant_eq(ctx, c_type, variant);
-            } else if (!_mv_1373.has_value) {
+            } else if (!_mv_1374.has_value) {
             }
             i = (i + 1);
         }
@@ -4707,15 +4707,15 @@ void transpiler_emit_multi_payload_eq(context_TranspileContext* ctx, slop_string
         int64_t i = 0;
         context_ctx_emit_header(ctx, SLOP_STR("            return true"));
         while (i < len) {
-            __auto_type _mv_1374 = ({ __auto_type _lst = payloads; size_t _idx = (size_t)i; slop_option_transpiler_PayloadSlot _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1374.has_value) {
-                __auto_type slot = _mv_1374.value;
+            __auto_type _mv_1375 = ({ __auto_type _lst = payloads; size_t _idx = (size_t)i; slop_option_transpiler_PayloadSlot _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1375.has_value) {
+                __auto_type slot = _mv_1375.value;
                 {
                     __auto_type a_access = context_ctx_str4(ctx, SLOP_STR("_a->data."), c_variant_name, SLOP_STR(".f"), int_to_string(arena, i));
                     __auto_type b_access = context_ctx_str4(ctx, SLOP_STR("_b->data."), c_variant_name, SLOP_STR(".f"), int_to_string(arena, i));
                     context_ctx_emit_header(ctx, context_ctx_str(ctx, SLOP_STR("                && "), transpiler_payload_eq_expr(ctx, slot.slop_type, slot.c_type, a_access, b_access)));
                 }
-            } else if (!_mv_1374.has_value) {
+            } else if (!_mv_1375.has_value) {
             }
             i = (i + 1);
         }
@@ -4732,11 +4732,11 @@ void transpiler_emit_struct_hash_fn(context_TranspileContext* ctx, slop_string c
         __auto_type len = ((int64_t)((fields).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1375 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1375.has_value) {
-                __auto_type field = _mv_1375.value;
+            __auto_type _mv_1376 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1376.has_value) {
+                __auto_type field = _mv_1376.value;
                 transpiler_emit_field_hash(ctx, field);
-            } else if (!_mv_1375.has_value) {
+            } else if (!_mv_1376.has_value) {
             }
             i = (i + 1);
         }
@@ -4803,11 +4803,11 @@ void transpiler_emit_struct_eq_fn(context_TranspileContext* ctx, slop_string c_t
             {
                 int64_t i = 0;
                 while (i < len) {
-                    __auto_type _mv_1376 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1376.has_value) {
-                        __auto_type field = _mv_1376.value;
+                    __auto_type _mv_1377 = ({ __auto_type _lst = fields; size_t _idx = (size_t)i; slop_option_context_FieldEntry _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1377.has_value) {
+                        __auto_type field = _mv_1377.value;
                         transpiler_emit_field_eq(ctx, field);
-                    } else if (!_mv_1376.has_value) {
+                    } else if (!_mv_1377.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -4865,9 +4865,9 @@ void transpiler_emit_struct_key_types_header(context_TranspileContext* ctx) {
         uint8_t banner = 0;
         int64_t i = 0;
         while (i < ((int64_t)((struct_key_types).len))) {
-            __auto_type _mv_1377 = ({ __auto_type _lst = struct_key_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1377.has_value) {
-                __auto_type c_type = _mv_1377.value;
+            __auto_type _mv_1378 = ({ __auto_type _lst = struct_key_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1378.has_value) {
+                __auto_type c_type = _mv_1378.value;
                 {
                     __auto_type emitted_marker = context_ctx_str(ctx, SLOP_STR("hasheq:"), c_type);
                     if (!(context_ctx_is_type_emitted(ctx, emitted_marker))) {
@@ -4892,7 +4892,7 @@ void transpiler_emit_struct_key_types_header(context_TranspileContext* ctx) {
                         }
                     }
                 }
-            } else if (!_mv_1377.has_value) {
+            } else if (!_mv_1378.has_value) {
             }
             i = (i + 1);
         }
@@ -4993,9 +4993,9 @@ void transpiler_emit_chan_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((chan_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1378 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1378.has_value) {
-                __auto_type ct = _mv_1378.value;
+            __auto_type _mv_1379 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1379.has_value) {
+                __auto_type ct = _mv_1379.value;
                 {
                     __auto_type elem_type = ct.elem_type;
                     __auto_type c_name = ct.c_name;
@@ -5020,7 +5020,7 @@ void transpiler_emit_chan_types_header(context_TranspileContext* ctx) {
                         }
                     }
                 }
-            } else if (!_mv_1378.has_value) {
+            } else if (!_mv_1379.has_value) {
             }
             i = (i + 1);
         }
@@ -5034,9 +5034,9 @@ void transpiler_emit_chan_funcs_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((chan_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1379 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1379.has_value) {
-                __auto_type ct = _mv_1379.value;
+            __auto_type _mv_1380 = ({ __auto_type _lst = chan_types; size_t _idx = (size_t)i; slop_option_context_ChanType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1380.has_value) {
+                __auto_type ct = _mv_1380.value;
                 {
                     __auto_type elem_type = ct.elem_type;
                     __auto_type c_name = ct.c_name;
@@ -5044,7 +5044,7 @@ void transpiler_emit_chan_funcs_header(context_TranspileContext* ctx) {
                         transpiler_emit_chan_send_recv_funcs(ctx, c_name, elem_type);
                     }
                 }
-            } else if (!_mv_1379.has_value) {
+            } else if (!_mv_1380.has_value) {
             }
             i = (i + 1);
         }
@@ -5180,9 +5180,9 @@ void transpiler_emit_thread_types_header(context_TranspileContext* ctx) {
         __auto_type len = ((int64_t)((thread_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1380 = ({ __auto_type _lst = thread_types; size_t _idx = (size_t)i; slop_option_context_ThreadType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1380.has_value) {
-                __auto_type tt = _mv_1380.value;
+            __auto_type _mv_1381 = ({ __auto_type _lst = thread_types; size_t _idx = (size_t)i; slop_option_context_ThreadType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1381.has_value) {
+                __auto_type tt = _mv_1381.value;
                 {
                     __auto_type result_type = tt.result_type;
                     __auto_type c_name = tt.c_name;
@@ -5214,7 +5214,7 @@ void transpiler_emit_thread_types_header(context_TranspileContext* ctx) {
                         }
                     }
                 }
-            } else if (!_mv_1380.has_value) {
+            } else if (!_mv_1381.has_value) {
             }
             i = (i + 1);
         }
@@ -5259,44 +5259,44 @@ slop_string transpiler_uppercase_name(context_TranspileContext* ctx, slop_string
 
 uint8_t transpiler_is_simple_enum_def(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1381 = (*item);
-    switch (_mv_1381.tag) {
+    __auto_type _mv_1382 = (*item);
+    switch (_mv_1382.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1381.data.lst;
+            __auto_type lst = _mv_1382.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 3) {
                     return 0;
                 } else {
-                    __auto_type _mv_1382 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1382.has_value) {
-                        __auto_type def_expr = _mv_1382.value;
-                        __auto_type _mv_1383 = (*def_expr);
-                        switch (_mv_1383.tag) {
+                    __auto_type _mv_1383 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1383.has_value) {
+                        __auto_type def_expr = _mv_1383.value;
+                        __auto_type _mv_1384 = (*def_expr);
+                        switch (_mv_1384.tag) {
                             case types_SExpr_lst:
                             {
-                                __auto_type def_lst = _mv_1383.data.lst;
+                                __auto_type def_lst = _mv_1384.data.lst;
                                 {
                                     __auto_type def_items = def_lst.items;
                                     if (((int64_t)((def_items).len)) < 1) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1384 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1384.has_value) {
-                                            __auto_type head = _mv_1384.value;
-                                            __auto_type _mv_1385 = (*head);
-                                            switch (_mv_1385.tag) {
+                                        __auto_type _mv_1385 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1385.has_value) {
+                                            __auto_type head = _mv_1385.value;
+                                            __auto_type _mv_1386 = (*head);
+                                            switch (_mv_1386.tag) {
                                                 case types_SExpr_sym:
                                                 {
-                                                    __auto_type sym = _mv_1385.data.sym;
+                                                    __auto_type sym = _mv_1386.data.sym;
                                                     return (string_eq(sym.name, SLOP_STR("enum")) && !(transpiler_has_enum_payload_variants(def_items)));
                                                 }
                                                 default: {
                                                     return 0;
                                                 }
                                             }
-                                        } else if (!_mv_1384.has_value) {
+                                        } else if (!_mv_1385.has_value) {
                                             return 0;
                                         }
                                         SLOP_UNREACHABLE();
@@ -5307,7 +5307,7 @@ uint8_t transpiler_is_simple_enum_def(types_SExpr* item) {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1382.has_value) {
+                    } else if (!_mv_1383.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -5327,23 +5327,11 @@ void transpiler_emit_module_types_header(context_TranspileContext* ctx, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1386 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1386.has_value) {
-                __auto_type item = _mv_1386.value;
-                if (transpiler_is_type_def(item) && transpiler_is_type_alias_def(item)) {
-                    transpiler_emit_type_alias_to_header(ctx, item);
-                }
-            } else if (!_mv_1386.has_value) {
-            }
-            i = (i + 1);
-        }
-        i = start;
-        while (i < len) {
             __auto_type _mv_1387 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_1387.has_value) {
                 __auto_type item = _mv_1387.value;
-                if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
-                    transpiler_emit_type_to_header(ctx, item);
+                if (transpiler_is_type_def(item) && transpiler_is_type_alias_def(item)) {
+                    transpiler_emit_type_alias_to_header(ctx, item);
                 }
             } else if (!_mv_1387.has_value) {
             }
@@ -5354,10 +5342,22 @@ void transpiler_emit_module_types_header(context_TranspileContext* ctx, slop_lis
             __auto_type _mv_1388 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
             if (_mv_1388.has_value) {
                 __auto_type item = _mv_1388.value;
-                if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
+                if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
                     transpiler_emit_type_to_header(ctx, item);
                 }
             } else if (!_mv_1388.has_value) {
+            }
+            i = (i + 1);
+        }
+        i = start;
+        while (i < len) {
+            __auto_type _mv_1389 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1389.has_value) {
+                __auto_type item = _mv_1389.value;
+                if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
+                    transpiler_emit_type_to_header(ctx, item);
+                }
+            } else if (!_mv_1389.has_value) {
             }
             i = (i + 1);
         }
@@ -5370,13 +5370,13 @@ void transpiler_emit_simple_type_aliases_header(context_TranspileContext* ctx, s
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1389 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1389.has_value) {
-                __auto_type item = _mv_1389.value;
+            __auto_type _mv_1390 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1390.has_value) {
+                __auto_type item = _mv_1390.value;
                 if ((transpiler_is_type_def(item)) && (transpiler_is_type_alias_def(item)) && (!(transpiler_is_result_type_alias_def(item)))) {
                     transpiler_emit_type_alias_to_header(ctx, item);
                 }
-            } else if (!_mv_1389.has_value) {
+            } else if (!_mv_1390.has_value) {
             }
             i = (i + 1);
         }
@@ -5389,13 +5389,13 @@ void transpiler_emit_type_aliases_header(context_TranspileContext* ctx, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1390 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1390.has_value) {
-                __auto_type item = _mv_1390.value;
+            __auto_type _mv_1391 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1391.has_value) {
+                __auto_type item = _mv_1391.value;
                 if ((transpiler_is_type_def(item)) && (transpiler_is_type_alias_def(item)) && (transpiler_is_result_type_alias_def(item))) {
                     transpiler_emit_type_alias_to_header(ctx, item);
                 }
-            } else if (!_mv_1390.has_value) {
+            } else if (!_mv_1391.has_value) {
             }
             i = (i + 1);
         }
@@ -5408,13 +5408,13 @@ void transpiler_emit_simple_enums_header(context_TranspileContext* ctx, slop_lis
         __auto_type len = ((int64_t)((items).len));
         int64_t i = start;
         while (i < len) {
-            __auto_type _mv_1391 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1391.has_value) {
-                __auto_type item = _mv_1391.value;
+            __auto_type _mv_1392 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1392.has_value) {
+                __auto_type item = _mv_1392.value;
                 if (transpiler_is_type_def(item) && transpiler_is_simple_enum_def(item)) {
                     transpiler_emit_type_to_header(ctx, item);
                 }
-            } else if (!_mv_1391.has_value) {
+            } else if (!_mv_1392.has_value) {
             }
             i = (i + 1);
         }
@@ -5429,9 +5429,9 @@ void transpiler_emit_pending_container_deps(context_TranspileContext* ctx, types
         __auto_type len = ((int64_t)((field_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1392 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1392.has_value) {
-                __auto_type field_type = _mv_1392.value;
+            __auto_type _mv_1393 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1393.has_value) {
+                __auto_type field_type = _mv_1393.value;
                 if (!(context_ctx_is_type_emitted(ctx, field_type)) && transpiler_is_emittable_container_type(ctx, field_type)) {
                     if (strlib_starts_with(field_type, SLOP_STR("slop_option_"))) {
                         transpiler_emit_option_by_c_name(ctx, field_type);
@@ -5440,7 +5440,7 @@ void transpiler_emit_pending_container_deps(context_TranspileContext* ctx, types
                         transpiler_emit_list_by_c_name(ctx, field_type);
                     }
                 }
-            } else if (!_mv_1392.has_value) {
+            } else if (!_mv_1393.has_value) {
             }
             i = (i + 1);
         }
@@ -5454,13 +5454,13 @@ void transpiler_emit_option_by_c_name(context_TranspileContext* ctx, slop_string
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1393 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1393.has_value) {
-                __auto_type ot = _mv_1393.value;
+            __auto_type _mv_1394 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1394.has_value) {
+                __auto_type ot = _mv_1394.value;
                 if (string_eq(ot.c_name, c_name)) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1393.has_value) {
+            } else if (!_mv_1394.has_value) {
             }
             i = (i + 1);
         }
@@ -5474,13 +5474,13 @@ void transpiler_emit_list_by_c_name(context_TranspileContext* ctx, slop_string c
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1394 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1394.has_value) {
-                __auto_type lt = _mv_1394.value;
+            __auto_type _mv_1395 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1395.has_value) {
+                __auto_type lt = _mv_1395.value;
                 if (string_eq(lt.c_name, c_name)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1394.has_value) {
+            } else if (!_mv_1395.has_value) {
             }
             i = (i + 1);
         }
@@ -5501,9 +5501,9 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                 int64_t i = start;
                 while (i < len) {
                     if (!(transpiler_index_in_list(emitted, i))) {
-                        __auto_type _mv_1395 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1395.has_value) {
-                            __auto_type item = _mv_1395.value;
+                        __auto_type _mv_1396 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1396.has_value) {
+                            __auto_type item = _mv_1396.value;
                             if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                                 if (transpiler_type_deps_satisfied(ctx, item)) {
                                     transpiler_emit_pending_container_deps(ctx, item);
@@ -5513,7 +5513,7 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                                     transpiler_emit_option_list_for_type(ctx, item);
                                 }
                             }
-                        } else if (!_mv_1395.has_value) {
+                        } else if (!_mv_1396.has_value) {
                         }
                     }
                     i = (i + 1);
@@ -5530,9 +5530,9 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                     int64_t i = start;
                     while (i < len) {
                         if (!(transpiler_index_in_list(emitted, i))) {
-                            __auto_type _mv_1396 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1396.has_value) {
-                                __auto_type item = _mv_1396.value;
+                            __auto_type _mv_1397 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1397.has_value) {
+                                __auto_type item = _mv_1397.value;
                                 if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                                     if (transpiler_type_deps_satisfied(ctx, item)) {
                                         transpiler_emit_pending_container_deps(ctx, item);
@@ -5542,7 +5542,7 @@ void transpiler_emit_struct_union_types_sorted(context_TranspileContext* ctx, sl
                                         transpiler_emit_option_list_for_type(ctx, item);
                                     }
                                 }
-                            } else if (!_mv_1396.has_value) {
+                            } else if (!_mv_1397.has_value) {
                             }
                         }
                         i = (i + 1);
@@ -5559,13 +5559,13 @@ uint8_t transpiler_has_unemitted_struct_types(slop_list_types_SExpr_ptr items, i
         uint8_t found = 0;
         while ((i < len) && !(found)) {
             if (!(transpiler_index_in_list(emitted, i))) {
-                __auto_type _mv_1397 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1397.has_value) {
-                    __auto_type item = _mv_1397.value;
+                __auto_type _mv_1398 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1398.has_value) {
+                    __auto_type item = _mv_1398.value;
                     if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                         found = 1;
                     }
-                } else if (!_mv_1397.has_value) {
+                } else if (!_mv_1398.has_value) {
                 }
             }
             i = (i + 1);
@@ -5580,26 +5580,26 @@ void transpiler_break_list_cycles(context_TranspileContext* ctx, slop_list_types
         int64_t i = start;
         while (i < len) {
             if (!(transpiler_index_in_list(emitted, i))) {
-                __auto_type _mv_1398 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1398.has_value) {
-                    __auto_type item = _mv_1398.value;
+                __auto_type _mv_1399 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1399.has_value) {
+                    __auto_type item = _mv_1399.value;
                     if (transpiler_is_type_def(item) && transpiler_is_struct_type_def(item)) {
                         {
                             __auto_type blocking_deps = transpiler_find_blocking_list_deps(ctx, item);
                             __auto_type dep_len = ((int64_t)((blocking_deps).len));
                             __auto_type j = 0;
                             while (j < dep_len) {
-                                __auto_type _mv_1399 = ({ __auto_type _lst = blocking_deps; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                if (_mv_1399.has_value) {
-                                    __auto_type dep_name = _mv_1399.value;
+                                __auto_type _mv_1400 = ({ __auto_type _lst = blocking_deps; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                if (_mv_1400.has_value) {
+                                    __auto_type dep_name = _mv_1400.value;
                                     transpiler_emit_list_declare_by_c_name(ctx, dep_name);
-                                } else if (!_mv_1399.has_value) {
+                                } else if (!_mv_1400.has_value) {
                                 }
                                 j = (j + 1);
                             }
                         }
                     }
-                } else if (!_mv_1398.has_value) {
+                } else if (!_mv_1399.has_value) {
                 }
             }
             i = (i + 1);
@@ -5617,13 +5617,13 @@ slop_list_string transpiler_find_blocking_list_deps(context_TranspileContext* ct
         __auto_type result = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1400 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1400.has_value) {
-                __auto_type field_type = _mv_1400.value;
+            __auto_type _mv_1401 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1401.has_value) {
+                __auto_type field_type = _mv_1401.value;
                 if ((strlib_starts_with(field_type, SLOP_STR("slop_list_"))) && (!(context_ctx_is_type_emitted(ctx, field_type))) && (!(transpiler_is_runtime_list_type(field_type)))) {
                     ({ __auto_type _lst_p = &(result); __auto_type _item = (field_type); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                 }
-            } else if (!_mv_1400.has_value) {
+            } else if (!_mv_1401.has_value) {
             }
             i = (i + 1);
         }
@@ -5638,13 +5638,13 @@ void transpiler_emit_list_declare_by_c_name(context_TranspileContext* ctx, slop_
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1401 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1401.has_value) {
-                __auto_type lt = _mv_1401.value;
+            __auto_type _mv_1402 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1402.has_value) {
+                __auto_type lt = _mv_1402.value;
                 if (string_eq(lt.c_name, c_name)) {
                     transpiler_emit_list_type_declare_only(ctx, lt);
                 }
-            } else if (!_mv_1401.has_value) {
+            } else if (!_mv_1402.has_value) {
             }
             i = (i + 1);
         }
@@ -5657,13 +5657,13 @@ uint8_t transpiler_index_in_list(slop_list_int lst, int64_t idx) {
         int64_t i = 0;
         uint8_t found = 0;
         while ((i < len) && !(found)) {
-            __auto_type _mv_1402 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_int _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1402.has_value) {
-                __auto_type v = _mv_1402.value;
+            __auto_type _mv_1403 = ({ __auto_type _lst = lst; size_t _idx = (size_t)i; slop_option_int _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1403.has_value) {
+                __auto_type v = _mv_1403.value;
                 if (v == idx) {
                     found = 1;
                 }
-            } else if (!_mv_1402.has_value) {
+            } else if (!_mv_1403.has_value) {
             }
             i = (i + 1);
         }
@@ -5680,13 +5680,13 @@ uint8_t transpiler_type_deps_satisfied(context_TranspileContext* ctx, types_SExp
         int64_t i = 0;
         uint8_t all_satisfied = 1;
         while ((i < len) && all_satisfied) {
-            __auto_type _mv_1403 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1403.has_value) {
-                __auto_type field_type = _mv_1403.value;
+            __auto_type _mv_1404 = ({ __auto_type _lst = field_types; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1404.has_value) {
+                __auto_type field_type = _mv_1404.value;
                 if (!(transpiler_type_is_available(ctx, field_type))) {
                     all_satisfied = 0;
                 }
-            } else if (!_mv_1403.has_value) {
+            } else if (!_mv_1404.has_value) {
             }
             i = (i + 1);
         }
@@ -5733,34 +5733,34 @@ slop_list_string transpiler_get_type_field_types(context_TranspileContext* ctx, 
     {
         __auto_type arena = (*ctx).arena;
         __auto_type result = ((slop_list_string){ .data = (slop_string*)slop_arena_alloc(arena, 16 * sizeof(slop_string)), .len = 0, .cap = 16 });
-        __auto_type _mv_1404 = (*type_def);
-        switch (_mv_1404.tag) {
+        __auto_type _mv_1405 = (*type_def);
+        switch (_mv_1405.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1404.data.lst;
+                __auto_type lst = _mv_1405.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 3) {
-                        __auto_type _mv_1405 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1405.has_value) {
-                            __auto_type def_expr = _mv_1405.value;
-                            __auto_type _mv_1406 = (*def_expr);
-                            switch (_mv_1406.tag) {
+                        __auto_type _mv_1406 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1406.has_value) {
+                            __auto_type def_expr = _mv_1406.value;
+                            __auto_type _mv_1407 = (*def_expr);
+                            switch (_mv_1407.tag) {
                                 case types_SExpr_lst:
                                 {
-                                    __auto_type def_lst = _mv_1406.data.lst;
+                                    __auto_type def_lst = _mv_1407.data.lst;
                                     {
                                         __auto_type def_items = def_lst.items;
                                         __auto_type def_len = ((int64_t)((def_items).len));
                                         if (def_len > 0) {
-                                            __auto_type _mv_1407 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1407.has_value) {
-                                                __auto_type head = _mv_1407.value;
-                                                __auto_type _mv_1408 = (*head);
-                                                switch (_mv_1408.tag) {
+                                            __auto_type _mv_1408 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1408.has_value) {
+                                                __auto_type head = _mv_1408.value;
+                                                __auto_type _mv_1409 = (*head);
+                                                switch (_mv_1409.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type sym = _mv_1408.data.sym;
+                                                        __auto_type sym = _mv_1409.data.sym;
                                                         {
                                                             __auto_type kind = sym.name;
                                                             if (string_eq(kind, SLOP_STR("record"))) {
@@ -5776,7 +5776,7 @@ slop_list_string transpiler_get_type_field_types(context_TranspileContext* ctx, 
                                                         break;
                                                     }
                                                 }
-                                            } else if (!_mv_1407.has_value) {
+                                            } else if (!_mv_1408.has_value) {
                                             }
                                         }
                                     }
@@ -5786,7 +5786,7 @@ slop_list_string transpiler_get_type_field_types(context_TranspileContext* ctx, 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1405.has_value) {
+                        } else if (!_mv_1406.has_value) {
                         }
                     }
                 }
@@ -5808,25 +5808,25 @@ slop_list_string transpiler_extract_record_field_types(context_TranspileContext*
         __auto_type len = ((int64_t)((def_items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1409 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1409.has_value) {
-                __auto_type field_expr = _mv_1409.value;
-                __auto_type _mv_1410 = (*field_expr);
-                switch (_mv_1410.tag) {
+            __auto_type _mv_1410 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1410.has_value) {
+                __auto_type field_expr = _mv_1410.value;
+                __auto_type _mv_1411 = (*field_expr);
+                switch (_mv_1411.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type field_lst = _mv_1410.data.lst;
+                        __auto_type field_lst = _mv_1411.data.lst;
                         if (((int64_t)((field_lst.items).len)) >= 2) {
-                            __auto_type _mv_1411 = ({ __auto_type _lst = field_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1411.has_value) {
-                                __auto_type type_expr = _mv_1411.value;
+                            __auto_type _mv_1412 = ({ __auto_type _lst = field_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1412.has_value) {
+                                __auto_type type_expr = _mv_1412.value;
                                 {
                                     __auto_type type_str = transpiler_get_field_type_string(ctx, type_expr);
                                     if (!(string_eq(type_str, SLOP_STR("")))) {
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (type_str); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
                                 }
-                            } else if (!_mv_1411.has_value) {
+                            } else if (!_mv_1412.has_value) {
                             }
                         }
                         break;
@@ -5835,7 +5835,7 @@ slop_list_string transpiler_extract_record_field_types(context_TranspileContext*
                         break;
                     }
                 }
-            } else if (!_mv_1409.has_value) {
+            } else if (!_mv_1410.has_value) {
             }
             i = (i + 1);
         }
@@ -5851,25 +5851,25 @@ slop_list_string transpiler_extract_union_variant_types(context_TranspileContext
         __auto_type len = ((int64_t)((def_items).len));
         int64_t i = 1;
         while (i < len) {
-            __auto_type _mv_1412 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1412.has_value) {
-                __auto_type variant_expr = _mv_1412.value;
-                __auto_type _mv_1413 = (*variant_expr);
-                switch (_mv_1413.tag) {
+            __auto_type _mv_1413 = ({ __auto_type _lst = def_items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1413.has_value) {
+                __auto_type variant_expr = _mv_1413.value;
+                __auto_type _mv_1414 = (*variant_expr);
+                switch (_mv_1414.tag) {
                     case types_SExpr_lst:
                     {
-                        __auto_type variant_lst = _mv_1413.data.lst;
+                        __auto_type variant_lst = _mv_1414.data.lst;
                         if (((int64_t)((variant_lst.items).len)) >= 2) {
-                            __auto_type _mv_1414 = ({ __auto_type _lst = variant_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1414.has_value) {
-                                __auto_type type_expr = _mv_1414.value;
+                            __auto_type _mv_1415 = ({ __auto_type _lst = variant_lst.items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1415.has_value) {
+                                __auto_type type_expr = _mv_1415.value;
                                 {
                                     __auto_type type_str = transpiler_get_field_type_string(ctx, type_expr);
                                     if (!(string_eq(type_str, SLOP_STR("")))) {
                                         ({ __auto_type _lst_p = &(result); __auto_type _item = (type_str); if (_lst_p->len >= _lst_p->cap) { size_t _new_cap = _lst_p->cap == 0 ? 16 : _lst_p->cap * 2; __typeof__(_lst_p->data) _new_data = (__typeof__(_lst_p->data))slop_arena_alloc(arena, _new_cap * sizeof(*_lst_p->data)); if (_lst_p->len > 0) memcpy(_new_data, _lst_p->data, _lst_p->len * sizeof(*_lst_p->data)); _lst_p->data = _new_data; _lst_p->cap = _new_cap; } _lst_p->data[_lst_p->len++] = _item; (void)0; });
                                     }
                                 }
-                            } else if (!_mv_1414.has_value) {
+                            } else if (!_mv_1415.has_value) {
                             }
                         }
                         break;
@@ -5878,7 +5878,7 @@ slop_list_string transpiler_extract_union_variant_types(context_TranspileContext
                         break;
                     }
                 }
-            } else if (!_mv_1412.has_value) {
+            } else if (!_mv_1413.has_value) {
             }
             i = (i + 1);
         }
@@ -5891,18 +5891,18 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1415 = (*type_expr);
-        switch (_mv_1415.tag) {
+        __auto_type _mv_1416 = (*type_expr);
+        switch (_mv_1416.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1415.data.sym;
+                __auto_type sym = _mv_1416.data.sym;
                 {
                     __auto_type name = sym.name;
-                    __auto_type _mv_1416 = context_ctx_lookup_type(ctx, name);
-                    if (_mv_1416.has_value) {
-                        __auto_type entry = _mv_1416.value;
+                    __auto_type _mv_1417 = context_ctx_lookup_type(ctx, name);
+                    if (_mv_1417.has_value) {
+                        __auto_type entry = _mv_1417.value;
                         return entry.c_name;
-                    } else if (!_mv_1416.has_value) {
+                    } else if (!_mv_1417.has_value) {
                         return ctype_to_c_type(arena, type_expr);
                     }
                     SLOP_UNREACHABLE();
@@ -5910,45 +5910,25 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1415.data.lst;
+                __auto_type lst = _mv_1416.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 1) {
                         return SLOP_STR("");
                     } else {
-                        __auto_type _mv_1417 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1417.has_value) {
-                            __auto_type head = _mv_1417.value;
-                            __auto_type _mv_1418 = (*head);
-                            switch (_mv_1418.tag) {
+                        __auto_type _mv_1418 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1418.has_value) {
+                            __auto_type head = _mv_1418.value;
+                            __auto_type _mv_1419 = (*head);
+                            switch (_mv_1419.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type sym = _mv_1418.data.sym;
+                                    __auto_type sym = _mv_1419.data.sym;
                                     {
                                         __auto_type kind = sym.name;
                                         if (string_eq(kind, SLOP_STR("Ptr"))) {
                                             return SLOP_STR("");
                                         } else if (string_eq(kind, SLOP_STR("Option"))) {
-                                            if (((int64_t)((items).len)) >= 2) {
-                                                __auto_type _mv_1419 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1419.has_value) {
-                                                    __auto_type inner = _mv_1419.value;
-                                                    {
-                                                        __auto_type inner_str = transpiler_get_field_type_string(ctx, inner);
-                                                        if (string_eq(inner_str, SLOP_STR(""))) {
-                                                            return SLOP_STR("");
-                                                        } else {
-                                                            return context_ctx_str(ctx, SLOP_STR("slop_option_"), ctype_type_to_identifier(arena, inner_str));
-                                                        }
-                                                    }
-                                                } else if (!_mv_1419.has_value) {
-                                                    return SLOP_STR("");
-                                                }
-                                                SLOP_UNREACHABLE();
-                                            } else {
-                                                return SLOP_STR("");
-                                            }
-                                        } else if (string_eq(kind, SLOP_STR("List"))) {
                                             if (((int64_t)((items).len)) >= 2) {
                                                 __auto_type _mv_1420 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
                                                 if (_mv_1420.has_value) {
@@ -5958,10 +5938,30 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                                                         if (string_eq(inner_str, SLOP_STR(""))) {
                                                             return SLOP_STR("");
                                                         } else {
-                                                            return context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, inner_str));
+                                                            return context_ctx_str(ctx, SLOP_STR("slop_option_"), ctype_type_to_identifier(arena, inner_str));
                                                         }
                                                     }
                                                 } else if (!_mv_1420.has_value) {
+                                                    return SLOP_STR("");
+                                                }
+                                                SLOP_UNREACHABLE();
+                                            } else {
+                                                return SLOP_STR("");
+                                            }
+                                        } else if (string_eq(kind, SLOP_STR("List"))) {
+                                            if (((int64_t)((items).len)) >= 2) {
+                                                __auto_type _mv_1421 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1421.has_value) {
+                                                    __auto_type inner = _mv_1421.value;
+                                                    {
+                                                        __auto_type inner_str = transpiler_get_field_type_string(ctx, inner);
+                                                        if (string_eq(inner_str, SLOP_STR(""))) {
+                                                            return SLOP_STR("");
+                                                        } else {
+                                                            return context_ctx_str(ctx, SLOP_STR("slop_list_"), ctype_type_to_identifier(arena, inner_str));
+                                                        }
+                                                    }
+                                                } else if (!_mv_1421.has_value) {
                                                     return SLOP_STR("");
                                                 }
                                                 SLOP_UNREACHABLE();
@@ -5977,7 +5977,7 @@ slop_string transpiler_get_field_type_string(context_TranspileContext* ctx, type
                                     return SLOP_STR("");
                                 }
                             }
-                        } else if (!_mv_1417.has_value) {
+                        } else if (!_mv_1418.has_value) {
                             return SLOP_STR("");
                         }
                         SLOP_UNREACHABLE();
@@ -6006,31 +6006,31 @@ void transpiler_emit_option_list_for_type(context_TranspileContext* ctx, types_S
 slop_string transpiler_get_type_c_name(context_TranspileContext* ctx, types_SExpr* type_def) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
-    __auto_type _mv_1421 = (*type_def);
-    switch (_mv_1421.tag) {
+    __auto_type _mv_1422 = (*type_def);
+    switch (_mv_1422.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1421.data.lst;
+            __auto_type lst = _mv_1422.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return SLOP_STR("");
                 } else {
-                    __auto_type _mv_1422 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1422.has_value) {
-                        __auto_type name_expr = _mv_1422.value;
-                        __auto_type _mv_1423 = (*name_expr);
-                        switch (_mv_1423.tag) {
+                    __auto_type _mv_1423 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1423.has_value) {
+                        __auto_type name_expr = _mv_1423.value;
+                        __auto_type _mv_1424 = (*name_expr);
+                        switch (_mv_1424.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1423.data.sym;
+                                __auto_type sym = _mv_1424.data.sym;
                                 {
                                     __auto_type name = sym.name;
-                                    __auto_type _mv_1424 = context_ctx_lookup_type(ctx, name);
-                                    if (_mv_1424.has_value) {
-                                        __auto_type entry = _mv_1424.value;
+                                    __auto_type _mv_1425 = context_ctx_lookup_type(ctx, name);
+                                    if (_mv_1425.has_value) {
+                                        __auto_type entry = _mv_1425.value;
                                         return entry.c_name;
-                                    } else if (!_mv_1424.has_value) {
+                                    } else if (!_mv_1425.has_value) {
                                         return SLOP_STR("");
                                     }
                                     SLOP_UNREACHABLE();
@@ -6040,7 +6040,7 @@ slop_string transpiler_get_type_c_name(context_TranspileContext* ctx, types_SExp
                                 return SLOP_STR("");
                             }
                         }
-                    } else if (!_mv_1422.has_value) {
+                    } else if (!_mv_1423.has_value) {
                         return SLOP_STR("");
                     }
                     SLOP_UNREACHABLE();
@@ -6060,13 +6060,13 @@ void transpiler_emit_option_for_inner_type(context_TranspileContext* ctx, slop_s
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1425 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1425.has_value) {
-                __auto_type ot = _mv_1425.value;
+            __auto_type _mv_1426 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1426.has_value) {
+                __auto_type ot = _mv_1426.value;
                 if (string_eq(ot.inner_type, inner_c_name) && !(transpiler_is_pointer_elem_type(ot.inner_type))) {
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1425.has_value) {
+            } else if (!_mv_1426.has_value) {
             }
             i = (i + 1);
         }
@@ -6080,14 +6080,14 @@ void transpiler_emit_list_for_elem_type(context_TranspileContext* ctx, slop_stri
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1426 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1426.has_value) {
-                __auto_type lt = _mv_1426.value;
+            __auto_type _mv_1427 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1427.has_value) {
+                __auto_type lt = _mv_1427.value;
                 if (string_eq(lt.elem_type, elem_c_name) && !(transpiler_is_pointer_elem_type(lt.elem_type))) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                     transpiler_emit_option_for_inner_type(ctx, lt.c_name);
                 }
-            } else if (!_mv_1426.has_value) {
+            } else if (!_mv_1427.has_value) {
             }
             i = (i + 1);
         }
@@ -6105,13 +6105,13 @@ uint8_t transpiler_struct_uses_value_list_or_option(context_TranspileContext* ct
             __auto_type len = ((int64_t)((list_types).len));
             int64_t i = 0;
             while ((i < len) && !(found)) {
-                __auto_type _mv_1427 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1427.has_value) {
-                    __auto_type lt = _mv_1427.value;
+                __auto_type _mv_1428 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1428.has_value) {
+                    __auto_type lt = _mv_1428.value;
                     if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_struct_uses_list_type(ctx, type_def, lt.c_name)) {
                         found = 1;
                     }
-                } else if (!_mv_1427.has_value) {
+                } else if (!_mv_1428.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6121,13 +6121,13 @@ uint8_t transpiler_struct_uses_value_list_or_option(context_TranspileContext* ct
                 __auto_type len2 = ((int64_t)((option_types).len));
                 int64_t j = 0;
                 while ((j < len2) && !(found)) {
-                    __auto_type _mv_1428 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)j; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1428.has_value) {
-                        __auto_type ot = _mv_1428.value;
+                    __auto_type _mv_1429 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)j; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1429.has_value) {
+                        __auto_type ot = _mv_1429.value;
                         if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_struct_uses_option_type(ctx, type_def, ot.c_name)) {
                             found = 1;
                         }
-                    } else if (!_mv_1428.has_value) {
+                    } else if (!_mv_1429.has_value) {
                     }
                     j = (j + 1);
                 }
@@ -6145,13 +6145,13 @@ void transpiler_emit_struct_dependent_list_types(context_TranspileContext* ctx, 
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1429 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1429.has_value) {
-                __auto_type lt = _mv_1429.value;
+            __auto_type _mv_1430 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1430.has_value) {
+                __auto_type lt = _mv_1430.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_struct_uses_list_type(ctx, type_def, lt.c_name)) {
                     transpiler_emit_single_list_type_header(ctx, lt);
                 }
-            } else if (!_mv_1429.has_value) {
+            } else if (!_mv_1430.has_value) {
             }
             i = (i + 1);
         }
@@ -6166,14 +6166,14 @@ void transpiler_emit_struct_dependent_option_types(context_TranspileContext* ctx
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1430 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1430.has_value) {
-                __auto_type ot = _mv_1430.value;
+            __auto_type _mv_1431 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1431.has_value) {
+                __auto_type ot = _mv_1431.value;
                 if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_struct_uses_option_type(ctx, type_def, ot.c_name)) {
                     transpiler_emit_list_type_if_needed(ctx, ot.inner_type);
                     transpiler_emit_single_option_type_header(ctx, ot);
                 }
-            } else if (!_mv_1430.has_value) {
+            } else if (!_mv_1431.has_value) {
             }
             i = (i + 1);
         }
@@ -6188,15 +6188,15 @@ void transpiler_emit_struct_dependent_list_types_safe(context_TranspileContext* 
         __auto_type len = ((int64_t)((list_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1431 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1431.has_value) {
-                __auto_type lt = _mv_1431.value;
+            __auto_type _mv_1432 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1432.has_value) {
+                __auto_type lt = _mv_1432.value;
                 if (!(transpiler_is_pointer_elem_type(lt.elem_type)) && transpiler_struct_uses_list_type(ctx, type_def, lt.c_name)) {
                     if (transpiler_is_type_emitted_or_primitive(ctx, lt.elem_type)) {
                         transpiler_emit_single_list_type_header(ctx, lt);
                     }
                 }
-            } else if (!_mv_1431.has_value) {
+            } else if (!_mv_1432.has_value) {
             }
             i = (i + 1);
         }
@@ -6211,16 +6211,16 @@ void transpiler_emit_struct_dependent_option_types_safe(context_TranspileContext
         __auto_type len = ((int64_t)((option_types).len));
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1432 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1432.has_value) {
-                __auto_type ot = _mv_1432.value;
+            __auto_type _mv_1433 = ({ __auto_type _lst = option_types; size_t _idx = (size_t)i; slop_option_context_OptionType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1433.has_value) {
+                __auto_type ot = _mv_1433.value;
                 if (!(transpiler_is_pointer_elem_type(ot.inner_type)) && transpiler_struct_uses_option_type(ctx, type_def, ot.c_name)) {
                     if (transpiler_is_type_emitted_or_primitive(ctx, ot.inner_type)) {
                         transpiler_emit_list_type_if_needed_safe(ctx, ot.inner_type);
                         transpiler_emit_single_option_type_header(ctx, ot);
                     }
                 }
-            } else if (!_mv_1432.has_value) {
+            } else if (!_mv_1433.has_value) {
             }
             i = (i + 1);
         }
@@ -6245,9 +6245,9 @@ uint8_t transpiler_is_imported_type(context_TranspileContext* ctx, slop_string t
     if (strlib_starts_with(type_name, SLOP_STR("slop_list_")) || strlib_starts_with(type_name, SLOP_STR("slop_option_"))) {
         return 0;
     } else {
-        __auto_type _mv_1433 = context_ctx_get_module(ctx);
-        if (_mv_1433.has_value) {
-            __auto_type current_mod = _mv_1433.value;
+        __auto_type _mv_1434 = context_ctx_get_module(ctx);
+        if (_mv_1434.has_value) {
+            __auto_type current_mod = _mv_1434.value;
             {
                 __auto_type arena = (*ctx).arena;
                 __auto_type c_mod = ctype_to_c_name(arena, current_mod);
@@ -6261,7 +6261,7 @@ uint8_t transpiler_is_imported_type(context_TranspileContext* ctx, slop_string t
                     }
                 }
             }
-        } else if (!_mv_1433.has_value) {
+        } else if (!_mv_1434.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();
@@ -6293,13 +6293,13 @@ void transpiler_emit_list_type_if_needed_safe(context_TranspileContext* ctx, slo
             __auto_type len = ((int64_t)((list_types).len));
             int64_t i = 0;
             while (i < len) {
-                __auto_type _mv_1434 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1434.has_value) {
-                    __auto_type lt = _mv_1434.value;
+                __auto_type _mv_1435 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1435.has_value) {
+                    __auto_type lt = _mv_1435.value;
                     if (string_eq(lt.c_name, inner_type) && transpiler_is_type_emitted_or_primitive(ctx, lt.elem_type)) {
                         transpiler_emit_single_list_type_header(ctx, lt);
                     }
-                } else if (!_mv_1434.has_value) {
+                } else if (!_mv_1435.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6315,13 +6315,13 @@ void transpiler_emit_list_type_if_needed(context_TranspileContext* ctx, slop_str
             __auto_type len = ((int64_t)((list_types).len));
             int64_t i = 0;
             while (i < len) {
-                __auto_type _mv_1435 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1435.has_value) {
-                    __auto_type lt = _mv_1435.value;
+                __auto_type _mv_1436 = ({ __auto_type _lst = list_types; size_t _idx = (size_t)i; slop_option_context_ListType _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1436.has_value) {
+                    __auto_type lt = _mv_1436.value;
                     if (string_eq(lt.c_name, inner_type)) {
                         transpiler_emit_single_list_type_header(ctx, lt);
                     }
-                } else if (!_mv_1435.has_value) {
+                } else if (!_mv_1436.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6334,21 +6334,21 @@ uint8_t transpiler_struct_uses_list_type(context_TranspileContext* ctx, types_SE
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1436 = (*type_def);
-        switch (_mv_1436.tag) {
+        __auto_type _mv_1437 = (*type_def);
+        switch (_mv_1437.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1436.data.lst;
+                __auto_type lst = _mv_1437.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 3) {
                         return 0;
                     } else {
-                        __auto_type _mv_1437 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1437.has_value) {
-                            __auto_type body_expr = _mv_1437.value;
+                        __auto_type _mv_1438 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1438.has_value) {
+                            __auto_type body_expr = _mv_1438.value;
                             return transpiler_type_body_uses_typename(ctx, body_expr, list_type_name);
-                        } else if (!_mv_1437.has_value) {
+                        } else if (!_mv_1438.has_value) {
                             return 0;
                         }
                         SLOP_UNREACHABLE();
@@ -6373,24 +6373,24 @@ uint8_t transpiler_type_body_uses_typename(context_TranspileContext* ctx, types_
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1438 = (*body_expr);
-        switch (_mv_1438.tag) {
+        __auto_type _mv_1439 = (*body_expr);
+        switch (_mv_1439.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1438.data.lst;
+                __auto_type lst = _mv_1439.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     __auto_type found = 0;
                     __auto_type i = 1;
                     while ((i < len) && !(found)) {
-                        __auto_type _mv_1439 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1439.has_value) {
-                            __auto_type field_expr = _mv_1439.value;
+                        __auto_type _mv_1440 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1440.has_value) {
+                            __auto_type field_expr = _mv_1440.value;
                             if (transpiler_field_uses_typename(ctx, field_expr, typename)) {
                                 found = 1;
                             }
-                        } else if (!_mv_1439.has_value) {
+                        } else if (!_mv_1440.has_value) {
                         }
                         i = (i + 1);
                     }
@@ -6407,24 +6407,24 @@ uint8_t transpiler_type_body_uses_typename(context_TranspileContext* ctx, types_
 uint8_t transpiler_field_uses_typename(context_TranspileContext* ctx, types_SExpr* field_expr, slop_string typename) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((field_expr != NULL)), "(!= field-expr nil)");
-    __auto_type _mv_1440 = (*field_expr);
-    switch (_mv_1440.tag) {
+    __auto_type _mv_1441 = (*field_expr);
+    switch (_mv_1441.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1440.data.lst;
+            __auto_type lst = _mv_1441.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return 0;
                 } else {
-                    __auto_type _mv_1441 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1441.has_value) {
-                        __auto_type type_expr = _mv_1441.value;
+                    __auto_type _mv_1442 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1442.has_value) {
+                        __auto_type type_expr = _mv_1442.value;
                         {
                             __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                             return string_eq(c_type, typename);
                         }
-                    } else if (!_mv_1441.has_value) {
+                    } else if (!_mv_1442.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -6442,33 +6442,33 @@ void transpiler_emit_type_to_header(context_TranspileContext* ctx, types_SExpr* 
     SLOP_PRE(((type_def != NULL)), "(!= type-def nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1442 = (*type_def);
-        switch (_mv_1442.tag) {
+        __auto_type _mv_1443 = (*type_def);
+        switch (_mv_1443.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1442.data.lst;
+                __auto_type lst = _mv_1443.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type len = ((int64_t)((items).len));
                     if (len >= 3) {
-                        __auto_type _mv_1443 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1443.has_value) {
-                            __auto_type name_expr = _mv_1443.value;
-                            __auto_type _mv_1444 = (*name_expr);
-                            switch (_mv_1444.tag) {
+                        __auto_type _mv_1444 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1444.has_value) {
+                            __auto_type name_expr = _mv_1444.value;
+                            __auto_type _mv_1445 = (*name_expr);
+                            switch (_mv_1445.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1444.data.sym;
+                                    __auto_type name_sym = _mv_1445.data.sym;
                                     {
                                         __auto_type type_name = name_sym.name;
                                         __auto_type base_name = ctype_to_c_name(arena, type_name);
                                         __auto_type c_name = ((context_ctx_prefixing_enabled(ctx)) ? ({ __auto_type _mv = context_ctx_get_module(ctx); _mv.has_value ? ({ __auto_type mod_name = _mv.value; context_ctx_str(ctx, ctype_to_c_name(arena, mod_name), context_ctx_str(ctx, SLOP_STR("_"), base_name)); }) : (base_name); }) : base_name);
-                                        __auto_type _mv_1445 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1445.has_value) {
-                                            __auto_type body_expr = _mv_1445.value;
+                                        __auto_type _mv_1446 = ({ __auto_type _lst = items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1446.has_value) {
+                                            __auto_type body_expr = _mv_1446.value;
                                             transpiler_emit_type_body_to_header(ctx, type_name, c_name, body_expr);
                                             context_ctx_mark_type_emitted(ctx, c_name);
-                                        } else if (!_mv_1445.has_value) {
+                                        } else if (!_mv_1446.has_value) {
                                         }
                                     }
                                     break;
@@ -6477,7 +6477,7 @@ void transpiler_emit_type_to_header(context_TranspileContext* ctx, types_SExpr* 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1443.has_value) {
+                        } else if (!_mv_1444.has_value) {
                         }
                     }
                 }
@@ -6495,23 +6495,23 @@ void transpiler_emit_type_body_to_header(context_TranspileContext* ctx, slop_str
     SLOP_PRE(((body_expr != NULL)), "(!= body-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1446 = (*body_expr);
-        switch (_mv_1446.tag) {
+        __auto_type _mv_1447 = (*body_expr);
+        switch (_mv_1447.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1446.data.lst;
+                __auto_type lst = _mv_1447.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) < 1) {
                     } else {
-                        __auto_type _mv_1447 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1447.has_value) {
-                            __auto_type kind_expr = _mv_1447.value;
-                            __auto_type _mv_1448 = (*kind_expr);
-                            switch (_mv_1448.tag) {
+                        __auto_type _mv_1448 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1448.has_value) {
+                            __auto_type kind_expr = _mv_1448.value;
+                            __auto_type _mv_1449 = (*kind_expr);
+                            switch (_mv_1449.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type kind_sym = _mv_1448.data.sym;
+                                    __auto_type kind_sym = _mv_1449.data.sym;
                                     {
                                         __auto_type kind = kind_sym.name;
                                         if (string_eq(kind, SLOP_STR("enum"))) {
@@ -6529,7 +6529,7 @@ void transpiler_emit_type_body_to_header(context_TranspileContext* ctx, slop_str
                                     break;
                                 }
                             }
-                        } else if (!_mv_1447.has_value) {
+                        } else if (!_mv_1448.has_value) {
                         }
                     }
                 }
@@ -6550,14 +6550,14 @@ void transpiler_emit_enum_to_header(context_TranspileContext* ctx, slop_string c
         int64_t i = 1;
         context_ctx_emit_header(ctx, SLOP_STR("typedef enum {"));
         while (i < len) {
-            __auto_type _mv_1449 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1449.has_value) {
-                __auto_type variant_expr = _mv_1449.value;
-                __auto_type _mv_1450 = (*variant_expr);
-                switch (_mv_1450.tag) {
+            __auto_type _mv_1450 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1450.has_value) {
+                __auto_type variant_expr = _mv_1450.value;
+                __auto_type _mv_1451 = (*variant_expr);
+                switch (_mv_1451.tag) {
                     case types_SExpr_sym:
                     {
-                        __auto_type variant_sym = _mv_1450.data.sym;
+                        __auto_type variant_sym = _mv_1451.data.sym;
                         {
                             __auto_type variant_name = variant_sym.name;
                             __auto_type c_variant = context_ctx_str3(ctx, c_name, SLOP_STR("_"), ctype_to_c_name(arena, variant_name));
@@ -6574,7 +6574,7 @@ void transpiler_emit_enum_to_header(context_TranspileContext* ctx, slop_string c
                         break;
                     }
                 }
-            } else if (!_mv_1449.has_value) {
+            } else if (!_mv_1450.has_value) {
             }
             i = (i + 1);
         }
@@ -6592,11 +6592,11 @@ void transpiler_emit_struct_to_header(context_TranspileContext* ctx, slop_string
         int64_t i = 1;
         context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("struct "), c_name, SLOP_STR(" {")));
         while (i < len) {
-            __auto_type _mv_1451 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1451.has_value) {
-                __auto_type field_expr = _mv_1451.value;
+            __auto_type _mv_1452 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1452.has_value) {
+                __auto_type field_expr = _mv_1452.value;
                 transpiler_emit_field_to_header(ctx, raw_type_name, c_name, field_expr);
-            } else if (!_mv_1451.has_value) {
+            } else if (!_mv_1452.has_value) {
             }
             i = (i + 1);
         }
@@ -6611,28 +6611,28 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
     SLOP_PRE(((field_expr != NULL)), "(!= field-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1452 = (*field_expr);
-        switch (_mv_1452.tag) {
+        __auto_type _mv_1453 = (*field_expr);
+        switch (_mv_1453.tag) {
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1452.data.lst;
+                __auto_type lst = _mv_1453.data.lst;
                 {
                     __auto_type items = lst.items;
                     if (((int64_t)((items).len)) >= 2) {
-                        __auto_type _mv_1453 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1453.has_value) {
-                            __auto_type name_expr = _mv_1453.value;
-                            __auto_type _mv_1454 = (*name_expr);
-                            switch (_mv_1454.tag) {
+                        __auto_type _mv_1454 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1454.has_value) {
+                            __auto_type name_expr = _mv_1454.value;
+                            __auto_type _mv_1455 = (*name_expr);
+                            switch (_mv_1455.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1454.data.sym;
+                                    __auto_type name_sym = _mv_1455.data.sym;
                                     {
                                         __auto_type field_name = name_sym.name;
                                         __auto_type c_field_name = ctype_to_c_name(arena, field_name);
-                                        __auto_type _mv_1455 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1455.has_value) {
-                                            __auto_type type_expr = _mv_1455.value;
+                                        __auto_type _mv_1456 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1456.has_value) {
+                                            __auto_type type_expr = _mv_1456.value;
                                             {
                                                 __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                 __auto_type slop_type_str = parser_pretty_print(arena, type_expr);
@@ -6641,7 +6641,7 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
                                                 context_ctx_register_field_type(ctx, raw_type_name, field_name, c_type, slop_type_str, is_ptr);
                                                 context_ctx_register_field_type(ctx, c_type_name, field_name, c_type, slop_type_str, is_ptr);
                                             }
-                                        } else if (!_mv_1455.has_value) {
+                                        } else if (!_mv_1456.has_value) {
                                         }
                                     }
                                     break;
@@ -6650,7 +6650,7 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
                                     break;
                                 }
                             }
-                        } else if (!_mv_1453.has_value) {
+                        } else if (!_mv_1454.has_value) {
                         }
                     }
                 }
@@ -6665,31 +6665,31 @@ void transpiler_emit_field_to_header(context_TranspileContext* ctx, slop_string 
 
 uint8_t transpiler_is_pointer_type_expr_header(types_SExpr* type_expr) {
     SLOP_PRE(((type_expr != NULL)), "(!= type-expr nil)");
-    __auto_type _mv_1456 = (*type_expr);
-    switch (_mv_1456.tag) {
+    __auto_type _mv_1457 = (*type_expr);
+    switch (_mv_1457.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1456.data.lst;
+            __auto_type lst = _mv_1457.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return 0;
                 } else {
-                    __auto_type _mv_1457 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1457.has_value) {
-                        __auto_type head = _mv_1457.value;
-                        __auto_type _mv_1458 = (*head);
-                        switch (_mv_1458.tag) {
+                    __auto_type _mv_1458 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1458.has_value) {
+                        __auto_type head = _mv_1458.value;
+                        __auto_type _mv_1459 = (*head);
+                        switch (_mv_1459.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1458.data.sym;
+                                __auto_type sym = _mv_1459.data.sym;
                                 return string_eq(sym.name, SLOP_STR("Ptr"));
                             }
                             default: {
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1457.has_value) {
+                    } else if (!_mv_1458.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -6712,9 +6712,9 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
         {
             int64_t i = 1;
             while (i < len) {
-                __auto_type _mv_1459 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1459.has_value) {
-                    __auto_type variant_expr = _mv_1459.value;
+                __auto_type _mv_1460 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1460.has_value) {
+                    __auto_type variant_expr = _mv_1460.value;
                     {
                         __auto_type variant_name = transpiler_get_variant_name(variant_expr);
                         __auto_type c_variant = context_ctx_str3(ctx, c_name, SLOP_STR("_"), ctype_to_c_name(arena, variant_name));
@@ -6725,7 +6725,7 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
                             context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("    "), c_variant, SLOP_STR(",")));
                         }
                     }
-                } else if (!_mv_1459.has_value) {
+                } else if (!_mv_1460.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6738,11 +6738,11 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
         {
             int64_t i = 1;
             while (i < len) {
-                __auto_type _mv_1460 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1460.has_value) {
-                    __auto_type variant_expr = _mv_1460.value;
+                __auto_type _mv_1461 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1461.has_value) {
+                    __auto_type variant_expr = _mv_1461.value;
                     transpiler_emit_union_variant_to_header(ctx, variant_expr);
-                } else if (!_mv_1460.has_value) {
+                } else if (!_mv_1461.has_value) {
                 }
                 i = (i + 1);
             }
@@ -6756,36 +6756,36 @@ void transpiler_emit_union_to_header(context_TranspileContext* ctx, slop_string 
 
 slop_string transpiler_get_variant_name(types_SExpr* variant_expr) {
     SLOP_PRE(((variant_expr != NULL)), "(!= variant-expr nil)");
-    __auto_type _mv_1461 = (*variant_expr);
-    switch (_mv_1461.tag) {
+    __auto_type _mv_1462 = (*variant_expr);
+    switch (_mv_1462.tag) {
         case types_SExpr_sym:
         {
-            __auto_type sym = _mv_1461.data.sym;
+            __auto_type sym = _mv_1462.data.sym;
             return sym.name;
         }
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1461.data.lst;
+            __auto_type lst = _mv_1462.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 1) {
                     return SLOP_STR("unknown");
                 } else {
-                    __auto_type _mv_1462 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1462.has_value) {
-                        __auto_type name_expr = _mv_1462.value;
-                        __auto_type _mv_1463 = (*name_expr);
-                        switch (_mv_1463.tag) {
+                    __auto_type _mv_1463 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1463.has_value) {
+                        __auto_type name_expr = _mv_1463.value;
+                        __auto_type _mv_1464 = (*name_expr);
+                        switch (_mv_1464.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type name_sym = _mv_1463.data.sym;
+                                __auto_type name_sym = _mv_1464.data.sym;
                                 return name_sym.name;
                             }
                             default: {
                                 return SLOP_STR("unknown");
                             }
                         }
-                    } else if (!_mv_1462.has_value) {
+                    } else if (!_mv_1463.has_value) {
                         return SLOP_STR("unknown");
                     }
                     SLOP_UNREACHABLE();
@@ -6803,35 +6803,35 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
     SLOP_PRE(((variant_expr != NULL)), "(!= variant-expr nil)");
     {
         __auto_type arena = (*ctx).arena;
-        __auto_type _mv_1464 = (*variant_expr);
-        switch (_mv_1464.tag) {
+        __auto_type _mv_1465 = (*variant_expr);
+        switch (_mv_1465.tag) {
             case types_SExpr_sym:
             {
-                __auto_type sym = _mv_1464.data.sym;
+                __auto_type sym = _mv_1465.data.sym;
                 break;
             }
             case types_SExpr_lst:
             {
-                __auto_type lst = _mv_1464.data.lst;
+                __auto_type lst = _mv_1465.data.lst;
                 {
                     __auto_type items = lst.items;
                     __auto_type num_items = ((int64_t)((items).len));
                     if (num_items >= 2) {
-                        __auto_type _mv_1465 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1465.has_value) {
-                            __auto_type name_expr = _mv_1465.value;
-                            __auto_type _mv_1466 = (*name_expr);
-                            switch (_mv_1466.tag) {
+                        __auto_type _mv_1466 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1466.has_value) {
+                            __auto_type name_expr = _mv_1466.value;
+                            __auto_type _mv_1467 = (*name_expr);
+                            switch (_mv_1467.tag) {
                                 case types_SExpr_sym:
                                 {
-                                    __auto_type name_sym = _mv_1466.data.sym;
+                                    __auto_type name_sym = _mv_1467.data.sym;
                                     {
                                         __auto_type variant_name = name_sym.name;
                                         __auto_type c_field = ctype_to_c_name(arena, variant_name);
                                         if (num_items == 2) {
-                                            __auto_type _mv_1467 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1467.has_value) {
-                                                __auto_type type_expr = _mv_1467.value;
+                                            __auto_type _mv_1468 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1468.has_value) {
+                                                __auto_type type_expr = _mv_1468.value;
                                                 {
                                                     __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                     {
@@ -6839,14 +6839,14 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
                                                         context_ctx_emit_header(ctx, context_ctx_str4(ctx, SLOP_STR("        "), actual_type, SLOP_STR(" "), context_ctx_str(ctx, c_field, SLOP_STR(";"))));
                                                     }
                                                 }
-                                            } else if (!_mv_1467.has_value) {
+                                            } else if (!_mv_1468.has_value) {
                                             }
                                         } else if (num_items >= 3) {
                                             context_ctx_emit_header(ctx, SLOP_STR("        struct {"));
                                             for (int64_t fi = 1; fi < num_items; fi++) {
-                                                __auto_type _mv_1468 = ({ __auto_type _lst = items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                                if (_mv_1468.has_value) {
-                                                    __auto_type type_expr = _mv_1468.value;
+                                                __auto_type _mv_1469 = ({ __auto_type _lst = items; size_t _idx = (size_t)fi; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                                if (_mv_1469.has_value) {
+                                                    __auto_type type_expr = _mv_1469.value;
                                                     {
                                                         __auto_type c_type = context_to_c_type_prefixed(ctx, type_expr);
                                                         {
@@ -6855,7 +6855,7 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
                                                             context_ctx_emit_header(ctx, context_ctx_str5(ctx, SLOP_STR("            "), actual_type, SLOP_STR(" "), field_name, SLOP_STR(";")));
                                                         }
                                                     }
-                                                } else if (!_mv_1468.has_value) {
+                                                } else if (!_mv_1469.has_value) {
                                                 }
                                             }
                                             context_ctx_emit_header(ctx, context_ctx_str3(ctx, SLOP_STR("        } "), c_field, SLOP_STR(";")));
@@ -6868,7 +6868,7 @@ void transpiler_emit_union_variant_to_header(context_TranspileContext* ctx, type
                                     break;
                                 }
                             }
-                        } else if (!_mv_1465.has_value) {
+                        } else if (!_mv_1466.has_value) {
                         }
                     }
                 }
@@ -6888,9 +6888,9 @@ void transpiler_emit_module_consts(context_TranspileContext* ctx, slop_list_type
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1469 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1469.has_value) {
-                __auto_type item = _mv_1469.value;
+            __auto_type _mv_1470 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1470.has_value) {
+                __auto_type item = _mv_1470.value;
                 if (transpiler_is_const_def(item)) {
                     {
                         __auto_type const_name = transpiler_get_const_name(item);
@@ -6899,7 +6899,7 @@ void transpiler_emit_module_consts(context_TranspileContext* ctx, slop_list_type
                     }
                     emitted_any = 1;
                 }
-            } else if (!_mv_1469.has_value) {
+            } else if (!_mv_1470.has_value) {
             }
             i = (i + 1);
         }
@@ -6911,31 +6911,31 @@ void transpiler_emit_module_consts(context_TranspileContext* ctx, slop_list_type
 
 slop_string transpiler_get_const_name(types_SExpr* item) {
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1470 = (*item);
-    switch (_mv_1470.tag) {
+    __auto_type _mv_1471 = (*item);
+    switch (_mv_1471.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1470.data.lst;
+            __auto_type lst = _mv_1471.data.lst;
             {
                 __auto_type items = lst.items;
                 if (((int64_t)((items).len)) < 2) {
                     return SLOP_STR("");
                 } else {
-                    __auto_type _mv_1471 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1471.has_value) {
-                        __auto_type name_expr = _mv_1471.value;
-                        __auto_type _mv_1472 = (*name_expr);
-                        switch (_mv_1472.tag) {
+                    __auto_type _mv_1472 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1472.has_value) {
+                        __auto_type name_expr = _mv_1472.value;
+                        __auto_type _mv_1473 = (*name_expr);
+                        switch (_mv_1473.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type sym = _mv_1472.data.sym;
+                                __auto_type sym = _mv_1473.data.sym;
                                 return sym.name;
                             }
                             default: {
                                 return SLOP_STR("");
                             }
                         }
-                    } else if (!_mv_1471.has_value) {
+                    } else if (!_mv_1472.has_value) {
                         return SLOP_STR("");
                     }
                     SLOP_UNREACHABLE();
@@ -6955,15 +6955,15 @@ void transpiler_emit_module_consts_header(context_TranspileContext* ctx, slop_li
         int64_t i = start;
         uint8_t emitted_any = 0;
         while (i < len) {
-            __auto_type _mv_1473 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1473.has_value) {
-                __auto_type item = _mv_1473.value;
+            __auto_type _mv_1474 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1474.has_value) {
+                __auto_type item = _mv_1474.value;
                 if (transpiler_is_const_def(item)) {
                     if (transpiler_emit_const_header_if_exported(ctx, item, exports)) {
                         emitted_any = 1;
                     }
                 }
-            } else if (!_mv_1473.has_value) {
+            } else if (!_mv_1474.has_value) {
             }
             i = (i + 1);
         }
@@ -6976,35 +6976,35 @@ void transpiler_emit_module_consts_header(context_TranspileContext* ctx, slop_li
 uint8_t transpiler_emit_const_header_if_exported(context_TranspileContext* ctx, types_SExpr* item, slop_list_string exports) {
     SLOP_PRE(((ctx != NULL)), "(!= ctx nil)");
     SLOP_PRE(((item != NULL)), "(!= item nil)");
-    __auto_type _mv_1474 = (*item);
-    switch (_mv_1474.tag) {
+    __auto_type _mv_1475 = (*item);
+    switch (_mv_1475.tag) {
         case types_SExpr_lst:
         {
-            __auto_type lst = _mv_1474.data.lst;
+            __auto_type lst = _mv_1475.data.lst;
             {
                 __auto_type const_items = lst.items;
                 if (((int64_t)((const_items).len)) < 4) {
                     return 0;
                 } else {
-                    __auto_type _mv_1475 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1475.has_value) {
-                        __auto_type name_expr = _mv_1475.value;
-                        __auto_type _mv_1476 = (*name_expr);
-                        switch (_mv_1476.tag) {
+                    __auto_type _mv_1476 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1476.has_value) {
+                        __auto_type name_expr = _mv_1476.value;
+                        __auto_type _mv_1477 = (*name_expr);
+                        switch (_mv_1477.tag) {
                             case types_SExpr_sym:
                             {
-                                __auto_type name_sym = _mv_1476.data.sym;
+                                __auto_type name_sym = _mv_1477.data.sym;
                                 {
                                     __auto_type raw_name = name_sym.name;
                                     if (!(transpiler_list_contains_str(exports, raw_name))) {
                                         return 0;
                                     } else {
-                                        __auto_type _mv_1477 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                        if (_mv_1477.has_value) {
-                                            __auto_type type_expr = _mv_1477.value;
+                                        __auto_type _mv_1478 = ({ __auto_type _lst = const_items; size_t _idx = (size_t)2; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                        if (_mv_1478.has_value) {
+                                            __auto_type type_expr = _mv_1478.value;
                                             transpiler_emit_const_header_decl(ctx, raw_name, type_expr, ({ __auto_type _mv = ({ __auto_type _lst = const_items; size_t _idx = (size_t)3; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; }); _mv.has_value ? ({ __auto_type v = _mv.value; v; }) : (NULL); }));
                                             return 1;
-                                        } else if (!_mv_1477.has_value) {
+                                        } else if (!_mv_1478.has_value) {
                                             return 0;
                                         }
                                         SLOP_UNREACHABLE();
@@ -7015,7 +7015,7 @@ uint8_t transpiler_emit_const_header_if_exported(context_TranspileContext* ctx, 
                                 return 0;
                             }
                         }
-                    } else if (!_mv_1475.has_value) {
+                    } else if (!_mv_1476.has_value) {
                         return 0;
                     }
                     SLOP_UNREACHABLE();
@@ -7066,13 +7066,13 @@ void transpiler_emit_module_functions(context_TranspileContext* ctx, slop_list_t
         int64_t i = start;
         context_ctx_start_function_buffer(ctx);
         while (i < len) {
-            __auto_type _mv_1478 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1478.has_value) {
-                __auto_type item = _mv_1478.value;
+            __auto_type _mv_1479 = ({ __auto_type _lst = items; size_t _idx = (size_t)i; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1479.has_value) {
+                __auto_type item = _mv_1479.value;
                 if (transpiler_is_fn_def(item)) {
                     defn_transpile_function(ctx, item);
                 }
-            } else if (!_mv_1478.has_value) {
+            } else if (!_mv_1479.has_value) {
             }
             i = (i + 1);
         }
@@ -7090,12 +7090,12 @@ void transpiler_emit_all_lambdas(context_TranspileContext* ctx) {
         int64_t i = 0;
         if (count > 0) {
             while (i < count) {
-                __auto_type _mv_1479 = ({ __auto_type _lst = lambdas; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                if (_mv_1479.has_value) {
-                    __auto_type lambda_code = _mv_1479.value;
+                __auto_type _mv_1480 = ({ __auto_type _lst = lambdas; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                if (_mv_1480.has_value) {
+                    __auto_type lambda_code = _mv_1480.value;
                     context_ctx_emit(ctx, lambda_code);
                     context_ctx_emit(ctx, SLOP_STR(""));
-                } else if (!_mv_1479.has_value) {
+                } else if (!_mv_1480.has_value) {
                 }
                 i = (i + 1);
             }
@@ -7113,11 +7113,11 @@ slop_string transpiler_generate_c_output(context_TranspileContext* ctx) {
         __auto_type result = SLOP_STR("");
         int64_t i = 0;
         while (i < len) {
-            __auto_type _mv_1480 = ({ __auto_type _lst = output_lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1480.has_value) {
-                __auto_type line = _mv_1480.value;
+            __auto_type _mv_1481 = ({ __auto_type _lst = output_lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1481.has_value) {
+                __auto_type line = _mv_1481.value;
                 result = context_ctx_str3(ctx, result, line, SLOP_STR("\n"));
-            } else if (!_mv_1480.has_value) {
+            } else if (!_mv_1481.has_value) {
             }
             i = (i + 1);
         }
@@ -7131,11 +7131,11 @@ void transpiler_transpile_file(context_TranspileContext* ctx, slop_list_types_SE
         __auto_type len = ((int64_t)((exprs).len));
         int64_t i = 0;
         if ((len > 0) && transpiler_is_module_expr(exprs)) {
-            __auto_type _mv_1481 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-            if (_mv_1481.has_value) {
-                __auto_type module_expr = _mv_1481.value;
+            __auto_type _mv_1482 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+            if (_mv_1482.has_value) {
+                __auto_type module_expr = _mv_1482.value;
                 transpiler_transpile_module(ctx, module_expr);
-            } else if (!_mv_1481.has_value) {
+            } else if (!_mv_1482.has_value) {
             }
         } else {
             emit_emit_standard_includes(ctx);
@@ -7151,34 +7151,34 @@ uint8_t transpiler_is_module_expr(slop_list_types_SExpr_ptr exprs) {
     if (((int64_t)((exprs).len)) < 1) {
         return 0;
     } else {
-        __auto_type _mv_1482 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1482.has_value) {
-            __auto_type first = _mv_1482.value;
-            __auto_type _mv_1483 = (*first);
-            switch (_mv_1483.tag) {
+        __auto_type _mv_1483 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1483.has_value) {
+            __auto_type first = _mv_1483.value;
+            __auto_type _mv_1484 = (*first);
+            switch (_mv_1484.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type lst = _mv_1483.data.lst;
+                    __auto_type lst = _mv_1484.data.lst;
                     {
                         __auto_type items = lst.items;
                         if (((int64_t)((items).len)) < 1) {
                             return 0;
                         } else {
-                            __auto_type _mv_1484 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1484.has_value) {
-                                __auto_type head = _mv_1484.value;
-                                __auto_type _mv_1485 = (*head);
-                                switch (_mv_1485.tag) {
+                            __auto_type _mv_1485 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1485.has_value) {
+                                __auto_type head = _mv_1485.value;
+                                __auto_type _mv_1486 = (*head);
+                                switch (_mv_1486.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1485.data.sym;
+                                        __auto_type sym = _mv_1486.data.sym;
                                         return string_eq(sym.name, SLOP_STR("module"));
                                     }
                                     default: {
                                         return 0;
                                     }
                                 }
-                            } else if (!_mv_1484.has_value) {
+                            } else if (!_mv_1485.has_value) {
                                 return 0;
                             }
                             SLOP_UNREACHABLE();
@@ -7189,7 +7189,7 @@ uint8_t transpiler_is_module_expr(slop_list_types_SExpr_ptr exprs) {
                     return 0;
                 }
             }
-        } else if (!_mv_1482.has_value) {
+        } else if (!_mv_1483.has_value) {
             return 0;
         }
         SLOP_UNREACHABLE();

--- a/bootstrap/transpiler/slop_transpiler_main.c
+++ b/bootstrap/transpiler/slop_transpiler_main.c
@@ -103,11 +103,11 @@ slop_string transpiler_main_lines_to_string(slop_arena* arena, slop_list_string 
                 int64_t total = 0;
                 int64_t i = 0;
                 while (i < len) {
-                    __auto_type _mv_1486 = ({ __auto_type _lst = lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                    if (_mv_1486.has_value) {
-                        __auto_type line = _mv_1486.value;
+                    __auto_type _mv_1487 = ({ __auto_type _lst = lines; size_t _idx = (size_t)i; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                    if (_mv_1487.has_value) {
+                        __auto_type line = _mv_1487.value;
                         total = (total + (((int64_t)(line.len)) + 1));
-                    } else if (!_mv_1486.has_value) {
+                    } else if (!_mv_1487.has_value) {
                     }
                     i = (i + 1);
                 }
@@ -116,9 +116,9 @@ slop_string transpiler_main_lines_to_string(slop_arena* arena, slop_list_string 
                     int64_t pos = 0;
                     int64_t j = 0;
                     while (j < len) {
-                        __auto_type _mv_1487 = ({ __auto_type _lst = lines; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                        if (_mv_1487.has_value) {
-                            __auto_type line = _mv_1487.value;
+                        __auto_type _mv_1488 = ({ __auto_type _lst = lines; size_t _idx = (size_t)j; slop_option_string _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                        if (_mv_1488.has_value) {
+                            __auto_type line = _mv_1488.value;
                             {
                                 __auto_type line_len = ((int64_t)(line.len));
                                 __auto_type line_data = line.data;
@@ -131,7 +131,7 @@ slop_string transpiler_main_lines_to_string(slop_arena* arena, slop_list_string 
                                 buf[pos] = 10;
                                 pos = (pos + 1);
                             }
-                        } else if (!_mv_1487.has_value) {
+                        } else if (!_mv_1488.has_value) {
                         }
                         j = (j + 1);
                     }
@@ -147,43 +147,43 @@ slop_string transpiler_main_extract_module_name(slop_list_types_SExpr_ptr exprs)
     if (((int64_t)((exprs).len)) < 1) {
         return SLOP_STR("unknown");
     } else {
-        __auto_type _mv_1488 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-        if (_mv_1488.has_value) {
-            __auto_type first_expr = _mv_1488.value;
-            __auto_type _mv_1489 = (*first_expr);
-            switch (_mv_1489.tag) {
+        __auto_type _mv_1489 = ({ __auto_type _lst = exprs; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+        if (_mv_1489.has_value) {
+            __auto_type first_expr = _mv_1489.value;
+            __auto_type _mv_1490 = (*first_expr);
+            switch (_mv_1490.tag) {
                 case types_SExpr_lst:
                 {
-                    __auto_type lst = _mv_1489.data.lst;
+                    __auto_type lst = _mv_1490.data.lst;
                     {
                         __auto_type items = lst.items;
                         if (((int64_t)((items).len)) < 2) {
                             return SLOP_STR("unknown");
                         } else {
-                            __auto_type _mv_1490 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                            if (_mv_1490.has_value) {
-                                __auto_type head = _mv_1490.value;
-                                __auto_type _mv_1491 = (*head);
-                                switch (_mv_1491.tag) {
+                            __auto_type _mv_1491 = ({ __auto_type _lst = items; size_t _idx = (size_t)0; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                            if (_mv_1491.has_value) {
+                                __auto_type head = _mv_1491.value;
+                                __auto_type _mv_1492 = (*head);
+                                switch (_mv_1492.tag) {
                                     case types_SExpr_sym:
                                     {
-                                        __auto_type sym = _mv_1491.data.sym;
+                                        __auto_type sym = _mv_1492.data.sym;
                                         if (string_eq(sym.name, SLOP_STR("module"))) {
-                                            __auto_type _mv_1492 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
-                                            if (_mv_1492.has_value) {
-                                                __auto_type name_expr = _mv_1492.value;
-                                                __auto_type _mv_1493 = (*name_expr);
-                                                switch (_mv_1493.tag) {
+                                            __auto_type _mv_1493 = ({ __auto_type _lst = items; size_t _idx = (size_t)1; slop_option_types_SExpr_ptr _r = {0}; if (_idx < _lst.len) { _r.has_value = true; _r.value = _lst.data[_idx]; } else { _r.has_value = false; } _r; });
+                                            if (_mv_1493.has_value) {
+                                                __auto_type name_expr = _mv_1493.value;
+                                                __auto_type _mv_1494 = (*name_expr);
+                                                switch (_mv_1494.tag) {
                                                     case types_SExpr_sym:
                                                     {
-                                                        __auto_type name_sym = _mv_1493.data.sym;
+                                                        __auto_type name_sym = _mv_1494.data.sym;
                                                         return name_sym.name;
                                                     }
                                                     default: {
                                                         return SLOP_STR("unknown");
                                                     }
                                                 }
-                                            } else if (!_mv_1492.has_value) {
+                                            } else if (!_mv_1493.has_value) {
                                                 return SLOP_STR("unknown");
                                             }
                                             SLOP_UNREACHABLE();
@@ -195,7 +195,7 @@ slop_string transpiler_main_extract_module_name(slop_list_types_SExpr_ptr exprs)
                                         return SLOP_STR("unknown");
                                     }
                                 }
-                            } else if (!_mv_1490.has_value) {
+                            } else if (!_mv_1491.has_value) {
                                 return SLOP_STR("unknown");
                             }
                             SLOP_UNREACHABLE();
@@ -206,7 +206,7 @@ slop_string transpiler_main_extract_module_name(slop_list_types_SExpr_ptr exprs)
                     return SLOP_STR("unknown");
                 }
             }
-        } else if (!_mv_1488.has_value) {
+        } else if (!_mv_1489.has_value) {
             return SLOP_STR("unknown");
         }
         SLOP_UNREACHABLE();
@@ -241,14 +241,14 @@ int main(int argc, char** _c_argv) {
                             __auto_type filename_ptr = ((uint8_t*)(filename));
                             __auto_type filename_str = (slop_string){.len = strlen(filename_ptr), .data = filename_ptr};
                             context_ctx_set_file(ctx, filename_str);
-                            __auto_type _mv_1494 = transpiler_main_read_file(arena, filename);
-                            if (_mv_1494.has_value) {
-                                __auto_type source = _mv_1494.value;
+                            __auto_type _mv_1495 = transpiler_main_read_file(arena, filename);
+                            if (_mv_1495.has_value) {
+                                __auto_type source = _mv_1495.value;
                                 {
                                     __auto_type result = transpiler_main_transpile_single_file_with_ctx(ctx, source, first);
                                     first = 0;
                                 }
-                            } else if (!_mv_1494.has_value) {
+                            } else if (!_mv_1495.has_value) {
                                 transpiler_main_print_str(((char*)(SLOP_STR("Error: Could not read file\n").data)));
                             }
                         }
@@ -269,9 +269,9 @@ int64_t transpiler_main_transpile_single_file_with_ctx(context_TranspileContext*
     {
         __auto_type arena = (*ctx).arena;
         __auto_type parse_result = parser_parse(arena, source);
-        __auto_type _mv_1495 = parse_result;
-        if (_mv_1495.is_ok) {
-            __auto_type exprs = _mv_1495.data.ok;
+        __auto_type _mv_1496 = parse_result;
+        if (_mv_1496.is_ok) {
+            __auto_type exprs = _mv_1496.data.ok;
             {
                 __auto_type mod_name = transpiler_main_extract_module_name(exprs);
                 context_ctx_reset_for_new_module(ctx, mod_name);
@@ -286,8 +286,8 @@ int64_t transpiler_main_transpile_single_file_with_ctx(context_TranspileContext*
                 transpiler_main_output_module_json(arena, ctx, mod_name, first);
                 return 0;
             }
-        } else if (!_mv_1495.is_ok) {
-            __auto_type err = _mv_1495.data.err;
+        } else if (!_mv_1496.is_ok) {
+            __auto_type err = _mv_1496.data.err;
             transpiler_main_print_str(((char*)(SLOP_STR("Parse error at line ").data)));
             transpiler_main_print_string(int_to_string(arena, err.line));
             transpiler_main_print_str(((char*)(SLOP_STR(", col ").data)));
@@ -304,9 +304,9 @@ int64_t transpiler_main_transpile_single_file_with_ctx(context_TranspileContext*
 int64_t transpiler_main_transpile_single_file(slop_arena* arena, slop_string source, uint8_t first) {
     {
         __auto_type parse_result = parser_parse(arena, source);
-        __auto_type _mv_1496 = parse_result;
-        if (_mv_1496.is_ok) {
-            __auto_type exprs = _mv_1496.data.ok;
+        __auto_type _mv_1497 = parse_result;
+        if (_mv_1497.is_ok) {
+            __auto_type exprs = _mv_1497.data.ok;
             {
                 __auto_type mod_name = transpiler_main_extract_module_name(exprs);
                 __auto_type ctx = context_context_new(arena);
@@ -323,8 +323,8 @@ int64_t transpiler_main_transpile_single_file(slop_arena* arena, slop_string sou
                 transpiler_main_output_module_json(arena, ctx, mod_name, first);
                 return 0;
             }
-        } else if (!_mv_1496.is_ok) {
-            __auto_type err = _mv_1496.data.err;
+        } else if (!_mv_1497.is_ok) {
+            __auto_type err = _mv_1497.data.err;
             transpiler_main_print_str(((char*)(SLOP_STR("Parse error at line ").data)));
             transpiler_main_print_string(int_to_string(arena, err.line));
             transpiler_main_print_str(((char*)(SLOP_STR(", col ").data)));

--- a/lib/compiler/transpiler/context.slop
+++ b/lib/compiler/transpiler/context.slop
@@ -81,6 +81,8 @@
     ends-with-star
     ;; Struct key type tracking
     ctx-register-struct-key-type ctx-has-struct-key-type ctx-get-struct-key-types
+    ;; Arena discovery (any arena-typed variable, not just one literally named 'arena')
+    ctx-find-arena-var
     ;; Type alias tracking for resolving Map/Set types
     TypeAliasEntry ctx-register-type-alias ctx-lookup-type-alias
     ;; Generic function support

--- a/lib/compiler/transpiler/expr.slop
+++ b/lib/compiler/transpiler/expr.slop
@@ -40,6 +40,7 @@
                    ctx-get-fields-for-type ctx-get-union-variants FieldEntry
                    ctx-register-list-type
                    ctx-register-struct-key-type ctx-has-struct-key-type ctx-lookup-type-alias ctx-register-chan-type
+                   ctx-find-arena-var
                    ctx-add-error ctx-add-error-at ctx-strict-unknown-symbols
                    ctx-sexpr-line ctx-sexpr-col ctx-list-first-line ctx-list-first-col
                    ctx-gensym ctx-add-deferred-lambda ctx-emit ctx-indent ctx-dedent ctx-get-output
@@ -6447,8 +6448,9 @@
                             "arena"))
               (size-idx (if is-named 3 1))
               (body-start (if is-named 4 2))
+              (c-arena-name (to-c-name arena arena-name))
               (c-local (if is-named
-                         (string-concat arena "_arena_" arena-name)
+                         (string-concat arena "_arena_" c-arena-name)
                          "_arena")))
           ;; Validate minimum length for named form
           (if (and is-named (< len 5))
@@ -6465,9 +6467,9 @@
                           ;; ({ slop_arena _arena = slop_arena_new(size);
                           (mut result (ctx-str5 ctx "({ slop_arena " c-local " = slop_arena_new(" size-c "); ")))
                       ;; slop_arena* arena = &_arena;
-                      (set! result (ctx-str5 ctx result "slop_arena* " arena-name " = &" (ctx-str ctx c-local "; ")))
+                      (set! result (ctx-str5 ctx result "slop_arena* " c-arena-name " = &" (ctx-str ctx c-local "; ")))
                       ;; Bind arena variable in scope
-                      (ctx-bind-var ctx (VarEntry arena-name arena-name "slop_arena*" "" true false false "" ""))
+                      (ctx-bind-var ctx (VarEntry arena-name c-arena-name "slop_arena*" "" true false false "" ""))
                       ;; Process body expressions - all but last are side-effects
                       (let ((mut i body-start))
                         (while (< i (- len 1))
@@ -6481,11 +6483,11 @@
                       (match (list-get items (- len 1))
                         ((some last-expr)
                           (let ((last-c (transpile-expr ctx last-expr))
-                                (free-part (ctx-str3 ctx "slop_arena_free(" arena-name "); ")))
+                                (free-part (ctx-str3 ctx "slop_arena_free(" c-arena-name "); ")))
                             (set! result (ctx-str5 ctx result "__auto_type _wa_result = " last-c "; " free-part))
                             (set! result (ctx-str ctx result "_wa_result; })"))))
                         ((none)
-                          (let ((free-part (ctx-str3 ctx "slop_arena_free(" arena-name "); ")))
+                          (let ((free-part (ctx-str3 ctx "slop_arena_free(" c-arena-name "); ")))
                             (set! result (ctx-str3 ctx result free-part "0; })")))))
                       result))
                   ((none)
@@ -6798,8 +6800,15 @@
             ;; Found arena variable, use it directly (it's already a pointer)
             (. entry c-name))
           ((none)
-            ;; No arena in scope - signal to caller to use malloc
-            "")))))
+            ;; Neither of the two conventional names. A named arena --
+            ;; (with-arena :as myarena ...) -- binds something else entirely, and
+            ;; without this the closure env fell back to malloc and was never
+            ;; freed. Search the scope chain for any arena-typed variable.
+            (match (ctx-find-arena-var ctx)
+              ((some entry) (. entry c-name))
+              ((none)
+                ;; Genuinely no arena in scope - signal to caller to use malloc
+                "")))))))
 
   (fn build-closure-instance ((ctx (Ptr TranspileContext)) (lambda-name String) (env-name String) (env-type String) (free-vars (List String)) (captured-accesses (List String)))
     (@intent "Build expression that creates closure instance")

--- a/lib/compiler/transpiler/match.slop
+++ b/lib/compiler/transpiler/match.slop
@@ -1523,8 +1523,9 @@
               (size-idx (if is-named 3 1))
               (body-start (if is-named 4 2))
               ;; C local var: _arena for unnamed (backward compat), _arena_<name> for named
+              (c-arena-name (to-c-name ctx-arena arena-name))
               (c-local (if is-named
-                         (string-concat ctx-arena "_arena_" arena-name)
+                         (string-concat ctx-arena "_arena_" c-arena-name)
                          "_arena")))
           ;; Validate minimum length for named form
           (if (and is-named (< len 4))
@@ -1540,10 +1541,10 @@
                   (let ((size-c (transpile-expr ctx size-expr)))
                     ;; Emit arena creation
                     (ctx-emit ctx (ctx-str5 ctx "slop_arena " c-local " = slop_arena_new(" size-c ");"))
-                    (ctx-emit ctx (ctx-str5 ctx "slop_arena* " arena-name " = &" c-local ";"))))
+                    (ctx-emit ctx (ctx-str5 ctx "slop_arena* " c-arena-name " = &" c-local ";"))))
                 ((none) (ctx-add-error-at ctx "missing size" (ctx-list-first-line items) (ctx-list-first-col items))))
               ;; Bind arena variable in scope
-              (ctx-bind-var ctx (VarEntry arena-name arena-name "slop_arena*" "" true false false "" ""))
+              (ctx-bind-var ctx (VarEntry arena-name c-arena-name "slop_arena*" "" true false false "" ""))
               ;; Process body statements
               (let ((mut i body-start))
                 (while (< i len)
@@ -1554,7 +1555,7 @@
                     ((none) (do)))
                   (set! i (+ i 1))))
               ;; Free arena
-              (ctx-emit ctx (ctx-str3 ctx "slop_arena_free(" arena-name ");"))
+              (ctx-emit ctx (ctx-str3 ctx "slop_arena_free(" c-arena-name ");"))
               ;; Close scope
               (ctx-pop-scope ctx)
               (ctx-dedent ctx)

--- a/lib/compiler/transpiler/stmt.slop
+++ b/lib/compiler/transpiler/stmt.slop
@@ -817,8 +817,13 @@
                   (size-idx (if is-named 3 1))
                   (body-start (if is-named 4 2))
                   ;; C local var: _arena for unnamed (backward compat), _arena_<name> for named
+                  ;; Mangle for C. Every other binder in the compiler runs its name
+                  ;; through to-c-name; this one did not, so an ordinary kebab-case
+                  ;; arena name emitted `slop_arena* my-scratch = ...` and failed to
+                  ;; parse. The SLOP name stays raw for scope lookup.
+                  (c-arena-name (to-c-name (. (deref ctx) arena) arena-name))
                   (c-local (if is-named
-                             (string-concat (. (deref ctx) arena) "_arena_" arena-name)
+                             (string-concat (. (deref ctx) arena) "_arena_" c-arena-name)
                              "_arena")))
               ;; Validate minimum length for named form
               (if (and is-named (< len 4))
@@ -842,10 +847,10 @@
                         (ctx-emit ctx "#ifdef SLOP_DEBUG")
                         (ctx-emit ctx (ctx-str3 ctx "SLOP_PRE(" c-local ".base != NULL, \"arena allocation failed\");"))
                         (ctx-emit ctx "#endif")
-                        (ctx-emit ctx (ctx-str5 ctx "slop_arena* " arena-name " = &" c-local ";"))))
+                        (ctx-emit ctx (ctx-str5 ctx "slop_arena* " c-arena-name " = &" c-local ";"))))
                     ((none) (ctx-add-error-at ctx "missing size" (ctx-sexpr-line expr) (ctx-sexpr-col expr))))
                   ;; Bind arena variable in scope
-                  (ctx-bind-var ctx (VarEntry arena-name arena-name "slop_arena*" "" true false false "" ""))
+                  (ctx-bind-var ctx (VarEntry arena-name c-arena-name "slop_arena*" "" true false false "" ""))
                   ;; Process body statements
                   (let ((mut i body-start))
                     (while (< i len)
@@ -856,7 +861,7 @@
                         ((none) (do)))
                       (set! i (+ i 1))))
                   ;; Free arena
-                  (ctx-emit ctx (ctx-str3 ctx "slop_arena_free(" arena-name ");"))
+                  (ctx-emit ctx (ctx-str3 ctx "slop_arena_free(" c-arena-name ");"))
                   ;; Close scope
                   (ctx-pop-scope ctx)
                   (ctx-dedent ctx)

--- a/tests/fixtures/test_with_arena_as_closure.slop
+++ b/tests/fixtures/test_with_arena_as_closure.slop
@@ -1,0 +1,34 @@
+;; Fixture for #75: a capturing closure inside a NAMED with-arena.
+;;
+;; The closure emitter looked for a variable literally called "arena" or
+;; "_arena" to allocate its environment from. (with-arena :as myarena ...)
+;; binds neither, so the env fell back to malloc and was never freed --
+;; a working program that leaks, announced only by a warning with no
+;; source location.
+;;
+;; "Did not malloc" cannot be observed from inside the program, so this
+;; is asserted against the generated C. Both forms are here so the
+;; assertion can require the named one to allocate from myarena
+;; specifically, not merely from some arena.
+(module with-arena-as-closure
+
+  (fn named ()
+    (@intent "capturing closure inside a named arena")
+    (@spec (() -> Int))
+    (with-arena :as myarena 65536
+      (let ((base 10)
+            (f (fn ((x Int)) (+ x base))))
+        (f 5))))
+
+  (fn unnamed ()
+    (@intent "the same closure inside an unnamed arena")
+    (@spec (() -> Int))
+    (with-arena 65536
+      (let ((base 10)
+            (f (fn ((x Int)) (+ x base))))
+        (f 5))))
+
+  (fn main ()
+    (@intent "Unused entry point; the fixture is never run")
+    (@spec (() -> Int))
+    0))

--- a/tests/test_transpiler_warnings.py
+++ b/tests/test_transpiler_warnings.py
@@ -442,3 +442,27 @@ class TestNilPointerType:
         )
         combined = result.stdout + result.stderr
         assert "expected Int, got <nil>" in combined, combined
+
+
+class TestWithArenaAsClosure:
+    """A closure inside a named arena allocates from it, not malloc (#75)."""
+
+    def test_named_arena_closure_uses_the_arena(self, tmp_path):
+        """`(with-arena :as myarena ...)` binds neither "arena" nor "_arena".
+
+        The env fell back to malloc and was never freed -- a working program
+        that leaks, announced only by a warning with no source location. Not
+        observable from inside the program, so assert on the emitted C.
+        """
+        output = str(tmp_path / "with_arena_as_closure.c")
+        rc, stdout, stderr = slop_transpile("fixtures/test_with_arena_as_closure.slop", output)
+        assert rc == 0, f"Transpile failed: {stderr}"
+        c_src = Path(output).read_text()
+
+        assert "malloc(" not in c_src, c_src
+        # The named form must allocate from that arena specifically, not merely
+        # from whichever arena happened to be findable.
+        assert "slop_arena_alloc(myarena" in c_src, c_src
+        assert "slop_arena_alloc(arena" in c_src, c_src
+        # And the warning that used to accompany the malloc must be gone.
+        assert "no arena in scope" not in (stdout + stderr), stdout + stderr

--- a/tests/test_with_arena_as.slop
+++ b/tests/test_with_arena_as.slop
@@ -1,0 +1,101 @@
+;; ============================================================
+;; Test: (with-arena :as name size body)
+;;
+;; Two regressions, both in the named form only -- the unnamed
+;; (with-arena size body) was always fine, which is what kept these
+;; hidden.
+;;
+;; #74: the name went straight into the generated C without passing
+;; through to-c-name, the way every other binder in the compiler does.
+;; An ordinary kebab-case arena name emitted
+;;
+;;     slop_arena* my-scratch = &_arena_my-scratch;
+;;
+;; which is not valid C. The three emitters -- statement, expression and
+;; match-arm position -- each had their own copy of the bug.
+;;
+;; #75: a capturing closure looked for a variable literally named
+;; "arena" or "_arena" to allocate its environment from. A named arena
+;; binds neither, so the env fell back to malloc and was never freed.
+;; The only signal was a warning with no source location, and the
+;; program worked -- it just leaked.
+;;
+;; The malloc half cannot be observed from inside the program; it is
+;; asserted against the generated C in tests/test_transpiler_warnings.py.
+;; What runs here is that the named form works at all.
+;; ============================================================
+
+(module test-with-arena-as
+
+  (fn kebab-name ()
+    (@intent "A hyphenated arena name must survive into valid C")
+    (@spec (() -> Int))
+    (with-arena :as my-scratch 4096
+      (let ((p (arena-alloc my-scratch 16)))
+        (if (!= p nil) 1 0))))
+
+  (fn closure-in-named-arena ()
+    (@intent "A capturing closure inside a named arena")
+    (@spec (() -> Int))
+    (with-arena :as my-scratch 65536
+      (let ((base 10)
+            (f (fn ((x Int)) (+ x base))))
+        (f 5))))
+
+  (fn closure-in-unnamed-arena ()
+    (@intent "The same closure unnamed, which always worked")
+    (@spec (() -> Int))
+    (with-arena 65536
+      (let ((base 10)
+            (f (fn ((x Int)) (+ x base))))
+        (f 5))))
+
+  (fn nested-named ()
+    (@intent "A named arena inside a named arena, both hyphenated")
+    (@spec (() -> Int))
+    (with-arena :as outer-pool 4096
+      (with-arena :as inner-pool 4096
+        (let ((a (arena-alloc outer-pool 8))
+              (b (arena-alloc inner-pool 8)))
+          (if (and (!= a nil) (!= b nil)) 1 0)))))
+
+  (fn test-kebab ()
+    (@intent "kebab-case arena name allocates")
+    (@spec (() -> Bool))
+    (== (kebab-name) 1))
+
+  (fn test-closure-named ()
+    (@intent "closure captures correctly inside a named arena")
+    (@spec (() -> Bool))
+    (== (closure-in-named-arena) 15))
+
+  (fn test-closure-unnamed ()
+    (@intent "closure captures correctly inside an unnamed arena")
+    (@spec (() -> Bool))
+    (== (closure-in-unnamed-arena) 15))
+
+  (fn test-nested ()
+    (@intent "nested named arenas do not collide")
+    (@spec (() -> Bool))
+    (== (nested-named) 1))
+
+  (fn main ()
+    (@intent "Run the with-arena :as tests")
+    (@spec (() -> Int))
+    (let ((mut failures 0))
+      (if (test-kebab)
+        (println "test-kebab: PASS")
+        (do (println "test-kebab: FAIL") (set! failures (+ failures 1))))
+      (if (test-closure-named)
+        (println "test-closure-named: PASS")
+        (do (println "test-closure-named: FAIL") (set! failures (+ failures 1))))
+      (if (test-closure-unnamed)
+        (println "test-closure-unnamed: PASS")
+        (do (println "test-closure-unnamed: FAIL") (set! failures (+ failures 1))))
+      (if (test-nested)
+        (println "test-nested: PASS")
+        (do (println "test-nested: FAIL") (set! failures (+ failures 1))))
+      (println "")
+      (if (== failures 0)
+        (do (println "All tests passed!") 0)
+        (do (print failures) (println " test(s) failed") 1)))))


### PR DESCRIPTION
Closes #74. Closes #75.

Two defects in the **named** form of `with-arena`. The unnamed form was always fine, which is what kept both hidden.

## #74 — the name was never mangled

The arena name went straight into the generated C without passing through `to-c-name`, the way every other binder in the compiler does. An ordinary kebab-case name emitted:

```c
slop_arena* my-scratch = &_arena_my-scratch;
```

which is not valid C. All three emitters carried their own copy — statement (`stmt.slop`), expression (`expr.slop`) and match-arm (`match.slop`) position. The SLOP name still binds raw for scope lookup; only the emitted identifier is mangled.

## #75 — the closure couldn't find the arena

A capturing closure allocated its environment by looking for a variable literally called `arena` or `_arena`. A named arena binds neither, so the env fell back to `malloc` and was never freed — a working program that leaks, announced only by a warning with no source location.

`find-arena-ptr-expr` now falls through to `ctx-find-arena-var`, which walks the scope chain for any arena-typed variable.

That function already existed and was already being called from `expr.slop` — but it was never exported from `context.slop` and never imported. The type checker had been correctly complaining about exactly this into a channel nobody reads (#93). Both sides are declared properly now.

## Testing

"Did not malloc" isn't observable from inside the program, so that half is asserted against the generated C, with a fixture keeping both forms so the assertion can require the named one to allocate from `myarena` **specifically** rather than merely from some arena. What runs in the native suite is that the named form works at all: kebab-case naming, a capturing closure, and nested named arenas.

## Review finding, investigated and filed as #102

Codex flagged that allocating from a named arena could turn an escaping closure from "leaked but usable" into a dangling pointer. I chased it down; the conclusion is that it is **not reachable, and not introduced here**:

- The exact repro doesn't compile. Any closure bound from a call or from a `with-arena` expression and then invoked fails with `called object type 'slop_closure_t' is not a function or function pointer`. Escaping closures don't work at all today.
- Where a closure *does* escape via a statement-position `return`, the `return` precedes the `slop_arena_free`, so that path leaks rather than dangles.
- The expression-position free-before-yield that would dangle is emitted **identically for the unnamed form**, and always has been. This change makes the named form consistent with it rather than making anything worse.

So #75 changes nothing observable there — but it does mean both forms now share the same latent lifetime issue instead of one accidentally sidestepping it via `malloc`. Filed as **#102**, with both halves: the `cc` error that should be a transpiler error, and the lifetime question underneath it.

| | |
|---|---|
| `make selfhost` | clean |
| `make test-native` | **45/45** (was 44) |
| `uv run pytest` | 487 passed, 1 xfailed |
| Bootstrap | fixed point; cold start clean |
| HOWL | builds unchanged |
