### PR TITLE
never report a contract verified on a contradictory axiom set (#115)

### DIFF
--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -71,6 +71,25 @@ class AxiomGenerationMixin:
                 count += self._count_bindings_of(item, name)
         return count
 
+    def _field_path(self, expr: 'SExpr') -> Optional[str]:
+        """A dotted path for a field access, in whichever spelling it is written.
+
+        `(. report results)` and `report.results` are the same list; the parser
+        keeps the second as one symbol. Returns None for anything that is not a
+        field access, so a plain variable still matches by name.
+        """
+        if isinstance(expr, Symbol):
+            return expr.name if '.' in expr.name.strip('.') else None
+        if is_form(expr, '.') and len(expr) >= 3:
+            head = self._field_path(expr[1])
+            if head is None:
+                head = expr[1].name if isinstance(expr[1], Symbol) else None
+            field = expr[2].name if isinstance(expr[2], Symbol) else None
+            if head is None or field is None:
+                return None
+            return f"{head}.{field}"
+        return None
+
     def _uses_outside(self, body: 'SExpr', target: 'SExpr', allowed) -> bool:
         """True if `target` appears anywhere in `body` in a context `allowed` rejects.
 
@@ -91,8 +110,13 @@ class AxiomGenerationMixin:
         target_name = target.name if target_is_symbol else None
         target_str = None if target_is_symbol else pretty_print(target)
         target_len = None if target_is_symbol else len(target)
+        # `(. report results)` and `report.results` denote the same list, and a
+        # body may use one to iterate and the other to mutate.
+        target_path = self._field_path(target)
 
         def matches(node):
+            if target_path is not None and self._field_path(node) == target_path:
+                return True
             if target_is_symbol:
                 return isinstance(node, Symbol) and node.name == target_name
             if not isinstance(node, SList) or len(node) != target_len:
@@ -358,7 +382,14 @@ class AxiomGenerationMixin:
         if self._list_escapes(fn_body, return_expr):
             return axioms
 
+        # A list the function allocated itself started empty, so the push sites
+        # account for its whole contents. One it was handed may already hold
+        # anything, so the same sites only raise its floor.
+        starts_empty = self._is_list_new(fn_body)
+
         if any(site.loop_depth > 0 for site in sites):
+            if not starts_empty:
+                return axioms
             early_exit = self._contains_any_form(fn_body, ('break', 'continue'))
             axioms.extend(self._loop_result_length_axioms(
                 fn_body, sites, terms, translator, early_exit))
@@ -370,7 +401,10 @@ class AxiomGenerationMixin:
             if not site.guard_conditions and not site.conditional
         )
         for t in terms:
-            if lower == upper:
+            if not starts_empty:
+                if lower:
+                    axioms.append(t >= z3.IntVal(lower))
+            elif lower == upper:
                 axioms.append(t == z3.IntVal(lower))
             else:
                 axioms.append(t >= z3.IntVal(lower))

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -55,58 +55,82 @@ class AxiomGenerationMixin:
                 count += self._count_bindings_of(item, name)
         return count
 
-    # A list variable's length is only derivable if push is the only thing that
-    # happens to it. These are the contexts a bare occurrence of the name may
-    # appear in without invalidating that: the target of a push, the argument of
-    # a read, its own binding, or the value being returned.
-    _LIST_READ_OPS = ('list-len', 'list-get')
+    def _uses_outside(self, body: 'SExpr', target: str, allowed) -> bool:
+        """True if `target` appears anywhere in `body` in a context `allowed` rejects.
 
-    def _list_escapes(self, expr: 'SExpr', name: str,
-                      parent_head: Optional[str] = None,
-                      index: int = -1, is_last: bool = False) -> bool:
-        """True if `name` is used in a way that leaves its length unknown.
-
-        Counting pushes only bounds a list if nothing else touches it. A
-        `list-pop` shortens it, a `set!` replaces it outright, and handing it to
-        a function that appends to it does the same at a distance. None of those
-        are modelled, so any occurrence outside the handful of contexts that are
-        means no bound may be claimed.
-        """
-        if isinstance(expr, Symbol):
-            if expr.name != name:
-                return False
-            if parent_head == 'list-push' and index == 1:
-                return False
-            if parent_head in self._LIST_READ_OPS and index == 1:
-                return False
-            if parent_head == 'mut' and index == 1:
-                return False
-            # The trailing position of a do/let block is the value it yields.
-            if parent_head in ('do', 'let') and is_last:
-                return False
-            return True
-
-        if isinstance(expr, SList):
-            head = expr[0].name if len(expr) and isinstance(expr[0], Symbol) else None
-            last = len(expr) - 1
-            for i, item in enumerate(expr.items):
-                if self._list_escapes(item, name, head, i, i == last):
-                    return True
-        return False
-
-    def _collection_is_mutated(self, fn_body: 'SExpr', coll: 'SExpr') -> bool:
-        """True if `coll` is pushed to anywhere in the body.
-
-        A loop bound is stated against the source's length as a single term, but
-        that term denotes one value: if the body also appends to the source, the
-        bound would be read against the enlarged length rather than the one the
-        loop saw.
+        `target` is a printed expression, so this works for a plain variable and
+        for something like `(. report results)` alike. `allowed` is called with
+        (parent_head, index, returns_value) for each occurrence and says whether
+        that use leaves the list's length knowable; returns_value is true only
+        for the value the function actually yields, which means the trailing
+        position of a do/let chain reached from the body root - `(list-pop (do r))`
+        has r in a trailing position, but that block is an argument, not a result.
         """
         from slop.parser import pretty_print
-        target = pretty_print(coll)
-        pushes: List = []
-        self._find_list_push_calls(fn_body, pushes)
-        return any(pretty_print(lst) == target for lst, _ in pushes)
+
+        def walk(node, parent_head, index, returns_value):
+            if pretty_print(node) == target:
+                return not allowed(parent_head, index, returns_value)
+            if not isinstance(node, SList):
+                return False
+            head = node[0].name if len(node) and isinstance(node[0], Symbol) else None
+            last = len(node) - 1
+            block = head in ('do', 'let')
+            for i, item in enumerate(node.items):
+                # The binder of a for-each is (var collection); name that
+                # position so a collection may be recognised there.
+                child_head = '@for-each-binder' if (head == 'for-each' and i == 1) else head
+                if isinstance(item, SList) and child_head == '@for-each-binder':
+                    for j, sub in enumerate(item.items):
+                        if walk(sub, '@for-each-binder', j, False):
+                            return True
+                    continue
+                if walk(item, head, i, returns_value and block and i == last):
+                    return True
+            return False
+
+        return walk(body, None, -1, True)
+
+    @staticmethod
+    def _accumulator_use_is_safe(parent_head, index, returns_value) -> bool:
+        """Contexts in which the returned list's length stays derivable.
+
+        Counting pushes bounds a list only if nothing else touches it. A
+        list-pop shortens it, a set! replaces it outright, and handing it to a
+        function that appends to it does the same at a distance. Only the target
+        of a push, the argument of a read, its own binding, and the value the
+        body yields are accounted for; anything else, including an operation
+        this does not know about, means no bound.
+        """
+        if parent_head == 'list-push' and index == 1:
+            return True
+        if parent_head in ('list-len', 'list-get') and index == 1:
+            return True
+        if parent_head == 'mut' and index == 1:
+            return True
+        return returns_value
+
+    @staticmethod
+    def _source_use_is_safe(parent_head, index, returns_value) -> bool:
+        """Contexts in which a loop's source collection is only read.
+
+        A loop bound is stated against the source's length as one term, so
+        anything that changes that length - a push, a pop, a reassignment, a
+        callee that appends - would have the bound read against a different
+        collection than the loop saw.
+        """
+        if parent_head == '@for-each-binder' and index == 1:
+            return True
+        return parent_head in ('list-len', 'list-get') and index == 1
+
+    def _list_escapes(self, expr: 'SExpr', name: str) -> bool:
+        """True if the returned list `name` is used in a way that hides its length."""
+        return self._uses_outside(expr, name, self._accumulator_use_is_safe)
+
+    def _source_escapes(self, fn_body: 'SExpr', coll: 'SExpr') -> bool:
+        """True if the loop's source collection is anything but read in this body."""
+        from slop.parser import pretty_print
+        return self._uses_outside(fn_body, pretty_print(coll), self._source_use_is_safe)
 
     def _contains_any_form(self, expr: 'SExpr', heads) -> bool:
         """True if `expr` contains a call to any of `heads`."""
@@ -283,7 +307,7 @@ class AxiomGenerationMixin:
             return []
 
         source = collections[0][0]
-        if self._collection_is_mutated(fn_body, source):
+        if self._source_escapes(fn_body, source):
             return []
 
         src_terms, links = self._length_terms_for(source, translator)

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -169,6 +169,19 @@ class AxiomGenerationMixin:
         """
         return parent_head == '.' and index == 1
 
+    def _is_stable_source(self, coll: 'SExpr') -> bool:
+        """True if `coll` is a shape whose dependencies can be enumerated.
+
+        A variable, or a field chain rooted at one. Anything else - an `if`
+        choosing between two collections, a call returning one - depends on
+        values this cannot list, so a mutation of one of them would go unnoticed
+        while the printed source expression stayed the same.
+        """
+        node = coll
+        while is_form(node, '.') and len(node) >= 2:
+            node = node[1]
+        return isinstance(node, Symbol)
+
     def _source_escapes(self, fn_body: 'SExpr', coll: 'SExpr') -> bool:
         """True if the loop's source collection is anything but read in this body."""
         if self._uses_outside(fn_body, coll, self._source_use_is_safe):
@@ -208,16 +221,23 @@ class AxiomGenerationMixin:
         """
         terms: List[z3.ArithRef] = []
 
-        name = None
         if isinstance(expr, Symbol):
-            name = expr.name
+            terms.extend(translator.list_length_terms(expr.name))
         elif is_form(expr, '.') and len(expr) >= 3:
             obj, fld = expr[1], expr[2]
             if isinstance(obj, Symbol) and isinstance(fld, Symbol):
-                # Same naming as _extract_map_push_axioms / _get_or_create_collection_seq
-                name = f"_field_{obj.name}_{fld.name}"
-        if name is not None:
-            terms.extend(translator.list_length_terms(name))
+                # Same key as _extract_map_push_axioms / _get_or_create_collection_seq.
+                # It names a Seq/array registration, not a variable - a parameter
+                # could legitimately be called _field_report_results, and reading
+                # it out of `variables` would tie that parameter's length to an
+                # unrelated field's.
+                key = f"_field_{obj.name}_{fld.name}"
+                seq = translator.list_seqs.get(key)
+                if seq is not None:
+                    terms.append(z3.Length(seq))
+                arr_entry = translator.list_arrays.get(key)
+                if arr_entry is not None:
+                    terms.append(arr_entry[1])
 
         handle = translator.translate_expr(expr)
         if handle is not None and z3.is_expr(handle) and handle.sort() == z3.IntSort():
@@ -363,6 +383,8 @@ class AxiomGenerationMixin:
             return []
 
         source = collections[0][0]
+        if not self._is_stable_source(source):
+            return []
         if self._source_escapes(fn_body, source):
             return []
 

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -108,8 +108,7 @@ class AxiomGenerationMixin:
         sites = self._collect_push_sites([fn_body], return_expr.name)
 
         if any(site.loop_depth > 0 for site in sites):
-            loop_axioms = self._loop_result_length_axioms(fn_body, terms, translator)
-            axioms.extend(loop_axioms)
+            axioms.extend(self._loop_result_length_axioms(sites, terms, translator))
             return axioms
 
         upper = len(sites)
@@ -125,30 +124,46 @@ class AxiomGenerationMixin:
                 axioms.append(t <= z3.IntVal(upper))
         return axioms
 
-    def _loop_result_length_axioms(self, fn_body: SExpr, terms: List[z3.ArithRef],
+    def _loop_result_length_axioms(self, sites: List['PushSiteInfo'],
+                                   terms: List[z3.ArithRef],
                                    translator: 'Z3Translator') -> List[z3.BoolRef]:
         """Length bound for a result built by pushing inside a loop.
 
-        Only the two recognised shapes give one: a map pushes exactly once per
-        source element, a filter at most once. Anything else - a while loop, a
-        nested join, several pushes per iteration - gets no bound, which leaves
-        the length unconstrained beyond the non-negativity the type carries.
+        The bound comes from the loop itself rather than from a named pattern:
+        every push site must sit inside the same single `for-each`, and then k
+        sites over a collection C give at most k*len(C) elements - exactly
+        len(C) when the one site is unconditional. That covers a map and a
+        filter alike, including a filter written as a `match` arm rather than a
+        `when`, which the pattern detectors do not recognise.
+
+        Anything else gets no bound: a `while` has no collection to measure, and
+        nested loops multiply out to a product this does not try to express. The
+        length is then left unconstrained beyond the non-negativity the type
+        carries, and the caller reports that it could not bound it.
         """
-        map_pattern = self._detect_map_pattern(fn_body)
-        if map_pattern is not None:
-            src_terms, links = self._length_terms_for(map_pattern.collection, translator)
-            if src_terms:
-                return links + [t == src_terms[0] for t in terms]
+        if not sites:
             return []
 
-        filter_pattern = self._detect_filter_pattern(fn_body)
-        if filter_pattern is not None:
-            src_terms, links = self._length_terms_for(filter_pattern.collection, translator)
-            if src_terms:
-                return links + [t <= src_terms[0] for t in terms]
+        collections = [site.loop_collections for site in sites]
+        if any(len(c) != 1 or c[0] is None for c in collections):
             return []
 
-        return []
+        from slop.parser import pretty_print
+        distinct = {pretty_print(c[0]) for c in collections}
+        if len(distinct) != 1:
+            return []
+
+        src_terms, links = self._length_terms_for(collections[0][0], translator)
+        if not src_terms:
+            return []
+        source_len = src_terms[0]
+
+        exact = (len(sites) == 1
+                 and not sites[0].guard_conditions
+                 and not sites[0].in_match_arm)
+        if exact:
+            return links + [t == source_len for t in terms]
+        return links + [t <= len(sites) * source_len for t in terms]
 
     def _extract_seq_push_axioms(self, fn_body: SExpr, postconditions: List[SExpr],
                                   translator: 'Z3Translator') -> List[z3.BoolRef]:

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -29,13 +29,18 @@ class AxiomGenerationMixin:
     """Mixin providing axiom generation methods."""
 
     def _count_bindings_of(self, expr: 'SExpr', name: str) -> int:
-        """How many `let` forms under `expr` bind `name`.
+        """How many forms under `expr` bind `name`.
 
         More than one means an inner binding shadows the outer, so pushes to the
-        two are not pushes to the same list.
+        two are not pushes to the same list. `for-each` binders count: a loop
+        variable may share the accumulator's name.
         """
         count = 0
         if isinstance(expr, SList):
+            if is_form(expr, 'for-each') and len(expr) >= 2 and isinstance(expr[1], SList):
+                binder = expr[1]
+                if len(binder) >= 1 and isinstance(binder[0], Symbol) and binder[0].name == name:
+                    count += 1
             if is_form(expr, 'let') and len(expr) >= 2 and isinstance(expr[1], SList):
                 for binding in expr[1].items:
                     if not isinstance(binding, SList) or len(binding) < 2:
@@ -49,6 +54,59 @@ class AxiomGenerationMixin:
             for item in expr.items:
                 count += self._count_bindings_of(item, name)
         return count
+
+    # A list variable's length is only derivable if push is the only thing that
+    # happens to it. These are the contexts a bare occurrence of the name may
+    # appear in without invalidating that: the target of a push, the argument of
+    # a read, its own binding, or the value being returned.
+    _LIST_READ_OPS = ('list-len', 'list-get')
+
+    def _list_escapes(self, expr: 'SExpr', name: str,
+                      parent_head: Optional[str] = None,
+                      index: int = -1, is_last: bool = False) -> bool:
+        """True if `name` is used in a way that leaves its length unknown.
+
+        Counting pushes only bounds a list if nothing else touches it. A
+        `list-pop` shortens it, a `set!` replaces it outright, and handing it to
+        a function that appends to it does the same at a distance. None of those
+        are modelled, so any occurrence outside the handful of contexts that are
+        means no bound may be claimed.
+        """
+        if isinstance(expr, Symbol):
+            if expr.name != name:
+                return False
+            if parent_head == 'list-push' and index == 1:
+                return False
+            if parent_head in self._LIST_READ_OPS and index == 1:
+                return False
+            if parent_head == 'mut' and index == 1:
+                return False
+            # The trailing position of a do/let block is the value it yields.
+            if parent_head in ('do', 'let') and is_last:
+                return False
+            return True
+
+        if isinstance(expr, SList):
+            head = expr[0].name if len(expr) and isinstance(expr[0], Symbol) else None
+            last = len(expr) - 1
+            for i, item in enumerate(expr.items):
+                if self._list_escapes(item, name, head, i, i == last):
+                    return True
+        return False
+
+    def _collection_is_mutated(self, fn_body: 'SExpr', coll: 'SExpr') -> bool:
+        """True if `coll` is pushed to anywhere in the body.
+
+        A loop bound is stated against the source's length as a single term, but
+        that term denotes one value: if the body also appends to the source, the
+        bound would be read against the enlarged length rather than the one the
+        loop saw.
+        """
+        from slop.parser import pretty_print
+        target = pretty_print(coll)
+        pushes: List = []
+        self._find_list_push_calls(fn_body, pushes)
+        return any(pretty_print(lst) == target for lst, _ in pushes)
 
     def _contains_any_form(self, expr: 'SExpr', heads) -> bool:
         """True if `expr` contains a call to any of `heads`."""
@@ -164,10 +222,16 @@ class AxiomGenerationMixin:
         if self._count_bindings_of(fn_body, name) > 1:
             return axioms
 
+        # Pushes are the only mutation modelled. A list-pop, a set! or a call
+        # that receives the list and appends to it all change the length in ways
+        # the count does not see.
+        if self._list_escapes(fn_body, name):
+            return axioms
+
         if any(site.loop_depth > 0 for site in sites):
             early_exit = self._contains_any_form(fn_body, ('break', 'continue'))
             axioms.extend(self._loop_result_length_axioms(
-                sites, terms, translator, early_exit))
+                fn_body, sites, terms, translator, early_exit))
             return axioms
 
         upper = len(sites)
@@ -183,7 +247,8 @@ class AxiomGenerationMixin:
                 axioms.append(t <= z3.IntVal(upper))
         return axioms
 
-    def _loop_result_length_axioms(self, sites: List['PushSiteInfo'],
+    def _loop_result_length_axioms(self, fn_body: 'SExpr',
+                                   sites: List['PushSiteInfo'],
                                    terms: List[z3.ArithRef],
                                    translator: 'Z3Translator',
                                    early_exit: bool = False) -> List[z3.BoolRef]:
@@ -217,7 +282,11 @@ class AxiomGenerationMixin:
         if len(distinct) != 1:
             return []
 
-        src_terms, links = self._length_terms_for(collections[0][0], translator)
+        source = collections[0][0]
+        if self._collection_is_mutated(fn_body, source):
+            return []
+
+        src_terms, links = self._length_terms_for(source, translator)
         if not src_terms:
             return []
         source_len = src_terms[0]

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -28,6 +28,128 @@ if TYPE_CHECKING:
 class AxiomGenerationMixin:
     """Mixin providing axiom generation methods."""
 
+    def _length_terms_for(self, expr: 'SExpr', translator: 'Z3Translator'):
+        """Every length term for the list denoted by `expr`, plus links between them.
+
+        A list can carry more than one length representation at once (see
+        Z3Translator.list_length_terms). Callers assert a bound on all of them
+        and add the links, so the fact is visible whichever one the contract
+        happened to translate to.
+        """
+        terms: List[z3.ArithRef] = []
+
+        name = None
+        if isinstance(expr, Symbol):
+            name = expr.name
+        elif is_form(expr, '.') and len(expr) >= 3:
+            obj, fld = expr[1], expr[2]
+            if isinstance(obj, Symbol) and isinstance(fld, Symbol):
+                # Same naming as _extract_map_push_axioms / _get_or_create_collection_seq
+                name = f"_field_{obj.name}_{fld.name}"
+        if name is not None:
+            terms.extend(translator.list_length_terms(name))
+
+        handle = translator.translate_expr(expr)
+        if handle is not None and z3.is_expr(handle) and handle.sort() == z3.IntSort():
+            func = translator.variables.get("field_len")
+            if func is None:
+                func = z3.Function("field_len", z3.IntSort(), z3.IntSort())
+                translator.variables["field_len"] = func
+            field_len = func(handle)
+            if not any(z3.eq(field_len, t) for t in terms):
+                terms.append(field_len)
+
+        links = [terms[0] == t for t in terms[1:]]
+        return terms, links
+
+    def _result_length_axioms(self, fn_body: SExpr,
+                              translator: 'Z3Translator') -> List[z3.BoolRef]:
+        """Sound bounds on the length of the list this function returns.
+
+        This replaces two axioms that used to be emitted independently and
+        contradicted each other on any body that pushes (issue #115): a flat
+        `field_len($result) == 0` derived from the `(mut r (list-new ...))`
+        binding, which ignored every push, and a `field_len($result) >= n`
+        derived from the push count, which was itself wrong for a conditional
+        or looping push. An unsatisfiable pair makes every postcondition
+        discharge without being proved.
+
+        What the push sites support:
+
+            no pushes                                 len == 0
+            n straight-line unconditional pushes      len == n
+            n sites, some conditional, none in a loop 0 <= len <= n
+            unconditional push in a map loop          len == len(source)
+            guarded push in a filter loop             0 <= len <= len(source)
+            any other loop push                       no bound
+
+        A push under a `match` arm or a `when`/`if` guard is conditional: it
+        contributes to the upper bound but not the lower. A push inside a loop
+        runs an unknown number of times, so the site count bounds nothing - only
+        a recognised map/filter shape gives a bound there, from the length of
+        the collection being iterated.
+        """
+        terms = translator.list_length_terms('$result')
+        if not terms:
+            return []
+
+        axioms: List[z3.BoolRef] = list(translator.link_list_length_terms('$result'))
+
+        return_expr = self._get_return_expr(fn_body)
+
+        # A bare (list-new ...) return is empty, with no body to push from.
+        if is_form(return_expr, 'list-new'):
+            axioms.extend(t == z3.IntVal(0) for t in terms)
+            return axioms
+
+        if not isinstance(return_expr, Symbol):
+            return axioms
+
+        sites = self._collect_push_sites([fn_body], return_expr.name)
+
+        if any(site.loop_depth > 0 for site in sites):
+            loop_axioms = self._loop_result_length_axioms(fn_body, terms, translator)
+            axioms.extend(loop_axioms)
+            return axioms
+
+        upper = len(sites)
+        lower = sum(
+            1 for site in sites
+            if not site.guard_conditions and not site.in_match_arm
+        )
+        for t in terms:
+            if lower == upper:
+                axioms.append(t == z3.IntVal(lower))
+            else:
+                axioms.append(t >= z3.IntVal(lower))
+                axioms.append(t <= z3.IntVal(upper))
+        return axioms
+
+    def _loop_result_length_axioms(self, fn_body: SExpr, terms: List[z3.ArithRef],
+                                   translator: 'Z3Translator') -> List[z3.BoolRef]:
+        """Length bound for a result built by pushing inside a loop.
+
+        Only the two recognised shapes give one: a map pushes exactly once per
+        source element, a filter at most once. Anything else - a while loop, a
+        nested join, several pushes per iteration - gets no bound, which leaves
+        the length unconstrained beyond the non-negativity the type carries.
+        """
+        map_pattern = self._detect_map_pattern(fn_body)
+        if map_pattern is not None:
+            src_terms, links = self._length_terms_for(map_pattern.collection, translator)
+            if src_terms:
+                return links + [t == src_terms[0] for t in terms]
+            return []
+
+        filter_pattern = self._detect_filter_pattern(fn_body)
+        if filter_pattern is not None:
+            src_terms, links = self._length_terms_for(filter_pattern.collection, translator)
+            if src_terms:
+                return links + [t <= src_terms[0] for t in terms]
+            return []
+
+        return []
+
     def _extract_seq_push_axioms(self, fn_body: SExpr, postconditions: List[SExpr],
                                   translator: 'Z3Translator') -> List[z3.BoolRef]:
         """Generate axioms connecting pushed elements to their source.

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -127,6 +127,13 @@ class AxiomGenerationMixin:
 
         axioms: List[z3.BoolRef] = list(translator.link_list_length_terms('$result'))
 
+        # _get_return_expr only looks at the trailing expression. An explicit
+        # (return ...) elsewhere in the body is a second exit it cannot see, and
+        # whatever that path returns is just as much $result - so nothing about
+        # the trailing expression describes the result on its own.
+        if self._contains_any_form(fn_body, ('return',)):
+            return axioms
+
         return_expr = self._get_return_expr(fn_body)
 
         # A bare (list-new ...) return is empty, with no body to push from.
@@ -158,7 +165,7 @@ class AxiomGenerationMixin:
             return axioms
 
         if any(site.loop_depth > 0 for site in sites):
-            early_exit = self._contains_any_form(fn_body, ('break', 'continue', 'return'))
+            early_exit = self._contains_any_form(fn_body, ('break', 'continue'))
             axioms.extend(self._loop_result_length_axioms(
                 sites, terms, translator, early_exit))
             return axioms

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -28,6 +28,27 @@ if TYPE_CHECKING:
 class AxiomGenerationMixin:
     """Mixin providing axiom generation methods."""
 
+    @staticmethod
+    def _binding_name(binding: 'SList') -> Optional[str]:
+        """The name a `let` binding introduces, across the three spellings.
+
+        (name value), (mut name value) and ((mut name) value) all bind a name;
+        the last is easy to miss, since its head is a list rather than a symbol.
+        """
+        head = binding[0]
+        if isinstance(head, Symbol):
+            if head.name == 'mut' and len(binding) >= 3:
+                target = binding[1]
+            else:
+                target = head
+        elif isinstance(head, SList) and len(head) >= 2:
+            if not (isinstance(head[0], Symbol) and head[0].name == 'mut'):
+                return None
+            target = head[1]
+        else:
+            return None
+        return target.name if isinstance(target, Symbol) else None
+
     def _count_bindings_of(self, expr: 'SExpr', name: str) -> int:
         """How many forms under `expr` bind `name`.
 
@@ -43,14 +64,9 @@ class AxiomGenerationMixin:
                     count += 1
             if is_form(expr, 'let') and len(expr) >= 2 and isinstance(expr[1], SList):
                 for binding in expr[1].items:
-                    if not isinstance(binding, SList) or len(binding) < 2:
-                        continue
-                    head = binding[0]
-                    if not isinstance(head, Symbol):
-                        continue
-                    bound = binding[1] if head.name == 'mut' and len(binding) >= 3 else head
-                    if isinstance(bound, Symbol) and bound.name == name:
-                        count += 1
+                    if isinstance(binding, SList) and len(binding) >= 2:
+                        if self._binding_name(binding) == name:
+                            count += 1
             for item in expr.items:
                 count += self._count_bindings_of(item, name)
         return count

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -49,6 +49,32 @@ class AxiomGenerationMixin:
             return None
         return target.name if isinstance(target, Symbol) else None
 
+    def _binding_in_scope_at_tail(self, body: 'SExpr', name: str):
+        """The initializer bound to `name` where the body returns, and its scope.
+
+        Follows the tail of the body - the last form of each nested do/let,
+        which is what the function actually yields - and keeps the innermost
+        binding of `name` seen on the way. Returns (None, body) when the name is
+        not bound here at all, which is the case for a parameter.
+        """
+        initializer = None
+        scope = body
+        node = body
+        while True:
+            if is_form(node, 'let') and len(node) >= 3:
+                bindings = node[1]
+                if isinstance(bindings, SList):
+                    for binding in bindings.items:
+                        if (isinstance(binding, SList) and len(binding) >= 2
+                                and self._binding_name(binding) == name):
+                            initializer = binding[-1]
+                            scope = node
+                node = node.items[-1]
+            elif is_form(node, 'do') and len(node) >= 2:
+                node = node.items[-1]
+            else:
+                return initializer, scope
+
     def _count_bindings_of(self, expr: 'SExpr', name: str) -> int:
         """How many forms under `expr` bind `name`.
 
@@ -357,7 +383,14 @@ class AxiomGenerationMixin:
             return axioms
 
         name = return_expr.name
-        sites = self._collect_push_sites([fn_body], name)
+
+        # Resolve the returned name to the binding that governs it, and work
+        # inside that binding's scope from here on. Scanning the whole body
+        # instead conflates same-named bindings in disjoint scopes, and lets an
+        # unrelated (list-new ...) elsewhere decide whether the returned list
+        # started empty.
+        initializer, scope = self._binding_in_scope_at_tail(fn_body, name)
+        sites = self._collect_push_sites([scope], name)
 
         # Fail closed. _collect_push_sites is a whitelist walk: it classifies
         # the forms it knows and silently returns nothing for the rest, which is
@@ -368,31 +401,31 @@ class AxiomGenerationMixin:
         # or a push built by (set! name (list-push name x)) - and no bound may
         # be claimed. Without this, a push under a `cond` yielded no sites and
         # so "proved" the result empty.
-        if len(sites) != self._count_push_to_var([fn_body], name):
+        if len(sites) != self._count_push_to_var([scope], name):
             return axioms
 
         # A nested (let ((mut name ...))) rebinds the name to a different list.
         # Pushes to the inner one are still counted against the outer, so bail.
-        if self._count_bindings_of(fn_body, name) > 1:
+        if self._count_bindings_of(scope, name) > 1:
             return axioms
 
         # Pushes are the only mutation modelled. A list-pop, a set! or a call
         # that receives the list and appends to it all change the length in ways
         # the count does not see.
-        if self._list_escapes(fn_body, return_expr):
+        if self._list_escapes(scope, return_expr):
             return axioms
 
         # A list the function allocated itself started empty, so the push sites
         # account for its whole contents. One it was handed may already hold
         # anything, so the same sites only raise its floor.
-        starts_empty = self._is_list_new(fn_body)
+        starts_empty = is_form(initializer, 'list-new')
 
         if any(site.loop_depth > 0 for site in sites):
             if not starts_empty:
                 return axioms
-            early_exit = self._contains_any_form(fn_body, ('break', 'continue'))
+            early_exit = self._contains_any_form(scope, ('break', 'continue'))
             axioms.extend(self._loop_result_length_axioms(
-                fn_body, sites, terms, translator, early_exit))
+                scope, sites, terms, translator, early_exit))
             return axioms
 
         upper = len(sites)

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -28,6 +28,38 @@ if TYPE_CHECKING:
 class AxiomGenerationMixin:
     """Mixin providing axiom generation methods."""
 
+    def _count_bindings_of(self, expr: 'SExpr', name: str) -> int:
+        """How many `let` forms under `expr` bind `name`.
+
+        More than one means an inner binding shadows the outer, so pushes to the
+        two are not pushes to the same list.
+        """
+        count = 0
+        if isinstance(expr, SList):
+            if is_form(expr, 'let') and len(expr) >= 2 and isinstance(expr[1], SList):
+                for binding in expr[1].items:
+                    if not isinstance(binding, SList) or len(binding) < 2:
+                        continue
+                    head = binding[0]
+                    if not isinstance(head, Symbol):
+                        continue
+                    bound = binding[1] if head.name == 'mut' and len(binding) >= 3 else head
+                    if isinstance(bound, Symbol) and bound.name == name:
+                        count += 1
+            for item in expr.items:
+                count += self._count_bindings_of(item, name)
+        return count
+
+    def _contains_any_form(self, expr: 'SExpr', heads) -> bool:
+        """True if `expr` contains a call to any of `heads`."""
+        if isinstance(expr, SList):
+            if len(expr) >= 1 and isinstance(expr[0], Symbol) and expr[0].name in heads:
+                return True
+            for item in expr.items:
+                if self._contains_any_form(item, heads):
+                    return True
+        return False
+
     def _length_terms_for(self, expr: 'SExpr', translator: 'Z3Translator'):
         """Every length term for the list denoted by `expr`, plus links between them.
 
@@ -105,16 +137,36 @@ class AxiomGenerationMixin:
         if not isinstance(return_expr, Symbol):
             return axioms
 
-        sites = self._collect_push_sites([fn_body], return_expr.name)
+        name = return_expr.name
+        sites = self._collect_push_sites([fn_body], name)
+
+        # Fail closed. _collect_push_sites is a whitelist walk: it classifies
+        # the forms it knows and silently returns nothing for the rest, which is
+        # fine for a heuristic but not for deriving a bound. A plain recursive
+        # count of every (list-push name ...) in the body says how many there
+        # really are; if the structured walk saw a different number it passed
+        # through something it does not model - a form it does not descend into,
+        # or a push built by (set! name (list-push name x)) - and no bound may
+        # be claimed. Without this, a push under a `cond` yielded no sites and
+        # so "proved" the result empty.
+        if len(sites) != self._count_push_to_var([fn_body], name):
+            return axioms
+
+        # A nested (let ((mut name ...))) rebinds the name to a different list.
+        # Pushes to the inner one are still counted against the outer, so bail.
+        if self._count_bindings_of(fn_body, name) > 1:
+            return axioms
 
         if any(site.loop_depth > 0 for site in sites):
-            axioms.extend(self._loop_result_length_axioms(sites, terms, translator))
+            early_exit = self._contains_any_form(fn_body, ('break', 'continue', 'return'))
+            axioms.extend(self._loop_result_length_axioms(
+                sites, terms, translator, early_exit))
             return axioms
 
         upper = len(sites)
         lower = sum(
             1 for site in sites
-            if not site.guard_conditions and not site.in_match_arm
+            if not site.guard_conditions and not site.conditional
         )
         for t in terms:
             if lower == upper:
@@ -126,7 +178,8 @@ class AxiomGenerationMixin:
 
     def _loop_result_length_axioms(self, sites: List['PushSiteInfo'],
                                    terms: List[z3.ArithRef],
-                                   translator: 'Z3Translator') -> List[z3.BoolRef]:
+                                   translator: 'Z3Translator',
+                                   early_exit: bool = False) -> List[z3.BoolRef]:
         """Length bound for a result built by pushing inside a loop.
 
         The bound comes from the loop itself rather than from a named pattern:
@@ -140,6 +193,10 @@ class AxiomGenerationMixin:
         nested loops multiply out to a product this does not try to express. The
         length is then left unconstrained beyond the non-negativity the type
         carries, and the caller reports that it could not bound it.
+
+        `early_exit` suppresses the exact case: with a break, continue or return
+        in the body the single push no longer runs once per element. The k*len(C)
+        upper bound survives, since every exit only makes the loop shorter.
         """
         if not sites:
             return []
@@ -160,7 +217,8 @@ class AxiomGenerationMixin:
 
         exact = (len(sites) == 1
                  and not sites[0].guard_conditions
-                 and not sites[0].in_match_arm)
+                 and not sites[0].conditional
+                 and not early_exit)
         if exact:
             return links + [t == source_len for t in terms]
         return links + [t <= len(sites) * source_len for t in terms]

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -159,7 +159,7 @@ class AxiomGenerationMixin:
         return self._uses_outside(expr, target, self._accumulator_use_is_safe)
 
     @staticmethod
-    def _owner_use_is_safe(parent_head, index, returns_value) -> bool:
+    def _owner_use_is_safe(parent_head, index, returns_value) -> bool:  # noqa: D401
         """Contexts in which the owner of a field-valued collection is only read.
 
         For a source like `(. report results)`, `report` itself has to stay put:
@@ -182,6 +182,18 @@ class AxiomGenerationMixin:
             node = node[1]
         return isinstance(node, Symbol)
 
+    @staticmethod
+    def _dotted_symbol_owners(name: str) -> List[str]:
+        """The owner prefixes of a shorthand field symbol, e.g. `report.results`.
+
+        The parser keeps that spelling as one symbol rather than a (. ...) form,
+        so a chain written this way needs its prefixes recovered by hand.
+        """
+        if '.' not in name or name.startswith('.') or name.endswith('.'):
+            return []
+        parts = name.split('.')
+        return ['.'.join(parts[:i]) for i in range(1, len(parts))]
+
     def _source_escapes(self, fn_body: 'SExpr', coll: 'SExpr') -> bool:
         """True if the loop's source collection is anything but read in this body."""
         if self._uses_outside(fn_body, coll, self._source_use_is_safe):
@@ -193,12 +205,18 @@ class AxiomGenerationMixin:
         return False
 
     def _owner_expressions(self, coll: 'SExpr') -> List['SExpr']:
-        """The sub-expressions a field-access source depends on."""
+        """The sub-expressions a field-access source depends on.
+
+        Covers both spellings: the `(. report results)` form and the shorthand
+        `report.results`, which the parser keeps as a single symbol.
+        """
         owners: List['SExpr'] = []
         node = coll
         while is_form(node, '.') and len(node) >= 2:
             node = node[1]
             owners.append(node)
+        if isinstance(node, Symbol):
+            owners.extend(Symbol(prefix) for prefix in self._dotted_symbol_owners(node.name))
         return owners
 
     def _contains_any_form(self, expr: 'SExpr', heads) -> bool:

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -55,11 +55,11 @@ class AxiomGenerationMixin:
                 count += self._count_bindings_of(item, name)
         return count
 
-    def _uses_outside(self, body: 'SExpr', target: str, allowed) -> bool:
+    def _uses_outside(self, body: 'SExpr', target: 'SExpr', allowed) -> bool:
         """True if `target` appears anywhere in `body` in a context `allowed` rejects.
 
-        `target` is a printed expression, so this works for a plain variable and
-        for something like `(. report results)` alike. `allowed` is called with
+        `target` is an expression, so this works for a plain variable and for
+        something like `(. report results)` alike. `allowed` is called with
         (parent_head, index, returns_value) for each occurrence and says whether
         that use leaves the list's length knowable; returns_value is true only
         for the value the function actually yields, which means the trailing
@@ -68,8 +68,23 @@ class AxiomGenerationMixin:
         """
         from slop.parser import pretty_print
 
+        # Printing every node to compare it is quadratic on a large body, and
+        # the rule files this runs over are large. Compare structurally, and
+        # print only for a compound target against a node that could match it.
+        target_is_symbol = isinstance(target, Symbol)
+        target_name = target.name if target_is_symbol else None
+        target_str = None if target_is_symbol else pretty_print(target)
+        target_len = None if target_is_symbol else len(target)
+
+        def matches(node):
+            if target_is_symbol:
+                return isinstance(node, Symbol) and node.name == target_name
+            if not isinstance(node, SList) or len(node) != target_len:
+                return False
+            return pretty_print(node) == target_str
+
         def walk(node, parent_head, index, returns_value):
-            if pretty_print(node) == target:
+            if matches(node):
                 return not allowed(parent_head, index, returns_value)
             if not isinstance(node, SList):
                 return False
@@ -123,9 +138,9 @@ class AxiomGenerationMixin:
             return True
         return parent_head in ('list-len', 'list-get') and index == 1
 
-    def _list_escapes(self, expr: 'SExpr', name: str) -> bool:
-        """True if the returned list `name` is used in a way that hides its length."""
-        return self._uses_outside(expr, name, self._accumulator_use_is_safe)
+    def _list_escapes(self, expr: 'SExpr', target: 'SExpr') -> bool:
+        """True if the returned list is used in a way that hides its length."""
+        return self._uses_outside(expr, target, self._accumulator_use_is_safe)
 
     @staticmethod
     def _owner_use_is_safe(parent_head, index, returns_value) -> bool:
@@ -140,24 +155,21 @@ class AxiomGenerationMixin:
 
     def _source_escapes(self, fn_body: 'SExpr', coll: 'SExpr') -> bool:
         """True if the loop's source collection is anything but read in this body."""
-        from slop.parser import pretty_print
-        if self._uses_outside(fn_body, pretty_print(coll), self._source_use_is_safe):
+        if self._uses_outside(fn_body, coll, self._source_use_is_safe):
             return True
         # A field access is only as stable as the value it reads from.
-        if is_form(coll, '.') and len(coll) >= 2:
-            for owner in self._owner_expressions(coll):
-                if self._uses_outside(fn_body, owner, self._owner_use_is_safe):
-                    return True
+        for owner in self._owner_expressions(coll):
+            if self._uses_outside(fn_body, owner, self._owner_use_is_safe):
+                return True
         return False
 
-    def _owner_expressions(self, coll: 'SExpr') -> List[str]:
-        """The printed sub-expressions a field-access source depends on."""
-        from slop.parser import pretty_print
-        owners: List[str] = []
+    def _owner_expressions(self, coll: 'SExpr') -> List['SExpr']:
+        """The sub-expressions a field-access source depends on."""
+        owners: List['SExpr'] = []
         node = coll
         while is_form(node, '.') and len(node) >= 2:
             node = node[1]
-            owners.append(pretty_print(node))
+            owners.append(node)
         return owners
 
     def _contains_any_form(self, expr: 'SExpr', heads) -> bool:
@@ -277,7 +289,7 @@ class AxiomGenerationMixin:
         # Pushes are the only mutation modelled. A list-pop, a set! or a call
         # that receives the list and appends to it all change the length in ways
         # the count does not see.
-        if self._list_escapes(fn_body, name):
+        if self._list_escapes(fn_body, return_expr):
             return axioms
 
         if any(site.loop_depth > 0 for site in sites):

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -127,10 +127,38 @@ class AxiomGenerationMixin:
         """True if the returned list `name` is used in a way that hides its length."""
         return self._uses_outside(expr, name, self._accumulator_use_is_safe)
 
+    @staticmethod
+    def _owner_use_is_safe(parent_head, index, returns_value) -> bool:
+        """Contexts in which the owner of a field-valued collection is only read.
+
+        For a source like `(. report results)`, `report` itself has to stay put:
+        a `(set! report other)` after the loop, or handing `report` to a callee
+        that replaces its list, changes which collection the bound is read
+        against without touching the printed source expression at all.
+        """
+        return parent_head == '.' and index == 1
+
     def _source_escapes(self, fn_body: 'SExpr', coll: 'SExpr') -> bool:
         """True if the loop's source collection is anything but read in this body."""
         from slop.parser import pretty_print
-        return self._uses_outside(fn_body, pretty_print(coll), self._source_use_is_safe)
+        if self._uses_outside(fn_body, pretty_print(coll), self._source_use_is_safe):
+            return True
+        # A field access is only as stable as the value it reads from.
+        if is_form(coll, '.') and len(coll) >= 2:
+            for owner in self._owner_expressions(coll):
+                if self._uses_outside(fn_body, owner, self._owner_use_is_safe):
+                    return True
+        return False
+
+    def _owner_expressions(self, coll: 'SExpr') -> List[str]:
+        """The printed sub-expressions a field-access source depends on."""
+        from slop.parser import pretty_print
+        owners: List[str] = []
+        node = coll
+        while is_form(node, '.') and len(node) >= 2:
+            node = node[1]
+            owners.append(pretty_print(node))
+        return owners
 
     def _contains_any_form(self, expr: 'SExpr', heads) -> bool:
         """True if `expr` contains a call to any of `heads`."""

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -263,9 +263,12 @@ class AxiomGenerationMixin:
             if func is None:
                 func = z3.Function("field_len", z3.IntSort(), z3.IntSort())
                 translator.variables["field_len"] = func
-            field_len = func(handle)
-            if not any(z3.eq(field_len, t) for t in terms):
-                terms.append(field_len)
+            if isinstance(func, z3.FuncDeclRef) and func.arity() == 1:
+                # Occupied by a user binding of that name otherwise; see
+                # Z3Translator.field_len_term.
+                field_len = func(handle)
+                if not any(z3.eq(field_len, t) for t in terms):
+                    terms.append(field_len)
 
         links = [terms[0] == t for t in terms[1:]]
         return terms, links

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -220,10 +220,19 @@ class AxiomGenerationMixin:
         return owners
 
     def _contains_any_form(self, expr: 'SExpr', heads) -> bool:
-        """True if `expr` contains a call to any of `heads`."""
+        """True if `expr` calls any of `heads` in this function's own body.
+
+        The walk stops at a nested `(fn ...)`: a callback's `return` leaves the
+        callback, and its `break` belongs to a loop inside it, so neither says
+        anything about the enclosing function's exits. Counting them suppressed
+        the result-length axioms of any function that passes a callback.
+        """
         if isinstance(expr, SList):
-            if len(expr) >= 1 and isinstance(expr[0], Symbol) and expr[0].name in heads:
-                return True
+            if len(expr) >= 1 and isinstance(expr[0], Symbol):
+                if expr[0].name in heads:
+                    return True
+                if expr[0].name == 'fn':
+                    return False
             for item in expr.items:
                 if self._contains_any_form(item, heads):
                     return True
@@ -249,7 +258,7 @@ class AxiomGenerationMixin:
                 # could legitimately be called _field_report_results, and reading
                 # it out of `variables` would tie that parameter's length to an
                 # unrelated field's.
-                key = f"_field_{obj.name}_{fld.name}"
+                key = translator.field_collection_key(obj.name, fld.name)
                 seq = translator.list_seqs.get(key)
                 if seq is not None:
                     terms.append(z3.Length(seq))
@@ -597,9 +606,8 @@ class AxiomGenerationMixin:
             obj = map_pattern.collection[1]
             field = map_pattern.collection[2]
             if isinstance(obj, Symbol) and isinstance(field, Symbol):
-                # Must match naming convention in _get_or_create_collection_seq:
-                # "_field_{obj_name}_{field_name}"
-                source_name = f"_field_{obj.name}_{field.name}"
+                # Must match the key _get_or_create_collection_seq registers under
+                source_name = translator.field_collection_key(obj.name, field.name)
                 if source_name not in translator.list_seqs:
                     translator._create_list_seq(source_name)
                 source_seq = translator.list_seqs.get(source_name)
@@ -825,7 +833,7 @@ class AxiomGenerationMixin:
             obj = pattern.outer_collection[1]
             field = pattern.outer_collection[2]
             if isinstance(obj, Symbol) and isinstance(field, Symbol):
-                outer_name = f"_field_{obj.name}_{field.name}"
+                outer_name = translator.field_collection_key(obj.name, field.name)
                 if outer_name not in translator.list_seqs:
                     translator._create_list_seq(outer_name)
                 outer_seq = translator.list_seqs.get(outer_name)
@@ -1073,7 +1081,7 @@ class AxiomGenerationMixin:
             field = match_ctx.collection_expr[2]
             if isinstance(obj, Symbol) and isinstance(field, Symbol):
                 # The index is (. obj by-predicate), parent list is (. obj triples)
-                parent_name = f"_field_{obj.name}_triples"
+                parent_name = translator.field_collection_key(obj.name, "triples")
                 if parent_name not in translator.list_seqs:
                     translator._create_list_seq(parent_name)
                 parent_seq = translator.list_seqs.get(parent_name)

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -1181,21 +1181,22 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         return False
 
     def _axioms_are_contradictory(self, assertions) -> bool:
-        """True if this axiom set is unsatisfiable, so nothing follows from it.
+        """True unless this axiom set is shown satisfiable, so a proof from it holds.
 
-        Deciding it outright is the expensive direction - a consistent set means
-        Z3 has to produce a model, and with quantified sequence axioms it often
-        cannot inside the timeout. When that happens, fall back to the ground
-        fragment: dropping assertions can only make a set easier to satisfy, so
-        an unsatisfiable ground subset proves the whole set unsatisfiable, and
-        the ground fragment is cheap to decide.
+        Showing satisfiability is the expensive direction - Z3 has to produce a
+        model, and with quantified sequence axioms it often cannot inside the
+        timeout. Answering "cannot tell" with "fine, accept the proof" would
+        make the guard optional exactly where it is hardest, so instead: when
+        the full set is undecided, retry on the ground fragment. Dropping
+        assertions can only make a set easier to satisfy, so a satisfiable
+        ground subset is not proof of anything - but it is cheap, and in
+        practice it settles.
 
-        That leaves one gap, stated rather than hidden: a contradiction that
-        needs a quantified axiom to derive, in a set Z3 cannot settle in time,
-        is not caught. Every contradiction seen in practice has been ground -
-        two conflicting claims about the same length - and unsatisfiability is
-        the direction Z3 answers quickly, so a timeout here almost always means
-        satisfiable-but-hard rather than contradictory.
+        Ground-satisfiable-but-quantifier-undecided is where the line falls: the
+        proof is accepted, on the grounds that every contradiction seen here has
+        been ground (two conflicting claims about one length) and that
+        unsatisfiability is the direction Z3 answers quickly. An undecided
+        ground fragment gets no such benefit and the proof is withheld.
         """
         assertions = list(assertions)
         solver = z3.Solver()
@@ -1208,12 +1209,15 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         ground = [a for a in assertions if not self._contains_quantifier(a)]
         if len(ground) == len(assertions):
-            return False
+            # Nothing was dropped, so there is no cheaper question left to ask.
+            return True
         ground_solver = z3.Solver()
         ground_solver.set("timeout", self.timeout_ms)
         for a in ground:
             ground_solver.add(a)
-        return ground_solver.check() == z3.unsat
+        # An undecided ground fragment leaves the whole question open, and the
+        # guard exists so that an unestablished proof is not reported as one.
+        return ground_solver.check() != z3.sat
 
     def _inconsistent_context_result(
         self, solver, translator, fn_name, fn_form,
@@ -1293,12 +1297,29 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         for message, extra in authored:
             for a in extra:
                 layer.add(a)
-            if layer.check() == z3.unsat:
+            outcome = layer.check()
+            if outcome == z3.unsat:
                 return VerificationResult(
                     name=fn_name,
                     verified=False,
                     status="failed",
                     message=message,
+                    location=SourceLocation(self.filename, fn_form.line, fn_form.col)
+                )
+            if outcome == z3.unknown:
+                # This layer may be the culprit. Adding the next one and
+                # blaming whichever check happens to come back unsat would name
+                # the wrong cause, which is the one thing this loop exists to
+                # avoid.
+                return VerificationResult(
+                    name=fn_name,
+                    verified=False,
+                    status="unknown",
+                    message=(
+                        "The axioms for this function contradict each other, but which "
+                        "part is responsible could not be determined within the timeout. "
+                        "Raise the timeout to get a specific diagnosis."
+                    ),
                     location=SourceLocation(self.filename, fn_form.line, fn_form.col)
                 )
 

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -3088,10 +3088,23 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             layer.set("timeout", self.timeout_ms)
             for c in translator.constraints[:pre_constraint_count]:
                 layer.add(c)
-            for p in pre_z3:
-                layer.add(p)
+            if layer.check() == z3.unsat and not pre_z3:
+                # Unsat before any @pre was added: the parameter or result types
+                # themselves admit no value, e.g. an empty range (Int 5 .. 3).
+                return VerificationResult(
+                    name=fn_name,
+                    verified=False,
+                    status="failed",
+                    message=(
+                        "Parameter or result types admit no value: their constraints "
+                        "cannot all hold, so the function can never be called. An "
+                        "empty range type such as (Int 5 .. 3) does this."
+                    ),
+                    location=SourceLocation(self.filename, fn_form.line, fn_form.col)
+                )
+
             authored = [
-                (self._unsatisfiable_precondition_message(preconditions), []),
+                (self._unsatisfiable_precondition_message(preconditions), pre_z3),
                 (
                     "Type invariants are contradictory: no value of the parameter "
                     "types can satisfy them together with the preconditions, so the "

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -1168,6 +1168,96 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             return self._get_return_expr(expr.items[-1])
         return expr
 
+    def _inconsistent_context_result(
+        self, solver, translator, fn_name, fn_form,
+        pre_z3, preconditions, invariant_z3, range_field_axioms, assume_z3,
+        pre_constraint_count,
+    ):
+        """A result to report when the axioms contradict each other, else None.
+
+        Issue #115. Every contract is discharged by asking whether
+        (axioms AND NOT contract) is satisfiable, so if the axioms alone are
+        unsatisfiable that answers "no" for any contract and it reports verified
+        having proved nothing.
+
+        Only worth asking once a contract has come back proved: a counterexample
+        is itself a model of the axioms, so a sat result has already shown them
+        consistent.
+
+        Four things can make the context unsat and they are not the same
+        problem, so the layers are added one at a time and the first one that
+        tips it over names the cause. Three of them are the author's contract;
+        only what survives all three is ours.
+        """
+        if solver.check() != z3.unsat:
+            return None
+
+        layer = z3.Solver()
+        layer.set("timeout", self.timeout_ms)
+        for c in translator.constraints[:pre_constraint_count]:
+            layer.add(c)
+
+        if layer.check() == z3.unsat:
+            # Unsat before any @pre was added: the parameter or result types
+            # themselves admit no value, e.g. an empty range (Int 5 .. 3).
+            return VerificationResult(
+                name=fn_name,
+                verified=False,
+                status="failed",
+                message=(
+                    "Parameter or result types admit no value: their constraints "
+                    "cannot all hold, so the function can never be called. An "
+                    "empty range type such as (Int 5 .. 3) does this."
+                ),
+                location=SourceLocation(self.filename, fn_form.line, fn_form.col)
+            )
+
+        authored = [
+            (self._unsatisfiable_precondition_message(preconditions), pre_z3),
+            (
+                "Type invariants are contradictory: no value of the parameter "
+                "types can satisfy them together with the preconditions, so the "
+                "function has no legal input.",
+                invariant_z3 + range_field_axioms,
+            ),
+            (
+                "Assumptions are contradictory: the @assume set cannot hold "
+                "together with the preconditions, so it would discharge any "
+                "postcondition. @assume is trusted, not checked - narrow it.",
+                assume_z3,
+            ),
+            (
+                "A contract or body expression cannot be well-defined: the side "
+                "conditions from translating them cannot all hold. A division by "
+                "a zero denominator or a value outside its range type does this.",
+                translator.constraints[pre_constraint_count:],
+            ),
+        ]
+        for message, extra in authored:
+            for a in extra:
+                layer.add(a)
+            if layer.check() == z3.unsat:
+                return VerificationResult(
+                    name=fn_name,
+                    verified=False,
+                    status="failed",
+                    message=message,
+                    location=SourceLocation(self.filename, fn_form.line, fn_form.col)
+                )
+
+        return VerificationResult(
+            name=fn_name,
+            verified=False,
+            status="unknown",
+            message=(
+                "Verification context is inconsistent: the axioms generated for this "
+                "function contradict each other, so nothing can be proved from them. "
+                "This is a verifier defect, not a problem with the contract - please "
+                "report it with the function body."
+            ),
+            location=SourceLocation(self.filename, fn_form.line, fn_form.col)
+        )
+
     def _unsatisfiable_precondition_message(
         self, preconditions: List[Tuple[Optional[str], SExpr]]
     ) -> str:
@@ -3069,85 +3159,6 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             for equality in self._result_sequence_equality(fn_body, translator):
                 solver.add(equality)
 
-        # Vacuity guard (issue #115)
-        #
-        # Every postcondition below is discharged by asking whether
-        # (axioms AND NOT post) is satisfiable. If the axioms alone are already
-        # unsatisfiable that question answers "no" for *any* post, so every
-        # contract on this function reports verified without having been proved.
-        # Two different things make the base context unsat and they need
-        # different messages: an unsatisfiable @pre, which is the caller
-        # contract being impossible, and axioms we generated that contradict
-        # each other, which is a defect in this verifier.
-        if solver.check() == z3.unsat:
-            # Narrow it down, adding one authored layer at a time: the @pre set,
-            # then the parameters' type invariants, then @assume. Each of those
-            # is the author's own contract being impossible and is reported as
-            # such; only a contradiction that survives all three is ours.
-            layer = z3.Solver()
-            layer.set("timeout", self.timeout_ms)
-            for c in translator.constraints[:pre_constraint_count]:
-                layer.add(c)
-            if layer.check() == z3.unsat and not pre_z3:
-                # Unsat before any @pre was added: the parameter or result types
-                # themselves admit no value, e.g. an empty range (Int 5 .. 3).
-                return VerificationResult(
-                    name=fn_name,
-                    verified=False,
-                    status="failed",
-                    message=(
-                        "Parameter or result types admit no value: their constraints "
-                        "cannot all hold, so the function can never be called. An "
-                        "empty range type such as (Int 5 .. 3) does this."
-                    ),
-                    location=SourceLocation(self.filename, fn_form.line, fn_form.col)
-                )
-
-            authored = [
-                (self._unsatisfiable_precondition_message(preconditions), pre_z3),
-                (
-                    "Type invariants are contradictory: no value of the parameter "
-                    "types can satisfy them together with the preconditions, so the "
-                    "function has no legal input.",
-                    invariant_z3,
-                ),
-                (
-                    "Assumptions are contradictory: the @assume set cannot hold "
-                    "together with the preconditions, so it would discharge any "
-                    "postcondition. @assume is trusted, not checked - narrow it.",
-                    assume_z3,
-                ),
-                (
-                    "A contract or body expression cannot be well-defined: the side "
-                    "conditions from translating them cannot all hold. A division by "
-                    "a zero denominator or a value outside its range type does this.",
-                    translator.constraints[pre_constraint_count:],
-                ),
-            ]
-            for message, extra in authored:
-                for a in extra:
-                    layer.add(a)
-                if layer.check() == z3.unsat:
-                    return VerificationResult(
-                        name=fn_name,
-                        verified=False,
-                        status="failed",
-                        message=message,
-                        location=SourceLocation(self.filename, fn_form.line, fn_form.col)
-                    )
-            return VerificationResult(
-                name=fn_name,
-                verified=False,
-                status="unknown",
-                message=(
-                    "Verification context is inconsistent: the axioms generated for this "
-                    "function contradict each other, so nothing can be proved from them. "
-                    "This is a verifier defect, not a problem with the contract - please "
-                    "report it with the function body."
-                ),
-                location=SourceLocation(self.filename, fn_form.line, fn_form.col)
-            )
-
         # First try all postconditions together (fast path)
         solver.push()
         solver.add(z3.Not(z3.And(*post_z3)))
@@ -3155,6 +3166,15 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         solver.pop()
 
         if result == z3.unsat:
+            # Proved - but check the axioms were consistent before believing it.
+            inconsistent = self._inconsistent_context_result(
+                solver, translator, fn_name, fn_form,
+                pre_z3, preconditions, invariant_z3, range_field_axioms, assume_z3,
+                pre_constraint_count,
+            )
+            if inconsistent is not None:
+                return inconsistent
+
             # Postconditions always hold when preconditions are met
             # Now verify properties (universal assertions - independent of preconditions)
             if prop_z3:
@@ -3223,29 +3243,45 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
                     prop_str = pretty_print(prop_expr)
 
-                    # Vacuity guard (issue #115): the property solver carries a
+                    # Vacuity guard (issue #115). The property solver carries a
                     # different axiom subset from the postcondition solver, so it
-                    # needs its own consistency check. An unsat base context here
-                    # would make every property "hold" without being proved.
+                    # needs its own consistency check.
                     #
                     # Ahead of the emptiness short-circuit below: that path
                     # reports verified without consulting Z3 at all, so a
                     # property matching an emptiness axiom would otherwise be the
                     # one thing that can still pass on a contradictory context.
-                    if prop_solver.check() == z3.unsat:
-                        unknown_properties.append((prop_name, prop_str,
-                            "verification context is inconsistent (verifier defect)"))
-                        continue
+                    # Everything asserted so far is the axiom set; Not(prop)
+                    # goes on next. Kept aside so the consistency check below
+                    # can be run on the axioms alone without disturbing the
+                    # solver, whose stack the structural-vacuity branch reuses.
+                    prop_axioms = list(prop_solver.assertions())
 
-                    # Short-circuit: if pattern analysis already proves this property
-                    # (the axiom is structurally identical to the property), skip Z3.
+                    def _axioms_are_inconsistent():
+                        consistency = z3.Solver()
+                        consistency.set("timeout", self.timeout_ms)
+                        for a in prop_axioms:
+                            consistency.add(a)
+                        return consistency.check() == z3.unsat
+
                     if emptiness_verified:
+                        if _axioms_are_inconsistent():
+                            unknown_properties.append((prop_name, prop_str,
+                                "verification context is inconsistent (verifier defect)"))
                         continue
 
                     # Check if NOT property is satisfiable
                     prop_solver.add(z3.Not(prop_z3_expr))
 
                     prop_result = prop_solver.check()
+
+                    if prop_result == z3.unsat and _axioms_are_inconsistent():
+                        # Proved only because the axioms contradict each other.
+                        # Asked only of a proof: a sat result is itself a model
+                        # of the axioms, so it has already shown them consistent.
+                        unknown_properties.append((prop_name, prop_str,
+                            "verification context is inconsistent (verifier defect)"))
+                        continue
 
                     if prop_result == z3.sat:
                         model = prop_solver.model()
@@ -3375,18 +3411,26 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             else:
                 message = "Contract may be violated"
 
-            # Get counterexample from one more check
+            # Get counterexample from one more check.
+            #
+            # The same query said sat above, but this is a fresh solve on a
+            # solver that has since learned from other checks, and it can time
+            # out where the first did not. Asking an unknown solver for its
+            # model raises, which took down the whole file rather than one
+            # function - so a failure that cannot be illustrated is reported
+            # without an illustration.
             solver.push()
             solver.add(z3.Not(z3.And(*post_z3)))
-            solver.check()
-            model = solver.model()
+            counterexample_result = solver.check()
+            model = solver.model() if counterexample_result == z3.sat else None
             solver.pop()
 
             counterexample = {}
-            for decl in model.decls():
-                name = decl.name()
-                if not name.startswith('field_'):  # Skip internal functions
-                    counterexample[name] = str(model[decl])
+            if model is not None:
+                for decl in model.decls():
+                    name = decl.name()
+                    if not name.startswith('field_'):  # Skip internal functions
+                        counterexample[name] = str(model[decl])
 
             # Generate actionable suggestions for failed verification
             suggestions = self._generate_failure_suggestion(fn_form, fn_body)
@@ -3404,7 +3448,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 verified=False,
                 status="failed",
                 message=message,
-                counterexample=counterexample,
+                counterexample=counterexample or None,
                 location=SourceLocation(self.filename, fn_form.line, fn_form.col),
                 suggestions=suggestions if suggestions else None
             )

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -1265,6 +1265,25 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 location=SourceLocation(self.filename, fn_form.line, fn_form.col)
             )
 
+        # The assumptions are held back to the end, so that a contradiction
+        # they introduce is distinguishable from one already present without
+        # them - @assume is trusted, so one that the body refutes is the
+        # author's error rather than ours.
+        assumption_assertions = (
+            list(translator.constraints[assume_constraint_start:assume_constraint_end])
+            + list(assume_z3)
+        )
+
+        def _is_assumption(assertion) -> bool:
+            return any(z3.eq(assertion, a) for a in assumption_assertions)
+
+        # Everything else the main solver holds. Enumerating the kinds of axiom
+        # by hand does not work - Phase 3's record fields, Phase 4's union tags,
+        # the sequence identities and the rest are added straight to the solver -
+        # so take them from the solver itself. Re-adding assertions already in
+        # an earlier layer is harmless.
+        generated_axioms = [a for a in solver.assertions() if not _is_assumption(a)]
+
         authored = [
             (
                 self._unsatisfiable_precondition_message(preconditions),
@@ -1278,13 +1297,6 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 invariant_z3 + range_field_axioms,
             ),
             (
-                "Assumptions are contradictory: the @assume set cannot hold "
-                "together with the preconditions, so it would discharge any "
-                "postcondition. @assume is trusted, not checked - narrow it.",
-                list(translator.constraints[assume_constraint_start:assume_constraint_end])
-                + list(assume_z3),
-            ),
-            (
                 "A contract or body expression cannot be well-defined: the side "
                 "conditions from translating them cannot all hold. A division by "
                 "a zero denominator or a value outside its range type does this.",
@@ -1295,13 +1307,20 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 "The body cannot produce a value of the declared return type: "
                 "what it computes and what the type admits have no overlap. A "
                 "literal outside a range return type does this.",
-                body_equality,
+                list(body_equality) + list(result_length_axioms),
             ),
             (
-                "An assumption contradicts what the body does: @assume is "
-                "trusted, so an assumption the body already refutes would "
+                "Verification context is inconsistent: the axioms generated for this "
+                "function contradict each other, so nothing can be proved from them. "
+                "This is a verifier defect, not a problem with the contract - please "
+                "report it with the function body.",
+                generated_axioms,
+            ),
+            (
+                "An assumption contradicts the function: @assume is trusted, so "
+                "one that the body or the contract already refutes would "
                 "discharge any postcondition. Check it against the body.",
-                result_length_axioms,
+                assumption_assertions,
             ),
         ]
         for message, extra in authored:
@@ -1309,10 +1328,13 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 layer.add(a)
             outcome = layer.check()
             if outcome == z3.unsat:
+                # Only the verifier's own layer is our fault; the rest are the
+                # author's, and a contract that cannot hold is a failure.
+                ours = message.startswith("Verification context is inconsistent")
                 return VerificationResult(
                     name=fn_name,
                     verified=False,
-                    status="failed",
+                    status="unknown" if ours else "failed",
                     message=message,
                     location=SourceLocation(self.filename, fn_form.line, fn_form.col)
                 )
@@ -1333,6 +1355,9 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     location=SourceLocation(self.filename, fn_form.line, fn_form.col)
                 )
 
+        # Unreachable in principle - the last layer holds everything the main
+        # solver does, and that is unsat by hypothesis - but a layer's check can
+        # come back undecided, and saying so beats asserting a cause.
         return VerificationResult(
             name=fn_name,
             verified=False,

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -2917,8 +2917,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # This used to assert a flat field_len($result) == 0 whenever the body
         # bound a list with (mut r (list-new ...)), ignoring every push, which
         # contradicted the push-count axiom in Phase 7 - issue #115.
-        if fn_body is not None and self._is_list_new(fn_body):
-            if translator.use_array_encoding:
+        if fn_body is not None:
+            if translator.use_array_encoding and self._is_list_new(fn_body):
                 # Array encoding needs the representation to exist; the length
                 # claim itself comes from _result_length_axioms below.
                 translator._create_list_array('$result')

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -1168,6 +1168,21 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             return self._get_return_expr(expr.items[-1])
         return expr
 
+    def _unsatisfiable_precondition_message(
+        self, preconditions: List[Tuple[Optional[str], SExpr]]
+    ) -> str:
+        """Message for a @pre set that no input can satisfy, naming each one."""
+        from slop.parser import pretty_print
+        if not preconditions:
+            return "Preconditions are unsatisfiable"
+        details = []
+        for pre_name, pre_expr in preconditions:
+            pre_str = pretty_print(pre_expr)
+            details.append(f"'{pre_name}': {pre_str}" if pre_name else pre_str)
+        if len(details) == 1:
+            return f"Precondition is unsatisfiable: {details[0]}"
+        return "Preconditions are unsatisfiable:\n" + "\n".join(f"  • {d}" for d in details)
+
     def _propagate_properties_as_loop_invariants(
         self, fn_body: SExpr, properties: List[Tuple[Optional[str], SExpr]]
     ) -> List[SExpr]:
@@ -1500,8 +1515,15 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                         # Translate the pushed item
                         item_z3 = translator.translate_expr(item_expr)
                         if item_z3 is not None:
-                            # After push: length increases by 1
-                            axioms.append(length >= 1)
+                            # A push only raises the lower bound if it is
+                            # actually taken: one guarded by a when/if or sitting
+                            # in a match arm may not be, and one inside a loop
+                            # over an empty collection runs zero times. An
+                            # unconditional `length >= 1` here was the same
+                            # unsound shape as issue #115.
+                            taken = self._unconditional_push_count(body, lst_name)
+                            if taken >= 1:
+                                axioms.append(length >= taken)
 
                             # Key axiom for element properties:
                             # The pushed element exists somewhere in the array
@@ -1540,100 +1562,53 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                             # This works because all elements are pushed with type-pred
                             continue  # Use fallback axioms for length tracking
 
-            # Fallback: length-based axioms
-            # Get or create the field_len function
-            func_name = "field_len"
-            if func_name not in translator.variables:
-                func = z3.Function(func_name, z3.IntSort(), z3.IntSort())
-                translator.variables[func_name] = func
-            else:
-                func = translator.variables[func_name]
+            # Fallback: nothing sound to say about this list's length here.
+            #
+            # This used to introduce a fresh _list_pre_len_N with
+            #   pre_len == field_len(lst); post_len == pre_len + 1; post_len >= 1
+            # Nothing ever read post_len, and pre_len was fresh, so the three
+            # together said only field_len(lst) >= 0 - which the translator
+            # already asserts. The length of the *returned* list is derived
+            # from its push sites by _result_length_axioms, which is the only
+            # place that knows which pushes are conditional or in a loop.
+            #
+            # A push through an alias, e.g. (list-push (. c items) x), cannot be
+            # expressed at all while field_len is a function of the handle: the
+            # pushed-to list keeps its identity, so its pre- and post-lengths
+            # would have to be two values of one term.
+            pass
 
-            # Create a "pre-push length" variable for tracking
-            pre_len_name = f"_list_pre_len_{id(list_expr)}"
-            if pre_len_name not in translator.variables:
-                pre_len = z3.Int(pre_len_name)
-                translator.variables[pre_len_name] = pre_len
-
-                # The pre-push length equals what field_len returns for the list
-                axioms.append(pre_len == func(lst_z3))
-
-                # After the push, the length is pre_len + 1
-                # We need to constrain future references to this list's length
-                # Create a "post-push" marker
-                post_len_name = f"_list_post_len_{id(list_expr)}"
-                post_len = z3.Int(post_len_name)
-                translator.variables[post_len_name] = post_len
-                axioms.append(post_len == pre_len + 1)
-                axioms.append(post_len >= 1)  # After push, length is at least 1
-
-        # Connect returned list to $result
-        # If the function returns a list variable that had push called on it,
-        # add axiom: field_len($result) >= number_of_pushes
-        result_var = translator.variables.get('$result')
-        if result_var is not None and push_calls:
-            # Find the return expression
-            return_expr = self._get_return_expr(body)
-            if isinstance(return_expr, Symbol):
-                # Check if this variable had push calls
-                for list_expr, _ in push_calls:
-                    if isinstance(list_expr, Symbol) and list_expr.name == return_expr.name:
-                        # The returned variable is the one we pushed to
-                        func_name = "field_len"
-                        if func_name in translator.variables:
-                            func = translator.variables[func_name]
-                            # Count pushes to this list
-                            push_count = sum(
-                                1 for lst, _ in push_calls
-                                if isinstance(lst, Symbol) and lst.name == return_expr.name
-                            )
-                            # $result is the list after all pushes, so length >= push_count
-                            axioms.append(func(result_var) >= push_count)
-
-            elif isinstance(return_expr, SList) and is_form(return_expr, 'record-new'):
-                # record-new return: connect field-pushed lists to $result fields
-                # For (record-new Type (field1 val1) (field2 val2) ...),
-                # check if any field value matches a push target.
-                # If so: field_len(field_X($result)) == field_len(push_target) + push_count
-                from slop.parser import pretty_print
-                func_name = "field_len"
-                if func_name not in translator.variables:
-                    func = z3.Function(func_name, z3.IntSort(), z3.IntSort())
-                    translator.variables[func_name] = func
-                else:
-                    func = translator.variables[func_name]
-
-                # Build a map of push target repr -> count
-                push_target_counts: Dict[str, int] = {}
-                push_target_exprs: Dict[str, SExpr] = {}
-                for list_expr, _ in push_calls:
-                    key = pretty_print(list_expr)
-                    push_target_counts[key] = push_target_counts.get(key, 0) + 1
-                    push_target_exprs[key] = list_expr
-
-                for field_pair in return_expr.items[2:]:  # Skip 'record-new' and TypeName
-                    if isinstance(field_pair, SList) and len(field_pair) >= 2:
-                        field_name_sym = field_pair[0]
-                        field_value = field_pair[1]
-                        if isinstance(field_name_sym, Symbol):
-                            field_value_str = pretty_print(field_value)
-                            if field_value_str in push_target_counts:
-                                # This field references a list that was pushed to
-                                field_name = field_name_sym.name
-                                accessor_name = f"field_{field_name}"
-                                if accessor_name not in translator.variables:
-                                    accessor = z3.Function(accessor_name, z3.IntSort(), z3.IntSort())
-                                    translator.variables[accessor_name] = accessor
-                                else:
-                                    accessor = translator.variables[accessor_name]
-
-                                push_count = push_target_counts[field_value_str]
-                                lst_z3 = translator.translate_expr(push_target_exprs[field_value_str])
-                                if lst_z3 is not None:
-                                    # field_len(field_X($result)) == field_len(push_target) + push_count
-                                    axioms.append(func(accessor(result_var)) == func(lst_z3) + push_count)
+        # Nothing is asserted here about the length of the returned list.
+        #
+        # Two axioms used to be, and both were unsound (issue #115):
+        #
+        #   field_len($result) >= push_count
+        #     wrong whenever a push is conditional or inside a loop that may
+        #     run zero times, and it contradicted the flat field_len == 0 that
+        #     Phase 3.5 derived from the (mut r (list-new ...)) binding.
+        #     _result_length_axioms now derives one bound from the push sites.
+        #
+        #   field_len(field_X($result)) == field_len(push_target) + push_count
+        #     emitted when a record field held the pushed-to list. It fired
+        #     only when the field value *was* the push target, and in exactly
+        #     that case Phase 3 has already asserted
+        #     field_X($result) == push_target - so the pair reads X == X + 1.
+        #     push mutates the list in place; with field_len a function of the
+        #     handle there is no second term to carry the pre-push length.
 
         return axioms
+
+    def _unconditional_push_count(self, body: SExpr, list_name: str) -> int:
+        """How many pushes to `list_name` are certain to happen exactly once.
+
+        Sites under a when/if guard or inside a match arm may not run, and
+        sites inside a loop run an unknown number of times, so neither
+        contributes to a lower bound on the length.
+        """
+        return sum(
+            1 for site in self._collect_push_sites([body], list_name)
+            if site.loop_depth == 0 and not site.guard_conditions and not site.in_match_arm
+        )
 
     def _extract_conditional_record_axioms(self, cond_expr: SList, translator: Z3Translator) -> List:
         """Extract axioms for conditional with record-new in either branch.
@@ -1965,38 +1940,6 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                                             field_val[1], translator, base_accessor=payload_func(field_func)
                                         )
                                         axioms.extend(nested)
-        return axioms
-
-    def _extract_list_new_axioms(self, list_new_expr: SList, translator: Z3Translator) -> List:
-        """Extract axiom: field_len($result) == 0 for list-new
-
-        When list-new is called, the resulting list has length 0.
-        This allows proving postconditions like {(list-len $result) == 0}.
-
-        With array encoding enabled, also sets up the array representation.
-        """
-        axioms = []
-        result_var = translator.variables.get('$result')
-        if result_var is None:
-            return axioms
-
-        # With array encoding, set up array for $result
-        if translator.use_array_encoding:
-            arr, length = translator._create_list_array('$result')
-            # Empty list: length == 0
-            axioms.append(length == z3.IntVal(0))
-            return axioms
-
-        # Get or create field_len function (fallback for non-array encoding)
-        func_name = "field_len"
-        if func_name not in translator.variables:
-            func = z3.Function(func_name, z3.IntSort(), z3.IntSort())
-            translator.variables[func_name] = func
-        else:
-            func = translator.variables[func_name]
-
-        # list-new returns empty list: len == 0
-        axioms.append(func(result_var) == z3.IntVal(0))
         return axioms
 
     def _extract_record_field_range_axioms(self, translator: Z3Translator) -> List:
@@ -2649,27 +2592,11 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
             result = solver.check()
             if result == z3.unsat:
-                # Build message with precondition names/details
-                from slop.parser import pretty_print
-                if preconditions:
-                    pre_details = []
-                    for pre_name, pre_expr in preconditions:
-                        pre_str = pretty_print(pre_expr)
-                        if pre_name:
-                            pre_details.append(f"'{pre_name}': {pre_str}")
-                        else:
-                            pre_details.append(pre_str)
-                    if len(preconditions) == 1:
-                        message = f"Precondition is unsatisfiable: {pre_details[0]}"
-                    else:
-                        message = "Preconditions are unsatisfiable:\n" + "\n".join(f"  • {p}" for p in pre_details)
-                else:
-                    message = "Preconditions are unsatisfiable"
                 return VerificationResult(
                     name=fn_name,
                     verified=False,
                     status="failed",
-                    message=message,
+                    message=self._unsatisfiable_precondition_message(preconditions),
                     location=SourceLocation(self.filename, fn_form.line, fn_form.col)
                 )
             return VerificationResult(
@@ -2743,12 +2670,16 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             for axiom in field_axioms:
                 solver.add(axiom)
 
-        # Phase 3.5: Add list-new axioms if body is list-new
-        # For (list-new arena Type), add: field_len($result) == 0
+        # Phase 3.5: Length of a returned list, derived from its push sites.
+        # This used to assert a flat field_len($result) == 0 whenever the body
+        # bound a list with (mut r (list-new ...)), ignoring every push, which
+        # contradicted the push-count axiom in Phase 7 - issue #115.
         if fn_body is not None and self._is_list_new(fn_body):
-            return_expr = self._get_return_expr(fn_body)
-            list_axioms = self._extract_list_new_axioms(return_expr, translator)
-            for axiom in list_axioms:
+            if translator.use_array_encoding:
+                # Array encoding needs the representation to exist; the length
+                # claim itself comes from _result_length_axioms below.
+                translator._create_list_array('$result')
+            for axiom in self._result_length_axioms(fn_body, translator):
                 solver.add(axiom)
 
         # Phase 4: Add union tag axiom if body is union-new
@@ -3095,6 +3026,76 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     # WP computation failed - continue with standard verification
                     pass
 
+        # Under Seq encoding the returned local and $result get separate Seq
+        # constants, so a fact about one is invisible to the other. The property
+        # solver below already equates them; the postcondition solver needs it
+        # too, or a @loop-invariant stated about the local proves nothing about
+        # the result.
+        if fn_body is not None and translator.use_seq_encoding:
+            ret_expr = self._get_return_expr(fn_body)
+            if isinstance(ret_expr, Symbol):
+                result_seq = translator.list_seqs.get('$result')
+                ret_seq = translator.list_seqs.get(ret_expr.name)
+                if (result_seq is not None and ret_seq is not None
+                        and not z3.eq(result_seq, ret_seq)):
+                    solver.add(result_seq == ret_seq)
+
+        # Vacuity guard (issue #115)
+        #
+        # Every postcondition below is discharged by asking whether
+        # (axioms AND NOT post) is satisfiable. If the axioms alone are already
+        # unsatisfiable that question answers "no" for *any* post, so every
+        # contract on this function reports verified without having been proved.
+        # Two different things make the base context unsat and they need
+        # different messages: an unsatisfiable @pre, which is the caller
+        # contract being impossible, and axioms we generated that contradict
+        # each other, which is a defect in this verifier.
+        if solver.check() == z3.unsat:
+            # Narrow it down: the @pre set alone, then @pre plus @assume, then
+            # everything. The first two are the author's own contracts being
+            # impossible and are reported as such; only what is left over is
+            # ours.
+            layer = z3.Solver()
+            layer.set("timeout", self.timeout_ms)
+            for c in translator.constraints:
+                layer.add(c)
+            for p in pre_z3:
+                layer.add(p)
+            if layer.check() == z3.unsat:
+                return VerificationResult(
+                    name=fn_name,
+                    verified=False,
+                    status="failed",
+                    message=self._unsatisfiable_precondition_message(preconditions),
+                    location=SourceLocation(self.filename, fn_form.line, fn_form.col)
+                )
+            for a in assume_z3:
+                layer.add(a)
+            if layer.check() == z3.unsat:
+                return VerificationResult(
+                    name=fn_name,
+                    verified=False,
+                    status="failed",
+                    message=(
+                        "Assumptions are contradictory: the @assume set cannot hold "
+                        "together with the preconditions, so it would discharge any "
+                        "postcondition. @assume is trusted, not checked - narrow it."
+                    ),
+                    location=SourceLocation(self.filename, fn_form.line, fn_form.col)
+                )
+            return VerificationResult(
+                name=fn_name,
+                verified=False,
+                status="unknown",
+                message=(
+                    "Verification context is inconsistent: the axioms generated for this "
+                    "function contradict each other, so nothing can be proved from them. "
+                    "This is a verifier defect, not a problem with the contract - please "
+                    "report it with the function body."
+                ),
+                location=SourceLocation(self.filename, fn_form.line, fn_form.col)
+            )
+
         # First try all postconditions together (fast path)
         solver.push()
         solver.add(z3.Not(z3.And(*post_z3)))
@@ -3178,12 +3179,21 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     if emptiness_verified:
                         continue
 
+                    prop_str = pretty_print(prop_expr)
+
+                    # Vacuity guard (issue #115): the property solver carries a
+                    # different axiom subset from the postcondition solver, so it
+                    # needs its own consistency check. An unsat base context here
+                    # would make every property "hold" without being proved.
+                    if prop_solver.check() == z3.unsat:
+                        unknown_properties.append((prop_name, prop_str,
+                            "verification context is inconsistent (verifier defect)"))
+                        continue
+
                     # Check if NOT property is satisfiable
                     prop_solver.add(z3.Not(prop_z3_expr))
 
                     prop_result = prop_solver.check()
-
-                    prop_str = pretty_print(prop_expr)
 
                     if prop_result == z3.sat:
                         model = prop_solver.model()

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -1168,6 +1168,53 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             return self._get_return_expr(expr.items[-1])
         return expr
 
+    @staticmethod
+    def _contains_quantifier(expr) -> bool:
+        """True if `expr` has a ForAll or Exists anywhere inside it."""
+        stack = [expr]
+        while stack:
+            node = stack.pop()
+            if z3.is_quantifier(node):
+                return True
+            if z3.is_app(node):
+                stack.extend(node.children())
+        return False
+
+    def _axioms_are_contradictory(self, assertions) -> bool:
+        """True if this axiom set is unsatisfiable, so nothing follows from it.
+
+        Deciding it outright is the expensive direction - a consistent set means
+        Z3 has to produce a model, and with quantified sequence axioms it often
+        cannot inside the timeout. When that happens, fall back to the ground
+        fragment: dropping assertions can only make a set easier to satisfy, so
+        an unsatisfiable ground subset proves the whole set unsatisfiable, and
+        the ground fragment is cheap to decide.
+
+        That leaves one gap, stated rather than hidden: a contradiction that
+        needs a quantified axiom to derive, in a set Z3 cannot settle in time,
+        is not caught. Every contradiction seen in practice has been ground -
+        two conflicting claims about the same length - and unsatisfiability is
+        the direction Z3 answers quickly, so a timeout here almost always means
+        satisfiable-but-hard rather than contradictory.
+        """
+        assertions = list(assertions)
+        solver = z3.Solver()
+        solver.set("timeout", self.timeout_ms)
+        for a in assertions:
+            solver.add(a)
+        outcome = solver.check()
+        if outcome != z3.unknown:
+            return outcome == z3.unsat
+
+        ground = [a for a in assertions if not self._contains_quantifier(a)]
+        if len(ground) == len(assertions):
+            return False
+        ground_solver = z3.Solver()
+        ground_solver.set("timeout", self.timeout_ms)
+        for a in ground:
+            ground_solver.add(a)
+        return ground_solver.check() == z3.unsat
+
     def _inconsistent_context_result(
         self, solver, translator, fn_name, fn_form,
         pre_z3, preconditions, invariant_z3, range_field_axioms, assume_z3,
@@ -1189,7 +1236,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         tips it over names the cause. Three of them are the author's contract;
         only what survives all three is ours.
         """
-        if solver.check() != z3.unsat:
+        if not self._axioms_are_contradictory(solver.assertions()):
             return None
 
         layer = z3.Solver()
@@ -3257,15 +3304,9 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     # solver, whose stack the structural-vacuity branch reuses.
                     prop_axioms = list(prop_solver.assertions())
 
-                    def _axioms_are_inconsistent():
-                        consistency = z3.Solver()
-                        consistency.set("timeout", self.timeout_ms)
-                        for a in prop_axioms:
-                            consistency.add(a)
-                        return consistency.check() == z3.unsat
 
                     if emptiness_verified:
-                        if _axioms_are_inconsistent():
+                        if self._axioms_are_contradictory(prop_axioms):
                             unknown_properties.append((prop_name, prop_str,
                                 "verification context is inconsistent (verifier defect)"))
                         continue
@@ -3275,13 +3316,13 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
                     prop_result = prop_solver.check()
 
-                    if prop_result == z3.unsat and _axioms_are_inconsistent():
-                        # Proved only because the axioms contradict each other.
+                    if prop_result == z3.unsat:
                         # Asked only of a proof: a sat result is itself a model
                         # of the axioms, so it has already shown them consistent.
-                        unknown_properties.append((prop_name, prop_str,
-                            "verification context is inconsistent (verifier defect)"))
-                        continue
+                        if self._axioms_are_contradictory(prop_axioms):
+                            unknown_properties.append((prop_name, prop_str,
+                                "verification context is inconsistent (verifier defect)"))
+                            continue
 
                     if prop_result == z3.sat:
                         model = prop_solver.model()

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -2480,6 +2480,14 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             else:
                 failed_pres.append((pre_name, pre_expr))
 
+        # Everything in translator.constraints so far belongs to the parameter
+        # declarations and the preconditions. Translating postconditions and the
+        # body appends more - a division adds its own non-zero side condition,
+        # for one - and replaying the whole list when diagnosing an
+        # unsatisfiable @pre would blame the preconditions for a contradiction
+        # that came from a postcondition.
+        pre_constraint_count = len(translator.constraints)
+
         # Translate postconditions
         post_z3: List[z3.BoolRef] = []
         failed_posts: List[SExpr] = []
@@ -2651,10 +2659,13 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # For (type T (record ...) (@invariant cond)), when param has type T,
         # add cond substituted with param.field references
         param_invariants = self._collect_parameter_invariants(params)
+        invariant_z3: List[z3.BoolRef] = []
         for param_name, inv_expr in param_invariants:
             inv_z3 = translator.translate_expr(inv_expr)
             if inv_z3 is not None:
-                solver.add(self._ensure_bool(inv_z3))
+                inv_bool = self._ensure_bool(inv_z3)
+                solver.add(inv_bool)
+                invariant_z3.append(inv_bool)
 
         # Phase 1b: Add range type axioms for record fields
         # For record types with range-typed fields like (inferred-count (Int 0 ..)),
@@ -3069,38 +3080,48 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # contract being impossible, and axioms we generated that contradict
         # each other, which is a defect in this verifier.
         if solver.check() == z3.unsat:
-            # Narrow it down: the @pre set alone, then @pre plus @assume, then
-            # everything. The first two are the author's own contracts being
-            # impossible and are reported as such; only what is left over is
-            # ours.
+            # Narrow it down, adding one authored layer at a time: the @pre set,
+            # then the parameters' type invariants, then @assume. Each of those
+            # is the author's own contract being impossible and is reported as
+            # such; only a contradiction that survives all three is ours.
             layer = z3.Solver()
             layer.set("timeout", self.timeout_ms)
-            for c in translator.constraints:
+            for c in translator.constraints[:pre_constraint_count]:
                 layer.add(c)
             for p in pre_z3:
                 layer.add(p)
-            if layer.check() == z3.unsat:
-                return VerificationResult(
-                    name=fn_name,
-                    verified=False,
-                    status="failed",
-                    message=self._unsatisfiable_precondition_message(preconditions),
-                    location=SourceLocation(self.filename, fn_form.line, fn_form.col)
-                )
-            for a in assume_z3:
-                layer.add(a)
-            if layer.check() == z3.unsat:
-                return VerificationResult(
-                    name=fn_name,
-                    verified=False,
-                    status="failed",
-                    message=(
-                        "Assumptions are contradictory: the @assume set cannot hold "
-                        "together with the preconditions, so it would discharge any "
-                        "postcondition. @assume is trusted, not checked - narrow it."
-                    ),
-                    location=SourceLocation(self.filename, fn_form.line, fn_form.col)
-                )
+            authored = [
+                (self._unsatisfiable_precondition_message(preconditions), []),
+                (
+                    "Type invariants are contradictory: no value of the parameter "
+                    "types can satisfy them together with the preconditions, so the "
+                    "function has no legal input.",
+                    invariant_z3,
+                ),
+                (
+                    "Assumptions are contradictory: the @assume set cannot hold "
+                    "together with the preconditions, so it would discharge any "
+                    "postcondition. @assume is trusted, not checked - narrow it.",
+                    assume_z3,
+                ),
+                (
+                    "A contract or body expression cannot be well-defined: the side "
+                    "conditions from translating them cannot all hold. A division by "
+                    "a zero denominator or a value outside its range type does this.",
+                    translator.constraints[pre_constraint_count:],
+                ),
+            ]
+            for message, extra in authored:
+                for a in extra:
+                    layer.add(a)
+                if layer.check() == z3.unsat:
+                    return VerificationResult(
+                        name=fn_name,
+                        verified=False,
+                        status="failed",
+                        message=message,
+                        location=SourceLocation(self.filename, fn_form.line, fn_form.col)
+                    )
             return VerificationResult(
                 name=fn_name,
                 verified=False,

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -1607,7 +1607,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         """
         return sum(
             1 for site in self._collect_push_sites([body], list_name)
-            if site.loop_depth == 0 and not site.guard_conditions and not site.in_match_arm
+            if site.loop_depth == 0 and not site.guard_conditions and not site.conditional
         )
 
     def _extract_conditional_record_axioms(self, cond_expr: SList, translator: Z3Translator) -> List:

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -1598,6 +1598,29 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         return axioms
 
+    def _result_sequence_equality(self, fn_body: SExpr,
+                                  translator: Z3Translator) -> List:
+        """Equate $result's Seq with the returned local's, when they must agree.
+
+        Under Seq encoding the two get separate constants, so a @loop-invariant
+        stated about the local proves nothing about the result unless they are
+        tied together.
+
+        Withheld when the body contains an explicit (return ...):
+        _get_return_expr only sees the trailing expression, and equating
+        $result with it would claim the other exit cannot happen.
+        """
+        if self._contains_any_form(fn_body, ('return',)):
+            return []
+        ret_expr = self._get_return_expr(fn_body)
+        if not isinstance(ret_expr, Symbol):
+            return []
+        result_seq = translator.list_seqs.get('$result')
+        ret_seq = translator.list_seqs.get(ret_expr.name)
+        if result_seq is None or ret_seq is None or z3.eq(result_seq, ret_seq):
+            return []
+        return [result_seq == ret_seq]
+
     def _unconditional_push_count(self, body: SExpr, list_name: str) -> int:
         """How many pushes to `list_name` are certain to happen exactly once.
 
@@ -3032,13 +3055,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # too, or a @loop-invariant stated about the local proves nothing about
         # the result.
         if fn_body is not None and translator.use_seq_encoding:
-            ret_expr = self._get_return_expr(fn_body)
-            if isinstance(ret_expr, Symbol):
-                result_seq = translator.list_seqs.get('$result')
-                ret_seq = translator.list_seqs.get(ret_expr.name)
-                if (result_seq is not None and ret_seq is not None
-                        and not z3.eq(result_seq, ret_seq)):
-                    solver.add(result_seq == ret_seq)
+            for equality in self._result_sequence_equality(fn_body, translator):
+                solver.add(equality)
 
         # Vacuity guard (issue #115)
         #
@@ -3127,13 +3145,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     # Loop invariants reference the local variable (e.g., 'result'),
                     # while properties reference '$result' - these are different Z3 seqs
                     if fn_body is not None and translator.use_seq_encoding:
-                        return_expr = self._get_return_expr(fn_body)
-                        if isinstance(return_expr, Symbol):
-                            ret_name = return_expr.name
-                            result_seq = translator.list_seqs.get('$result')
-                            ret_seq = translator.list_seqs.get(ret_name)
-                            if result_seq is not None and ret_seq is not None and not z3.eq(result_seq, ret_seq):
-                                prop_solver.add(result_seq == ret_seq)
+                        for equality in self._result_sequence_equality(fn_body, translator):
+                            prop_solver.add(equality)
 
                     # Add pattern axioms (filter/map/fold axioms derived from loop analysis)
                     # These are needed for properties that reason about collection contents

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -1224,6 +1224,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         pre_z3, preconditions, invariant_z3, range_field_axioms, assume_z3,
         type_constraint_count, pre_constraint_count,
         assume_constraint_start, assume_constraint_end, body_equality,
+        result_length_axioms,
     ):
         """A result to report when the axioms contradict each other, else None.
 
@@ -1295,6 +1296,12 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 "what it computes and what the type admits have no overlap. A "
                 "literal outside a range return type does this.",
                 body_equality,
+            ),
+            (
+                "An assumption contradicts what the body does: @assume is "
+                "trusted, so an assumption the body already refutes would "
+                "discharge any postcondition. Check it against the body.",
+                result_length_axioms,
             ),
         ]
         for message, extra in authored:
@@ -2881,6 +2888,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 solver.add(axiom)
 
         # Phase 3.5: Length of a returned list, derived from its push sites.
+        result_length_axioms: List[z3.BoolRef] = []
         # This used to assert a flat field_len($result) == 0 whenever the body
         # bound a list with (mut r (list-new ...)), ignoring every push, which
         # contradicted the push-count axiom in Phase 7 - issue #115.
@@ -2889,7 +2897,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 # Array encoding needs the representation to exist; the length
                 # claim itself comes from _result_length_axioms below.
                 translator._create_list_array('$result')
-            for axiom in self._result_length_axioms(fn_body, translator):
+            result_length_axioms = self._result_length_axioms(fn_body, translator)
+            for axiom in result_length_axioms:
                 solver.add(axiom)
 
         # Phase 4: Add union tag axiom if body is union-new
@@ -3258,6 +3267,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 pre_z3, preconditions, invariant_z3, range_field_axioms, assume_z3,
                 type_constraint_count, pre_constraint_count,
                 assume_constraint_start, assume_constraint_end, body_equality,
+                result_length_axioms,
             )
             if inconsistent is not None:
                 return inconsistent

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -1218,7 +1218,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
     def _inconsistent_context_result(
         self, solver, translator, fn_name, fn_form,
         pre_z3, preconditions, invariant_z3, range_field_axioms, assume_z3,
-        pre_constraint_count,
+        type_constraint_count, pre_constraint_count, body_equality,
     ):
         """A result to report when the axioms contradict each other, else None.
 
@@ -1241,7 +1241,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         layer = z3.Solver()
         layer.set("timeout", self.timeout_ms)
-        for c in translator.constraints[:pre_constraint_count]:
+        for c in translator.constraints[:type_constraint_count]:
             layer.add(c)
 
         if layer.check() == z3.unsat:
@@ -1260,7 +1260,11 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             )
 
         authored = [
-            (self._unsatisfiable_precondition_message(preconditions), pre_z3),
+            (
+                self._unsatisfiable_precondition_message(preconditions),
+                list(translator.constraints[type_constraint_count:pre_constraint_count])
+                + list(pre_z3),
+            ),
             (
                 "Type invariants are contradictory: no value of the parameter "
                 "types can satisfy them together with the preconditions, so the "
@@ -1277,7 +1281,13 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 "A contract or body expression cannot be well-defined: the side "
                 "conditions from translating them cannot all hold. A division by "
                 "a zero denominator or a value outside its range type does this.",
-                translator.constraints[pre_constraint_count:],
+                list(translator.constraints[pre_constraint_count:]),
+            ),
+            (
+                "The body cannot produce a value of the declared return type: "
+                "what it computes and what the type admits have no overlap. A "
+                "literal outside a range return type does this.",
+                body_equality,
             ),
         ]
         for message, extra in authored:
@@ -2607,6 +2617,13 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             elif self._references_result_collection(postconditions) or self._references_result_collection(property_exprs):
                 translator._create_list_seq('$result')
 
+        # Everything in translator.constraints up to here comes from declaring
+        # the parameters and $result. Each later phase appends its own side
+        # conditions - a division adds a non-zero denominator, a range type adds
+        # its bounds - so the diagnosis below can only attribute a contradiction
+        # correctly if it knows where each phase's constraints begin.
+        type_constraint_count = len(translator.constraints)
+
         # Translate preconditions
         pre_z3: List[z3.BoolRef] = []
         failed_pres: List[Tuple[Optional[str], SExpr]] = []
@@ -2617,12 +2634,6 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             else:
                 failed_pres.append((pre_name, pre_expr))
 
-        # Everything in translator.constraints so far belongs to the parameter
-        # declarations and the preconditions. Translating postconditions and the
-        # body appends more - a division adds its own non-zero side condition,
-        # for one - and replaying the whole list when diagnosing an
-        # unsatisfiable @pre would blame the preconditions for a contradiction
-        # that came from a postcondition.
         pre_constraint_count = len(translator.constraints)
 
         # Translate postconditions
@@ -2813,10 +2824,12 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         # Add body constraint for path-sensitive analysis
         # This constrains $result to equal the translated function body
+        body_equality: List[z3.BoolRef] = []
         if body_z3 is not None:
             result_var = translator.variables.get('$result')
             if result_var is not None:
-                solver.add(result_var == body_z3)
+                body_equality.append(result_var == body_z3)
+                solver.add(body_equality[0])
 
         # Phase 2: Add reflexivity axioms for equality functions
         # For any function ending in -eq, add axiom: fn_eq(x, x) == true
@@ -3217,7 +3230,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             inconsistent = self._inconsistent_context_result(
                 solver, translator, fn_name, fn_form,
                 pre_z3, preconditions, invariant_z3, range_field_axioms, assume_z3,
-                pre_constraint_count,
+                type_constraint_count, pre_constraint_count, body_equality,
             )
             if inconsistent is not None:
                 return inconsistent

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -1222,7 +1222,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
     def _inconsistent_context_result(
         self, solver, translator, fn_name, fn_form,
         pre_z3, preconditions, invariant_z3, range_field_axioms, assume_z3,
-        type_constraint_count, pre_constraint_count, body_equality,
+        type_constraint_count, pre_constraint_count,
+        assume_constraint_start, assume_constraint_end, body_equality,
     ):
         """A result to report when the axioms contradict each other, else None.
 
@@ -1279,13 +1280,15 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 "Assumptions are contradictory: the @assume set cannot hold "
                 "together with the preconditions, so it would discharge any "
                 "postcondition. @assume is trusted, not checked - narrow it.",
-                assume_z3,
+                list(translator.constraints[assume_constraint_start:assume_constraint_end])
+                + list(assume_z3),
             ),
             (
                 "A contract or body expression cannot be well-defined: the side "
                 "conditions from translating them cannot all hold. A division by "
                 "a zero denominator or a value outside its range type does this.",
-                list(translator.constraints[pre_constraint_count:]),
+                list(translator.constraints[pre_constraint_count:assume_constraint_start])
+                + list(translator.constraints[assume_constraint_end:]),
             ),
             (
                 "The body cannot produce a value of the declared return type: "
@@ -2677,6 +2680,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             # This enables path-sensitive reasoning through conditionals
 
         # Translate assumptions (trusted axioms) - AFTER body so local vars are declared
+        assume_constraint_start = len(translator.constraints)
         assume_z3: List[z3.BoolRef] = []
         failed_assumes: List[SExpr] = []
         for assume in assumptions:
@@ -2685,6 +2689,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 assume_z3.append(self._ensure_bool(z3_assume))
             else:
                 failed_assumes.append(assume)
+        assume_constraint_end = len(translator.constraints)
 
         # Translate properties (universal assertions)
         # properties is List[Tuple[Optional[str], SExpr]] - (name, expr) tuples
@@ -3251,7 +3256,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             inconsistent = self._inconsistent_context_result(
                 solver, translator, fn_name, fn_form,
                 pre_z3, preconditions, invariant_z3, range_field_axioms, assume_z3,
-                type_constraint_count, pre_constraint_count, body_equality,
+                type_constraint_count, pre_constraint_count,
+                assume_constraint_start, assume_constraint_end, body_equality,
             )
             if inconsistent is not None:
                 return inconsistent

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -3187,20 +3187,25 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                         if result_var is not None:
                             prop_solver.add(result_var == body_z3)
 
-                    # Short-circuit: if pattern analysis already proves this property
-                    # (the axiom is structurally identical to the property), skip Z3.
-                    if emptiness_verified:
-                        continue
-
                     prop_str = pretty_print(prop_expr)
 
                     # Vacuity guard (issue #115): the property solver carries a
                     # different axiom subset from the postcondition solver, so it
                     # needs its own consistency check. An unsat base context here
                     # would make every property "hold" without being proved.
+                    #
+                    # Ahead of the emptiness short-circuit below: that path
+                    # reports verified without consulting Z3 at all, so a
+                    # property matching an emptiness axiom would otherwise be the
+                    # one thing that can still pass on a contradictory context.
                     if prop_solver.check() == z3.unsat:
                         unknown_properties.append((prop_name, prop_str,
                             "verification context is inconsistent (verifier defect)"))
+                        continue
+
+                    # Short-circuit: if pattern analysis already proves this property
+                    # (the axiom is structurally identical to the property), skip Z3.
+                    if emptiness_verified:
                         continue
 
                     # Check if NOT property is satisfiable

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -2922,7 +2922,14 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 # Array encoding needs the representation to exist; the length
                 # claim itself comes from _result_length_axioms below.
                 translator._create_list_array('$result')
-            result_length_axioms = self._result_length_axioms(fn_body, translator)
+            # A multi-form body keeps only its last expression in fn_body, so a
+            # push in an earlier form would be invisible to the push scan and
+            # the result would look shorter than it is.
+            whole_body = fn_body
+            if all_body_exprs and len(all_body_exprs) > 1:
+                whole_body = SList([Symbol('do')] + list(all_body_exprs),
+                                   fn_body.line, fn_body.col)
+            result_length_axioms = self._result_length_axioms(whole_body, translator)
             for axiom in result_length_axioms:
                 solver.add(axiom)
 

--- a/src/slop/verifier/loop_patterns.py
+++ b/src/slop/verifier/loop_patterns.py
@@ -37,6 +37,8 @@ class PushSiteInfo:
     pushed_expr: 'SExpr'                # The expression being pushed
     guard_conditions: List['SExpr']     # Enclosing when/if conditions (innermost last)
     bindings: Dict[str, 'SExpr']        # Variable bindings in scope at this push
+    in_match_arm: bool = False          # Inside a match clause, so not always taken
+    loop_depth: int = 0                 # Enclosing while/for-each nesting depth
 
 
 @dataclass

--- a/src/slop/verifier/loop_patterns.py
+++ b/src/slop/verifier/loop_patterns.py
@@ -39,6 +39,10 @@ class PushSiteInfo:
     bindings: Dict[str, 'SExpr']        # Variable bindings in scope at this push
     in_match_arm: bool = False          # Inside a match clause, so not always taken
     loop_depth: int = 0                 # Enclosing while/for-each nesting depth
+    loop_collections: List[Optional['SExpr']] = field(default_factory=list)
+                                        # Collection of each enclosing loop,
+                                        # outermost first; None for a `while`,
+                                        # whose trip count is unknown
 
 
 @dataclass

--- a/src/slop/verifier/loop_patterns.py
+++ b/src/slop/verifier/loop_patterns.py
@@ -37,7 +37,11 @@ class PushSiteInfo:
     pushed_expr: 'SExpr'                # The expression being pushed
     guard_conditions: List['SExpr']     # Enclosing when/if conditions (innermost last)
     bindings: Dict[str, 'SExpr']        # Variable bindings in scope at this push
-    in_match_arm: bool = False          # Inside a match clause, so not always taken
+    conditional: bool = False           # May not be taken: a match arm, an if or
+                                        # cond branch. Distinct from
+                                        # guard_conditions, which holds the
+                                        # guards that are expressible as terms -
+                                        # a match arm has none.
     loop_depth: int = 0                 # Enclosing while/for-each nesting depth
     loop_collections: List[Optional['SExpr']] = field(default_factory=list)
                                         # Collection of each enclosing loop,

--- a/src/slop/verifier/pattern_detection.py
+++ b/src/slop/verifier/pattern_detection.py
@@ -2282,7 +2282,9 @@ class PatternDetectionMixin:
     def _collect_push_sites(
         self, stmts: list, result_var: str,
         bindings: Optional[Dict[str, 'SExpr']] = None,
-        guards: Optional[List['SExpr']] = None
+        guards: Optional[List['SExpr']] = None,
+        in_match_arm: bool = False,
+        loop_depth: int = 0
     ) -> List[PushSiteInfo]:
         """Collect all list-push sites to result_var with their context.
 
@@ -2294,6 +2296,14 @@ class PatternDetectionMixin:
             result_var: Name of the result variable being pushed to
             bindings: Variable bindings in scope (accumulated from let forms)
             guards: Guard conditions enclosing this scope (from when/if forms)
+            in_match_arm: True inside a match clause body, where the push is
+                taken only for that variant. Match arms carry no entry in
+                `guards` - the pattern is not a translatable condition - so
+                without this flag such a push is indistinguishable from an
+                unconditional one.
+            loop_depth: Enclosing while/for-each nesting depth. A push at depth
+                > 0 runs an unknown number of times, so the count of sites is
+                not an upper bound on the result length.
 
         Returns:
             List of PushSiteInfo for each push site found
@@ -2316,7 +2326,9 @@ class PatternDetectionMixin:
                     sites.append(PushSiteInfo(
                         pushed_expr=stmt[2],
                         guard_conditions=list(guards),
-                        bindings=dict(bindings)
+                        bindings=dict(bindings),
+                        in_match_arm=in_match_arm,
+                        loop_depth=loop_depth
                     ))
                 continue
 
@@ -2324,7 +2336,8 @@ class PatternDetectionMixin:
             if is_form(stmt, 'when') and len(stmt) >= 3:
                 new_guards = guards + [stmt[1]]
                 sites += self._collect_push_sites(
-                    stmt.items[2:], result_var, bindings, new_guards
+                    stmt.items[2:], result_var, bindings, new_guards,
+                    in_match_arm, loop_depth
                 )
                 continue
 
@@ -2332,11 +2345,13 @@ class PatternDetectionMixin:
             if is_form(stmt, 'if') and len(stmt) >= 3:
                 new_guards = guards + [stmt[1]]
                 sites += self._collect_push_sites(
-                    [stmt[2]], result_var, bindings, new_guards
+                    [stmt[2]], result_var, bindings, new_guards,
+                    in_match_arm, loop_depth
                 )
                 if len(stmt) >= 4:
                     sites += self._collect_push_sites(
-                        [stmt[3]], result_var, bindings, guards
+                        [stmt[3]], result_var, bindings, guards,
+                        in_match_arm, loop_depth
                     )
                 continue
 
@@ -2358,28 +2373,32 @@ class PatternDetectionMixin:
                                 if var_name:
                                     new_bindings[var_name] = var_value
                 sites += self._collect_push_sites(
-                    stmt.items[2:], result_var, new_bindings, guards
+                    stmt.items[2:], result_var, new_bindings, guards,
+                    in_match_arm, loop_depth
                 )
                 continue
 
             # (do body...) — recurse into body
             if is_form(stmt, 'do'):
                 sites += self._collect_push_sites(
-                    stmt.items[1:], result_var, bindings, guards
+                    stmt.items[1:], result_var, bindings, guards,
+                    in_match_arm, loop_depth
                 )
                 continue
 
             # (while condition body...) — recurse into body
             if is_form(stmt, 'while') and len(stmt) >= 3:
                 sites += self._collect_push_sites(
-                    stmt.items[2:], result_var, bindings, guards
+                    stmt.items[2:], result_var, bindings, guards,
+                    in_match_arm, loop_depth + 1
                 )
                 continue
 
             # (for-each (var collection) body...) — recurse into body
             if is_form(stmt, 'for-each') and len(stmt) >= 3:
                 sites += self._collect_push_sites(
-                    stmt.items[2:], result_var, bindings, guards
+                    stmt.items[2:], result_var, bindings, guards,
+                    in_match_arm, loop_depth + 1
                 )
                 continue
 
@@ -2397,7 +2416,8 @@ class PatternDetectionMixin:
                                 if pat_head.name == 'some':
                                     arm_bindings[pat_var.name] = pattern
                         sites += self._collect_push_sites(
-                            clause.items[1:], result_var, arm_bindings, guards
+                            clause.items[1:], result_var, arm_bindings, guards,
+                            True, loop_depth
                         )
                 continue
 
@@ -2407,7 +2427,8 @@ class PatternDetectionMixin:
                 for arg in stmt.items:
                     if isinstance(arg, SList) and is_form(arg, 'fn') and len(arg) >= 3:
                         sites += self._collect_push_sites(
-                            arg.items[2:], result_var, bindings, guards
+                            arg.items[2:], result_var, bindings, guards,
+                            in_match_arm, loop_depth + 1
                         )
 
         return sites

--- a/src/slop/verifier/pattern_detection.py
+++ b/src/slop/verifier/pattern_detection.py
@@ -2283,7 +2283,7 @@ class PatternDetectionMixin:
         self, stmts: list, result_var: str,
         bindings: Optional[Dict[str, 'SExpr']] = None,
         guards: Optional[List['SExpr']] = None,
-        in_match_arm: bool = False,
+        conditional: bool = False,
         loop_depth: int = 0,
         loop_collections: Optional[List] = None
     ) -> List[PushSiteInfo]:
@@ -2297,11 +2297,11 @@ class PatternDetectionMixin:
             result_var: Name of the result variable being pushed to
             bindings: Variable bindings in scope (accumulated from let forms)
             guards: Guard conditions enclosing this scope (from when/if forms)
-            in_match_arm: True inside a match clause body, where the push is
-                taken only for that variant. Match arms carry no entry in
-                `guards` - the pattern is not a translatable condition - so
-                without this flag such a push is indistinguishable from an
-                unconditional one.
+            conditional: True inside a branch that may not be taken - a match
+                arm, either arm of an `if`, a `cond` clause. An `if` else branch
+                and a match arm carry no entry in `guards` (there is no term to
+                record), so without this flag such a push is indistinguishable
+                from an unconditional one.
             loop_depth: Enclosing while/for-each nesting depth. A push at depth
                 > 0 runs an unknown number of times, so the count of sites is
                 not an upper bound on the result length.
@@ -2334,7 +2334,7 @@ class PatternDetectionMixin:
                         pushed_expr=stmt[2],
                         guard_conditions=list(guards),
                         bindings=dict(bindings),
-                        in_match_arm=in_match_arm,
+                        conditional=conditional,
                         loop_depth=loop_depth,
                         loop_collections=list(loop_collections)
                     ))
@@ -2345,7 +2345,7 @@ class PatternDetectionMixin:
                 new_guards = guards + [stmt[1]]
                 sites += self._collect_push_sites(
                     stmt.items[2:], result_var, bindings, new_guards,
-                    in_match_arm, loop_depth, loop_collections
+                    True, loop_depth, loop_collections
                 )
                 continue
 
@@ -2354,12 +2354,30 @@ class PatternDetectionMixin:
                 new_guards = guards + [stmt[1]]
                 sites += self._collect_push_sites(
                     [stmt[2]], result_var, bindings, new_guards,
-                    in_match_arm, loop_depth, loop_collections
+                    True, loop_depth, loop_collections
                 )
                 if len(stmt) >= 4:
+                    # The else branch runs when the condition is false. There is
+                    # no negated term to add to `guards`, so it is marked
+                    # conditional instead - otherwise a push that only happens
+                    # in the else branch reads as one that always happens.
                     sites += self._collect_push_sites(
                         [stmt[3]], result_var, bindings, guards,
-                        in_match_arm, loop_depth, loop_collections
+                        True, loop_depth, loop_collections
+                    )
+                continue
+
+            # (cond (test body...) ... (else body...)) — every clause is conditional
+            if is_form(stmt, 'cond') and len(stmt) >= 2:
+                for clause in stmt.items[1:]:
+                    if not isinstance(clause, SList) or len(clause) < 2:
+                        continue
+                    test = clause[0]
+                    is_else = isinstance(test, Symbol) and test.name == 'else'
+                    clause_guards = guards if is_else else guards + [test]
+                    sites += self._collect_push_sites(
+                        clause.items[1:], result_var, bindings, clause_guards,
+                        True, loop_depth, loop_collections
                     )
                 continue
 
@@ -2382,7 +2400,7 @@ class PatternDetectionMixin:
                                     new_bindings[var_name] = var_value
                 sites += self._collect_push_sites(
                     stmt.items[2:], result_var, new_bindings, guards,
-                    in_match_arm, loop_depth, loop_collections
+                    conditional, loop_depth, loop_collections
                 )
                 continue
 
@@ -2390,7 +2408,7 @@ class PatternDetectionMixin:
             if is_form(stmt, 'do'):
                 sites += self._collect_push_sites(
                     stmt.items[1:], result_var, bindings, guards,
-                    in_match_arm, loop_depth, loop_collections
+                    conditional, loop_depth, loop_collections
                 )
                 continue
 
@@ -2398,7 +2416,7 @@ class PatternDetectionMixin:
             if is_form(stmt, 'while') and len(stmt) >= 3:
                 sites += self._collect_push_sites(
                     stmt.items[2:], result_var, bindings, guards,
-                    in_match_arm, loop_depth + 1, loop_collections + [None]
+                    conditional, loop_depth + 1, loop_collections + [None]
                 )
                 continue
 
@@ -2408,7 +2426,7 @@ class PatternDetectionMixin:
                 coll = binder[1] if isinstance(binder, SList) and len(binder) >= 2 else None
                 sites += self._collect_push_sites(
                     stmt.items[2:], result_var, bindings, guards,
-                    in_match_arm, loop_depth + 1, loop_collections + [coll]
+                    conditional, loop_depth + 1, loop_collections + [coll]
                 )
                 continue
 
@@ -2438,7 +2456,7 @@ class PatternDetectionMixin:
                     if isinstance(arg, SList) and is_form(arg, 'fn') and len(arg) >= 3:
                         sites += self._collect_push_sites(
                             arg.items[2:], result_var, bindings, guards,
-                            in_match_arm, loop_depth + 1, loop_collections + [None]
+                            conditional, loop_depth + 1, loop_collections + [None]
                         )
 
         return sites

--- a/src/slop/verifier/pattern_detection.py
+++ b/src/slop/verifier/pattern_detection.py
@@ -2284,7 +2284,8 @@ class PatternDetectionMixin:
         bindings: Optional[Dict[str, 'SExpr']] = None,
         guards: Optional[List['SExpr']] = None,
         in_match_arm: bool = False,
-        loop_depth: int = 0
+        loop_depth: int = 0,
+        loop_collections: Optional[List] = None
     ) -> List[PushSiteInfo]:
         """Collect all list-push sites to result_var with their context.
 
@@ -2304,6 +2305,10 @@ class PatternDetectionMixin:
             loop_depth: Enclosing while/for-each nesting depth. A push at depth
                 > 0 runs an unknown number of times, so the count of sites is
                 not an upper bound on the result length.
+            loop_collections: The collection each enclosing loop iterates,
+                outermost first, or None for a `while` whose trip count is not
+                a collection length. A single for-each with one push inside
+                bounds the result by the length of its collection.
 
         Returns:
             List of PushSiteInfo for each push site found
@@ -2312,6 +2317,8 @@ class PatternDetectionMixin:
             bindings = {}
         if guards is None:
             guards = []
+        if loop_collections is None:
+            loop_collections = []
 
         sites: List[PushSiteInfo] = []
 
@@ -2328,7 +2335,8 @@ class PatternDetectionMixin:
                         guard_conditions=list(guards),
                         bindings=dict(bindings),
                         in_match_arm=in_match_arm,
-                        loop_depth=loop_depth
+                        loop_depth=loop_depth,
+                        loop_collections=list(loop_collections)
                     ))
                 continue
 
@@ -2337,7 +2345,7 @@ class PatternDetectionMixin:
                 new_guards = guards + [stmt[1]]
                 sites += self._collect_push_sites(
                     stmt.items[2:], result_var, bindings, new_guards,
-                    in_match_arm, loop_depth
+                    in_match_arm, loop_depth, loop_collections
                 )
                 continue
 
@@ -2346,12 +2354,12 @@ class PatternDetectionMixin:
                 new_guards = guards + [stmt[1]]
                 sites += self._collect_push_sites(
                     [stmt[2]], result_var, bindings, new_guards,
-                    in_match_arm, loop_depth
+                    in_match_arm, loop_depth, loop_collections
                 )
                 if len(stmt) >= 4:
                     sites += self._collect_push_sites(
                         [stmt[3]], result_var, bindings, guards,
-                        in_match_arm, loop_depth
+                        in_match_arm, loop_depth, loop_collections
                     )
                 continue
 
@@ -2374,7 +2382,7 @@ class PatternDetectionMixin:
                                     new_bindings[var_name] = var_value
                 sites += self._collect_push_sites(
                     stmt.items[2:], result_var, new_bindings, guards,
-                    in_match_arm, loop_depth
+                    in_match_arm, loop_depth, loop_collections
                 )
                 continue
 
@@ -2382,7 +2390,7 @@ class PatternDetectionMixin:
             if is_form(stmt, 'do'):
                 sites += self._collect_push_sites(
                     stmt.items[1:], result_var, bindings, guards,
-                    in_match_arm, loop_depth
+                    in_match_arm, loop_depth, loop_collections
                 )
                 continue
 
@@ -2390,15 +2398,17 @@ class PatternDetectionMixin:
             if is_form(stmt, 'while') and len(stmt) >= 3:
                 sites += self._collect_push_sites(
                     stmt.items[2:], result_var, bindings, guards,
-                    in_match_arm, loop_depth + 1
+                    in_match_arm, loop_depth + 1, loop_collections + [None]
                 )
                 continue
 
             # (for-each (var collection) body...) — recurse into body
             if is_form(stmt, 'for-each') and len(stmt) >= 3:
+                binder = stmt[1]
+                coll = binder[1] if isinstance(binder, SList) and len(binder) >= 2 else None
                 sites += self._collect_push_sites(
                     stmt.items[2:], result_var, bindings, guards,
-                    in_match_arm, loop_depth + 1
+                    in_match_arm, loop_depth + 1, loop_collections + [coll]
                 )
                 continue
 
@@ -2417,7 +2427,7 @@ class PatternDetectionMixin:
                                     arm_bindings[pat_var.name] = pattern
                         sites += self._collect_push_sites(
                             clause.items[1:], result_var, arm_bindings, guards,
-                            True, loop_depth
+                            True, loop_depth, loop_collections
                         )
                 continue
 
@@ -2428,7 +2438,7 @@ class PatternDetectionMixin:
                     if isinstance(arg, SList) and is_form(arg, 'fn') and len(arg) >= 3:
                         sites += self._collect_push_sites(
                             arg.items[2:], result_var, bindings, guards,
-                            in_match_arm, loop_depth + 1
+                            in_match_arm, loop_depth + 1, loop_collections + [None]
                         )
 
         return sites

--- a/src/slop/verifier/pattern_detection.py
+++ b/src/slop/verifier/pattern_detection.py
@@ -2389,6 +2389,8 @@ class PatternDetectionMixin:
                     for binding in let_bindings.items:
                         if isinstance(binding, SList) and len(binding) >= 2:
                             first = binding[0]
+                            var_name = None
+                            var_value = None
                             if isinstance(first, Symbol):
                                 if first.name == 'mut' and len(binding) >= 3:
                                     var_name = binding[1].name if isinstance(binding[1], Symbol) else None
@@ -2396,8 +2398,13 @@ class PatternDetectionMixin:
                                 else:
                                     var_name = first.name
                                     var_value = binding[1]
-                                if var_name:
-                                    new_bindings[var_name] = var_value
+                            elif (isinstance(first, SList) and len(first) >= 2
+                                  and isinstance(first[0], Symbol) and first[0].name == 'mut'):
+                                # ((mut var) value), the alternative spelling
+                                var_name = first[1].name if isinstance(first[1], Symbol) else None
+                                var_value = binding[1]
+                            if var_name:
+                                new_bindings[var_name] = var_value
                 sites += self._collect_push_sites(
                     stmt.items[2:], result_var, new_bindings, guards,
                     conditional, loop_depth, loop_collections

--- a/src/slop/verifier/translator.py
+++ b/src/slop/verifier/translator.py
@@ -245,6 +245,17 @@ class Z3Translator:
         self.list_seqs[name] = seq
         return seq
 
+    @staticmethod
+    def field_collection_key(obj_name: str, field_name: str) -> str:
+        """Registry key for the collection held in `obj.field`.
+
+        list_seqs and list_arrays are keyed by variable name, and a field
+        collection has no variable to name it. The key has to be one no SLOP
+        identifier can be, or a parameter spelled the same way would share the
+        registration and inherit its facts - a space does it.
+        """
+        return f"_field {obj_name}.{field_name}"
+
     def _get_list_seq(self, name: str) -> Optional[z3.SeqRef]:
         """Get the Seq variable for a list."""
         return self.list_seqs.get(name)
@@ -428,7 +439,7 @@ class Z3Translator:
             # Build a unique name for this field access
             obj_name = obj_expr.name if isinstance(obj_expr, Symbol) else "_obj"
             field_name = field_expr.name if isinstance(field_expr, Symbol) else "_field"
-            seq_name = f"_field_{obj_name}_{field_name}"
+            seq_name = self.field_collection_key(obj_name, field_name)
 
             if seq_name in self.list_seqs:
                 return self.list_seqs[seq_name]

--- a/src/slop/verifier/translator.py
+++ b/src/slop/verifier/translator.py
@@ -249,6 +249,53 @@ class Z3Translator:
         """Get the Seq variable for a list."""
         return self.list_seqs.get(name)
 
+    # ------------------------------------------------------------------
+    # Length vocabulary
+    #
+    # One list can end up with three different Z3 terms for its length:
+    # field_len(x) from the uninterpreted-accessor encoding, Length(seq) under
+    # Seq encoding, and the length component under array encoding. Which one
+    # (list-len x) translates to depends on the encoding flags and on the order
+    # things were registered, so an axiom asserted about one of them is
+    # invisible to a goal written in terms of another. That split is what makes
+    # a @property (which turns Seq encoding on) break an unrelated @post about
+    # list-len in the same function - issue #69.
+    # ------------------------------------------------------------------
+
+    def field_len_term(self, name: str) -> Optional[z3.ArithRef]:
+        """field_len(x) for the variable `name`, if that variable exists."""
+        var = self.variables.get(name)
+        if var is None or not z3.is_expr(var) or var.sort() != z3.IntSort():
+            return None
+        func = self.variables.get("field_len")
+        if func is None:
+            func = z3.Function("field_len", z3.IntSort(), z3.IntSort())
+            self.variables["field_len"] = func
+        return func(var)
+
+    def list_length_terms(self, name: str) -> List[z3.ArithRef]:
+        """Every Z3 term that currently represents the length of list `name`."""
+        terms: List[z3.ArithRef] = []
+        field_len = self.field_len_term(name)
+        if field_len is not None:
+            terms.append(field_len)
+        seq = self.list_seqs.get(name)
+        if seq is not None:
+            terms.append(z3.Length(seq))
+        arr_entry = self.list_arrays.get(name)
+        if arr_entry is not None:
+            terms.append(arr_entry[1])
+        return terms
+
+    def link_list_length_terms(self, name: str) -> List[z3.BoolRef]:
+        """Equalities tying together every length representation of `name`.
+
+        Asserting these lets a length fact stated in one vocabulary discharge a
+        goal written in another.
+        """
+        terms = self.list_length_terms(name)
+        return [terms[0] == other for other in terms[1:]]
+
     def _translate_list_len_seq(self, lst_expr: SExpr) -> Optional[z3.ArithRef]:
         """Translate (list-len lst) using Seq encoding.
 

--- a/src/slop/verifier/translator.py
+++ b/src/slop/verifier/translator.py
@@ -263,7 +263,13 @@ class Z3Translator:
     # ------------------------------------------------------------------
 
     def field_len_term(self, name: str) -> Optional[z3.ArithRef]:
-        """field_len(x) for the variable `name`, if that variable exists."""
+        """field_len(x) for the variable `name`, if that variable exists.
+
+        `variables` holds user bindings and the verifier's own accessors in one
+        namespace, so "field_len" may have been claimed by a parameter of that
+        name. Calling a Z3 constant raises, which would take down the whole
+        file, so an occupied slot means no term rather than a crash.
+        """
         var = self.variables.get(name)
         if var is None or not z3.is_expr(var) or var.sort() != z3.IntSort():
             return None
@@ -271,6 +277,8 @@ class Z3Translator:
         if func is None:
             func = z3.Function("field_len", z3.IntSort(), z3.IntSort())
             self.variables["field_len"] = func
+        elif not isinstance(func, z3.FuncDeclRef) or func.arity() != 1:
+            return None
         return func(var)
 
     def list_length_terms(self, name: str) -> List[z3.ArithRef]:

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -7407,3 +7407,90 @@ class TestResultLengthFailsClosed:
     def test_loop_binder_shadowing_the_accumulator(self):
         assert self._one(self.BINDER_SHADOWS,
                          "(== (list-len $result) (list-len items))").status != 'verified'
+
+    SOURCE_POPPED = '''
+        (let ((mut r (list-new arena Int)))
+          (do (for-each (x items) (list-push r x)) (list-pop items) r))'''
+    RETURN_SHAPED_ARGUMENT = '''
+        (let ((mut r (list-new arena Int)))
+          (do (list-push r 1) (list-pop (do r)) r))'''
+
+    def test_source_shortened_after_the_loop(self):
+        """The bound is against one length term; a pop makes that term denote a
+        different collection than the loop iterated."""
+        assert self._one(self.SOURCE_POPPED,
+                         "(== (list-len $result) (list-len items))").status != 'verified'
+
+    def test_trailing_position_of_an_argument_block_is_not_the_result(self):
+        """`(list-pop (do r))` has r trailing a do block, but that block is an
+        argument. Only the block the function actually yields is exempt."""
+        assert self._one(self.RETURN_SHAPED_ARGUMENT,
+                         "(== (list-len $result) 1)").status != 'verified'
+
+
+class TestInconsistencyAttribution:
+    """Issue #115: an unsat base context has several causes, and the report has
+    to name the right one - three of them are the author's contract, one is
+    ours, and only the last should ask for a bug report.
+    """
+
+    @staticmethod
+    def _verify(src):
+        from slop.verifier import verify_source
+        return verify_source(src)[0]
+
+    def test_unsatisfiable_preconditions(self):
+        r = self._verify('''
+        (fn impossible ((n Int))
+          (@spec ((Int) -> Int))
+          (@pre (> n 10))
+          (@pre (< n 5))
+          (@post (== $result n))
+          n)
+        ''')
+        assert r.status == 'failed'
+        assert 'unsatisfiable' in r.message.lower()
+        assert 'verifier defect' not in r.message
+
+    def test_contradictory_type_invariants(self):
+        r = self._verify('''
+        (module m
+          (type Weird (record (x Int))
+            (@invariant (> x 0))
+            (@invariant (< x 0)))
+          (fn f ((w Weird))
+            (@spec ((Weird) -> Int))
+            (@post (== $result 1))
+            1))
+        ''')
+        assert r.status == 'failed'
+        assert 'Type invariants are contradictory' in r.message
+
+    def test_contradictory_assumptions(self):
+        r = self._verify('''
+        (fn contradictory ((n Int))
+          (@spec ((Int) -> Int))
+          (@assume (== n 1))
+          (@assume (== n 2))
+          (@post (== $result 42))
+          n)
+        ''')
+        assert r.status == 'failed'
+        assert 'Assumptions are contradictory' in r.message
+
+    def test_ill_defined_contract_expression(self):
+        """A postcondition's own side conditions, not the preconditions.
+
+        translator.constraints accumulates across phases, so replaying the whole
+        list when diagnosing an unsatisfiable @pre blamed the preconditions for
+        a contradiction a postcondition introduced.
+        """
+        r = self._verify('''
+        (fn f ((n Int))
+          (@spec ((Int) -> Int))
+          (@post (== (/ 1 0) 0))
+          n)
+        ''')
+        assert r.status == 'failed'
+        assert 'well-defined' in r.message
+        assert 'Precondition' not in r.message

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -7676,3 +7676,58 @@ class TestGroundFragmentFallback:
         assert verifier._contains_quantifier(z3.And(z3.BoolVal(True),
                                                     z3.ForAll([i], p(i))))
         assert not verifier._contains_quantifier(z3.Int('x') == 0)
+
+
+class TestInconsistencyAttributionLayers:
+    """Each phase of translation adds its own side conditions to a single
+    growing list, and the main solver holds one more assertion beyond it - the
+    body equality. Diagnosing an unsat context means knowing which layer tipped
+    it over; getting that wrong sends the reader to the wrong place.
+    """
+
+    @staticmethod
+    def _verify(src):
+        from slop.verifier import verify_source
+        return verify_source(src)[0]
+
+    def test_precondition_side_condition_belongs_to_the_precondition(self):
+        """The @pre's own division constraint lands before the snapshot, so a
+        naive prefix blames the parameter types for it."""
+        r = self._verify('''
+        (fn f ((n Int))
+          (@spec ((Int) -> Int))
+          (@pre (== (/ 1 0) n))
+          (@post (== $result n))
+          n)
+        ''')
+        assert r.status == 'failed'
+        assert 'Precondition is unsatisfiable' in r.message
+
+    def test_body_outside_the_return_range(self):
+        """$result == body is asserted directly on the main solver, not through
+        translator.constraints, so a layered replay has to carry it too."""
+        r = self._verify('''
+        (module m
+          (fn f ()
+            (@spec (() -> (Int 0 .. 1)))
+            (@post (>= $result 0))
+            2))
+        ''')
+        assert r.status == 'failed'
+        assert 'declared return type' in r.message
+        assert 'verifier defect' not in r.message
+
+    def test_alternative_mutable_binding_shadows(self):
+        """((mut name) value) is a supported spelling whose head is a list, so a
+        scan that expects a symbol head misses it and counts the inner push
+        against the outer list."""
+        r = self._verify('''
+        (fn f ((arena Arena))
+          (@spec ((Arena) -> (List Int)))
+          (@post (== (list-len $result) 1))
+          (let (((mut result) (list-new arena Int)))
+            (do (let (((mut result) (list-new arena Int)))
+                  (list-push result 1))
+                result)))
+        ''')
+        assert r.status != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8025,3 +8025,24 @@ class TestReturnedPreexistingList:
                   (list-pop report.results)
                   r))))
         ''') != 'verified'
+
+    def test_a_push_in_an_earlier_top_level_form_counts(self):
+        """A multi-form body keeps only its last expression in fn_body, so a
+        push in an earlier form is invisible to a scan of that alone - and an
+        unseen push makes the result look shorter than it is."""
+        assert self._status('''
+        (fn f ((xs (List Int)))
+          (@spec (((List Int)) -> (List Int)))
+          (@post (>= (list-len $result) 1))
+          (list-push xs 1)
+          xs)
+        ''') == 'verified'
+
+    def test_earlier_forms_do_not_gain_an_upper_bound(self):
+        assert self._status('''
+        (fn f ((xs (List Int)))
+          (@spec (((List Int)) -> (List Int)))
+          (@post (== (list-len $result) 1))
+          (list-push xs 1)
+          xs)
+        ''') != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -7368,3 +7368,42 @@ class TestResultLengthFailsClosed:
             ''' % (post, self.EARLY_RETURN)
             result = verify_source(src)[0]
             assert result.status != 'verified', f"{post}: {result.message}"
+
+    POP = '''
+        (let ((mut r (list-new arena Int)))
+          (do (list-push r 1) (list-pop r) r))'''
+    REASSIGN = '''
+        (let ((mut r (list-new arena Int)))
+          (do (set! r items) r))'''
+    ESCAPES = '''
+        (let ((mut r (list-new arena Int)))
+          (do (list-push r 1) (helper arena r) r))'''
+    SOURCE_MUTATED = '''
+        (let ((mut r (list-new arena Int)))
+          (do (for-each (x items) (list-push r x))
+              (list-push items 9)
+              r))'''
+    BINDER_SHADOWS = '''
+        (let ((mut result (list-new arena Int)))
+          (do (for-each (result items) (list-push result 1)) result))'''
+
+    def test_pop_is_not_modelled(self):
+        """Counting pushes only bounds a list if nothing else shortens it."""
+        assert self._one(self.POP, "(== (list-len $result) 1)").status != 'verified'
+
+    def test_reassignment_is_not_modelled(self):
+        assert self._one(self.REASSIGN, "(== (list-len $result) 0)").status != 'verified'
+
+    def test_accumulator_handed_to_a_function_escapes(self):
+        """The callee may append to it, and nothing here can see that."""
+        assert self._one(self.ESCAPES, "(== (list-len $result) 1)").status != 'verified'
+
+    def test_source_mutated_after_the_loop(self):
+        """len($result) == len(items) holds for the length the loop saw, not the
+        one the postcondition reads after the body appends to items."""
+        assert self._one(self.SOURCE_MUTATED,
+                         "(== (list-len $result) (list-len items))").status != 'verified'
+
+    def test_loop_binder_shadowing_the_accumulator(self):
+        assert self._one(self.BINDER_SHADOWS,
+                         "(== (list-len $result) (list-len items))").status != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -7276,3 +7276,69 @@ class TestVacuityGuard:
             result))
         '''
         assert verify_source(src)[0].status != 'verified'
+
+
+class TestResultLengthFailsClosed:
+    """A length bound may only be claimed when the push scan is trustworthy.
+
+    _collect_push_sites is a whitelist walk. It classifies the forms it knows
+    and returns nothing for the rest, which is fine for a heuristic but not for
+    deriving a bound: a push the walk did not see reads as a push that does not
+    happen, and "no pushes" means "the result is empty". Each case here paired a
+    false claim with a true weaker one, so the tests pin both that the false one
+    is rejected and that rejecting it did not cost the true one.
+    """
+
+    @staticmethod
+    def _one(body, post):
+        from slop.verifier import verify_source
+        src = '''
+        (fn f ((arena Arena) (flag Bool) (n Int) (items (List Int)))
+          (@spec ((Arena Bool Int (List Int)) -> (List Int)))
+          (@alloc arena)
+          (@post %s)
+          %s)
+        ''' % (post, body)
+        return verify_source(src)[0]
+
+    IF_ELSE = '''
+        (let ((mut result (list-new arena Int)))
+          (do (if flag (do) (list-push result 1)) result))'''
+    COND = '''
+        (let ((mut result (list-new arena Int)))
+          (do (cond ((> n 0) (list-push result 1)) (else (do))) result))'''
+    BREAK = '''
+        (let ((mut result (list-new arena Int)))
+          (do (for-each (x items) (list-push result x) (break)) result))'''
+    SHADOW = '''
+        (let ((mut result (list-new arena Int)))
+          (do (let ((mut result (list-new arena Int)))
+                (list-push result 1))
+              result))'''
+    SET_BANG = '''
+        (let ((mut result (list-new arena Int)))
+          (do (for-each (x items) (set! result (list-push result x))) result))'''
+
+    def test_push_only_in_else_branch_is_conditional(self):
+        """The else branch has no term to record as a guard, so it has to be
+        marked conditional or it reads as a push that always happens."""
+        assert self._one(self.IF_ELSE, "(== (list-len $result) 1)").status != 'verified'
+        assert self._one(self.IF_ELSE, "(<= (list-len $result) 1)").status == 'verified'
+
+    def test_push_under_cond_is_seen(self):
+        assert self._one(self.COND, "(== (list-len $result) 0)").status != 'verified'
+        assert self._one(self.COND, "(<= (list-len $result) 1)").status == 'verified'
+
+    def test_loop_with_break_is_not_exact(self):
+        """One unguarded push per iteration stops meaning one per element once
+        the loop can leave early. The upper bound survives; the equality does not."""
+        assert self._one(self.BREAK, "(== (list-len $result) (list-len items))").status != 'verified'
+        assert self._one(self.BREAK, "(<= (list-len $result) (list-len items))").status == 'verified'
+
+    def test_shadowed_binding_is_not_the_returned_list(self):
+        assert self._one(self.SHADOW, "(== (list-len $result) 1)").status != 'verified'
+
+    def test_push_through_set_is_not_counted_as_absent(self):
+        """(set! result (list-push result x)) is a push the structured walk does
+        not descend to. The plain count sees it, the mismatch forces a bail."""
+        assert self._one(self.SET_BANG, "(== (list-len $result) 0)").status != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -7963,3 +7963,65 @@ class TestAssumptionAgainstBody:
               (do (for-each (x (. report results)) (list-push r x)) r))))
         '''
         assert verify_source(src)[0].status != 'verified'
+
+
+class TestReturnedPreexistingList:
+    """A list the function allocated started empty, so its push sites account
+    for the whole contents. One it was handed may already hold anything, so the
+    same sites only raise its floor.
+    """
+
+    @staticmethod
+    def _status(src):
+        from slop.verifier import verify_source
+        return verify_source(src)[0].status
+
+    def test_lower_bound_on_a_returned_parameter(self):
+        assert self._status('''
+        (fn f ((xs (List Int)))
+          (@spec (((List Int)) -> (List Int)))
+          (@post (>= (list-len $result) 1))
+          (do (list-push xs 1) xs))
+        ''') == 'verified'
+
+    def test_no_upper_bound_on_a_returned_parameter(self):
+        assert self._status('''
+        (fn f ((xs (List Int)))
+          (@spec (((List Int)) -> (List Int)))
+          (@post (== (list-len $result) 1))
+          (do (list-push xs 1) xs))
+        ''') != 'verified'
+
+    def test_a_conditional_push_raises_no_floor(self):
+        assert self._status('''
+        (fn f ((xs (List Int)) (flag Bool))
+          (@spec (((List Int) Bool) -> (List Int)))
+          (@post (>= (list-len $result) 1))
+          (do (when flag (list-push xs 1)) xs))
+        ''') != 'verified'
+
+    def test_a_loop_push_onto_a_handed_list_claims_nothing(self):
+        """The loop equality is about a list that started empty; for one that
+        did not, len(source) is not even a floor."""
+        assert self._status('''
+        (fn f ((xs (List Int)) (ys (List Int)))
+          (@spec (((List Int) (List Int)) -> (List Int)))
+          (@post (>= (list-len $result) (list-len ys)))
+          (do (for-each (y ys) (list-push xs y)) xs))
+        ''') != 'verified'
+
+    def test_mixed_field_spellings_count_as_the_same_list(self):
+        """`(. report results)` and `report.results` denote one list, and a body
+        may iterate with one spelling and mutate with the other."""
+        assert self._status('''
+        (module m
+          (type Rep (record (results (List Int))))
+          (fn f ((arena Arena) (report Rep))
+            (@spec ((Arena Rep) -> (List Int)))
+            (@alloc arena)
+            (@post (== (list-len $result) (list-len (. report results))))
+            (let ((mut r (list-new arena Int)))
+              (do (for-each (x (. report results)) (list-push r x))
+                  (list-pop report.results)
+                  r))))
+        ''') != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -3678,29 +3678,23 @@ class TestArrayEncoding:
         assert z3.is_bool(result)
 
     def test_list_new_with_array_encoding(self):
-        """Test list-new with array encoding creates proper axioms"""
+        """A body that is just (list-new ...) returns an empty list."""
         from slop.verifier import ContractVerifier, MinimalTypeEnv, Z3Translator
         from slop.parser import parse
         import z3
 
         env = MinimalTypeEnv()
         translator = Z3Translator(env, use_array_encoding=True)
-
-        # Declare $result
         translator.declare_variable('$result', z3.IntSort())
+        translator._create_list_array('$result')
 
         verifier = ContractVerifier(env)
 
-        # Extract axioms for list-new
-        list_new_expr = parse("(list-new arena Triple)")[0]
-        axioms = verifier._extract_list_new_axioms(list_new_expr, translator)
+        body = parse("(list-new arena Triple)")[0]
+        axioms = verifier._result_length_axioms(body, translator)
 
-        # Should have created array for $result
         assert '$result' in translator.list_arrays
-
-        # Should have axiom that length is 0
         assert len(axioms) >= 1
-        # First axiom should be length == 0 (may be normalized to 0 == length)
         has_length_zero = any("== 0" in str(a) or "0 ==" in str(a) for a in axioms)
         assert has_length_zero, f"Expected length == 0 axiom, got: {axioms}"
 
@@ -6965,3 +6959,258 @@ class TestMatchArmPostconditionPropagation:
         verifier = ContractVerifier(env, function_registry=registry)
         result = verifier.verify_function(fn_form)
         assert result.status == "verified", f"Expected verified, got {result.status}: {result.message}"
+
+
+# ============================================================================
+# Issue #115: a self-contradictory axiom set discharges every contract
+# ============================================================================
+
+_PUSH_BODY_SHAPES = {
+    # name -> (body, params, expected length bound as (lower, upper|None))
+    'no_pushes': ('''
+        (let ((mut r (list-new arena Msg)))
+          r)''', 0, 0),
+    'one_unconditional_push': ('''
+        (let ((mut r (list-new arena Msg)))
+          (do (list-push r (record-new Msg (v 1) (to root))) r))''', 1, 1),
+    'two_unconditional_pushes': ('''
+        (let ((mut r (list-new arena Msg)))
+          (do (list-push r (record-new Msg (v 1) (to root)))
+              (list-push r (record-new Msg (v 2) (to root)))
+              r))''', 2, 2),
+    'push_under_when': ('''
+        (let ((mut r (list-new arena Msg)))
+          (do (when (> root 0) (list-push r (record-new Msg (v 1) (to root)))) r))''', 0, 1),
+    'push_in_one_match_arm': ('''
+        (let ((mut r (list-new arena Msg)))
+          (do (match ax
+                ((a n) (list-push r (record-new Msg (v n) (to root))))
+                ((b _) (do)))
+              r))''', 0, 1),
+    'push_in_both_match_arms': ('''
+        (let ((mut r (list-new arena Msg)))
+          (do (match ax
+                ((a n) (list-push r (record-new Msg (v n) (to root))))
+                ((b n) (list-push r (record-new Msg (v n) (to root)))))
+              r))''', 0, 2),
+    'guarded_and_unguarded': ('''
+        (let ((mut r (list-new arena Msg)))
+          (do (list-push r (record-new Msg (v 1) (to root)))
+              (when (> root 0) (list-push r (record-new Msg (v 2) (to root))))
+              r))''', 1, 2),
+}
+
+
+def _push_shape_source(body, post):
+    """A list-returning function over Msg/Ax with `post` as its @post."""
+    return '''
+    (module probe
+      (type Msg (record (v Int) (to Int)))
+      (type Ax  (union (a Int) (b Int)))
+
+      (fn build ((arena Arena) (ax Ax) (root Int))
+        (@spec ((Arena Ax Int) -> (List Msg)))
+        (@alloc arena)
+        (@post %s)
+        %s))
+    ''' % (post, body)
+
+
+class TestResultLengthBounds:
+    """Issue #115: the length of a push-built result, derived from its push sites.
+
+    Two axioms used to be emitted about it independently - a flat
+    field_len($result) == 0 from the (mut r (list-new ...)) binding and a
+    field_len($result) >= push_count from the push count - and the pair was
+    unsatisfiable, so every postcondition on such a function reported verified
+    without being proved. These pin the bound that replaced them.
+    """
+
+    @pytest.mark.parametrize("shape", sorted(_PUSH_BODY_SHAPES))
+    def test_lower_bound_holds(self, shape):
+        from slop.verifier import verify_source
+        body, lower, _ = _PUSH_BODY_SHAPES[shape]
+        src = _push_shape_source(body, "{(list-len $result) >= %d}" % lower)
+        result = verify_source(src, filename="probe.slop")[0]
+        assert result.status == 'verified', f"{shape}: {result.message}"
+
+    @pytest.mark.parametrize("shape", sorted(_PUSH_BODY_SHAPES))
+    def test_upper_bound_holds(self, shape):
+        from slop.verifier import verify_source
+        body, _, upper = _PUSH_BODY_SHAPES[shape]
+        src = _push_shape_source(body, "{(list-len $result) <= %d}" % upper)
+        result = verify_source(src, filename="probe.slop")[0]
+        assert result.status == 'verified', f"{shape}: {result.message}"
+
+    @pytest.mark.parametrize("shape", sorted(_PUSH_BODY_SHAPES))
+    def test_below_lower_bound_fails(self, shape):
+        """A length claim the body does not support must not verify."""
+        from slop.verifier import verify_source
+        body, lower, _ = _PUSH_BODY_SHAPES[shape]
+        src = _push_shape_source(body, "{(list-len $result) == %d}" % (lower - 1))
+        result = verify_source(src, filename="probe.slop")[0]
+        assert result.status != 'verified', f"{shape}: {result.message}"
+
+    @pytest.mark.parametrize("shape", sorted(_PUSH_BODY_SHAPES))
+    def test_above_upper_bound_fails(self, shape):
+        from slop.verifier import verify_source
+        body, _, upper = _PUSH_BODY_SHAPES[shape]
+        src = _push_shape_source(body, "{(list-len $result) == %d}" % (upper + 1))
+        result = verify_source(src, filename="probe.slop")[0]
+        assert result.status != 'verified', f"{shape}: {result.message}"
+
+    def test_map_loop_length_equals_source(self):
+        """One unconditional push per source element: len($result) == len(source)."""
+        from slop.verifier import verify_source
+        src = '''
+        (fn transform ((arena Arena) (items (List Int)))
+          (@spec ((Arena (List Int)) -> (List Int)))
+          (@post (== (list-len $result) (list-len items)))
+          (let ((mut result (list-new arena Int)))
+            (for-each (x items)
+              (list-push result (item-new arena x)))
+            result))
+        '''
+        assert verify_source(src)[0].status == 'verified'
+
+    def test_map_loop_length_is_not_zero(self):
+        """The same body must not prove the result empty."""
+        from slop.verifier import verify_source
+        src = '''
+        (fn transform ((arena Arena) (items (List Int)))
+          (@spec ((Arena (List Int)) -> (List Int)))
+          (@post (== (list-len $result) 0))
+          (let ((mut result (list-new arena Int)))
+            (for-each (x items)
+              (list-push result (item-new arena x)))
+            result))
+        '''
+        assert verify_source(src)[0].status != 'verified'
+
+    def test_filter_loop_length_bounded_by_source(self):
+        """A guarded push per element: len($result) <= len(source)."""
+        from slop.verifier import verify_source
+        src = '''
+        (fn keep-positive ((arena Arena) (items (List Int)))
+          (@spec ((Arena (List Int)) -> (List Int)))
+          (@post (<= (list-len $result) (list-len items)))
+          (let ((mut result (list-new arena Int)))
+            (for-each (x items)
+              (when (> x 0)
+                (list-push result x)))
+            result))
+        '''
+        assert verify_source(src)[0].status == 'verified'
+
+
+class TestVacuityGuard:
+    """Issue #115: nothing may be reported verified on a contradictory context."""
+
+    def test_false_length_postcondition_is_not_verified(self):
+        from slop.verifier import verify_source
+        body, _, _ = _PUSH_BODY_SHAPES['one_unconditional_push']
+        for claim in ("== 0", "== 99", ">= 2"):
+            src = _push_shape_source(body, "{(list-len $result) %s}" % claim)
+            result = verify_source(src, filename="probe.slop")[0]
+            assert result.status == 'failed', f"len {claim}: {result.status} {result.message}"
+
+    def test_true_length_postcondition_still_verifies(self):
+        """The guard must not blanket-downgrade contracts that do hold."""
+        from slop.verifier import verify_source
+        body, _, _ = _PUSH_BODY_SHAPES['one_unconditional_push']
+        src = _push_shape_source(body, "{(list-len $result) == 1}")
+        assert verify_source(src, filename="probe.slop")[0].status == 'verified'
+
+    def test_unsatisfiable_precondition_is_reported_as_such(self):
+        """An impossible @pre is a user error, not a verifier defect - the two
+        make the base context unsat for different reasons and must not be
+        reported with the same message."""
+        from slop.verifier import verify_source
+        src = '''
+        (fn impossible ((n Int))
+          (@spec ((Int) -> Int))
+          (@pre (> n 10))
+          (@pre (< n 5))
+          (@post (== $result n))
+          n)
+        '''
+        result = verify_source(src)[0]
+        assert result.status == 'failed'
+        assert 'unsatisfiable' in result.message.lower()
+        assert 'verifier defect' not in result.message
+
+    def test_no_fixture_produces_a_contradictory_context(self):
+        """The invariant behind the guard, checked directly.
+
+        Every contract is discharged by asking whether (axioms AND NOT post) is
+        satisfiable. If the axioms alone are unsat that answer is "no" for any
+        post, so the contract reports verified having proved nothing. This walks
+        a corpus of shapes and re-checks each base context standalone. It does
+        not go through the guard, so it still fires if the guard is removed.
+        """
+        import z3 as _z3
+        from slop.verifier import verify_source
+
+        snapshots = []
+        orig_push = _z3.Solver.push
+        orig_check = _z3.Solver.check
+
+        def push(self, *a, **k):
+            # At this point the goal has not been pushed yet, so the assertions
+            # are exactly the axioms.
+            self._slop_base = list(self.assertions())
+            return orig_push(self, *a, **k)
+
+        def check(self, *a, **k):
+            if self.num_scopes() > 0:
+                base = getattr(self, '_slop_base', None)
+                if base is not None:
+                    snapshots.append(base)
+            else:
+                # A check outside any scope is the guard's own consistency
+                # check. Recording it here keeps this test independent of the
+                # guard: remove the guard and the same set still gets examined
+                # on the push below.
+                snapshots.append(list(self.assertions()))
+            return orig_check(self, *a, **k)
+
+        _z3.Solver.push, _z3.Solver.check = push, check
+        try:
+            for shape, (body, lower, upper) in sorted(_PUSH_BODY_SHAPES.items()):
+                for post in ("{(list-len $result) >= %d}" % lower,
+                             "{(list-len $result) <= %d}" % upper,
+                             "{(list-len $result) == %d}" % (upper + 1)):
+                    verify_source(_push_shape_source(body, post), filename="probe.slop")
+        finally:
+            _z3.Solver.push, _z3.Solver.check = orig_push, orig_check
+
+        assert snapshots, "instrumentation caught no solver contexts"
+        for base in snapshots:
+            solver = _z3.Solver()
+            solver.set("timeout", 5000)
+            for assertion in base:
+                solver.add(assertion)
+            assert solver.check() != _z3.unsat, (
+                "axiom set is self-contradictory, so every contract on this "
+                "function would discharge without being proved:\n  "
+                + "\n  ".join(str(a) for a in base)
+            )
+
+    def test_contradictory_assumptions_are_reported_as_such(self):
+        """@assume is trusted, so a contradictory set would discharge anything.
+
+        That is the author's error, not a verifier defect, and the guard has to
+        say which - otherwise the report sends them to the wrong place.
+        """
+        from slop.verifier import verify_source
+        src = '''
+        (fn contradictory ((n Int))
+          (@spec ((Int) -> Int))
+          (@assume (== n 1))
+          (@assume (== n 2))
+          (@post (== $result 42))
+          n)
+        '''
+        result = verify_source(src)[0]
+        assert result.status == 'failed'
+        assert 'Assumptions are contradictory' in result.message

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -7213,7 +7213,7 @@ class TestVacuityGuard:
         '''
         result = verify_source(src)[0]
         assert result.status == 'failed'
-        assert 'Assumptions are contradictory' in result.message
+        assert 'An assumption contradicts the function' in result.message
 
     def test_match_arm_filter_loop_bounded_by_source(self):
         """A filter written as a match arm, not a `when`.
@@ -7476,7 +7476,7 @@ class TestInconsistencyAttribution:
           n)
         ''')
         assert r.status == 'failed'
-        assert 'Assumptions are contradictory' in r.message
+        assert 'An assumption contradicts the function' in r.message
 
     def test_ill_defined_assumption_names_the_assumption(self):
         """An @assume's own side conditions live in the same growing list as a
@@ -7490,7 +7490,7 @@ class TestInconsistencyAttribution:
           n)
         ''')
         assert r.status == 'failed'
-        assert 'Assumptions are contradictory' in r.message
+        assert 'An assumption contradicts the function' in r.message
 
     def test_ill_defined_contract_expression(self):
         """A postcondition's own side conditions, not the preconditions.
@@ -7912,7 +7912,9 @@ class TestCallbackBoundaries:
 class TestAssumptionAgainstBody:
     def test_an_assumption_the_body_refutes_is_named(self):
         """@assume is trusted, so one the body already refutes discharges
-        everything. That is the author's error, not a verifier defect."""
+        everything. That is the author's error, not a verifier defect - and the
+        body fact that refutes it here is a record-field axiom added straight to
+        the solver, not something the diagnosis could have enumerated by hand."""
         from slop.verifier import verify_source
         src = '''
         (fn f ((arena Arena))
@@ -7924,7 +7926,25 @@ class TestAssumptionAgainstBody:
         '''
         r = verify_source(src)[0]
         assert r.status == 'failed'
-        assert 'contradicts what the body does' in r.message
+        assert 'An assumption contradicts the function' in r.message
+
+    def test_an_assumption_refuted_by_a_record_field_is_named(self):
+        """The refuting fact is Phase 3's field_x($result) == 1, which never
+        passes through translator.constraints. The diagnosis takes the generated
+        axioms from the solver rather than listing their kinds."""
+        from slop.verifier import verify_source
+        src = '''
+        (module m
+          (type R (record (x Int)))
+          (fn f ()
+            (@spec (() -> R))
+            (@assume (== (. $result x) 0))
+            (@post (== (. $result x) 5))
+            (record-new R (x 1))))
+        '''
+        r = verify_source(src)[0]
+        assert r.status == 'failed'
+        assert 'An assumption contradicts the function' in r.message
 
     def test_a_parameter_named_like_a_field_key_is_not_the_field(self):
         """The Seq registry is keyed by name, and a field collection has no

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -4885,7 +4885,7 @@ class TestSequenceTheory:
         assert z3.is_quantifier(result)
 
         # Should have created a Seq for the field access
-        assert "_field_delta_triples" in translator.list_seqs
+        assert translator.field_collection_key("delta", "triples") in translator.list_seqs
 
     def test_function_call_collection_translation(self):
         """Test (forall (elem (fn-name args)) body) translation for function calls"""
@@ -5018,7 +5018,7 @@ class TestSequenceTheory:
 
         # Should have created Seqs
         assert '$result' in translator.list_seqs
-        assert '_field_delta_triples' in translator.list_seqs
+        assert translator.field_collection_key('delta', 'triples') in translator.list_seqs
 
     def test_property_verification_with_collection_quantifier(self):
         """Integration test: property with collection-bound forall"""
@@ -5899,7 +5899,7 @@ class TestNestedLoopPattern:
 
         # Create seqs
         translator._create_list_seq('$result')
-        translator._create_list_seq('_field_delta_triples')
+        translator._create_list_seq(translator.field_collection_key('delta', 'triples'))
 
         # Nested loop pattern body
         body = parse("""
@@ -6032,7 +6032,7 @@ class TestNestedLoopPattern:
 
         # Create seqs
         translator._create_list_seq('$result')
-        translator._create_list_seq('_field_delta_triples')
+        translator._create_list_seq(translator.field_collection_key('delta', 'triples'))
 
         # Simplified eq-trans body
         body = parse("""
@@ -7871,3 +7871,75 @@ class TestInternalNamespaceCollisions:
         translator.variables['field_len'] = z3.Int('field_len')
         assert translator.field_len_term('xs') is None
         assert translator.list_length_terms('xs') == []
+
+
+class TestCallbackBoundaries:
+    """A callback is a separate function. Its `return` leaves the callback and
+    its `break` belongs to a loop inside it, so neither describes the enclosing
+    function's exits - counting them suppressed the length axioms of every
+    function that passes one.
+    """
+
+    def test_a_callback_local_return_does_not_suppress_the_bound(self):
+        from slop.verifier import verify_source
+        src = '''
+        (fn f ((arena Arena) (g Graph))
+          (@spec ((Arena Graph) -> (List Int)))
+          (@alloc arena)
+          (@post (== (list-len $result) 1))
+          (let ((mut r (list-new arena Int)))
+            (do (list-push r 1)
+                (graph-for-each g (fn ((x Int)) (do (return 0))))
+                r)))
+        '''
+        assert verify_source(src)[0].status == 'verified'
+
+    def test_an_outer_return_still_suppresses_it(self):
+        from slop.verifier import verify_source
+        src = '''
+        (fn f ((arena Arena) (flag Bool) (items (List Int)))
+          (@spec ((Arena Bool (List Int)) -> (List Int)))
+          (@alloc arena)
+          (@post (== (list-len $result) 1))
+          (let ((mut r (list-new arena Int)))
+            (do (when flag (return items))
+                (list-push r 1)
+                r)))
+        '''
+        assert verify_source(src)[0].status != 'verified'
+
+
+class TestAssumptionAgainstBody:
+    def test_an_assumption_the_body_refutes_is_named(self):
+        """@assume is trusted, so one the body already refutes discharges
+        everything. That is the author's error, not a verifier defect."""
+        from slop.verifier import verify_source
+        src = '''
+        (fn f ((arena Arena))
+          (@spec ((Arena) -> (List Int)))
+          (@assume (== (list-len $result) 0))
+          (@post (== (list-len $result) 7))
+          (let ((mut r (list-new arena Int)))
+            (do (list-push r 1) r)))
+        '''
+        r = verify_source(src)[0]
+        assert r.status == 'failed'
+        assert 'contradicts what the body does' in r.message
+
+    def test_a_parameter_named_like_a_field_key_is_not_the_field(self):
+        """The Seq registry is keyed by name, and a field collection has no
+        variable to name it. A key a parameter could also be spelled would let
+        that parameter's sequence stand in for the field's."""
+        from slop.verifier import verify_source
+        src = '''
+        (module m
+          (type Rep (record (results (List Int))))
+          (fn f ((arena Arena) (report Rep) (_field_report_results (List Int)))
+            (@spec ((Arena Rep (List Int)) -> (List Int)))
+            (@alloc arena)
+            (@post (<= (list-len $result) (list-len _field_report_results)))
+            (@property p (forall (x $result) (>= x 0)))
+            (let ((mut r (list-new arena Int)))
+              (do (for-each (x (. report results)) (list-push r x)) r))))
+        '''
+        assert verify_source(src)[0].status != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -7342,3 +7342,29 @@ class TestResultLengthFailsClosed:
         """(set! result (list-push result x)) is a push the structured walk does
         not descend to. The plain count sees it, the mismatch forces a bail."""
         assert self._one(self.SET_BANG, "(== (list-len $result) 0)").status != 'verified'
+
+    EARLY_RETURN = '''
+        (do
+          (when flag (return items))
+          (list-new arena Int))'''
+
+    def test_explicit_return_is_a_second_exit(self):
+        """_get_return_expr sees only the trailing expression.
+
+        With `(when flag (return items))` above it, `items` is just as much
+        $result as the trailing `(list-new ...)`, so neither the length bound
+        nor the sequence identity may be taken from the trailing form alone.
+        The length half of this false-verified before this branch too.
+        """
+        from slop.verifier import verify_source
+        for post in ("(== (list-len $result) 0)",
+                     "(forall (e $result) (> e 0))"):
+            src = '''
+            (fn pick ((arena Arena) (flag Bool) (items (List Int)))
+              (@spec ((Arena Bool (List Int)) -> (List Int)))
+              (@alloc arena)
+              (@post %s)
+              %s)
+            ''' % (post, self.EARLY_RETURN)
+            result = verify_source(src)[0]
+            assert result.status != 'verified', f"{post}: {result.message}"

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -7214,3 +7214,65 @@ class TestVacuityGuard:
         result = verify_source(src)[0]
         assert result.status == 'failed'
         assert 'Assumptions are contradictory' in result.message
+
+    def test_match_arm_filter_loop_bounded_by_source(self):
+        """A filter written as a match arm, not a `when`.
+
+        The map/filter pattern detectors do not recognise this shape, so the
+        bound has to come from the loop structure itself.
+        """
+        from slop.verifier import verify_source
+        src = '''
+        (module probe
+          (type Sev (enum lo hi))
+          (type Res (record (sev Sev)))
+          (type Report (record (results (List Res))))
+
+          (fn get-high ((arena Arena) (report Report))
+            (@spec ((Arena Report) -> (List Res)))
+            (@alloc arena)
+            (@post (>= (list-len $result) 0))
+            (@post (<= (list-len $result) (list-len (. report results))))
+            (let ((mut result (list-new arena Res)))
+              (for-each (r (. report results))
+                (match (. r sev)
+                  (hi (list-push result r))
+                  (_ (do))))
+              result)))
+        '''
+        result = verify_source(src, filename="probe.slop")[0]
+        assert result.status == 'verified', result.message
+
+    def test_two_pushes_per_iteration_bounded_by_twice_source(self):
+        from slop.verifier import verify_source
+        src = '''
+        (fn duplicate ((arena Arena) (items (List Int)))
+          (@spec ((Arena (List Int)) -> (List Int)))
+          (@post (<= (list-len $result) (* 2 (list-len items))))
+          (let ((mut result (list-new arena Int)))
+            (for-each (x items)
+              (list-push result x)
+              (list-push result x))
+            result))
+        '''
+        assert verify_source(src)[0].status == 'verified'
+
+    def test_while_loop_push_gets_no_length_bound(self):
+        """A while loop has no collection to measure, so nothing is claimed.
+
+        The claim below is true of the body but not derivable, and the point is
+        that the verifier does not instead claim something false.
+        """
+        from slop.verifier import verify_source
+        src = '''
+        (fn drain ((arena Arena) (n Int))
+          (@spec ((Arena Int) -> (List Int)))
+          (@post (== (list-len $result) 0))
+          (let ((mut result (list-new arena Int))
+                (mut i 0))
+            (while (< i n)
+              (list-push result i)
+              (set! i (+ i 1)))
+            result))
+        '''
+        assert verify_source(src)[0].status != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -7630,3 +7630,49 @@ class TestVacuityGuardCost:
         status, calls = self._guard_calls(self.SRC % 5)
         assert status == 'failed'
         assert calls == 0
+
+
+class TestGroundFragmentFallback:
+    """Deciding consistency outright is the expensive direction: a consistent
+    axiom set means Z3 has to produce a model, and with quantified sequence
+    axioms it often cannot inside the timeout. Dropping assertions can only make
+    a set easier to satisfy, so an unsatisfiable ground subset still proves the
+    whole set unsatisfiable - and the ground fragment is cheap.
+    """
+
+    @staticmethod
+    def _verifier(timeout_ms):
+        from slop.verifier import ContractVerifier, MinimalTypeEnv
+        return ContractVerifier(MinimalTypeEnv(), "<test>", timeout_ms)
+
+    def test_ground_contradiction_found_when_the_full_check_times_out(self):
+        import z3
+        x = z3.Int('x')
+        f = z3.Function('f', z3.IntSort(), z3.IntSort(), z3.IntSort())
+        i, j, k = z3.Ints('i j k')
+        # A quantified axiom Z3 will not settle in a millisecond, alongside a
+        # contradiction that needs no quantifier reasoning at all.
+        hard = z3.ForAll([i, j, k], f(f(i, j), k) == f(i, f(j, k)))
+        assertions = [hard, x == 0, x >= 1]
+
+        verifier = self._verifier(1)
+        assert verifier._axioms_are_contradictory(assertions)
+
+    def test_a_satisfiable_set_is_not_called_contradictory(self):
+        import z3
+        x = z3.Int('x')
+        i = z3.Int('i')
+        g = z3.Function('g', z3.IntSort(), z3.IntSort())
+        assertions = [z3.ForAll([i], g(i) >= 0), x == 3]
+
+        verifier = self._verifier(5000)
+        assert not verifier._axioms_are_contradictory(assertions)
+
+    def test_quantifier_detection_sees_nested_quantifiers(self):
+        import z3
+        i = z3.Int('i')
+        p = z3.Function('p', z3.IntSort(), z3.BoolSort())
+        verifier = self._verifier(1000)
+        assert verifier._contains_quantifier(z3.And(z3.BoolVal(True),
+                                                    z3.ForAll([i], p(i))))
+        assert not verifier._contains_quantifier(z3.Int('x') == 0)

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -7731,3 +7731,37 @@ class TestInconsistencyAttributionLayers:
                 result)))
         ''')
         assert r.status != 'verified'
+
+    def test_compound_loop_source_gets_no_bound(self):
+        """`(if flag items other)` depends on values the escape check cannot
+        enumerate, so `(set! flag ...)` after the loop changes which collection
+        the bound is read against without touching the source expression."""
+        from slop.verifier import verify_source
+        src = '''
+        (fn f ((arena Arena) (mut flag Bool) (items (List Int)) (other (List Int)))
+          (@spec ((Arena Bool (List Int) (List Int)) -> (List Int)))
+          (@alloc arena)
+          (@post (== (list-len $result) (list-len (if flag items other))))
+          (let ((mut r (list-new arena Int)))
+            (do (for-each (x (if flag items other)) (list-push r x))
+                (set! flag (not flag))
+                r)))
+        '''
+        assert verify_source(src)[0].status != 'verified'
+
+    def test_synthetic_field_key_is_not_a_user_variable(self):
+        """`_field_report_results` is the registry key for `(. report results)`
+        and also a legal parameter name. Reading it out of the variable table
+        would tie an unrelated parameter's length to the field's."""
+        from slop.verifier import verify_source
+        src = '''
+        (module m
+          (type Rep (record (results (List Int))))
+          (fn f ((arena Arena) (report Rep) (_field_report_results (List Int)))
+            (@spec ((Arena Rep (List Int)) -> (List Int)))
+            (@alloc arena)
+            (@post (== (list-len (. report results)) (list-len _field_report_results)))
+            (let ((mut r (list-new arena Int)))
+              (do (for-each (x (. report results)) (list-push r x)) r))))
+        '''
+        assert verify_source(src)[0].status != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -7548,3 +7548,85 @@ class TestBaselineTypeContradiction:
         assert r.status == 'failed'
         assert 'admit no value' in r.message
         assert 'Precondition' not in r.message
+
+    def test_empty_range_type_is_found_even_with_a_precondition(self):
+        """The contradiction predates the @pre, so a @pre that is true of
+        nothing in particular must not take the blame for it."""
+        from slop.verifier import verify_source
+        src = '''
+        (module m
+          (type Empty (Int 5 .. 3))
+          (fn f ((n Empty))
+            (@spec ((Empty) -> Int))
+            (@pre (> n 0))
+            (@post (== $result 1))
+            1))
+        '''
+        r = verify_source(src)[0]
+        assert r.status == 'failed'
+        assert 'admit no value' in r.message
+
+    def test_range_field_conflicting_with_an_invariant(self):
+        """The range axioms for record fields are part of what makes the main
+        solver unsat, so the layer that names invariants has to carry them."""
+        from slop.verifier import verify_source
+        src = '''
+        (module m
+          (type Weird (record (x (Int 0 ..)))
+            (@invariant (< x 0)))
+          (fn f ((w Weird))
+            (@spec ((Weird) -> Int))
+            (@post (== $result 1))
+            1))
+        '''
+        r = verify_source(src)[0]
+        assert r.status == 'failed'
+        assert 'Type invariants are contradictory' in r.message
+        assert 'verifier defect' not in r.message
+
+
+class TestVacuityGuardCost:
+    """The guard asks whether the axioms are consistent. That question only
+    needs asking of a proof: a counterexample is itself a model of the axioms,
+    so a sat result has already answered it. Running it up front instead cost a
+    full satisfiability check on every function, which on a large rule file is
+    the expensive direction - Z3 has to find a model rather than refute one, and
+    it took growl's rule files from seconds to minutes.
+    """
+
+    SRC = (
+        '(fn f ((arena Arena))\n'
+        '  (@spec ((Arena) -> (List Int)))\n'
+        '  (@post (== (list-len $result) %d))\n'
+        '  (let ((mut r (list-new arena Int)))\n'
+        '    (do (list-push r 1) r)))\n'
+    )
+
+    @staticmethod
+    def _guard_calls(src):
+        import slop.verifier.contract_verifier as cv
+        from slop.verifier import verify_source
+
+        calls = {"n": 0}
+        orig = cv.ContractVerifier._inconsistent_context_result
+
+        def counted(self, *a, **k):
+            calls["n"] += 1
+            return orig(self, *a, **k)
+
+        cv.ContractVerifier._inconsistent_context_result = counted
+        try:
+            status = verify_source(src)[0].status
+        finally:
+            cv.ContractVerifier._inconsistent_context_result = orig
+        return status, calls["n"]
+
+    def test_the_guard_runs_on_a_proof(self):
+        status, calls = self._guard_calls(self.SRC % 1)
+        assert status == 'verified'
+        assert calls == 1
+
+    def test_the_guard_does_not_run_on_a_counterexample(self):
+        status, calls = self._guard_calls(self.SRC % 5)
+        assert status == 'failed'
+        assert calls == 0

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -7478,6 +7478,20 @@ class TestInconsistencyAttribution:
         assert r.status == 'failed'
         assert 'Assumptions are contradictory' in r.message
 
+    def test_ill_defined_assumption_names_the_assumption(self):
+        """An @assume's own side conditions live in the same growing list as a
+        postcondition's, so without their own marks they fall through to the
+        generic layer and the assumption escapes the blame."""
+        r = self._verify('''
+        (fn f ((n Int))
+          (@spec ((Int) -> Int))
+          (@assume (== (/ 1 0) n))
+          (@post (== $result n))
+          n)
+        ''')
+        assert r.status == 'failed'
+        assert 'Assumptions are contradictory' in r.message
+
     def test_ill_defined_contract_expression(self):
         """A postcondition's own side conditions, not the preconditions.
 
@@ -7824,3 +7838,36 @@ class TestInconsistencyAttributionLayers:
               (do (for-each (x report.results) (list-push r x)) r))))
         '''
         assert verify_source(src)[0].status == 'verified'
+
+
+class TestInternalNamespaceCollisions:
+    """`translator.variables` holds user bindings and the verifier's own
+    accessors in one namespace, so a parameter can claim a name the verifier
+    uses. Calling a Z3 constant raises, which aborts the whole file rather than
+    one function.
+    """
+
+    def test_a_parameter_named_field_len_does_not_abort_the_file(self):
+        from slop.verifier import verify_source
+        src = '''
+        (module m
+          (type T (record (xs (List Int))))
+          (fn f ((arena Arena) (field_len Int) (t T))
+            (@spec ((Arena Int T) -> (List Int)))
+            (@alloc arena)
+            (@post (all-positive $result))
+            (let ((mut r (list-new arena Int)))
+              (do (for-each (x (. t xs)) (list-push r x)) r))))
+        '''
+        results = verify_source(src)
+        assert results, "verification produced no result at all"
+        assert results[0].status in ('verified', 'failed', 'unknown', 'timeout')
+
+    def test_field_len_term_declines_an_occupied_name(self):
+        import z3
+        from slop.verifier import MinimalTypeEnv, Z3Translator
+        translator = Z3Translator(MinimalTypeEnv())
+        translator.variables['xs'] = z3.Int('xs')
+        translator.variables['field_len'] = z3.Int('field_len')
+        assert translator.field_len_term('xs') is None
+        assert translator.list_length_terms('xs') == []

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8046,3 +8046,36 @@ class TestReturnedPreexistingList:
           (list-push xs 1)
           xs)
         ''') != 'verified'
+
+
+class TestReturnedBindingScope:
+    """The returned name has to be resolved to the binding that actually
+    governs it. A body-wide scan conflates same-named bindings in disjoint
+    scopes, and lets an unrelated allocation decide whether the returned list
+    started empty.
+    """
+
+    @staticmethod
+    def _status(src):
+        from slop.verifier import verify_source
+        return verify_source(src)[0].status
+
+    def test_an_unrelated_allocation_does_not_make_the_result_empty(self):
+        assert self._status('''
+        (fn f ((arena Arena) (xs (List Int)))
+          (@spec ((Arena (List Int)) -> (List Int)))
+          (@alloc arena)
+          (@post (== (list-len $result) 0))
+          (let ((mut tmp (list-new arena Int))) tmp)
+          xs)
+        ''') != 'verified'
+
+    def test_disjoint_bindings_of_the_same_name_are_not_shadowing(self):
+        assert self._status('''
+        (fn f ((arena Arena))
+          (@spec ((Arena) -> (List Int)))
+          (@alloc arena)
+          (@post (== (list-len $result) 0))
+          (let ((mut r (list-new arena Int))) (list-push r 1))
+          (let ((mut r (list-new arena Int))) r))
+        ''') == 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -7494,3 +7494,57 @@ class TestInconsistencyAttribution:
         assert r.status == 'failed'
         assert 'well-defined' in r.message
         assert 'Precondition' not in r.message
+
+    def test_field_source_owner_reassigned(self):
+        """A field source is only as stable as the value it reads from.
+
+        `(set! report other)` never mentions `(. report results)`, so a check
+        keyed on the printed source expression alone does not see it.
+        """
+        from slop.verifier import verify_source
+        src = '''
+        (module m
+          (type Rep (record (results (List Int))))
+          (fn f ((arena Arena) (report Rep) (other Rep))
+            (@spec ((Arena Rep Rep) -> (List Int)))
+            (@alloc arena)
+            (@post (== (list-len $result) (list-len (. report results))))
+            (let ((mut r (list-new arena Int)))
+              (do (for-each (x (. report results)) (list-push r x))
+                  (set! report other)
+                  r))))
+        '''
+        assert verify_source(src)[0].status != 'verified'
+
+    def test_field_source_owner_untouched_still_bounds(self):
+        from slop.verifier import verify_source
+        src = '''
+        (module m
+          (type Rep (record (results (List Int))))
+          (fn f ((arena Arena) (report Rep))
+            (@spec ((Arena Rep) -> (List Int)))
+            (@alloc arena)
+            (@post (== (list-len $result) (list-len (. report results))))
+            (let ((mut r (list-new arena Int)))
+              (do (for-each (x (. report results)) (list-push r x)) r))))
+        '''
+        assert verify_source(src)[0].status == 'verified'
+
+
+class TestBaselineTypeContradiction:
+    def test_empty_range_type_is_not_blamed_on_preconditions(self):
+        """The layer is unsat before any @pre is added, and the function has
+        none - reporting them as unsatisfiable names something that is not there."""
+        from slop.verifier import verify_source
+        src = '''
+        (module m
+          (type Empty (Int 5 .. 3))
+          (fn f ((n Empty))
+            (@spec ((Empty) -> Int))
+            (@post (== $result 1))
+            1))
+        '''
+        r = verify_source(src)[0]
+        assert r.status == 'failed'
+        assert 'admit no value' in r.message
+        assert 'Precondition' not in r.message

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -7668,6 +7668,33 @@ class TestGroundFragmentFallback:
         verifier = self._verifier(5000)
         assert not verifier._axioms_are_contradictory(assertions)
 
+    def test_an_undecided_ground_fragment_withholds_the_proof(self):
+        """The fallback is what makes an undecided full check acceptable. If it
+        is undecided too, nothing has been established and the proof is not
+        accepted - answering "cannot tell" with "fine" would disable the guard
+        exactly where it is hardest."""
+        import z3
+        n = 40
+        xs = [z3.Int(f'ground_{k}') for k in range(n)]
+        i = z3.Int('i')
+        g = z3.Function('g', z3.IntSort(), z3.IntSort())
+        # A ground pigeonhole big enough not to settle in a millisecond, plus a
+        # quantified assertion so the ground fragment is a strict subset.
+        ground = [z3.And(x >= 0, x < n - 1) for x in xs] + [z3.Distinct(*xs)]
+        assertions = [z3.ForAll([i], g(i) >= 0)] + ground
+
+        verifier = self._verifier(1)
+        assert verifier._axioms_are_contradictory(assertions)
+
+    def test_an_all_ground_set_that_cannot_be_decided_withholds_the_proof(self):
+        import z3
+        n = 40
+        xs = [z3.Int(f'only_ground_{k}') for k in range(n)]
+        assertions = [z3.And(x >= 0, x < n - 1) for x in xs] + [z3.Distinct(*xs)]
+
+        verifier = self._verifier(1)
+        assert verifier._axioms_are_contradictory(assertions)
+
     def test_quantifier_detection_sees_nested_quantifiers(self):
         import z3
         i = z3.Int('i')
@@ -7765,3 +7792,35 @@ class TestInconsistencyAttributionLayers:
               (do (for-each (x (. report results)) (list-push r x)) r))))
         '''
         assert verify_source(src)[0].status != 'verified'
+
+    def test_dotted_field_source_owner_reassigned(self):
+        """`report.results` is one symbol to the parser, not a (. ...) form, so
+        the owner has to be recovered from the name before it can be tracked."""
+        from slop.verifier import verify_source
+        src = '''
+        (module m
+          (type Rep (record (results (List Int))))
+          (fn f ((arena Arena) (mut report Rep) (other Rep))
+            (@spec ((Arena Rep Rep) -> (List Int)))
+            (@alloc arena)
+            (@post (== (list-len $result) (list-len report.results)))
+            (let ((mut r (list-new arena Int)))
+              (do (for-each (x report.results) (list-push r x))
+                  (set! report other)
+                  r))))
+        '''
+        assert verify_source(src)[0].status != 'verified'
+
+    def test_dotted_field_source_untouched_still_bounds(self):
+        from slop.verifier import verify_source
+        src = '''
+        (module m
+          (type Rep (record (results (List Int))))
+          (fn f ((arena Arena) (report Rep))
+            (@spec ((Arena Rep) -> (List Int)))
+            (@alloc arena)
+            (@post (== (list-len $result) (list-len report.results)))
+            (let ((mut r (list-new arena Int)))
+              (do (for-each (x report.results) (list-push r x)) r))))
+        '''
+        assert verify_source(src)[0].status == 'verified'


### PR DESCRIPTION
Closes #115.

## The bug

`slop verify` reported **`verified` for postconditions that are false**. On a function that pushes
onto the list it returns:

```lisp
(fn c1 ((arena Arena) (root Int))
  (@spec ((Arena Int) -> (List Msg)))
  (@post {(list-len $result) == 99})          ; also: == 0
  (let ((mut r (list-new arena Msg)))
    (do (list-push r (record-new Msg (v 1) (to root))) r)))
```
```
verified: c1
```

Two phases asserted contradictory facts about the same term — a flat `field_len($result) == 0`
derived from the `(mut r (list-new ...))` binding, ignoring every push, and
`field_len($result) >= push_count` derived from the push count. `(axioms AND NOT post)` is then
unsat for *any* post, so everything discharged without being proved.

Measured before this change: **13 of 140** solver contexts in `tests/test_verifier.py` were
self-contradictory — including the two tests that exist to demonstrate the verifier proves
soundness properties — along with 8 functions in snarl.

## The fix

**A vacuity guard.** Before believing a proof, check the base context on its own. Unsat means
nothing can be proved from it. Asked only of a proof: a counterexample is itself a model of the
axioms, so a `sat` result has already answered the question, and a failing function pays nothing.

Four causes get four messages — an impossible `@pre`, contradictory type invariants, an `@assume`
the body refutes, an ill-defined expression — and only what survives all of them asks for a bug
report. The layer that carries the generated axioms is taken from `solver.assertions()` rather
than reconstructed by hand, because reconstructing it kept missing kinds.

**One sound length model.** `_result_length_axioms` derives a single bound from the push sites on
the returned binding:

| push sites | bound |
|---|---|
| none | `len == 0` |
| *n* straight-line unconditional | `len == n` |
| *n* sites, some conditional, none in a loop | `0 <= len <= n` |
| unconditional push in a `for-each` over C | `len == len(C)` |
| *k* sites in a `for-each` over C | `len <= k*len(C)` |
| anything else | no bound |

A list the function allocated started empty, so its sites account for the whole contents; one it
was handed only gets its floor raised. `PushSiteInfo` gains `conditional`, `loop_depth` and
`loop_collections` to support this — a `match` arm carried no entry in `guard_conditions`, and loop
bodies carried no marker at all, so a push in either was indistinguishable from an unconditional
one.

**It fails closed.** `_collect_push_sites` is a whitelist walk, and a bound derived from an
incomplete picture is how this bug happened in the first place. A plain recursive count
cross-checks it; an escape analysis requires every occurrence of the list to sit in a context whose
effect on the length is known; a source must be a variable or a field chain whose owners are only
read. Anything else means no bound.

**A length-vocabulary bridge.** One list could carry three length terms at once — `field_len(x)`,
`Length(seq)`, the array length — picked by encoding flags and never linked, so an axiom stated in
one was invisible to a goal written in another. That is also why a `@property` broke an unrelated
`@post` about `list-len` in the same function (#69); the contamination half of that issue is fixed
here.

Two axioms are retired as unsound rather than replaced: the pre/post length bookkeeping in
`_extract_list_axioms` was dead (nothing read `post_len`, `pre_len` was fresh), and
`field_len(field_X($result)) == field_len(push_target) + push_count` fired exactly when the record
field *was* the push target, where Phase 3 has already asserted the two equal — so the pair read
`X == X + 1`.

## Tests

280 → 372 in `tests/test_verifier.py`; full suite 493 → 585; `make test-native` 50/50 unchanged.

The durable one is a meta-test that walks a corpus of body shapes, re-checks each base context
standalone, and asserts none is unsatisfiable. It does not go through the guard, so it still fires
if the guard is removed. **13 self-contradictory contexts → 0.**

Every soundness fix below is pinned by a test pairing the false claim with the true weaker one, so
a future loosening has to break one of the two.

## Downstream

Measured before and after on all four projects, per function. No edits outside this repo.

| | change |
|---|---|
| slop-rdf | none |
| howl | none |
| snarl | 2 verified → failed |
| growl | 20 → failed, 21 → unknown, 2 → timeout, 1 timeout → verified |

**Those were false proofs.** In the baseline, 30 of 44 growl rule functions carry an axiom
asserting the result list is *empty* — `0 == _len_$result_1` on bodies that push in nested loops —
so a `@post` quantified over the result's elements was discharged against an empty list. Same
defect as the contradiction, a false axiom rather than a conflicting pair, which is why the guard
alone would not have caught it and the length model was needed.

snarl's two are true but underivable: `find-subclasses` pushes from a `while` loop, and
`report-add-result` pushes through an alias and needs an `old()` the language does not have.

**Honest answers are slower.** growl's `scm.slop` goes from 9s to 45s, because Z3 now has to engage
with goals it used to discharge against an empty result.

## Left for later

- **#116** — a `while` loop over a mutable counter builds a self-contradictory axiom set (`0 == i`
  and `Not(10 > i)` about one constant). Found here, surfaced by the guard as `unknown` rather than
  a false pass, but the modelling gap is untouched. It is also why a `while`-built list gets no
  length bound.
- The guard's one stated limit: a contradiction that needs a quantified axiom to derive, in a set
  Z3 cannot settle in time, is not caught. Deciding satisfiability outright is the expensive
  direction, so an undecided full check retries on the ground fragment — sound, since dropping
  assertions only makes a set easier to satisfy — and an undecided *ground* fragment withholds the
  proof. Every contradiction seen in practice has been ground.

16 rounds of `codex exec review`; every finding reproduced before fixing.
