### PR TITLE
carry a record's field facts through a branch (#70)

### DIFF
--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -283,6 +283,10 @@ class AxiomGenerationMixin:
                     return True
                 if expr[0].name == 'fn':
                     return False
+                # Quoted forms are data. A (return ...) inside one is a symbol
+                # the function never executes.
+                if expr[0].name == 'quote':
+                    return False
             for item in expr.items:
                 if self._contains_any_form(item, heads):
                     return True

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -1653,11 +1653,18 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         return False
 
     def _is_conditional_with_record_new(self, expr: SExpr) -> bool:
-        """Check if expression is (if cond (record-new ...) else) or (if cond then (record-new ...))"""
-        if is_form(expr, 'if') and len(expr) >= 4:
-            then_branch = expr[2]
-            else_branch = expr[3]
-            return self._is_record_new(then_branch) or self._is_record_new(else_branch)
+        """True for an `if` or `cond` with a record-new in at least one branch.
+
+        `cond` counts: it is the same shape, and a function that assembles its
+        result differently under three conditions rather than two should not
+        lose its field axioms for it.
+        """
+        if is_form(expr, 'if') and len(expr) >= 3:
+            return any(self._is_record_new(branch) for branch in expr.items[2:])
+        if is_form(expr, 'cond') and len(expr) >= 2:
+            return any(self._is_record_new(clause[-1])
+                       for clause in expr.items[1:]
+                       if isinstance(clause, SList) and len(clause) >= 2)
         return False
 
     def _find_list_push_calls(self, expr: SExpr, result: List[Tuple[SExpr, SExpr]]):
@@ -1836,104 +1843,64 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             if site.loop_depth == 0 and not site.guard_conditions and not site.conditional
         )
 
-    def _extract_conditional_record_axioms(self, cond_expr: SList, translator: Z3Translator) -> List:
-        """Extract axioms for conditional with record-new in either branch.
+    def _extract_conditional_record_axioms(self, cond_expr: SList, translator: Z3Translator,
+                                           bindings: Optional[Dict[str, SExpr]] = None) -> List:
+        """Axioms for a conditional whose branches build or pass along a record.
 
-        For (if cond (record-new Type (f1 v1) ...) var):
-        - Add: cond => field_f1($result) == v1
-        - Add: !cond => field_f1($result) == field_f1(var)
-
-        For (if cond var (record-new Type (f1 v1) ...)):
-        - Add: !cond => field_f1($result) == v1
-        - Add: cond => field_f1($result) == field_f1(var)
+        Each branch contributes its own facts under its own guard. A branch that
+        constructs a record goes through _extract_record_field_axioms, so it
+        picks up everything a record-new says - the length of a `list-new`
+        field, a nested record, a string length, a union tag - rather than only
+        the field-equals-value line this used to reimplement (issue #70). A
+        branch that yields something else carries that value's fields across
+        under the same guard.
         """
         axioms = []
         result_var = translator.variables.get('$result')
         if result_var is None:
             return axioms
+        if bindings is None:
+            bindings = {}
 
-        if len(cond_expr) < 4:
+        branches = self._branch_conditions(cond_expr, translator)
+        if branches is None:
+            return axioms
+
+        field_names: List[str] = []
+        passthrough: List = []
+
+        for guard, branch in branches:
+            if self._is_record_new(branch):
+                record_new = self._get_return_expr(branch)
+                for item in record_new.items[2:]:
+                    if isinstance(item, SList) and len(item) >= 2 and isinstance(item[0], Symbol):
+                        if item[0].name not in field_names:
+                            field_names.append(item[0].name)
+                axioms.extend(self._extract_record_field_axioms(
+                    record_new, translator, base_accessor=result_var,
+                    path_cond=guard, bindings=bindings))
+            else:
+                passthrough.append((guard, branch))
+
+        # A branch that yields an existing record: under its guard the result is
+        # that value, so the fields the other branches name agree with it.
+        for guard, branch in passthrough:
+            branch_z3 = translator.translate_expr(branch)
+            if branch_z3 is None:
+                continue
+            for field_name in field_names:
+                axioms.append(z3.Implies(
+                    guard,
+                    translator._translate_field_for_obj(result_var, field_name)
+                    == translator._translate_field_for_obj(branch_z3, field_name)))
+
+        if not (is_form(cond_expr, 'if') and len(cond_expr) >= 4):
             return axioms
 
         condition = cond_expr[1]
         then_branch = cond_expr[2]
         else_branch = cond_expr[3]
-
-        # Translate the condition
-        cond_z3 = translator.translate_expr(condition)
-        if cond_z3 is None:
-            return axioms
-
-        # Defensive check: ensure condition is Bool before using z3.Not()
-        # Some predicates may not be detected as Bool-returning, handle gracefully
-        if cond_z3.sort() != z3.BoolSort():
-            return axioms
-
-        # Determine which branch has record-new
-        record_new_in_then = self._is_record_new(then_branch)
-        record_new_in_else = self._is_record_new(else_branch)
-
-        # Handle case where BOTH branches are record-new
-        if record_new_in_then and record_new_in_else:
-            # Extract field axioms from both branches
-            then_return = self._get_return_expr(then_branch)
-            else_return = self._get_return_expr(else_branch)
-
-            # Process then branch: cond => field($result) == value
-            for item in then_return.items[2:]:  # Skip 'record-new' and Type
-                if isinstance(item, SList) and len(item) >= 2:
-                    field_name = item[0].name if isinstance(item[0], Symbol) else None
-                    if field_name:
-                        field_value = translator.translate_expr(item[1])
-                        if field_value is not None:
-                            field_func = translator._translate_field_for_obj(result_var, field_name)
-                            axioms.append(z3.Implies(cond_z3, field_func == field_value))
-
-            # Process else branch: !cond => field($result) == value
-            for item in else_return.items[2:]:  # Skip 'record-new' and Type
-                if isinstance(item, SList) and len(item) >= 2:
-                    field_name = item[0].name if isinstance(item[0], Symbol) else None
-                    if field_name:
-                        field_value = translator.translate_expr(item[1])
-                        if field_value is not None:
-                            field_func = translator._translate_field_for_obj(result_var, field_name)
-                            axioms.append(z3.Implies(z3.Not(cond_z3), field_func == field_value))
-
-            return axioms
-
-        if record_new_in_then:
-            record_branch = then_branch
-            var_branch = else_branch
-            record_cond = cond_z3  # record-new happens when cond is true
-        elif record_new_in_else:
-            record_branch = else_branch
-            var_branch = then_branch
-            record_cond = z3.Not(cond_z3)  # record-new happens when cond is false
-        else:
-            return axioms
-
-        # Extract field values from record-new branch
-        field_names = []
-        for item in record_branch.items[2:]:  # Skip 'record-new' and Type
-            if isinstance(item, SList) and len(item) >= 2:
-                field_name = item[0].name if isinstance(item[0], Symbol) else None
-                if field_name:
-                    field_names.append(field_name)
-                    field_value = translator.translate_expr(item[1])
-                    if field_value is not None:
-                        field_func = translator._translate_field_for_obj(result_var, field_name)
-                        # Add: record_cond => field($result) == value
-                        axioms.append(z3.Implies(record_cond, field_func == field_value))
-
-        # Handle variable branch: add field equality axioms
-        if isinstance(var_branch, Symbol):
-            var_z3 = translator.translate_expr(var_branch)
-            if var_z3 is not None:
-                # For each field, add: !record_cond => field($result) == field(var)
-                for field_name in field_names:
-                    result_field = translator._translate_field_for_obj(result_var, field_name)
-                    var_field = translator._translate_field_for_obj(var_z3, field_name)
-                    axioms.append(z3.Implies(z3.Not(record_cond), result_field == var_field))
+        var_branch = else_branch if self._is_record_new(then_branch) else then_branch
 
         # Special case: conditional insert with contains check
         # Pattern: (if (contains coll item) coll (record-new ...add item...))
@@ -2062,110 +2029,222 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         return constraints
 
-    def _extract_record_field_axioms(self, record_new: SList, translator: Z3Translator,
-                                      base_accessor: Optional[z3.ExprRef] = None) -> List:
-        """Extract axioms: field_X($result) == value for each field in record-new
+    def _tail_bindings(self, body: SExpr) -> Dict[str, SExpr]:
+        """Every `let` binding in scope where the body yields its value.
 
-        Also handles:
-        - list-new as field value: add field_len(field_accessor($result)) == 0
-        - nested record-new: recursively extract field axioms for nested records
-        - string literals: add string_len axiom
+        Follows the tail - the last form of each nested do/let - so a field
+        written as `(xs e)` can be resolved back to what `e` was bound to.
+        Inner bindings win, which is the scoping a reader expects.
+        """
+        bindings: Dict[str, SExpr] = {}
+        node = body
+        while True:
+            if is_form(node, 'let') and len(node) >= 3:
+                if isinstance(node[1], SList):
+                    for binding in node[1].items:
+                        if isinstance(binding, SList) and len(binding) >= 2:
+                            name = self._binding_name(binding)
+                            if name:
+                                bindings[name] = binding[-1]
+                node = node.items[-1]
+            elif is_form(node, 'do') and len(node) >= 2:
+                node = node.items[-1]
+            else:
+                return bindings
+
+    def _resolve_binding(self, expr: SExpr, bindings: Dict[str, SExpr]) -> SExpr:
+        """Follow a symbol through the let bindings in scope, to its initializer."""
+        seen = set()
+        node = expr
+        while isinstance(node, Symbol) and node.name in bindings and node.name not in seen:
+            seen.add(node.name)
+            node = bindings[node.name]
+        return node
+
+    def _condition_term(self, cond_expr: SExpr, translator: Z3Translator):
+        """A Bool term for a branch condition, opaque or not.
+
+        An `if` on a function call translates to an Int, and refusing to model
+        the branch at all then loses every fact that holds in *both* arms -
+        which is the usual reason to write one. A fresh Bool keeps the branch
+        structure without claiming to know which way the test goes.
+        """
+        translated = translator.translate_expr(cond_expr)
+        if translated is not None and translated.sort() == z3.BoolSort():
+            return translated
+        self._opaque_condition_counter = getattr(self, '_opaque_condition_counter', 0) + 1
+        return z3.Bool(f"_path_{self._opaque_condition_counter}")
+
+    def _branch_conditions(self, expr: SExpr, translator: Z3Translator):
+        """[(guard, branch)] for an `if` or `cond`, or None if it is neither.
+
+        A `cond` clause runs when its own test holds *and* no earlier one did,
+        so each guard carries the negation of the tests above it. Taking the
+        test alone would claim a later clause runs when an earlier one already
+        matched.
+        """
+        if is_form(expr, 'if') and len(expr) >= 3:
+            guard = self._condition_term(expr[1], translator)
+            branches = [(guard, expr[2])]
+            if len(expr) >= 4:
+                branches.append((z3.Not(guard), expr[3]))
+            return branches
+
+        if is_form(expr, 'cond') and len(expr) >= 2:
+            branches = []
+            earlier: List = []
+            for clause in expr.items[1:]:
+                if not isinstance(clause, SList) or len(clause) < 2:
+                    return None
+                test = clause[0]
+                body = clause[-1]
+                if isinstance(test, Symbol) and test.name == 'else':
+                    guard = z3.And(*[z3.Not(t) for t in earlier]) if earlier else z3.BoolVal(True)
+                    branches.append((guard, body))
+                    break
+                term = self._condition_term(test, translator)
+                guard = z3.And(term, *[z3.Not(t) for t in earlier]) if earlier else term
+                branches.append((guard, body))
+                earlier.append(term)
+            return branches or None
+
+        return None
+
+    @staticmethod
+    def _conjoin(path_cond, guard):
+        """path_cond AND guard, with None standing for "no condition"."""
+        if path_cond is None:
+            return guard
+        if guard is None:
+            return path_cond
+        return z3.And(path_cond, guard)
+
+    def _record_value_axioms(self, field_func, value: SExpr, translator: Z3Translator,
+                             bindings: Dict[str, SExpr], path_cond) -> List:
+        """What is known about a record field, from the shape of its value.
+
+        Recurses through `if`/`cond` in the value itself, conjoining each
+        branch's guard, so `(xs (if c (list-new ...) (list-new ...)))` still
+        yields a length for both arms. A symbol is followed to what it was bound
+        to, which is what makes `(xs e)` work when `e` is a local empty list.
+        """
+        branches = self._branch_conditions(value, translator)
+        if branches is not None:
+            axioms = []
+            for guard, branch in branches:
+                axioms.extend(self._record_value_axioms(
+                    field_func, branch, translator, bindings,
+                    self._conjoin(path_cond, guard)))
+            return axioms
+
+        axioms = []
+
+        def add(axiom):
+            axioms.append(axiom if path_cond is None else z3.Implies(path_cond, axiom))
+
+        resolved = self._resolve_binding(value, bindings)
+
+        # A freshly created list is empty. Reaching it through a binding counts:
+        # a syntactic test for (list-new ...) misses (xs e), and that shape is
+        # not rare.
+        if is_form(resolved, 'list-new'):
+            add(self._length_accessor(translator)(field_func) == z3.IntVal(0))
+
+        if is_form(resolved, 'record-new'):
+            axioms.extend(self._extract_record_field_axioms(
+                resolved, translator, base_accessor=field_func,
+                path_cond=path_cond, bindings=bindings))
+
+        if isinstance(resolved, String):
+            str_len_func_name = "string_len"
+            if str_len_func_name not in translator.variables:
+                str_len_func = z3.Function(str_len_func_name, z3.IntSort(), z3.IntSort())
+                translator.variables[str_len_func_name] = str_len_func
+            else:
+                str_len_func = translator.variables[str_len_func_name]
+            add(str_len_func(field_func) == z3.IntVal(len(resolved.value)))
+
+        # Option/Result constructors: tag, and payload where there is one.
+        if isinstance(resolved, SList) and len(resolved) >= 1:
+            head = resolved[0]
+            if isinstance(head, Symbol) and head.name in {'some', 'none', 'ok', 'error'}:
+                constructor = head.name
+                # Tag index mapping (matches translator.py lines 54-92)
+                tag_idx = {'none': 0, 'some': 1, 'ok': 0, 'error': 1}.get(constructor, 0)
+                if "union_tag" not in translator.variables:
+                    tag_func = z3.Function("union_tag", z3.IntSort(), z3.IntSort())
+                    translator.variables["union_tag"] = tag_func
+                else:
+                    tag_func = translator.variables["union_tag"]
+                add(tag_func(field_func) == z3.IntVal(tag_idx))
+
+                if len(resolved) >= 2 and constructor != 'none':
+                    payload = translator.translate_expr(resolved[1])
+                    if payload is not None:
+                        payload_func_name = f"union_payload_{constructor}"
+                        if payload_func_name not in translator.variables:
+                            payload_func = z3.Function(
+                                payload_func_name, z3.IntSort(), z3.IntSort())
+                            translator.variables[payload_func_name] = payload_func
+                        else:
+                            payload_func = translator.variables[payload_func_name]
+                        add(payload_func(field_func) == payload)
+
+                        if is_form(resolved[1], 'record-new'):
+                            axioms.extend(self._extract_record_field_axioms(
+                                resolved[1], translator,
+                                base_accessor=payload_func(field_func),
+                                path_cond=path_cond, bindings=bindings))
+        return axioms
+
+    @staticmethod
+    def _length_accessor(translator: Z3Translator):
+        """The field_len function, created if this is its first use."""
+        func = translator.variables.get("field_len")
+        if func is None:
+            func = z3.Function("field_len", z3.IntSort(), z3.IntSort())
+            translator.variables["field_len"] = func
+        return func
+
+    def _extract_record_field_axioms(self, record_new: SList, translator: Z3Translator,
+                                      base_accessor: Optional[z3.ExprRef] = None,
+                                      path_cond=None,
+                                      bindings: Optional[Dict[str, SExpr]] = None) -> List:
+        """Axioms for each field of a record-new: its value, and what that implies.
+
+        `path_cond` guards every axiom, for a record built on one branch of a
+        conditional. `bindings` are the let bindings in scope, used to follow a
+        field value written as a local name.
 
         Args:
             record_new: The record-new expression
             translator: The Z3 translator
             base_accessor: The Z3 accessor for the base object (default: $result)
+            path_cond: Bool term this record is conditional on, or None
+            bindings: let bindings in scope at the record-new
         """
         axioms = []
         if base_accessor is None:
             base_accessor = translator.variables.get('$result')
         if base_accessor is None:
             return axioms
+        if bindings is None:
+            bindings = {}
 
         # record-new Type (field1 val1) (field2 val2) ...
         for item in record_new.items[2:]:  # Skip 'record-new' and Type
             if isinstance(item, SList) and len(item) >= 2:
                 field_name = item[0].name if isinstance(item[0], Symbol) else None
-                if field_name:
-                    field_func = translator._translate_field_for_obj(base_accessor, field_name)
-                    field_value = translator.translate_expr(item[1])
-                    if field_value is not None:
-                        axioms.append(field_func == field_value)
-
-                    # If field value is list-new, add length=0 axiom for the field
-                    if is_form(item[1], 'list-new'):
-                        func_name = "field_len"
-                        if func_name not in translator.variables:
-                            len_func = z3.Function(func_name, z3.IntSort(), z3.IntSort())
-                            translator.variables[func_name] = len_func
-                        else:
-                            len_func = translator.variables[func_name]
-                        axioms.append(len_func(field_func) == z3.IntVal(0))
-
-                    # If field value is a nested record-new, recursively extract its field axioms
-                    # This handles patterns like: (record-new Outer (inner (record-new Inner (x 1))))
-                    # We want: field_x(field_inner($result)) == 1
-                    if is_form(item[1], 'record-new'):
-                        nested_axioms = self._extract_record_field_axioms(
-                            item[1], translator, base_accessor=field_func
-                        )
-                        axioms.extend(nested_axioms)
-
-                    # If field value is a string literal, add string_len axiom
-                    # This allows proving postconditions like {(string-len (. report reason)) > 0}
-                    if isinstance(item[1], String):
-                        str_len_func_name = "string_len"
-                        if str_len_func_name not in translator.variables:
-                            str_len_func = z3.Function(str_len_func_name, z3.IntSort(), z3.IntSort())
-                            translator.variables[str_len_func_name] = str_len_func
-                        else:
-                            str_len_func = translator.variables[str_len_func_name]
-                        actual_len = len(item[1].value)
-                        axioms.append(str_len_func(field_func) == z3.IntVal(actual_len))
-
-                    # If field value is a union constructor (some, none, ok, error), add union axioms
-                    # This enables proving match postconditions on record fields containing Option/Result
-                    # e.g., (match $result.current-formula-id ((some id) (== id formula-id)) ((none) false))
-                    if isinstance(item[1], SList) and len(item[1]) >= 1:
-                        field_val = item[1]
-                        head = field_val[0]
-                        if isinstance(head, Symbol) and head.name in {'some', 'none', 'ok', 'error'}:
-                            constructor = head.name
-
-                            # Tag index mapping (matches translator.py lines 54-92)
-                            tag_map = {'none': 0, 'some': 1, 'ok': 0, 'error': 1}
-                            tag_idx = tag_map.get(constructor, 0)
-
-                            # Get/create union_tag function
-                            if "union_tag" not in translator.variables:
-                                tag_func = z3.Function("union_tag", z3.IntSort(), z3.IntSort())
-                                translator.variables["union_tag"] = tag_func
-                            else:
-                                tag_func = translator.variables["union_tag"]
-
-                            # Axiom 1: union_tag(field_X($result)) == tag_index
-                            axioms.append(tag_func(field_func) == z3.IntVal(tag_idx))
-
-                            # For constructors with payload (some, ok, error), add payload axiom
-                            if len(field_val) >= 2 and constructor != 'none':
-                                payload = translator.translate_expr(field_val[1])
-                                if payload is not None:
-                                    payload_func_name = f"union_payload_{constructor}"
-                                    if payload_func_name not in translator.variables:
-                                        payload_func = z3.Function(payload_func_name, z3.IntSort(), z3.IntSort())
-                                        translator.variables[payload_func_name] = payload_func
-                                    else:
-                                        payload_func = translator.variables[payload_func_name]
-
-                                    # Axiom 2: union_payload_<constructor>(field_X($result)) == payload
-                                    axioms.append(payload_func(field_func) == payload)
-
-                                    # If payload is record-new, recursively extract its fields
-                                    if is_form(field_val[1], 'record-new'):
-                                        nested = self._extract_record_field_axioms(
-                                            field_val[1], translator, base_accessor=payload_func(field_func)
-                                        )
-                                        axioms.extend(nested)
+                if not field_name:
+                    continue
+                field_func = translator._translate_field_for_obj(base_accessor, field_name)
+                field_value = translator.translate_expr(item[1])
+                if field_value is not None:
+                    equality = field_func == field_value
+                    axioms.append(equality if path_cond is None
+                                  else z3.Implies(path_cond, equality))
+                axioms.extend(self._record_value_axioms(
+                    field_func, item[1], translator, bindings, path_cond))
         return axioms
 
     def _extract_record_field_range_axioms(self, translator: Z3Translator) -> List:
@@ -2908,7 +2987,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         if fn_body is not None and self._is_record_new(fn_body):
             # Get the actual record-new form (may be inside a do block)
             return_expr = self._get_return_expr(fn_body)
-            field_axioms = self._extract_record_field_axioms(return_expr, translator)
+            field_axioms = self._extract_record_field_axioms(
+                return_expr, translator, bindings=self._tail_bindings(fn_body))
             for axiom in field_axioms:
                 solver.add(axiom)
 
@@ -3017,7 +3097,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         if fn_body is not None:
             return_expr = self._get_return_expr(fn_body)
             if self._is_conditional_with_record_new(return_expr):
-                cond_axioms = self._extract_conditional_record_axioms(return_expr, translator)
+                cond_axioms = self._extract_conditional_record_axioms(
+                    return_expr, translator, bindings=self._tail_bindings(fn_body))
                 for axiom in cond_axioms:
                     solver.add(axiom)
 

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -2239,6 +2239,10 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         node = body
         while True:
             if is_form(node, 'let') and len(node) >= 3:
+                # A binding initializer can return too, and there is no obvious
+                # guard for one that does.
+                if self._contains_any_form(node[1], ('return',)):
+                    return None
                 scan(node.items[2:-1])
                 node = node.items[-1]
             elif is_form(node, 'do') and len(node) >= 2:
@@ -3319,7 +3323,12 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     before = len(translator.constraints)
                     value_z3 = translator.translate_expr(value)
                     for constraint in translator.constraints[before:]:
-                        solver.add(z3.Implies(guard, constraint))
+                        guarded_constraint = z3.Implies(guard, constraint)
+                        solver.add(guarded_constraint)
+                        # constraint_terms is what the inconsistency diagnosis
+                        # replays; a condition only the solver knows about would
+                        # come out as a verifier defect.
+                        constraint_terms.append(guarded_constraint)
                     if value_z3 is None or value_z3.sort() != result_var.sort():
                         continue
                     exit_equality = z3.Implies(guard, result_var == value_z3)

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -3283,13 +3283,16 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     if value is None:
                         continue
                     # Translating a value can append side conditions - a
-                    # non-zero allocation, a string's length - and everything in
-                    # translator.constraints was copied to the solver before
-                    # this point, so the new ones have to be carried over.
+                    # non-zero allocation, a non-zero divisor, a string's length
+                    # - and everything in translator.constraints was copied to
+                    # the solver before this point, so the new ones have to be
+                    # carried over. Under this exit's guard, though: they hold
+                    # because this path ran, and `(when flag (return (/ n n)))`
+                    # would otherwise assert n != 0 for the path that did not.
                     before = len(translator.constraints)
                     value_z3 = translator.translate_expr(value)
                     for constraint in translator.constraints[before:]:
-                        solver.add(constraint)
+                        solver.add(z3.Implies(guard, constraint))
                     if value_z3 is None or value_z3.sort() != result_var.sort():
                         continue
                     exit_equality = z3.Implies(guard, result_var == value_z3)

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -1844,7 +1844,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         )
 
     def _extract_conditional_record_axioms(self, cond_expr: SList, translator: Z3Translator,
-                                           bindings: Optional[Dict[str, SExpr]] = None) -> List:
+                                           bindings: Optional[Dict[str, Tuple[SExpr, Dict]]] = None) -> List:
         """Axioms for a conditional whose branches build or pass along a record.
 
         Each branch contributes its own facts under its own guard. A branch that
@@ -2029,36 +2029,103 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         return constraints
 
-    def _tail_bindings(self, body: SExpr) -> Dict[str, SExpr]:
-        """Every `let` binding in scope where the body yields its value.
+    def _binding_is_stable(self, body: SExpr, name: str) -> bool:
+        """True if `name` is only read in this body, never changed.
+
+        Following a name back to its initializer is only valid while nothing has
+        changed what it holds. `list-push` and `list-pop` mutate the list in
+        place, `set!` replaces it outright, and handing it to a function lets
+        the callee do either - so only the handful of positions that are known
+        to be reads keep a binding resolvable.
+        """
+        def walk(node, parent_head, index, in_pair) -> bool:
+            if isinstance(node, Symbol):
+                if node.name != name:
+                    return True
+                if parent_head in ('list-len', 'list-get') and index == 1:
+                    return True
+                if parent_head == 'mut' and index == 1:
+                    return True
+                # Inside a let binding or a record-new field pair the name is
+                # either being bound or being read as a value. Neither changes
+                # what it holds, and the second is the use this resolution
+                # exists to serve.
+                if in_pair:
+                    return True
+                return False
+
+            if not isinstance(node, SList):
+                return True
+
+            head = node[0].name if len(node) and isinstance(node[0], Symbol) else None
+            is_record_new = is_form(node, 'record-new')
+            is_let_bindings = parent_head == 'let' and index == 1
+            for i, item in enumerate(node.items):
+                in_child_pair = (is_record_new and i >= 2) or is_let_bindings
+                if in_child_pair and isinstance(item, SList):
+                    # A pair's head is a name, not a call, so its children are
+                    # walked with no parent head of their own.
+                    for j, sub in enumerate(item.items):
+                        if not walk(sub, None, j, True):
+                            return False
+                    continue
+                if not walk(item, head, i, False):
+                    return False
+            return True
+
+        return walk(body, None, -1, False)
+
+    def _tail_bindings(self, body: SExpr) -> Dict[str, Tuple[SExpr, Dict]]:
+        """The `let` bindings in scope where the body yields its value.
 
         Follows the tail - the last form of each nested do/let - so a field
-        written as `(xs e)` can be resolved back to what `e` was bound to.
-        Inner bindings win, which is the scoping a reader expects.
+        written as `(xs e)` can be resolved back to what `e` was bound to. Each
+        entry carries the environment as it stood at its own binding, because a
+        later `let` may rebind a name an earlier initializer referred to: with
+        one flattened map, `(let ((x zs)) (let ((y x)) (let ((x (list-new ...)))`
+        would resolve `y` to the inner empty list rather than to `zs`.
+
+        A name that anything mutates is dropped rather than recorded.
         """
-        bindings: Dict[str, SExpr] = {}
+        bindings: Dict[str, Tuple[SExpr, Dict]] = {}
         node = body
         while True:
             if is_form(node, 'let') and len(node) >= 3:
                 if isinstance(node[1], SList):
                     for binding in node[1].items:
-                        if isinstance(binding, SList) and len(binding) >= 2:
-                            name = self._binding_name(binding)
-                            if name:
-                                bindings[name] = binding[-1]
+                        if not (isinstance(binding, SList) and len(binding) >= 2):
+                            continue
+                        name = self._binding_name(binding)
+                        if not name:
+                            continue
+                        if not self._binding_is_stable(body, name):
+                            bindings.pop(name, None)
+                            continue
+                        # The translator gives both bindings of a shadowed name
+                        # one Z3 constant, so a fact derived from the inner
+                        # initializer would be asserted about the outer value
+                        # too. Nothing may be resolved through such a name.
+                        if self._count_bindings_of(body, name) > 1:
+                            bindings.pop(name, None)
+                            continue
+                        bindings[name] = (binding[-1], dict(bindings))
                 node = node.items[-1]
             elif is_form(node, 'do') and len(node) >= 2:
                 node = node.items[-1]
             else:
                 return bindings
 
-    def _resolve_binding(self, expr: SExpr, bindings: Dict[str, SExpr]) -> SExpr:
-        """Follow a symbol through the let bindings in scope, to its initializer."""
+    def _resolve_binding(self, expr: SExpr, bindings: Dict[str, Tuple[SExpr, Dict]]) -> SExpr:
+        """Follow a symbol through the bindings in scope, to its initializer.
+
+        Each step continues in the environment that binding was made in, so a
+        name rebound later does not reach back into an earlier initializer.
+        """
         seen = set()
-        node = expr
-        while isinstance(node, Symbol) and node.name in bindings and node.name not in seen:
+        node, env = expr, bindings
+        while isinstance(node, Symbol) and node.name in env and node.name not in seen:
             seen.add(node.name)
-            node = bindings[node.name]
+            node, env = env[node.name]
         return node
 
     def _condition_term(self, cond_expr: SExpr, translator: Z3Translator):
@@ -2072,8 +2139,10 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         translated = translator.translate_expr(cond_expr)
         if translated is not None and translated.sort() == z3.BoolSort():
             return translated
-        self._opaque_condition_counter = getattr(self, '_opaque_condition_counter', 0) + 1
-        return z3.Bool(f"_path_{self._opaque_condition_counter}")
+        # FreshBool rather than a name of our own choosing: `_path_1` is a legal
+        # SLOP identifier, and colliding with a parameter of that name would tie
+        # the branch to an unrelated input.
+        return z3.FreshBool('_path')
 
     def _branch_conditions(self, expr: SExpr, translator: Z3Translator):
         """[(guard, branch)] for an `if` or `cond`, or None if it is neither.
@@ -2120,7 +2189,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         return z3.And(path_cond, guard)
 
     def _record_value_axioms(self, field_func, value: SExpr, translator: Z3Translator,
-                             bindings: Dict[str, SExpr], path_cond) -> List:
+                             bindings: Dict[str, Tuple[SExpr, Dict]], path_cond) -> List:
         """What is known about a record field, from the shape of its value.
 
         Recurses through `if`/`cond` in the value itself, conjoining each
@@ -2209,7 +2278,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
     def _extract_record_field_axioms(self, record_new: SList, translator: Z3Translator,
                                       base_accessor: Optional[z3.ExprRef] = None,
                                       path_cond=None,
-                                      bindings: Optional[Dict[str, SExpr]] = None) -> List:
+                                      bindings: Optional[Dict[str, Tuple[SExpr, Dict]]] = None) -> List:
         """Axioms for each field of a record-new: its value, and what that implies.
 
         `path_cond` guards every axiom, for a record built on one branch of a

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -1844,7 +1844,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         )
 
     def _extract_conditional_record_axioms(self, cond_expr: SList, translator: Z3Translator,
-                                           bindings: Optional[Dict[str, Tuple[SExpr, Dict]]] = None) -> List:
+                                           fn_body: Optional[SExpr] = None,
+                                           param_names: Optional[Set[str]] = None) -> List:
         """Axioms for a conditional whose branches build or pass along a record.
 
         Each branch contributes its own facts under its own guard. A branch that
@@ -1859,12 +1860,20 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         result_var = translator.variables.get('$result')
         if result_var is None:
             return axioms
-        if bindings is None:
-            bindings = {}
+        if fn_body is None:
+            fn_body = cond_expr
 
         branches = self._branch_conditions(cond_expr, translator)
         if branches is None:
             return axioms
+
+        # Every constructor about to be described, so a list stored in one of
+        # them still counts as read-only; a record built anywhere else is a way
+        # to reach the list again.
+        result_forms = tuple(
+            id(self._get_return_expr(branch)) for _, branch in branches
+            if self._is_record_new(branch))
+        bindings = self._tail_bindings(fn_body, param_names, result_forms=result_forms)
 
         field_names: List[str] = []
         passthrough: List = []
@@ -1872,13 +1881,18 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         for guard, branch in branches:
             if self._is_record_new(branch):
                 record_new = self._get_return_expr(branch)
+                # An arm may bind its own locals before constructing.
+                branch_bindings = dict(bindings)
+                branch_bindings.update(self._tail_bindings(
+                    branch, param_names, stability_body=fn_body,
+                    result_forms=result_forms))
                 for item in record_new.items[2:]:
                     if isinstance(item, SList) and len(item) >= 2 and isinstance(item[0], Symbol):
                         if item[0].name not in field_names:
                             field_names.append(item[0].name)
                 axioms.extend(self._extract_record_field_axioms(
                     record_new, translator, base_accessor=result_var,
-                    path_cond=guard, bindings=bindings))
+                    path_cond=guard, bindings=branch_bindings))
             else:
                 passthrough.append((guard, branch))
 
@@ -2051,6 +2065,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         return aliases
 
     def _binding_is_stable(self, body: SExpr, name: str,
+                           result_forms: Tuple[int, ...] = (),
                            seen: Optional[Set[str]] = None) -> bool:
         """True if `name` is only read in this body, never changed.
 
@@ -2060,9 +2075,13 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         the callee do either - so only the handful of positions that are known
         to be reads keep a binding resolvable.
 
-        A read is not always harmless: `(let ((a e)) (list-push a it))` mutates
-        the same list through another name. Every alias of the name has to be
-        stable too, which is what `seen` follows.
+        A read is not always harmless. `(let ((a e)) (list-push a it))` mutates
+        the same list through another name, so every alias has to be stable too
+        - that is what `seen` follows. And storing the list in a record hands
+        out another way to reach it: `(list-push (. box xs) it)` never mentions
+        `e`. So a record field counts as a read only inside `result_forms`, the
+        constructors whose fields are being described here, which nothing in the
+        function can reach through afterwards.
         """
         if seen is None:
             seen = set()
@@ -2071,7 +2090,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         seen.add(name)
 
         for alias in self._aliases_of(body, name):
-            if not self._binding_is_stable(body, alias, seen):
+            if not self._binding_is_stable(body, alias, result_forms, seen):
                 return False
 
         def walk(node, parent_head, index, in_pair) -> bool:
@@ -2082,10 +2101,9 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     return True
                 if parent_head == 'mut' and index == 1:
                     return True
-                # Inside a let binding or a record-new field pair the name is
-                # either being bound or being read as a value. Neither changes
-                # what it holds, and the second is the use this resolution
-                # exists to serve.
+                # A let binding or a field of a constructor being described
+                # here: the name is bound, or read as a value that nothing goes
+                # on to reach through.
                 if in_pair:
                     return True
                 return False
@@ -2094,10 +2112,12 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 return True
 
             head = node[0].name if len(node) and isinstance(node[0], Symbol) else None
-            is_record_new = is_form(node, 'record-new')
+            # An intermediate record is a way to reach the list again, so only
+            # the constructors whose fields are being described count as reads.
+            is_result_record = is_form(node, 'record-new') and id(node) in result_forms
             is_let_bindings = parent_head == 'let' and index == 1
             for i, item in enumerate(node.items):
-                in_child_pair = (is_record_new and i >= 2) or is_let_bindings
+                in_child_pair = (is_result_record and i >= 2) or is_let_bindings
                 if in_child_pair and isinstance(item, SList):
                     # A pair's head is a name, not a call, so its children are
                     # walked with no parent head of their own.
@@ -2112,7 +2132,9 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         return walk(body, None, -1, False)
 
     def _tail_bindings(self, body: SExpr,
-                       param_names: Optional[Set[str]] = None) -> Dict[str, Tuple[SExpr, Dict]]:
+                       param_names: Optional[Set[str]] = None,
+                       stability_body: Optional[SExpr] = None,
+                       result_forms: Tuple[int, ...] = ()) -> Dict[str, Tuple[SExpr, Dict]]:
         """The `let` bindings in scope where the body yields its value.
 
         Follows the tail - the last form of each nested do/let - so a field
@@ -2127,6 +2149,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         """
         if param_names is None:
             param_names = set()
+        if stability_body is None:
+            stability_body = body
         bindings: Dict[str, Tuple[SExpr, Dict]] = {}
         node = body
         while True:
@@ -2138,7 +2162,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                         name = self._binding_name(binding)
                         if not name:
                             continue
-                        if not self._binding_is_stable(body, name):
+                        if not self._binding_is_stable(stability_body, name, result_forms):
                             bindings.pop(name, None)
                             continue
                         # The translator gives every binding of a name one Z3
@@ -2148,7 +2172,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                         # through a name that is bound more than once, and a
                         # parameter counts as one of those bindings.
                         if (name in param_names
-                                or self._count_bindings_of(body, name) > 1):
+                                or self._count_bindings_of(stability_body, name) > 1):
                             bindings.pop(name, None)
                             continue
                         bindings[name] = (binding[-1], dict(bindings))
@@ -2240,7 +2264,12 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         yields a length for both arms. A symbol is followed to what it was bound
         to, which is what makes `(xs e)` work when `e` is a local empty list.
         """
-        branches = self._branch_conditions(value, translator)
+        # Resolve first: a field written as `(xs e)` where `e` was bound to an
+        # `if` is still a branch, and dispatching on the unresolved symbol would
+        # miss it.
+        resolved = self._resolve_binding(value, bindings)
+
+        branches = self._branch_conditions(resolved, translator)
         if branches is not None:
             axioms = []
             for guard, branch in branches:
@@ -2253,8 +2282,6 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         def add(axiom):
             axioms.append(axiom if path_cond is None else z3.Implies(path_cond, axiom))
-
-        resolved = self._resolve_binding(value, bindings)
 
         # A freshly created list is empty. Reaching it through a binding counts:
         # a syntactic test for (list-new ...) misses (xs e), and that shape is
@@ -3110,7 +3137,9 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             return_expr = self._get_return_expr(fn_body)
             field_axioms = self._extract_record_field_axioms(
                 return_expr, translator,
-                bindings=self._tail_bindings(fn_body, declared_param_names))
+                bindings=self._tail_bindings(
+                    fn_body, declared_param_names,
+                    result_forms=(id(return_expr),)))
             for axiom in field_axioms:
                 solver.add(axiom)
 
@@ -3220,8 +3249,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             return_expr = self._get_return_expr(fn_body)
             if self._is_conditional_with_record_new(return_expr):
                 cond_axioms = self._extract_conditional_record_axioms(
-                    return_expr, translator,
-                    bindings=self._tail_bindings(fn_body, declared_param_names))
+                    return_expr, translator, fn_body, declared_param_names)
                 for axiom in cond_axioms:
                     solver.add(axiom)
 

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -1224,7 +1224,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         pre_z3, preconditions, invariant_z3, range_field_axioms, assume_z3,
         type_constraint_count, pre_constraint_count,
         assume_constraint_start, assume_constraint_end, body_equality,
-        result_length_axioms,
+        result_length_axioms, constraint_terms,
     ):
         """A result to report when the axioms contradict each other, else None.
 
@@ -1247,7 +1247,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         layer = z3.Solver()
         layer.set("timeout", self.timeout_ms)
-        for c in translator.constraints[:type_constraint_count]:
+        for c in constraint_terms[:type_constraint_count]:
             layer.add(c)
 
         if layer.check() == z3.unsat:
@@ -1270,7 +1270,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # them - @assume is trusted, so one that the body refutes is the
         # author's error rather than ours.
         assumption_assertions = (
-            list(translator.constraints[assume_constraint_start:assume_constraint_end])
+            list(constraint_terms[assume_constraint_start:assume_constraint_end])
             + list(assume_z3)
         )
 
@@ -1287,7 +1287,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         authored = [
             (
                 self._unsatisfiable_precondition_message(preconditions),
-                list(translator.constraints[type_constraint_count:pre_constraint_count])
+                list(constraint_terms[type_constraint_count:pre_constraint_count])
                 + list(pre_z3),
             ),
             (
@@ -1300,8 +1300,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 "A contract or body expression cannot be well-defined: the side "
                 "conditions from translating them cannot all hold. A division by "
                 "a zero denominator or a value outside its range type does this.",
-                list(translator.constraints[pre_constraint_count:assume_constraint_start])
-                + list(translator.constraints[assume_constraint_end:]),
+                list(constraint_terms[pre_constraint_count:assume_constraint_start])
+                + list(constraint_terms[assume_constraint_end:]),
             ),
             (
                 "The body cannot produce a value of the declared return type: "
@@ -2186,10 +2186,25 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         failed = False
 
         def returned_value(stmts):
+            """The value a statement list returns directly, if that is all of it.
+
+            `(when c (if d (return 1) 0) (return 2))` returns 1 when d holds, so
+            taking the direct `(return 2)` as the whole story would model the
+            wrong value for part of the path. A nested return anywhere means the
+            shape is not one this can guard.
+            """
+            direct = None
+            found = False
             for stmt in stmts:
                 if is_form(stmt, 'return'):
-                    return stmt[1] if len(stmt) >= 2 else None, True
-            return None, False
+                    if found:
+                        return None, False
+                    direct = stmt[1] if len(stmt) >= 2 else None
+                    found = True
+                    continue
+                if self._contains_any_form(stmt, ('return',)):
+                    return None, False
+            return direct, found
 
         def note(guard_term, value):
             guard = z3.And(guard_term, *[z3.Not(t) for t in earlier]) if earlier else guard_term
@@ -3060,8 +3075,10 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # This is important because @loop-invariant may reference local variables
         # from let bindings, which are declared during body translation
         body_z3: Optional[z3.ExprRef] = None
+        body_constraint_start = len(translator.constraints)
         if fn_body is not None and postconditions:
             body_z3 = translator.translate_expr(fn_body)
+        body_constraint_end = len(translator.constraints)
             # If we can translate the body, constrain $result to equal it
             # This enables path-sensitive reasoning through conditionals
 
@@ -3198,13 +3215,49 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 location=SourceLocation(self.filename, fn_form.line, fn_form.col)
             )
 
+        # _get_return_expr picks the trailing form. An explicit (return ...)
+        # elsewhere is another exit, and what it yields is just as much $result,
+        # so nothing the trailing constructor says describes the result alone.
+        # A multi-form body keeps only its last expression in fn_body, so the
+        # earlier forms have to be looked at too - both for that check and for
+        # the bindings a constructor's fields may refer to.
+        # The last element is fn_body rather than all_body_exprs[-1]: those are
+        # the same form, but fn_body has been through
+        # _desugar_callback_iterations and the other has not, and the two trees
+        # share no nodes. Anything keyed on node identity - which constructor
+        # is the returned one - has to see the same tree it was taken from.
+        combined_body = fn_body
+        if fn_body is not None and all_body_exprs and len(all_body_exprs) > 1:
+            combined_body = SList(
+                [Symbol('do')] + list(all_body_exprs[:-1]) + [fn_body],
+                fn_body.line, fn_body.col)
+        # Exits other than the trailing form. `reached` is the condition under
+        # which control actually gets there; None means it always does, and a
+        # `return` in a shape _early_exits cannot guard leaves early_exits None,
+        # in which case nothing is claimed about the result at all.
+        early_exits = (self._early_exits(combined_body, translator)
+                       if combined_body is not None else [])
+        body_has_one_exit = early_exits is not None
+        reached_guard = None
+        if early_exits:
+            reached_guard = z3.And(*[z3.Not(guard) for guard, _ in early_exits])
+
+        # The tail's own side conditions - a non-zero divisor, a string length -
+        # only hold because the tail ran. An early return bypasses it, so they
+        # travel under the same guard as everything else derived from it.
+        constraint_terms = list(translator.constraints)
+        if reached_guard is not None:
+            for i in range(body_constraint_start, min(body_constraint_end,
+                                                      len(constraint_terms))):
+                constraint_terms[i] = z3.Implies(reached_guard, constraint_terms[i])
+
         # Check: can we satisfy preconditions but violate postconditions?
         # If (pre AND NOT post) is SAT, then contract can be violated
         solver = z3.Solver()
         solver.set("timeout", self.timeout_ms)
 
         # Add type constraints
-        for c in translator.constraints:
+        for c in constraint_terms:
             solver.add(c)
 
         # Add preconditions
@@ -3234,32 +3287,6 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         for axiom in range_field_axioms:
             solver.add(axiom)
 
-        # _get_return_expr picks the trailing form. An explicit (return ...)
-        # elsewhere is another exit, and what it yields is just as much $result,
-        # so nothing the trailing constructor says describes the result alone.
-        # A multi-form body keeps only its last expression in fn_body, so the
-        # earlier forms have to be looked at too - both for that check and for
-        # the bindings a constructor's fields may refer to.
-        # The last element is fn_body rather than all_body_exprs[-1]: those are
-        # the same form, but fn_body has been through
-        # _desugar_callback_iterations and the other has not, and the two trees
-        # share no nodes. Anything keyed on node identity - which constructor
-        # is the returned one - has to see the same tree it was taken from.
-        combined_body = fn_body
-        if fn_body is not None and all_body_exprs and len(all_body_exprs) > 1:
-            combined_body = SList(
-                [Symbol('do')] + list(all_body_exprs[:-1]) + [fn_body],
-                fn_body.line, fn_body.col)
-        # Exits other than the trailing form. `reached` is the condition under
-        # which control actually gets there; None means it always does, and a
-        # `return` in a shape _early_exits cannot guard leaves early_exits None,
-        # in which case nothing is claimed about the result at all.
-        early_exits = (self._early_exits(combined_body, translator)
-                       if combined_body is not None else [])
-        body_has_one_exit = early_exits is not None
-        reached_guard = None
-        if early_exits:
-            reached_guard = z3.And(*[z3.Not(guard) for guard, _ in early_exits])
 
         # Add body constraint for path-sensitive analysis
         # This constrains $result to equal the translated function body
@@ -3726,7 +3753,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 pre_z3, preconditions, invariant_z3, range_field_axioms, assume_z3,
                 type_constraint_count, pre_constraint_count,
                 assume_constraint_start, assume_constraint_end, body_equality,
-                result_length_axioms,
+                result_length_axioms, constraint_terms,
             )
             if inconsistent is not None:
                 return inconsistent

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -2029,7 +2029,29 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         return constraints
 
-    def _binding_is_stable(self, body: SExpr, name: str) -> bool:
+    def _aliases_of(self, body: SExpr, name: str) -> List[str]:
+        """Names bound directly to `name`, which therefore denote the same list."""
+        aliases: List[str] = []
+
+        def walk(node):
+            if not isinstance(node, SList):
+                return
+            if is_form(node, 'let') and len(node) >= 2 and isinstance(node[1], SList):
+                for binding in node[1].items:
+                    if isinstance(binding, SList) and len(binding) >= 2:
+                        value = binding[-1]
+                        if isinstance(value, Symbol) and value.name == name:
+                            bound = self._binding_name(binding)
+                            if bound and bound != name:
+                                aliases.append(bound)
+            for item in node.items:
+                walk(item)
+
+        walk(body)
+        return aliases
+
+    def _binding_is_stable(self, body: SExpr, name: str,
+                           seen: Optional[Set[str]] = None) -> bool:
         """True if `name` is only read in this body, never changed.
 
         Following a name back to its initializer is only valid while nothing has
@@ -2037,7 +2059,21 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         place, `set!` replaces it outright, and handing it to a function lets
         the callee do either - so only the handful of positions that are known
         to be reads keep a binding resolvable.
+
+        A read is not always harmless: `(let ((a e)) (list-push a it))` mutates
+        the same list through another name. Every alias of the name has to be
+        stable too, which is what `seen` follows.
         """
+        if seen is None:
+            seen = set()
+        if name in seen:
+            return True
+        seen.add(name)
+
+        for alias in self._aliases_of(body, name):
+            if not self._binding_is_stable(body, alias, seen):
+                return False
+
         def walk(node, parent_head, index, in_pair) -> bool:
             if isinstance(node, Symbol):
                 if node.name != name:
@@ -2075,7 +2111,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         return walk(body, None, -1, False)
 
-    def _tail_bindings(self, body: SExpr) -> Dict[str, Tuple[SExpr, Dict]]:
+    def _tail_bindings(self, body: SExpr,
+                       param_names: Optional[Set[str]] = None) -> Dict[str, Tuple[SExpr, Dict]]:
         """The `let` bindings in scope where the body yields its value.
 
         Follows the tail - the last form of each nested do/let - so a field
@@ -2085,8 +2122,11 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         one flattened map, `(let ((x zs)) (let ((y x)) (let ((x (list-new ...)))`
         would resolve `y` to the inner empty list rather than to `zs`.
 
-        A name that anything mutates is dropped rather than recorded.
+        A name that anything mutates is dropped rather than recorded, as is one
+        that shadows another binding or a parameter.
         """
+        if param_names is None:
+            param_names = set()
         bindings: Dict[str, Tuple[SExpr, Dict]] = {}
         node = body
         while True:
@@ -2101,11 +2141,14 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                         if not self._binding_is_stable(body, name):
                             bindings.pop(name, None)
                             continue
-                        # The translator gives both bindings of a shadowed name
-                        # one Z3 constant, so a fact derived from the inner
-                        # initializer would be asserted about the outer value
-                        # too. Nothing may be resolved through such a name.
-                        if self._count_bindings_of(body, name) > 1:
+                        # The translator gives every binding of a name one Z3
+                        # constant, so a fact derived from the inner initializer
+                        # would be asserted about the outer value too - or about
+                        # the parameter, which is worse. Nothing may be resolved
+                        # through a name that is bound more than once, and a
+                        # parameter counts as one of those bindings.
+                        if (name in param_names
+                                or self._count_bindings_of(body, name) > 1):
                             bindings.pop(name, None)
                             continue
                         bindings[name] = (binding[-1], dict(bindings))
@@ -2772,6 +2815,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                                   use_seq_encoding=use_seq_encoding)
 
         # Declare parameter variables
+        declared_param_names: Set[str] = set()
         for param in params:
             if isinstance(param, SList) and len(param) >= 2:
                 # Handle parameter modes: (name Type) or (in name Type) or (out name Type) or (mut name Type)
@@ -2784,6 +2828,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     # No mode: (name Type)
                     param_name = first.name if isinstance(first, Symbol) else None
                     param_type_expr = param[1]
+                if param_name:
+                    declared_param_names.add(param_name)
                 if param_name and param_type_expr:
                     param_type = _parse_type_expr_simple(param_type_expr, self.type_env.type_registry)
                     translator.declare_variable(param_name, param_type)
@@ -3053,11 +3099,18 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         # Phase 3: Add record field axioms if body is record-new
         # For (record-new Type (field1 val1) ...), add: field_field1($result) == val1
-        if fn_body is not None and self._is_record_new(fn_body):
+        # _get_return_expr picks the trailing form. An explicit (return ...)
+        # elsewhere is another exit, and what it yields is just as much $result,
+        # so nothing the trailing constructor says describes the result alone.
+        body_has_one_exit = (fn_body is not None
+                             and not self._contains_any_form(fn_body, ('return',)))
+
+        if fn_body is not None and body_has_one_exit and self._is_record_new(fn_body):
             # Get the actual record-new form (may be inside a do block)
             return_expr = self._get_return_expr(fn_body)
             field_axioms = self._extract_record_field_axioms(
-                return_expr, translator, bindings=self._tail_bindings(fn_body))
+                return_expr, translator,
+                bindings=self._tail_bindings(fn_body, declared_param_names))
             for axiom in field_axioms:
                 solver.add(axiom)
 
@@ -3163,11 +3216,12 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # Phase 5: Add conditional record-new axioms
         # For (if cond (record-new Type (f1 v1) ...) else), add: cond => field_f1($result) == v1
         # Use _get_return_expr to handle let/do wrappers
-        if fn_body is not None:
+        if fn_body is not None and body_has_one_exit:
             return_expr = self._get_return_expr(fn_body)
             if self._is_conditional_with_record_new(return_expr):
                 cond_axioms = self._extract_conditional_record_axioms(
-                    return_expr, translator, bindings=self._tail_bindings(fn_body))
+                    return_expr, translator,
+                    bindings=self._tail_bindings(fn_body, declared_param_names))
                 for axiom in cond_axioms:
                     solver.add(axiom)
 

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -1870,9 +1870,10 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # Every constructor about to be described, so a list stored in one of
         # them still counts as read-only; a record built anywhere else is a way
         # to reach the list again.
-        result_forms = tuple(
-            id(self._get_return_expr(branch)) for _, branch in branches
-            if self._is_record_new(branch))
+        result_forms: Tuple[int, ...] = ()
+        for _, branch in branches:
+            if self._is_record_new(branch):
+                result_forms += self._nested_record_forms(self._get_return_expr(branch))
         bindings = self._tail_bindings(fn_body, param_names, result_forms=result_forms)
         # A branch-local name may shadow an enclosing binding, which shares its
         # Z3 constant. Sibling arms do not: their axioms carry mutually
@@ -2135,6 +2136,26 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         return walk(body, None, -1, False)
 
+    def _nested_record_forms(self, expr: SExpr) -> Tuple[int, ...]:
+        """Every record-new inside `expr`, itself included.
+
+        A constructor nested in the one being returned is part of the same
+        value: it is built inline and nothing in the function can reach through
+        it afterwards, so a list stored there is as safe as one stored directly.
+        """
+        forms: List[int] = []
+
+        def walk(node):
+            if not isinstance(node, SList):
+                return
+            if is_form(node, 'record-new'):
+                forms.append(id(node))
+            for item in node.items:
+                walk(item)
+
+        walk(expr)
+        return tuple(forms)
+
     def _tail_binding_names(self, body: SExpr) -> Set[str]:
         """Every name bound along the tail of `body`, kept or not."""
         names: Set[str] = set()
@@ -2178,6 +2199,13 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         if stability_body is None:
             stability_body = body
         bindings: Dict[str, Tuple[SExpr, Dict]] = {}
+        # The translator gives every binding of a name one Z3 constant, so a
+        # fact derived from one initializer would be asserted about the other
+        # value too. That only matters for bindings whose scopes overlap: one
+        # further down this same tail, or a parameter. Two disjoint `let`s in a
+        # `do`, like two sibling branches, cannot see each other.
+        seen: Set[str] = set()
+        dropped: Set[str] = set()
         node = body
         while True:
             if is_form(node, 'let') and len(node) >= 3:
@@ -2186,19 +2214,15 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                         if not (isinstance(binding, SList) and len(binding) >= 2):
                             continue
                         name = self._binding_name(binding)
-                        if not name:
+                        if not name or name in dropped:
                             continue
-                        if not self._binding_is_stable(stability_body, name, result_forms):
+                        if name in seen or name in param_names:
+                            dropped.add(name)
                             bindings.pop(name, None)
                             continue
-                        # The translator gives every binding of a name one Z3
-                        # constant, so a fact derived from the inner initializer
-                        # would be asserted about the outer value too - or about
-                        # the parameter, which is worse. Nothing may be resolved
-                        # through a name that is bound more than once, and a
-                        # parameter counts as one of those bindings.
-                        if (name in param_names
-                                or self._count_bindings_of(body, name) > 1):
+                        seen.add(name)
+                        if not self._binding_is_stable(stability_body, name, result_forms):
+                            dropped.add(name)
                             bindings.pop(name, None)
                             continue
                         bindings[name] = (binding[-1], dict(bindings))
@@ -3165,7 +3189,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 return_expr, translator,
                 bindings=self._tail_bindings(
                     fn_body, declared_param_names,
-                    result_forms=(id(return_expr),)))
+                    result_forms=self._nested_record_forms(return_expr)))
             for axiom in field_axioms:
                 solver.add(axiom)
 

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -3282,12 +3282,32 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 for guard, value in early_exits:
                     if value is None:
                         continue
+                    # Translating a value can append side conditions - a
+                    # non-zero allocation, a string's length - and everything in
+                    # translator.constraints was copied to the solver before
+                    # this point, so the new ones have to be carried over.
+                    before = len(translator.constraints)
                     value_z3 = translator.translate_expr(value)
+                    for constraint in translator.constraints[before:]:
+                        solver.add(constraint)
                     if value_z3 is None or value_z3.sort() != result_var.sort():
                         continue
                     exit_equality = z3.Implies(guard, result_var == value_z3)
                     body_equality.append(exit_equality)
                     solver.add(exit_equality)
+
+                    # A record returned early needs its fields too: the
+                    # equality alone ties $result to a fresh identifier that
+                    # nothing else says anything about.
+                    exit_form = self._get_return_expr(value)
+                    if is_form(exit_form, 'record-new'):
+                        for axiom in self._extract_record_field_axioms(
+                                exit_form, translator, base_accessor=result_var,
+                                path_cond=guard,
+                                bindings=self._tail_bindings(
+                                    combined_body, declared_param_names,
+                                    result_forms=self._nested_record_forms(exit_form))):
+                            solver.add(axiom)
 
         # Phase 2: Add reflexivity axioms for equality functions
         # For any function ending in -eq, add axiom: fn_eq(x, x) == true

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -1845,7 +1845,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
     def _extract_conditional_record_axioms(self, cond_expr: SList, translator: Z3Translator,
                                            fn_body: Optional[SExpr] = None,
-                                           param_names: Optional[Set[str]] = None) -> List:
+                                           param_names: Optional[Set[str]] = None,
+                                           reached_guard=None) -> List:
         """Axioms for a conditional whose branches build or pass along a record.
 
         Each branch contributes its own facts under its own guard. A branch that
@@ -1897,7 +1898,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                             field_names.append(item[0].name)
                 axioms.extend(self._extract_record_field_axioms(
                     record_new, translator, base_accessor=result_var,
-                    path_cond=guard, bindings=branch_bindings))
+                    path_cond=self._conjoin(reached_guard, guard),
+                    bindings=branch_bindings))
             else:
                 passthrough.append((guard, branch))
 
@@ -1909,7 +1911,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 continue
             for field_name in field_names:
                 axioms.append(z3.Implies(
-                    guard,
+                    self._conjoin(reached_guard, guard),
                     translator._translate_field_for_obj(result_var, field_name)
                     == translator._translate_field_for_obj(branch_z3, field_name)))
 
@@ -2146,15 +2148,96 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         forms: List[int] = []
 
         def walk(node):
-            if not isinstance(node, SList):
+            if not isinstance(node, SList) or len(node) < 1:
                 return
             if is_form(node, 'record-new'):
                 forms.append(id(node))
-            for item in node.items:
-                walk(item)
+                # Only the field values, not everything underneath: a
+                # constructor handed to a call, as in
+                # (ys (touch (record-new Box (xs e)))), is an argument that
+                # callee may mutate through, not part of the value returned.
+                for item in node.items[2:]:
+                    if isinstance(item, SList) and len(item) >= 2:
+                        walk(item[-1])
+                return
+            head = node[0]
+            if isinstance(head, Symbol) and head.name in {'some', 'ok', 'error'} and len(node) >= 2:
+                walk(node[1])
 
         walk(expr)
         return tuple(forms)
+
+    def _early_exits(self, body: SExpr, translator: Z3Translator):
+        """[(guard, value)] for each `(return v)` that can run before the tail.
+
+        `_get_return_expr` sees only the trailing expression, so a function with
+        an early return has exits it does not know about - and `$result == body`
+        was asserted for the trailing one unconditionally, which proves whatever
+        that form yields regardless of which path ran.
+
+        Recognises a bare `(return v)`, `(when C ... (return v))` and
+        `(if C (return v) ...)` among the statements leading up to the tail.
+        Guards are cumulative: a later exit only runs if the earlier tests all
+        failed. Returns None if a `return` turns up in a shape this cannot
+        guard, which tells the caller to withhold rather than guess.
+        """
+        exits: List = []
+        earlier: List = []
+        failed = False
+
+        def returned_value(stmts):
+            for stmt in stmts:
+                if is_form(stmt, 'return'):
+                    return stmt[1] if len(stmt) >= 2 else None, True
+            return None, False
+
+        def note(guard_term, value):
+            guard = z3.And(guard_term, *[z3.Not(t) for t in earlier]) if earlier else guard_term
+            exits.append((guard, value))
+            earlier.append(guard_term)
+
+        def scan(stmts):
+            nonlocal failed
+            for stmt in stmts:
+                if not isinstance(stmt, SList):
+                    continue
+                if is_form(stmt, 'return'):
+                    note(z3.BoolVal(True), stmt[1] if len(stmt) >= 2 else None)
+                    return
+                if is_form(stmt, 'when') and len(stmt) >= 3:
+                    value, found = returned_value(stmt.items[2:])
+                    if found:
+                        note(self._condition_term(stmt[1], translator), value)
+                        continue
+                elif is_form(stmt, 'if') and len(stmt) >= 3:
+                    then_value, then_found = returned_value([stmt[2]])
+                    if then_found:
+                        note(self._condition_term(stmt[1], translator), then_value)
+                        if len(stmt) >= 4 and not self._contains_any_form(stmt[3], ('return',)):
+                            continue
+                        if len(stmt) < 4:
+                            continue
+                if self._contains_any_form(stmt, ('return',)):
+                    failed = True
+                    return
+
+        node = body
+        while True:
+            if is_form(node, 'let') and len(node) >= 3:
+                scan(node.items[2:-1])
+                node = node.items[-1]
+            elif is_form(node, 'do') and len(node) >= 2:
+                scan(node.items[1:-1])
+                node = node.items[-1]
+            else:
+                break
+            if failed:
+                return None
+        if failed:
+            return None
+        if self._contains_any_form(node, ('return',)):
+            return None
+        return exits
 
     def _tail_binding_names(self, body: SExpr) -> Set[str]:
         """Every name bound along the tail of `body`, kept or not."""
@@ -3151,14 +3234,60 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         for axiom in range_field_axioms:
             solver.add(axiom)
 
+        # _get_return_expr picks the trailing form. An explicit (return ...)
+        # elsewhere is another exit, and what it yields is just as much $result,
+        # so nothing the trailing constructor says describes the result alone.
+        # A multi-form body keeps only its last expression in fn_body, so the
+        # earlier forms have to be looked at too - both for that check and for
+        # the bindings a constructor's fields may refer to.
+        # The last element is fn_body rather than all_body_exprs[-1]: those are
+        # the same form, but fn_body has been through
+        # _desugar_callback_iterations and the other has not, and the two trees
+        # share no nodes. Anything keyed on node identity - which constructor
+        # is the returned one - has to see the same tree it was taken from.
+        combined_body = fn_body
+        if fn_body is not None and all_body_exprs and len(all_body_exprs) > 1:
+            combined_body = SList(
+                [Symbol('do')] + list(all_body_exprs[:-1]) + [fn_body],
+                fn_body.line, fn_body.col)
+        # Exits other than the trailing form. `reached` is the condition under
+        # which control actually gets there; None means it always does, and a
+        # `return` in a shape _early_exits cannot guard leaves early_exits None,
+        # in which case nothing is claimed about the result at all.
+        early_exits = (self._early_exits(combined_body, translator)
+                       if combined_body is not None else [])
+        body_has_one_exit = early_exits is not None
+        reached_guard = None
+        if early_exits:
+            reached_guard = z3.And(*[z3.Not(guard) for guard, _ in early_exits])
+
         # Add body constraint for path-sensitive analysis
         # This constrains $result to equal the translated function body
         body_equality: List[z3.BoolRef] = []
         if body_z3 is not None:
             result_var = translator.variables.get('$result')
             if result_var is not None:
-                body_equality.append(result_var == body_z3)
-                solver.add(body_equality[0])
+                # Only on the path that reaches the trailing form. Asserting it
+                # unconditionally proved whatever that form yields even for a
+                # call that took an earlier (return ...).
+                equality = (result_var == body_z3 if reached_guard is None
+                            else z3.Implies(reached_guard, result_var == body_z3))
+                body_equality.append(equality)
+                solver.add(equality)
+
+        # What each early exit yields is $result on its own path.
+        if early_exits:
+            result_var = translator.variables.get('$result')
+            if result_var is not None:
+                for guard, value in early_exits:
+                    if value is None:
+                        continue
+                    value_z3 = translator.translate_expr(value)
+                    if value_z3 is None or value_z3.sort() != result_var.sort():
+                        continue
+                    exit_equality = z3.Implies(guard, result_var == value_z3)
+                    body_equality.append(exit_equality)
+                    solver.add(exit_equality)
 
         # Phase 2: Add reflexivity axioms for equality functions
         # For any function ending in -eq, add axiom: fn_eq(x, x) == true
@@ -3176,19 +3305,15 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         # Phase 3: Add record field axioms if body is record-new
         # For (record-new Type (field1 val1) ...), add: field_field1($result) == val1
-        # _get_return_expr picks the trailing form. An explicit (return ...)
-        # elsewhere is another exit, and what it yields is just as much $result,
-        # so nothing the trailing constructor says describes the result alone.
-        body_has_one_exit = (fn_body is not None
-                             and not self._contains_any_form(fn_body, ('return',)))
 
         if fn_body is not None and body_has_one_exit and self._is_record_new(fn_body):
             # Get the actual record-new form (may be inside a do block)
             return_expr = self._get_return_expr(fn_body)
             field_axioms = self._extract_record_field_axioms(
                 return_expr, translator,
+                path_cond=reached_guard,
                 bindings=self._tail_bindings(
-                    fn_body, declared_param_names,
+                    combined_body, declared_param_names,
                     result_forms=self._nested_record_forms(return_expr)))
             for axiom in field_axioms:
                 solver.add(axiom)
@@ -3203,14 +3328,10 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 # Array encoding needs the representation to exist; the length
                 # claim itself comes from _result_length_axioms below.
                 translator._create_list_array('$result')
-            # A multi-form body keeps only its last expression in fn_body, so a
-            # push in an earlier form would be invisible to the push scan and
-            # the result would look shorter than it is.
-            whole_body = fn_body
-            if all_body_exprs and len(all_body_exprs) > 1:
-                whole_body = SList([Symbol('do')] + list(all_body_exprs),
-                                   fn_body.line, fn_body.col)
-            result_length_axioms = self._result_length_axioms(whole_body, translator)
+            # combined_body, not fn_body: a multi-form body keeps only its last
+            # expression there, and a push in an earlier form would be
+            # invisible to the push scan.
+            result_length_axioms = self._result_length_axioms(combined_body, translator)
             for axiom in result_length_axioms:
                 solver.add(axiom)
 
@@ -3299,7 +3420,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             return_expr = self._get_return_expr(fn_body)
             if self._is_conditional_with_record_new(return_expr):
                 cond_axioms = self._extract_conditional_record_axioms(
-                    return_expr, translator, fn_body, declared_param_names)
+                    return_expr, translator, combined_body, declared_param_names,
+                    reached_guard)
                 for axiom in cond_axioms:
                     solver.add(axiom)
 

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -1874,6 +1874,10 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             id(self._get_return_expr(branch)) for _, branch in branches
             if self._is_record_new(branch))
         bindings = self._tail_bindings(fn_body, param_names, result_forms=result_forms)
+        # A branch-local name may shadow an enclosing binding, which shares its
+        # Z3 constant. Sibling arms do not: their axioms carry mutually
+        # exclusive guards.
+        enclosing_names = set(param_names or ()) | self._tail_binding_names(fn_body)
 
         field_names: List[str] = []
         passthrough: List = []
@@ -1884,7 +1888,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 # An arm may bind its own locals before constructing.
                 branch_bindings = dict(bindings)
                 branch_bindings.update(self._tail_bindings(
-                    branch, param_names, stability_body=fn_body,
+                    branch, enclosing_names, stability_body=fn_body,
                     result_forms=result_forms))
                 for item in record_new.items[2:]:
                     if isinstance(item, SList) and len(item) >= 2 and isinstance(item[0], Symbol):
@@ -2131,6 +2135,24 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         return walk(body, None, -1, False)
 
+    def _tail_binding_names(self, body: SExpr) -> Set[str]:
+        """Every name bound along the tail of `body`, kept or not."""
+        names: Set[str] = set()
+        node = body
+        while True:
+            if is_form(node, 'let') and len(node) >= 3:
+                if isinstance(node[1], SList):
+                    for binding in node[1].items:
+                        if isinstance(binding, SList) and len(binding) >= 2:
+                            name = self._binding_name(binding)
+                            if name:
+                                names.add(name)
+                node = node.items[-1]
+            elif is_form(node, 'do') and len(node) >= 2:
+                node = node.items[-1]
+            else:
+                return names
+
     def _tail_bindings(self, body: SExpr,
                        param_names: Optional[Set[str]] = None,
                        stability_body: Optional[SExpr] = None,
@@ -2145,7 +2167,11 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         would resolve `y` to the inner empty list rather than to `zs`.
 
         A name that anything mutates is dropped rather than recorded, as is one
-        that shadows another binding or a parameter.
+        that shadows another binding or a parameter. `param_names` carries those
+        names - for a branch it also carries whatever the enclosing scopes bind,
+        since the translator shares one constant with them. Sibling branches are
+        not enclosing scopes: their facts are guarded by mutually exclusive
+        conditions and cannot reach each other.
         """
         if param_names is None:
             param_names = set()
@@ -2172,7 +2198,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                         # through a name that is bound more than once, and a
                         # parameter counts as one of those bindings.
                         if (name in param_names
-                                or self._count_bindings_of(stability_body, name) > 1):
+                                or self._count_bindings_of(body, name) > 1):
                             bindings.pop(name, None)
                             continue
                         bindings[name] = (binding[-1], dict(bindings))

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8620,3 +8620,15 @@ class TestEarlyExits:
           (when flag (return (arena-alloc arena 8)))
           1)
         ''') == 'verified'
+
+    def test_an_exit_value_side_condition_stays_on_its_path(self):
+        """`(/ n n)` asserts n != 0 because that division happened. It happens
+        only when the early return is taken, so the constraint belongs under the
+        same guard - unguarded, it proves the trailing path non-zero too."""
+        assert self._status('''
+        (fn d ((flag Bool) (n Int))
+          (@spec ((Bool Int) -> Int))
+          (@post (!= $result 0))
+          (when flag (return (/ n n)))
+          n)
+        ''') != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8425,3 +8425,49 @@ class TestConditionalRecordFields:
     (let ((e zs))
       (if c (let ((e (list-new arena Item))) (record-new F (flag true) (xs e) (ys e)))
             (record-new F (flag false) (xs e) (ys e)))))''') != 'verified'
+
+    def test_a_disjoint_earlier_let_may_reuse_the_name(self):
+        """Two `let`s in a `do` are as disjoint as two branches. Counting them
+        across the whole body discarded the binding that is actually in scope."""
+        assert self._status('''
+  (fn d1 ((arena Arena) (zs (List Item)))
+    (@spec ((Arena (List Item)) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (let ((e zs)) (list-len e))
+    (let ((e (list-new arena Item)))
+      (record-new F (flag true) (xs e) (ys e))))''') == 'verified'
+
+    def test_a_constructor_nested_in_the_result(self):
+        """A record built inline inside the returned one is part of the same
+        value; nothing can reach through it afterwards."""
+        from slop.verifier import verify_source
+        src = '''
+        (module probe
+          (type Item (record (v Int)))
+          (type Inner (record (xs (List Item))))
+          (type Outer (record (inner Inner)))
+          (fn d2 ((arena Arena))
+            (@spec ((Arena) -> Outer))
+            (@alloc arena)
+            (@post {(list-len (. (. $result inner) xs)) == 0})
+            (let ((e (list-new arena Item)))
+              (record-new Outer (inner (record-new Inner (xs e)))))))
+        '''
+        assert verify_source(src, filename="probe.slop")[0].status == 'verified'
+
+    def test_a_nested_constructor_holding_an_unknown_list(self):
+        from slop.verifier import verify_source
+        src = '''
+        (module probe
+          (type Item (record (v Int)))
+          (type Inner (record (xs (List Item))))
+          (type Outer (record (inner Inner)))
+          (fn d3 ((arena Arena) (zs (List Item)))
+            (@spec ((Arena (List Item)) -> Outer))
+            (@alloc arena)
+            (@post {(list-len (. (. $result inner) xs)) == 0})
+            (let ((e zs))
+              (record-new Outer (inner (record-new Inner (xs e)))))))
+        '''
+        assert verify_source(src, filename="probe.slop")[0].status != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8225,3 +8225,62 @@ class TestConditionalRecordFields:
     (record-new F (flag c)
       (xs (if c (list-new arena Item) zs))
       (ys (list-new arena Item))))''') != 'verified'
+
+    # --- a binding may only be followed while it still holds what it was given
+
+    def test_a_mutated_binding_is_not_followed(self):
+        """`(list-push e it)` changes what `e` holds, so its initializer no
+        longer describes the field it ends up in."""
+        assert self._status('''
+  (fn m1 ((arena Arena) (it Item))
+    (@spec ((Arena Item) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (let ((mut e (list-new arena Item)))
+      (list-push e it)
+      (record-new F (flag true) (xs e) (ys e))))''') != 'verified'
+
+    def test_a_binding_handed_to_a_function_is_not_followed(self):
+        """The callee may append to it, and nothing here can see that."""
+        assert self._status('''
+  (fn m2 ((arena Arena))
+    (@spec ((Arena) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (let ((e (list-new arena Item)))
+      (fill arena e)
+      (record-new F (flag true) (xs e) (ys e))))''') != 'verified'
+
+    def test_an_alias_chain_is_followed(self):
+        assert self._status('''
+  (fn m3 ((arena Arena))
+    (@spec ((Arena) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (let ((a (list-new arena Item)))
+      (let ((b a))
+        (record-new F (flag true) (xs b) (ys a)))))''') == 'verified'
+
+    def test_a_shadowed_name_is_not_followed(self):
+        """The translator gives both bindings of a shadowed name one Z3
+        constant, so a fact derived from the inner initializer would land on
+        the outer value too - here claiming the parameter `zs` is empty."""
+        assert self._status('''
+  (fn m4 ((arena Arena) (zs (List Item)))
+    (@spec ((Arena (List Item)) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (let ((x zs))
+      (let ((y x))
+        (let ((x (list-new arena Item)))
+          (record-new F (flag true) (xs y) (ys x))))))''') != 'verified'
+
+    def test_a_shadowed_name_does_not_leak_to_the_outer_value(self):
+        assert self._status('''
+  (fn m5 ((arena Arena) (zs (List Item)))
+    (@spec ((Arena (List Item)) -> F))
+    (@alloc arena)
+    (@post {(list-len zs) == 0})
+    (let ((x zs))
+      (let ((x (list-new arena Item)))
+        (record-new F (flag true) (xs x) (ys x)))))''') != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8284,3 +8284,52 @@ class TestConditionalRecordFields:
     (let ((x zs))
       (let ((x (list-new arena Item)))
         (record-new F (flag true) (xs x) (ys x)))))''') != 'verified'
+
+    def test_an_explicit_return_is_another_exit(self):
+        """_get_return_expr picks the trailing form. What a `(return ...)`
+        elsewhere yields is just as much $result, so the trailing constructor
+        does not describe the result on its own."""
+        assert self._status('''
+  (fn m6 ((arena Arena) (flag Bool) (old F))
+    (@spec ((Arena Bool F) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (let ((e (list-new arena Item)))
+      (when flag (return old))
+      (record-new F (flag true) (xs e) (ys e))))''') != 'verified'
+
+    def test_mutation_through_an_alias_invalidates_the_binding(self):
+        """`(let ((mut a e)) (list-push a it))` changes the same list, and the
+        occurrence of `e` in `(a e)` is a read - so stability has to follow the
+        aliases rather than just the name."""
+        assert self._status('''
+  (fn m7 ((arena Arena) (it Item))
+    (@spec ((Arena Item) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (let ((e (list-new arena Item)))
+      (let ((mut a e))
+        (list-push a it)
+        (record-new F (flag true) (xs e) (ys e)))))''') != 'verified'
+
+    def test_a_read_only_alias_keeps_the_binding(self):
+        assert self._status('''
+  (fn m8 ((arena Arena))
+    (@spec ((Arena) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (let ((e (list-new arena Item)))
+      (let ((a e))
+        (record-new F (flag true) (xs e) (ys a)))))''') == 'verified'
+
+    def test_a_local_shadowing_a_parameter_is_not_followed(self):
+        """A parameter is a binding of the name too, and shares the translator's
+        one constant with the local - so the local's initializer would describe
+        the caller's list."""
+        assert self._status('''
+  (fn m9 ((arena Arena) (e (List Item)))
+    (@spec ((Arena (List Item)) -> F))
+    (@alloc arena)
+    (@post {(list-len e) == 0})
+    (let ((e (list-new arena Item)))
+      (record-new F (flag true) (xs e) (ys e))))''') != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8657,3 +8657,35 @@ class TestEarlyExits:
           (when c (if d (return 1) 0) (return 2))
           3)
         ''') != 'verified'
+
+    def test_a_return_inside_a_let_initializer(self):
+        """The walk stepped over the binding list, so a return there left the
+        body looking like it had one exit."""
+        assert self._status('''
+        (module m
+          (type Item (record (v Int)))
+          (type F (record (xs (List Item))))
+          (fn r ((arena Arena) (flag Bool) (old F))
+            (@spec ((Arena Bool F) -> F))
+            (@alloc arena)
+            (@post {(list-len (. $result xs)) == 0})
+            (let ((ignored (if flag (return old) 0))
+                  (e (list-new arena Item)))
+              (record-new F (xs e)))))
+        ''') != 'verified'
+
+    def test_an_exit_side_condition_is_attributed_to_the_contract(self):
+        """A @pre that contradicts an exit's side condition is the author's
+        error; the diagnosis only sees it if constraint_terms carries it."""
+        from slop.verifier import verify_source
+        result = verify_source('''
+        (fn c ((flag Bool) (n Int))
+          (@spec ((Bool Int) -> Int))
+          (@pre flag)
+          (@pre (== n 0))
+          (@post (== $result 1))
+          (when flag (return (/ 1 n)))
+          1)
+        ''', filename="probe.slop")[0]
+        assert result.status == 'failed'
+        assert 'verifier defect' not in result.message

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8632,3 +8632,28 @@ class TestEarlyExits:
           (when flag (return (/ n n)))
           n)
         ''') != 'verified'
+
+    def test_the_tails_own_side_conditions_are_guarded_too(self):
+        """`(/ 1 n)` asserts n != 0 because the tail ran. When an early return
+        bypasses the tail, that assertion applies to a division that never
+        happened."""
+        assert self._status('''
+        (fn t ((flag Bool) (n Int))
+          (@spec ((Bool Int) -> Int))
+          (@pre flag)
+          (@post (and (== $result n) (!= $result 0)))
+          (when flag (return n))
+          (/ 1 n))
+        ''') != 'verified'
+
+    def test_a_nested_return_before_a_direct_one(self):
+        """`(when c (if d (return 1) 0) (return 2))` returns 1 when d holds, so
+        taking the direct return as the whole story models the wrong value for
+        part of the path."""
+        assert self._status('''
+        (fn u ((c Bool) (d Bool))
+          (@spec ((Bool Bool) -> Int))
+          (@post (== $result 2))
+          (when c (if d (return 1) 0) (return 2))
+          3)
+        ''') != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8584,3 +8584,39 @@ class TestEarlyExits:
             (for-each (x xs) (when flag (return g)))
             (record-new G (size 1))))
         ''') != 'verified'
+
+    def test_a_record_returned_early_gets_its_fields(self):
+        """The equality alone ties $result to a fresh identifier nothing else
+        describes, so the early path had no field facts at all."""
+        assert self._status('''
+        (module m
+          (type G (record (size Int)))
+          (fn add ((g G) (flag Bool))
+            (@spec ((G Bool) -> G))
+            (@post (== (. $result size) 1))
+            (when flag (return (record-new G (size 1))))
+            (record-new G (size 1))))
+        ''') == 'verified'
+
+    def test_an_early_record_that_differs(self):
+        assert self._status('''
+        (module m
+          (type G (record (size Int)))
+          (fn add ((g G) (flag Bool))
+            (@spec ((G Bool) -> G))
+            (@post (== (. $result size) 1))
+            (when flag (return (record-new G (size 2))))
+            (record-new G (size 1))))
+        ''') != 'verified'
+
+    def test_side_conditions_of_an_early_value_reach_the_solver(self):
+        """translator.constraints is copied into the solver before the exit
+        values are translated, so anything they append arrives too late."""
+        assert self._status('''
+        (fn a ((arena Arena) (flag Bool))
+          (@spec ((Arena Bool) -> Int))
+          (@alloc arena)
+          (@post (!= $result 0))
+          (when flag (return (arena-alloc arena 8)))
+          1)
+        ''') == 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8333,3 +8333,61 @@ class TestConditionalRecordFields:
     (@post {(list-len e) == 0})
     (let ((e (list-new arena Item)))
       (record-new F (flag true) (xs e) (ys e))))''') != 'verified'
+
+    def test_a_list_stored_in_another_record_is_reachable_again(self):
+        """`(list-push (. box xs) it)` never mentions `e`, so treating the
+        field write in `box` as a harmless read left `e` looking untouched."""
+        from slop.verifier import verify_source
+        src = '''
+        (module probe
+          (type Item (record (v Int)))
+          (type Box (record (xs (List Item))))
+          (type F (record (flag Bool) (xs (List Item)) (ys (List Item))))
+          (fn b1 ((arena Arena) (it Item))
+            (@spec ((Arena Item) -> F))
+            (@alloc arena)
+            (@post {(list-len (. $result xs)) == 0})
+            (let ((e (list-new arena Item)))
+              (let ((box (record-new Box (xs e))))
+                (list-push (. box xs) it)
+                (record-new F (flag true) (xs e) (ys e))))))
+        '''
+        assert verify_source(src, filename="probe.slop")[0].status != 'verified'
+
+    def test_a_branch_may_bind_its_own_locals(self):
+        assert self._status('''
+  (fn b2 ((arena Arena) (c Bool))
+    (@spec ((Arena Bool) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (if c (let ((e (list-new arena Item))) (record-new F (flag true) (xs e) (ys e)))
+          (let ((g (list-new arena Item))) (record-new F (flag false) (xs g) (ys g)))))''') == 'verified'
+
+    def test_a_branch_local_binding_that_is_not_empty(self):
+        assert self._status('''
+  (fn b3 ((arena Arena) (c Bool) (zs (List Item)))
+    (@spec ((Arena Bool (List Item)) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (if c (let ((e (list-new arena Item))) (record-new F (flag true) (xs e) (ys e)))
+          (record-new F (flag false) (xs zs) (ys zs))))''') != 'verified'
+
+    def test_a_binding_whose_initializer_is_a_conditional(self):
+        """`(xs e)` where `e` was bound to an `if` is still a branch; the
+        dispatch has to happen after the name is resolved."""
+        assert self._status('''
+  (fn b4 ((arena Arena) (c Bool))
+    (@spec ((Arena Bool) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (let ((e (if c (list-new arena Item) (list-new arena Item))))
+      (record-new F (flag true) (xs e) (ys e))))''') == 'verified'
+
+    def test_a_conditional_initializer_with_one_unknown_arm(self):
+        assert self._status('''
+  (fn b5 ((arena Arena) (c Bool) (zs (List Item)))
+    (@spec ((Arena Bool (List Item)) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (let ((e (if c (list-new arena Item) zs)))
+      (record-new F (flag true) (xs e) (ys e))))''') != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8079,3 +8079,149 @@ class TestReturnedBindingScope:
           (let ((mut r (list-new arena Int))) (list-push r 1))
           (let ((mut r (list-new arena Int))) r))
         ''') == 'verified'
+
+
+_RECORD_FIELD_PROBE = '''
+(module probe
+  (type Item (record (v Int)))
+  (type F (record (flag Bool) (xs (List Item)) (ys (List Item))))
+
+  (fn opaque? ((n Int))
+    (@spec ((Int) -> Bool))
+    (> n 3))
+
+%s)
+'''
+
+
+class TestConditionalRecordFields:
+    """Issue #70: what a record-new says about its fields, through a branch.
+
+    The conditional path used to reimplement one line of
+    _extract_record_field_axioms - field equals value - and drop everything else
+    it derives, including the length of a `list-new` field. So a postcondition
+    true of *both* arms of an `if` failed, and the `implies` in the issue was a
+    red herring: the plain form fails identically.
+    """
+
+    @staticmethod
+    def _status(fn_source):
+        from slop.verifier import verify_source
+        results = [r for r in verify_source(_RECORD_FIELD_PROBE % fn_source,
+                                            filename="probe.slop")
+                   if r.name != 'opaque?']
+        assert len(results) == 1
+        return results[0].status
+
+    EMPTY = "(xs (list-new arena Item)) (ys (list-new arena Item))"
+
+    def test_unconditional_record_new(self):
+        assert self._status('''
+  (fn v0 ((arena Arena))
+    (@spec ((Arena) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (record-new F (flag true) %s))''' % self.EMPTY) == 'verified'
+
+    def test_if_between_two_record_new(self):
+        assert self._status('''
+  (fn v1 ((arena Arena) (c Bool))
+    (@spec ((Arena Bool) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (if c (record-new F (flag true) %s)
+          (record-new F (flag false) %s)))''' % (self.EMPTY, self.EMPTY)) == 'verified'
+
+    def test_cond_between_two_record_new(self):
+        """`cond` is the same shape as `if` and was not recognised at all."""
+        assert self._status('''
+  (fn v2 ((arena Arena) (c Bool))
+    (@spec ((Arena Bool) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (cond (c (record-new F (flag true) %s))
+          (else (record-new F (flag false) %s))))''' % (self.EMPTY, self.EMPTY)) == 'verified'
+
+    def test_opaque_condition(self):
+        """A condition that does not translate to a Bool used to abandon the
+        whole analysis, which loses the facts that hold in both arms - the usual
+        reason to write the branch."""
+        assert self._status('''
+  (fn v3 ((arena Arena) (n Int))
+    (@spec ((Arena Int) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (if (opaque? n) (record-new F (flag true) %s)
+                    (record-new F (flag false) %s)))''' % (self.EMPTY, self.EMPTY)) == 'verified'
+
+    def test_per_field_conditional(self):
+        assert self._status('''
+  (fn v4 ((arena Arena) (c Bool))
+    (@spec ((Arena Bool) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (record-new F (flag c)
+      (xs (if c (list-new arena Item) (list-new arena Item)))
+      (ys (list-new arena Item))))''') == 'verified'
+
+    def test_let_bound_list_field(self):
+        """Even unconditionally, a field holding a local empty list lost its
+        length: the test for it was syntactic."""
+        assert self._status('''
+  (fn v5 ((arena Arena))
+    (@spec ((Arena) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (let ((e (list-new arena Item)))
+      (record-new F (flag true) (xs e) (ys e))))''') == 'verified'
+
+    def test_issue_70_r2_verbatim(self):
+        assert self._status('''
+  (fn r2 ((arena Arena) (c Bool))
+    (@spec ((Arena Bool) -> F))
+    (@alloc arena)
+    (@post (implies {(. $result flag) == true} {(list-len (. $result xs)) == 0}))
+    (if c (record-new F (flag true)  %s)
+          (record-new F (flag false) %s)))''' % (self.EMPTY, self.EMPTY)) == 'verified'
+
+    # --- the guards have to be exact, not just present --------------------
+
+    def test_one_arm_that_is_not_empty(self):
+        assert self._status('''
+  (fn n1 ((arena Arena) (c Bool) (zs (List Item)))
+    (@spec ((Arena Bool (List Item)) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (if c (record-new F (flag true) %s)
+          (record-new F (flag false) (xs zs) (ys (list-new arena Item)))))''' % self.EMPTY) != 'verified'
+
+    def test_a_cond_clause_does_not_borrow_an_earlier_one(self):
+        """A clause runs only when no earlier test matched, so each guard has to
+        carry the negation of the ones above it."""
+        assert self._status('''
+  (fn n2 ((arena Arena) (c Bool) (zs (List Item)))
+    (@spec ((Arena Bool (List Item)) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (cond (c (record-new F (flag true) (xs zs) (ys (list-new arena Item))))
+          (else (record-new F (flag false) %s))))''' % self.EMPTY) != 'verified'
+
+    def test_opaque_condition_does_not_become_a_free_choice(self):
+        """The fresh Bool must not let Z3 pick the arm that suits the goal."""
+        assert self._status('''
+  (fn n3 ((arena Arena) (n Int) (zs (List Item)))
+    (@spec ((Arena Int (List Item)) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (if (opaque? n) (record-new F (flag true) %s)
+                    (record-new F (flag false) (xs zs) (ys (list-new arena Item)))))''' % self.EMPTY) != 'verified'
+
+    def test_per_field_conditional_with_one_unknown_arm(self):
+        assert self._status('''
+  (fn n4 ((arena Arena) (c Bool) (zs (List Item)))
+    (@spec ((Arena Bool (List Item)) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (record-new F (flag c)
+      (xs (if c (list-new arena Item) zs))
+      (ys (list-new arena Item))))''') != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8471,3 +8471,116 @@ class TestConditionalRecordFields:
               (record-new Outer (inner (record-new Inner (xs e)))))))
         '''
         assert verify_source(src, filename="probe.slop")[0].status != 'verified'
+
+    def test_a_return_in_an_earlier_top_level_form(self):
+        """fn_body is only the last form. The exit check has to see the rest."""
+        assert self._status('''
+  (fn c1 ((arena Arena) (flag Bool) (c Bool) (old F))
+    (@spec ((Arena Bool Bool F) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (when flag (return old))
+    (if c (record-new F (flag true) (xs (list-new arena Item)) (ys (list-new arena Item)))
+          (record-new F (flag false) (xs (list-new arena Item)) (ys (list-new arena Item)))))''') != 'verified'
+
+    def test_a_multi_form_body_without_a_return(self):
+        assert self._status('''
+  (fn c2 ((arena Arena) (c Bool))
+    (@spec ((Arena Bool) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (println "hi")
+    (if c (record-new F (flag true) (xs (list-new arena Item)) (ys (list-new arena Item)))
+          (record-new F (flag false) (xs (list-new arena Item)) (ys (list-new arena Item)))))''') == 'verified'
+
+    def test_a_constructor_handed_to_a_call_is_not_part_of_the_result(self):
+        """`(ys (touch (record-new Box (xs e))))` builds a record as an
+        argument; the callee may mutate `e` through it."""
+        from slop.verifier import verify_source
+        src = '''
+        (module probe
+          (type Item (record (v Int)))
+          (type Box (record (xs (List Item))))
+          (type F (record (flag Bool) (xs (List Item)) (ys (List Item))))
+          (fn c3 ((arena Arena) (it Item))
+            (@spec ((Arena Item) -> F))
+            (@alloc arena)
+            (@post {(list-len (. $result xs)) == 0})
+            (let ((e (list-new arena Item)))
+              (record-new F (flag true) (xs e) (ys (touch (record-new Box (xs e))))))))
+        '''
+        assert verify_source(src, filename="probe.slop")[0].status != 'verified'
+
+
+class TestEarlyExits:
+    """An early `(return ...)` is a second path to $result.
+
+    `_get_return_expr` sees only the trailing form, and `$result == body` was
+    asserted for it unconditionally - so a postcondition true of the trailing
+    form was proved for a call that returned somewhere else. Withholding
+    everything is sound but loses contracts that hold on both paths, so each
+    exit is modelled as its own guarded path instead.
+    """
+
+    @staticmethod
+    def _status(src):
+        from slop.verifier import verify_source
+        return verify_source(src, filename="probe.slop")[0].status
+
+    def test_a_claim_true_only_of_the_trailing_form(self):
+        assert self._status('''
+        (fn pick ((flag Bool) (n Int))
+          (@spec ((Bool Int) -> Int))
+          (@post (== $result 7))
+          (when flag (return n))
+          7)
+        ''') != 'verified'
+
+    def test_a_claim_true_on_both_paths(self):
+        assert self._status('''
+        (fn pick ((flag Bool) (n Int))
+          (@spec ((Bool Int) -> Int))
+          (@pre (== n 7))
+          (@post (== $result 7))
+          (when flag (return n))
+          7)
+        ''') == 'verified'
+
+    def test_a_record_field_claim_that_both_paths_satisfy(self):
+        """slop-rdf's indexed-graph-add is this shape: return the graph
+        unchanged when the triple is already present, otherwise a bigger one."""
+        assert self._status('''
+        (module m
+          (type G (record (size Int)))
+          (fn add ((g G) (flag Bool))
+            (@spec ((G Bool) -> G))
+            (@pre (>= (. g size) 0))
+            (@post (>= (. $result size) (. g size)))
+            (when flag (return g))
+            (record-new G (size (+ (. g size) 1)))))
+        ''') == 'verified'
+
+    def test_a_record_field_claim_only_the_trailing_path_satisfies(self):
+        assert self._status('''
+        (module m
+          (type G (record (size Int)))
+          (fn add ((g G) (flag Bool))
+            (@spec ((G Bool) -> G))
+            (@pre (>= (. g size) 0))
+            (@post (> (. $result size) (. g size)))
+            (when flag (return g))
+            (record-new G (size (+ (. g size) 1)))))
+        ''') != 'verified'
+
+    def test_a_return_in_a_shape_that_cannot_be_guarded(self):
+        """A return inside a loop has no single condition to negate, so nothing
+        is claimed rather than something guessed."""
+        assert self._status('''
+        (module m
+          (type G (record (size Int)))
+          (fn add ((g G) (flag Bool) (xs (List Int)))
+            (@spec ((G Bool (List Int)) -> G))
+            (@post (== (. $result size) 1))
+            (for-each (x xs) (when flag (return g)))
+            (record-new G (size 1))))
+        ''') != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8689,3 +8689,21 @@ class TestEarlyExits:
         ''', filename="probe.slop")[0]
         assert result.status == 'failed'
         assert 'verifier defect' not in result.message
+
+    def test_a_return_inside_a_quoted_form_is_data(self):
+        """`(quote (return 1))` is a symbol the function never executes, so it
+        must not make the body look like it has a second exit."""
+        from slop.verifier import verify_source
+        src = '''
+        (module m
+          (type Item (record (v Int)))
+          (type F (record (xs (List Item))))
+          (fn q ((arena Arena))
+            (@spec ((Arena) -> F))
+            (@alloc arena)
+            (@post {(list-len (. $result xs)) == 0})
+            (let ((tag (quote (return 1)))
+                  (e (list-new arena Item)))
+              (record-new F (xs e)))))
+        '''
+        assert verify_source(src, filename="probe.slop")[0].status == 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8391,3 +8391,37 @@ class TestConditionalRecordFields:
     (@post {(list-len (. $result xs)) == 0})
     (let ((e (if c (list-new arena Item) zs)))
       (record-new F (flag true) (xs e) (ys e))))''') != 'verified'
+
+    def test_both_arms_may_use_the_same_local_name(self):
+        """Sibling arms are not enclosing scopes. Their axioms carry mutually
+        exclusive guards, so sharing a Z3 constant between them is harmless -
+        counting the two bindings as shadowing discarded both."""
+        assert self._status('''
+  (fn s1 ((arena Arena) (c Bool))
+    (@spec ((Arena Bool) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (if c (let ((e (list-new arena Item))) (record-new F (flag true) (xs e) (ys e)))
+          (let ((e (list-new arena Item))) (record-new F (flag false) (xs e) (ys e)))))''') == 'verified'
+
+    def test_the_same_local_name_with_one_arm_not_empty(self):
+        assert self._status('''
+  (fn s2 ((arena Arena) (c Bool) (zs (List Item)))
+    (@spec ((Arena Bool (List Item)) -> F))
+    (@alloc arena)
+    (@post {(list-len (. $result xs)) == 0})
+    (if c (let ((e (list-new arena Item))) (record-new F (flag true) (xs e) (ys e)))
+          (let ((e zs)) (record-new F (flag false) (xs e) (ys e)))))''') != 'verified'
+
+    def test_a_branch_local_shadowing_an_enclosing_binding(self):
+        """An enclosing scope *is* live at the same time, and shares the
+        constant - so the arm's fresh list would describe the outer value."""
+        assert self._status('''
+  (fn s3 ((arena Arena) (c Bool) (zs (List Item)))
+    (@spec ((Arena Bool (List Item)) -> F))
+    (@alloc arena)
+    (@pre c)
+    (@post {(list-len zs) == 0})
+    (let ((e zs))
+      (if c (let ((e (list-new arena Item))) (record-new F (flag true) (xs e) (ys e)))
+            (record-new F (flag false) (xs e) (ys e)))))''') != 'verified'


### PR DESCRIPTION
Closes #70.

## The bug

A `record-new` says more than what each field equals: a `list-new` field is empty, a nested record
has its own fields, a string literal has a length, a union constructor has a tag. The conditional
path reimplemented only the field-equals-value line and dropped the rest, so

```lisp
(if c (record-new F (flag true)  (xs (list-new arena Item)))
      (record-new F (flag false) (xs (list-new arena Item))))
```

could not prove `(== (list-len (. $result xs)) 0)` even though **both** arms give `xs` an empty
list. The `implies` in the issue is a red herring — the plain form fails identically.

## What now works

Both paths go through `_extract_record_field_axioms`, which takes a path condition and guards what
it derives. Five more shapes fall out of that:

| shape | before |
|---|---|
| `if` between two `record-new` | failed |
| `cond` between two `record-new` | failed — `_is_conditional_with_record_new` only knew `if` |
| a condition that does not translate to a `Bool` | failed — the analysis bailed |
| `(xs (if c (list-new …) (list-new …)))` | failed |
| `(xs e)` where `e` is a let-bound `list-new` | failed **even unconditionally** |
| an arm that binds its own locals before constructing | failed |

A `cond` clause's guard carries the negation of the tests above it, since a clause runs only when
no earlier one matched. An opaque condition becomes a fresh `Bool` rather than a reason to give up:
the branch structure is kept without claiming to know the test, which is enough for facts true in
both arms — the usual reason to write the branch.

## Soundness

Following a name back to its initializer is only valid while nothing has changed what it holds, and
review found seven ways that could go wrong. A binding is now followed only if:

- every occurrence of it is a read — a `list-push`, `list-pop`, `set!`, or being handed to a
  function all disqualify it, the last because the callee may append;
- every **alias** of it is too — `(let ((a e)) (list-push a it))` mutates the same list;
- it is not stored in an intermediate record — `(list-push (. box xs) it)` never mentions `e`;
- it does not shadow a parameter or an enclosing binding, which share the translator's one Z3
  constant (#118). Sibling arms may reuse a name: their axioms carry mutually exclusive guards.

Each initializer carries the environment it was bound in, so a name rebound later cannot reach back
into an earlier one. And the opaque-condition placeholder is a `FreshBool`, not a name a parameter
could also be spelled.

## Early returns, which turned out to be a live false-verify

`_get_return_expr` sees only the trailing form, so the first cut withheld the record axioms when a
body had an explicit `(return ...)`. That is sound but blunt — slop-rdf's `indexed-graph-add`
returns the graph unchanged when the triple is already present, and its
`(>= (. $result size) (. g size))`, true on both paths, went red.

It also left a worse problem in place. `$result == body` was asserted **unconditionally** for the
trailing form, so this verifies on `main` today:

```lisp
(fn pick ((flag Bool) (n Int))
  (@spec ((Bool Int) -> Int))
  (@post (== $result 7))
  (when flag (return n))
  7)
```

Both are the same missing idea, so each exit is now a path: `(return v)`,
`(when C … (return v))` and `(if C (return v) …)` before the tail contribute
`Implies(guard, $result == v)` plus that value's own field axioms and side conditions, guards
accumulate so a later exit only fires when the earlier tests failed, and everything derived from
the trailing form — the body equality, its side conditions, the record axioms — is guarded by the
negation of them all. A `return` with no single condition to negate (inside a loop, in a `let`
initializer, two in one `when`) still withholds everything rather than guessing.

## Tests

406 → 420 in `tests/test_verifier.py`; full suite 619 → 633; `make test-native` 50/50 unchanged.

Every positive case is paired with a negative one differing only in an arm the claim is false for,
so a future loosening has to break one of the two.

## Downstream

Measured before and after, per function: **no change** in slop-rdf, snarl, or howl. The
`indexed-graph-add` regression the early-return guard caused is gone. This PR only adds guarded
axioms, so the risk is a false pass rather than a lost proof — which is what the negative cases and
the eleven review rounds were for.

11 rounds of `codex exec review`; every finding reproduced before fixing. Also filed **#118** —
a shadowed `let` binding shares one Z3 constant with the binding it shadows, latent rather than
live, and alpha-renaming there would let several of the guards above go.
