### PR TITLE
give a loop's variables a value of their own after it (#116)

### DIFF
--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -2813,6 +2813,10 @@ class AxiomGenerationMixin:
                         bound, init = binding[1], binding[2]
                     elif isinstance(first, Symbol):
                         bound, init = first, binding[1]
+                    elif (isinstance(first, SList) and len(first) >= 2
+                          and isinstance(first[0], Symbol) and first[0].name == 'mut'):
+                        # ((mut name) init), the third spelling _translate_let takes
+                        bound, init = first[1], binding[1]
                     else:
                         continue
                     if isinstance(bound, Symbol) and bound.name == name:

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -2830,6 +2830,18 @@ class AxiomGenerationMixin:
 
         return walk(body) and found
 
+    def _count_returns(self, expr: 'SExpr') -> int:
+        """How many `(return ...)` forms this function body has of its own."""
+        if not isinstance(expr, SList) or len(expr) < 1:
+            return 0
+        head = expr[0]
+        if isinstance(head, Symbol):
+            if head.name in ('fn', 'quote'):
+                return 0
+            if head.name == 'return':
+                return 1 + sum(self._count_returns(item) for item in expr.items[1:])
+        return sum(self._count_returns(item) for item in expr.items)
+
     def _generate_count_axioms(self, pattern: CountPatternInfo,
                                translator: Z3Translator,
                                body: Optional['SExpr'] = None) -> List:
@@ -2851,11 +2863,17 @@ class AxiomGenerationMixin:
         if not (z3.is_expr(counted) and counted.sort() == z3.IntSort()):
             return axioms
         if body is not None:
-            # An early return yields something the loop never counted, and the
-            # bound is asserted about $result on every path.
-            if self._contains_any_form(body, ('return',)):
-                return axioms
             returned = self._get_return_expr(body)
+            # A trailing `(return count)` is not an early exit - it is how the
+            # function ends. Unwrap it, then require that nothing else returns:
+            # any other exit yields something the loop never counted, and this
+            # bound is asserted about $result on every path.
+            trailing_return = is_form(returned, 'return') and len(returned) >= 2
+            if trailing_return:
+                returned = returned[1]
+            other_returns = self._count_returns(body) > (1 if trailing_return else 0)
+            if other_returns:
+                return axioms
             if not (isinstance(returned, Symbol) and returned.name == pattern.count_var):
                 return axioms
             # The bound is one element at most, so the counter has to be raised

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -2768,9 +2768,31 @@ class AxiomGenerationMixin:
         head, left, right = value[0], value[1], value[2]
         if not (isinstance(head, Symbol) and head.name == '+'):
             return False
+        if isinstance(left, Number) and left.value == 1:
+            # (+ 1 count), which the detector accepts as well
+            left, right = right, left
         if not (isinstance(left, Symbol) and left.name == name):
             return False
         if not (isinstance(right, Number) and right.value == 1):
+            return False
+        # The assigned value may itself assign - `(do (set! count 100) 0)` looks
+        # like one write from outside.
+        nested: List = []
+
+        def nested_walk(node):
+            if not isinstance(node, SList) or len(node) < 1:
+                return
+            head_sym = node[0]
+            if isinstance(head_sym, Symbol):
+                if head_sym.name in ('fn', 'quote'):
+                    return
+                if head_sym.name == 'set!' and len(node) >= 3:
+                    nested.append(node)
+            for item in node.items:
+                nested_walk(item)
+
+        nested_walk(value)
+        if nested:
             return False
         return self._binding_starts_at_zero(body, name)
 

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -2742,7 +2742,8 @@ class AxiomGenerationMixin:
         return False
 
     def _generate_count_axioms(self, pattern: CountPatternInfo,
-                               translator: Z3Translator) -> List:
+                               translator: Z3Translator,
+                               body: Optional['SExpr'] = None) -> List:
         """Generate Z3 axioms for detected count pattern.
 
         Axioms:
@@ -2750,8 +2751,21 @@ class AxiomGenerationMixin:
         2. Count is bounded by collection size: $result <= (list-len collection)
         """
         axioms = []
+        # The bound describes the counter. _detect_count_pattern only finds a
+        # count-shaped loop; it does not check that the function returns the
+        # counter, and a function that returns something else would otherwise
+        # inherit the bound.
+        counted = translator.variables.get(pattern.count_var)
         result_var = translator.variables.get('$result')
-        if result_var is None:
+        if counted is None or result_var is None:
+            return axioms
+        if not (z3.is_expr(counted) and counted.sort() == z3.IntSort()):
+            return axioms
+        if body is not None:
+            returned = self._get_return_expr(body)
+            if not (isinstance(returned, Symbol) and returned.name == pattern.count_var):
+                return axioms
+        elif not z3.eq(counted, result_var):
             return axioms
 
         # Only add numeric axioms if result is an integer type

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -2741,6 +2741,69 @@ class AxiomGenerationMixin:
 
         return False
 
+    def _counter_rises_by_one(self, body: 'SExpr', name: str) -> bool:
+        """True if `name` starts at zero and every write adds exactly one."""
+        writes: List = []
+
+        def walk(node):
+            if not isinstance(node, SList) or len(node) < 1:
+                return
+            head = node[0]
+            if isinstance(head, Symbol):
+                if head.name in ('fn', 'quote'):
+                    return
+                if head.name == 'set!' and len(node) >= 3 and isinstance(node[1], Symbol):
+                    if node[1].name == name:
+                        writes.append(node[2])
+                    return
+            for item in node.items:
+                walk(item)
+
+        walk(body)
+        if len(writes) != 1:
+            return False
+        value = writes[0]
+        if not (isinstance(value, SList) and len(value) == 3):
+            return False
+        head, left, right = value[0], value[1], value[2]
+        if not (isinstance(head, Symbol) and head.name == '+'):
+            return False
+        if not (isinstance(left, Symbol) and left.name == name):
+            return False
+        if not (isinstance(right, Number) and right.value == 1):
+            return False
+        return self._binding_starts_at_zero(body, name)
+
+    def _binding_starts_at_zero(self, body: 'SExpr', name: str) -> bool:
+        """True if every `let` binding of `name` initialises it to 0."""
+        found = False
+
+        def walk(node):
+            nonlocal found
+            if not isinstance(node, SList):
+                return True
+            if is_form(node, 'let') and len(node) >= 2 and isinstance(node[1], SList):
+                for binding in node[1].items:
+                    if not (isinstance(binding, SList) and len(binding) >= 2):
+                        continue
+                    first = binding[0]
+                    if isinstance(first, Symbol) and first.name == 'mut' and len(binding) >= 3:
+                        bound, init = binding[1], binding[2]
+                    elif isinstance(first, Symbol):
+                        bound, init = first, binding[1]
+                    else:
+                        continue
+                    if isinstance(bound, Symbol) and bound.name == name:
+                        found = True
+                        if not (isinstance(init, Number) and init.value == 0):
+                            return False
+            for item in node.items:
+                if not walk(item):
+                    return False
+            return True
+
+        return walk(body) and found
+
     def _generate_count_axioms(self, pattern: CountPatternInfo,
                                translator: Z3Translator,
                                body: Optional['SExpr'] = None) -> List:
@@ -2764,6 +2827,12 @@ class AxiomGenerationMixin:
         if body is not None:
             returned = self._get_return_expr(body)
             if not (isinstance(returned, Symbol) and returned.name == pattern.count_var):
+                return axioms
+            # The bound is one element at most, so the counter has to be raised
+            # by exactly one at exactly one place. _detect_count_pattern matches
+            # the first increment it finds and says nothing about the rest, so a
+            # second one - or a (set! count 100) - would go unnoticed.
+            if not self._counter_rises_by_one(body, pattern.count_var):
                 return axioms
         elif not z3.eq(counted, result_var):
             return axioms

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -2825,6 +2825,10 @@ class AxiomGenerationMixin:
         if not (z3.is_expr(counted) and counted.sort() == z3.IntSort()):
             return axioms
         if body is not None:
+            # An early return yields something the loop never counted, and the
+            # bound is asserted about $result on every path.
+            if self._contains_any_form(body, ('return',)):
+                return axioms
             returned = self._get_return_expr(body)
             if not (isinstance(returned, Symbol) and returned.name == pattern.count_var):
                 return axioms

--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -2761,20 +2761,14 @@ class AxiomGenerationMixin:
         # Axiom 1: Count is non-negative
         axioms.append(result_var >= 0)
 
-        # Axiom 2: Count is bounded by collection size
-        # Translate the collection to get its Z3 representation
-        collection_z3 = translator.translate_expr(pattern.collection)
-        if collection_z3 is not None:
-            # Get or create list-len function
-            list_len_func_name = "fn_list-len_1"
-            if list_len_func_name not in translator.variables:
-                list_len_func = z3.Function(list_len_func_name, z3.IntSort(), z3.IntSort())
-                translator.variables[list_len_func_name] = list_len_func
-            else:
-                list_len_func = translator.variables[list_len_func_name]
-
-            collection_len = list_len_func(collection_z3)
-            axioms.append(result_var <= collection_len)
+        # Axiom 2: Count is bounded by collection size.
+        # Stated with the same length terms `(list-len collection)` translates
+        # to in a contract - fn_list-len_1 was a fourth spelling that no goal
+        # ever mentioned, so the bound was unusable (see #115's length bridge).
+        length_terms, links = self._length_terms_for(pattern.collection, translator)
+        axioms.extend(links)
+        for term in length_terms:
+            axioms.append(result_var <= term)
 
         return axioms
 

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -2236,9 +2236,9 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     return None, False
             return direct, found
 
-        def note(guard_term, value):
+        def note(guard_term, value, guard_expr):
             guard = z3.And(guard_term, *[z3.Not(t) for t in earlier]) if earlier else guard_term
-            exits.append((guard, value))
+            exits.append((guard, value, guard_expr))
             earlier.append(guard_term)
 
         def scan(stmts):
@@ -2247,17 +2247,17 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 if not isinstance(stmt, SList):
                     continue
                 if is_form(stmt, 'return'):
-                    note(z3.BoolVal(True), stmt[1] if len(stmt) >= 2 else None)
+                    note(z3.BoolVal(True), stmt[1] if len(stmt) >= 2 else None, stmt)
                     return
                 if is_form(stmt, 'when') and len(stmt) >= 3:
                     value, found = returned_value(stmt.items[2:])
                     if found:
-                        note(self._condition_term(stmt[1], translator), value)
+                        note(self._condition_term(stmt[1], translator), value, stmt[1])
                         continue
                 elif is_form(stmt, 'if') and len(stmt) >= 3:
                     then_value, then_found = returned_value([stmt[2]])
                     if then_found:
-                        note(self._condition_term(stmt[1], translator), then_value)
+                        note(self._condition_term(stmt[1], translator), then_value, stmt[1])
                         if len(stmt) >= 4 and not self._contains_any_form(stmt[3], ('return',)):
                             continue
                         if len(stmt) < 4:
@@ -3108,6 +3108,33 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # Translate function body BEFORE assumptions
         # This is important because @loop-invariant may reference local variables
         # from let bindings, which are declared during body translation
+        # _get_return_expr picks the trailing form. An explicit (return ...)
+        # elsewhere is another exit, and what it yields is just as much $result,
+        # so nothing the trailing constructor says describes the result alone.
+        # A multi-form body keeps only its last expression in fn_body, so the
+        # earlier forms have to be looked at too - both for that check and for
+        # the bindings a constructor's fields may refer to.
+        # The last element is fn_body rather than all_body_exprs[-1]: those are
+        # the same form, but fn_body has been through
+        # _desugar_callback_iterations and the other has not, and the two trees
+        # share no nodes. Anything keyed on node identity - which constructor
+        # is the returned one - has to see the same tree it was taken from.
+        combined_body = fn_body
+        if fn_body is not None and all_body_exprs and len(all_body_exprs) > 1:
+            combined_body = SList(
+                [Symbol('do')] + list(all_body_exprs[:-1]) + [fn_body],
+                fn_body.line, fn_body.col)
+        # Exits other than the trailing form. `reached` is the condition under
+        # which control actually gets there; None means it always does, and a
+        # `return` in a shape _early_exits cannot guard leaves early_exits None,
+        # in which case nothing is claimed about the result at all.
+        early_exits = (self._early_exits(combined_body, translator)
+                       if combined_body is not None else [])
+        body_has_one_exit = early_exits is not None
+        reached_guard = None
+        if early_exits:
+            reached_guard = z3.And(*[z3.Not(guard) for guard, _, _ in early_exits])
+
         body_z3: Optional[z3.ExprRef] = None
         body_constraint_start = len(translator.constraints)
         if fn_body is not None:
@@ -3258,32 +3285,17 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 location=SourceLocation(self.filename, fn_form.line, fn_form.col)
             )
 
-        # _get_return_expr picks the trailing form. An explicit (return ...)
-        # elsewhere is another exit, and what it yields is just as much $result,
-        # so nothing the trailing constructor says describes the result alone.
-        # A multi-form body keeps only its last expression in fn_body, so the
-        # earlier forms have to be looked at too - both for that check and for
-        # the bindings a constructor's fields may refer to.
-        # The last element is fn_body rather than all_body_exprs[-1]: those are
-        # the same form, but fn_body has been through
-        # _desugar_callback_iterations and the other has not, and the two trees
-        # share no nodes. Anything keyed on node identity - which constructor
-        # is the returned one - has to see the same tree it was taken from.
-        combined_body = fn_body
-        if fn_body is not None and all_body_exprs and len(all_body_exprs) > 1:
-            combined_body = SList(
-                [Symbol('do')] + list(all_body_exprs[:-1]) + [fn_body],
-                fn_body.line, fn_body.col)
-        # Exits other than the trailing form. `reached` is the condition under
-        # which control actually gets there; None means it always does, and a
-        # `return` in a shape _early_exits cannot guard leaves early_exits None,
-        # in which case nothing is claimed about the result at all.
-        early_exits = (self._early_exits(combined_body, translator)
-                       if combined_body is not None else [])
-        body_has_one_exit = early_exits is not None
-        reached_guard = None
-        if early_exits:
-            reached_guard = z3.And(*[z3.Not(guard) for guard, _ in early_exits])
+
+        # An exit guard was translated above, before the body, so it reads the
+        # versions in scope at the top. That is right for a guard before the
+        # first loop and wrong for one after it, and there is no program point
+        # here to tell them apart - so if any guard names something a loop or an
+        # assignment went on to replace, the exit modelling is withdrawn.
+        if early_exits and any(self._mentions_loop_versioned(guard_expr, translator)
+                               for _, _, guard_expr in early_exits):
+            early_exits = None
+            body_has_one_exit = False
+            reached_guard = None
 
         # Contracts have been translated by now - a @loop-invariant is about the
         # value the loop leaves behind, so it wants the final version. The
@@ -3356,7 +3368,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         if early_exits:
             result_var = translator.variables.get('$result')
             if result_var is not None:
-                for guard, value in early_exits:
+                for guard, value, _ in early_exits:
                     if value is None:
                         continue
                     # Translating a value can append side conditions - a

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -3122,16 +3122,6 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         pre_constraint_count = len(translator.constraints)
 
-        # Translate postconditions
-        post_z3: List[z3.BoolRef] = []
-        failed_posts: List[SExpr] = []
-        for post in postconditions:
-            z3_post = translator.translate_expr(post)
-            if z3_post is not None:
-                post_z3.append(self._ensure_bool(z3_post))
-            else:
-                failed_posts.append(post)
-
         # Translate function body BEFORE assumptions
         # This is important because @loop-invariant may reference local variables
         # from let bindings, which are declared during body translation
@@ -3150,6 +3140,21 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         if fn_body is not None and postconditions:
             body_z3 = translator.translate_expr(fn_body)
         body_constraint_end = len(translator.constraints)
+
+        # Postconditions are translated after the body, not before it: a @post
+        # speaks about the state the function ends in, so a mutable parameter
+        # in one means the value it was left with. @pre keeps the versions from
+        # before the body, which is what it is about.
+        # Translate postconditions
+        post_z3: List[z3.BoolRef] = []
+        failed_posts: List[SExpr] = []
+        for post in postconditions:
+            z3_post = translator.translate_expr(post)
+            if z3_post is not None:
+                post_z3.append(self._ensure_bool(z3_post))
+            else:
+                failed_posts.append(post)
+
 
         # _get_return_expr picks the trailing form. An explicit (return ...)
         # elsewhere is another exit, and what it yields is just as much $result,

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -110,8 +110,15 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         - Simple variable references (just returns True)
         - Simple function calls without control flow
         - Loops (require explicit invariants which we handle separately)
+        - Anything with an explicit (return ...), which the calculus walks
+          straight past: it substitutes an assignment's value even when a
+          return in that value means the assignment never happens, and the
+          resulting weakest precondition asserts the postcondition outright.
         """
         if not isinstance(body, SList) or len(body) == 0:
+            return False
+
+        if self._contains_any_form(body, ('return',)):
             return False
 
         head = body[0]

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -3285,6 +3285,13 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         if early_exits:
             reached_guard = z3.And(*[z3.Not(guard) for guard, _ in early_exits])
 
+        # Contracts have been translated by now - a @loop-invariant is about the
+        # value the loop leaves behind, so it wants the final version. The
+        # pattern phases below re-translate expressions from anywhere in the
+        # body instead, where a name with more than one version has no single
+        # value to give, so from here it stops answering.
+        translator.freeze_versions()
+
         # The tail's own side conditions - a non-zero divisor, a string length -
         # only hold because the tail ran. An early return bypasses it, so they
         # travel under the same guard as everything else derived from it.

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -3556,7 +3556,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         if fn_body is not None:
             count_pattern = self._detect_count_pattern(fn_body)
             if count_pattern is not None:
-                count_axioms = self._generate_count_axioms(count_pattern, translator)
+                count_axioms = self._generate_count_axioms(count_pattern, translator, fn_body)
                 for axiom in count_axioms:
                     solver.add(axiom)
 

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -3560,7 +3560,11 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         if fn_body is not None:
             count_pattern = self._detect_count_pattern(fn_body)
             if count_pattern is not None:
-                count_axioms = self._generate_count_axioms(count_pattern, translator, fn_body)
+                # combined_body, not fn_body: an early return in a form before
+                # the trailing one is another exit, and this bound is asserted
+                # about $result on every path.
+                count_axioms = self._generate_count_axioms(
+                    count_pattern, translator, combined_body)
                 for axiom in count_axioms:
                     solver.add(axiom)
 

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -695,6 +695,13 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         if not var_name:
             return
 
+        # Evaluated where the binding is, but this runs long after the body was
+        # translated. If the initializer mentions a name some loop reassigned,
+        # re-translating it reads the value the loop produced rather than the
+        # one the binding was given (issue #116).
+        if self._mentions_loop_versioned(init_expr, translator):
+            return
+
         # Handle simple expression bindings (not function calls)
         # Add axiom: var == init_expr
         if not isinstance(init_expr, SList) or len(init_expr) < 1:
@@ -754,6 +761,15 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             if z3_axiom is not None:
                 axioms.append(z3_axiom)
 
+    def _mentions_loop_versioned(self, expr: SExpr, translator: Z3Translator) -> bool:
+        """True if `expr` names a variable some loop reassigned."""
+        if isinstance(expr, Symbol):
+            return translator.is_loop_versioned(expr.name)
+        if isinstance(expr, SList):
+            return any(self._mentions_loop_versioned(item, translator)
+                       for item in expr.items)
+        return False
+
     def _add_binding_axiom(self, var_name: str, expr: SExpr, translator: Z3Translator, axioms: List):
         """Add axiom: var == expr for simple let bindings.
 
@@ -771,6 +787,13 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # version the loop produced instead (issue #116).
         var_z3 = translator.initial_variable(var_name)
         if var_z3 is None:
+            return
+
+        # This runs long after the body was translated, so re-translating the
+        # initializer reads whatever version of each name is current. If it
+        # mentions one a loop reassigned, the value it produces is not the one
+        # the binding was given.
+        if self._mentions_loop_versioned(expr, translator):
             return
 
         expr_z3 = translator.translate_expr(expr)
@@ -3083,6 +3106,15 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # from let bindings, which are declared during body translation
         body_z3: Optional[z3.ExprRef] = None
         body_constraint_start = len(translator.constraints)
+        if fn_body is not None:
+            # Which loops run whenever the body does. Without this every loop is
+            # taken as conditional and contributes no facts. The last form is
+            # fn_body rather than all_body_exprs[-1]: the same form, but
+            # _desugar_callback_iterations rebuilt it, and this is keyed on
+            # node identity.
+            for form in (list(all_body_exprs[:-1]) + [fn_body]
+                         if all_body_exprs else [fn_body]):
+                translator.note_body(form)
         if fn_body is not None and postconditions:
             body_z3 = translator.translate_expr(fn_body)
         body_constraint_end = len(translator.constraints)

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -2207,6 +2207,13 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         Recognises a bare `(return v)`, `(when C ... (return v))` and
         `(if C (return v) ...)` among the statements leading up to the tail.
+
+        Runs before the body is translated, so a guard reads the versions in
+        scope at the top - which is what a guard before the first loop means.
+        A guard naming a `let`-bound local has nothing to read yet and becomes
+        an unconstrained Bool, which leaves that exit looking possible when it
+        may not be; the conservative direction, and the price of not having
+        program points here.
         Guards are cumulative: a later exit only runs if the earlier tests all
         failed. Returns None if a `return` turns up in a shape this cannot
         guard, which tells the caller to withhold rather than guess.
@@ -2214,6 +2221,11 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         exits: List = []
         earlier: List = []
         failed = False
+        # Guards are read as they stood at the top of the body. That is what a
+        # guard before the first loop or assignment means; past one, the name it
+        # tests may have changed and there is no program point here to say
+        # which version it meant, so the whole modelling is given up.
+        reassigned = False
 
         def returned_value(stmts):
             """The value a statement list returns directly, if that is all of it.
@@ -2237,14 +2249,27 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             return direct, found
 
         def note(guard_term, value, guard_expr):
+            nonlocal failed
+            if reassigned and self._mentions_loop_versioned(guard_expr, translator):
+                failed = True
+                return
             guard = z3.And(guard_term, *[z3.Not(t) for t in earlier]) if earlier else guard_term
             exits.append((guard, value, guard_expr))
             earlier.append(guard_term)
 
         def scan(stmts):
-            nonlocal failed
+            nonlocal failed, reassigned
             for stmt in stmts:
                 if not isinstance(stmt, SList):
+                    continue
+                if (is_form(stmt, 'while') or is_form(stmt, 'for-each')
+                        or is_form(stmt, 'set!')):
+                    reassigned = True
+                    # A return inside a loop or an assigned value still has no
+                    # single condition to negate.
+                    if self._contains_any_form(stmt, ('return',)):
+                        failed = True
+                        return
                     continue
                 if is_form(stmt, 'return'):
                     note(z3.BoolVal(True), stmt[1] if len(stmt) >= 2 else None, stmt)
@@ -2275,6 +2300,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     return None
                 scan(node.items[2:-1])
                 node = node.items[-1]
+                if failed:
+                    return None
             elif is_form(node, 'do') and len(node) >= 2:
                 scan(node.items[1:-1])
                 node = node.items[-1]
@@ -3108,6 +3135,22 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # Translate function body BEFORE assumptions
         # This is important because @loop-invariant may reference local variables
         # from let bindings, which are declared during body translation
+
+        body_z3: Optional[z3.ExprRef] = None
+        body_constraint_start = len(translator.constraints)
+        if fn_body is not None:
+            # Which loops run whenever the body does. Without this every loop is
+            # taken as conditional and contributes no facts. The last form is
+            # fn_body rather than all_body_exprs[-1]: the same form, but
+            # _desugar_callback_iterations rebuilt it, and this is keyed on
+            # node identity.
+            for form in (list(all_body_exprs[:-1]) + [fn_body]
+                         if all_body_exprs else [fn_body]):
+                translator.note_body(form)
+        if fn_body is not None and postconditions:
+            body_z3 = translator.translate_expr(fn_body)
+        body_constraint_end = len(translator.constraints)
+
         # _get_return_expr picks the trailing form. An explicit (return ...)
         # elsewhere is another exit, and what it yields is just as much $result,
         # so nothing the trailing constructor says describes the result alone.
@@ -3128,27 +3171,14 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # which control actually gets there; None means it always does, and a
         # `return` in a shape _early_exits cannot guard leaves early_exits None,
         # in which case nothing is claimed about the result at all.
-        early_exits = (self._early_exits(combined_body, translator)
-                       if combined_body is not None else [])
+        with translator.initial_versions():
+            early_exits = (self._early_exits(combined_body, translator)
+                           if combined_body is not None else [])
         body_has_one_exit = early_exits is not None
         reached_guard = None
         if early_exits:
             reached_guard = z3.And(*[z3.Not(guard) for guard, _, _ in early_exits])
 
-        body_z3: Optional[z3.ExprRef] = None
-        body_constraint_start = len(translator.constraints)
-        if fn_body is not None:
-            # Which loops run whenever the body does. Without this every loop is
-            # taken as conditional and contributes no facts. The last form is
-            # fn_body rather than all_body_exprs[-1]: the same form, but
-            # _desugar_callback_iterations rebuilt it, and this is keyed on
-            # node identity.
-            for form in (list(all_body_exprs[:-1]) + [fn_body]
-                         if all_body_exprs else [fn_body]):
-                translator.note_body(form)
-        if fn_body is not None and postconditions:
-            body_z3 = translator.translate_expr(fn_body)
-        body_constraint_end = len(translator.constraints)
             # If we can translate the body, constrain $result to equal it
             # This enables path-sensitive reasoning through conditionals
 
@@ -3286,17 +3316,6 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             )
 
 
-        # An exit guard was translated above, before the body, so it reads the
-        # versions in scope at the top. That is right for a guard before the
-        # first loop and wrong for one after it, and there is no program point
-        # here to tell them apart - so if any guard names something a loop or an
-        # assignment went on to replace, the exit modelling is withdrawn.
-        if early_exits and any(self._mentions_loop_versioned(guard_expr, translator)
-                               for _, _, guard_expr in early_exits):
-            early_exits = None
-            body_has_one_exit = False
-            reached_guard = None
-
         # Contracts have been translated by now - a @loop-invariant is about the
         # value the loop leaves behind, so it wants the final version. The
         # pattern phases below re-translate expressions from anywhere in the
@@ -3353,7 +3372,11 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # Add body constraint for path-sensitive analysis
         # This constrains $result to equal the translated function body
         body_equality: List[z3.BoolRef] = []
-        if body_z3 is not None:
+        # early_exits is None when the body returns somewhere this cannot guard,
+        # or when a guard turned out to name something later reassigned. Either
+        # way the trailing form is not the only thing $result can be, so it is
+        # not equated with it at all.
+        if body_z3 is not None and early_exits is not None:
             result_var = translator.variables.get('$result')
             if result_var is not None:
                 # Only on the path that reaches the trailing form. Asserting it

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -766,7 +766,10 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             # Infer type from expression - default to Int
             translator.declare_variable(var_name, PrimitiveType('Int'))
 
-        var_z3 = translator.variables.get(var_name)
+        # The constant the name held before any loop reassigned it: this is the
+        # binding's *initial* value, and after a loop `variables` holds the
+        # version the loop produced instead (issue #116).
+        var_z3 = translator.initial_variable(var_name)
         if var_z3 is None:
             return
 

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -765,6 +765,41 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             if z3_axiom is not None:
                 axioms.append(z3_axiom)
 
+    def _body_bound_names(self, expr: SExpr) -> Set[str]:
+        """Every name the body introduces: let bindings, loop and lambda binders."""
+        names: Set[str] = set()
+
+        def walk(node):
+            if not isinstance(node, SList):
+                return
+            if is_form(node, 'let') and len(node) >= 2 and isinstance(node[1], SList):
+                for binding in node[1].items:
+                    if isinstance(binding, SList) and len(binding) >= 2:
+                        name = self._binding_name(binding)
+                        if name:
+                            names.add(name)
+            elif is_form(node, 'for-each') and len(node) >= 2:
+                binder = node[1]
+                if isinstance(binder, SList) and len(binder) >= 1 and isinstance(binder[0], Symbol):
+                    names.add(binder[0].name)
+            elif is_form(node, 'fn') and len(node) >= 2 and isinstance(node[1], SList):
+                for param in node[1].items:
+                    if isinstance(param, SList) and len(param) >= 1 and isinstance(param[0], Symbol):
+                        names.add(param[0].name)
+            elif is_form(node, 'match') and len(node) >= 3:
+                for clause in node.items[2:]:
+                    if isinstance(clause, SList) and len(clause) >= 1:
+                        pattern = clause[0]
+                        if isinstance(pattern, SList):
+                            for item in pattern.items[1:]:
+                                if isinstance(item, Symbol):
+                                    names.add(item.name)
+            for item in node.items:
+                walk(item)
+
+        walk(expr)
+        return names
+
     def _mentions_loop_versioned(self, expr: SExpr, translator: Z3Translator) -> bool:
         """True if `expr` names a variable some loop reassigned."""
         if isinstance(expr, Symbol):
@@ -3126,7 +3161,22 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # This is important because @loop-invariant may reference local variables
         # from let bindings, which are declared during body translation
 
+        # A multi-form body keeps only its last expression in fn_body, so the
+        # earlier forms have to be looked at too. The last element is fn_body
+        # rather than all_body_exprs[-1]: those are the same form, but fn_body
+        # has been through _desugar_callback_iterations and the other has not,
+        # and the two trees share no nodes. Anything keyed on node identity -
+        # which constructor is the returned one - has to see the same tree it
+        # was taken from.
+        combined_body = fn_body
+        if fn_body is not None and all_body_exprs and len(all_body_exprs) > 1:
+            combined_body = SList(
+                [Symbol('do')] + list(all_body_exprs[:-1]) + [fn_body],
+                fn_body.line, fn_body.col)
+
         body_z3: Optional[z3.ExprRef] = None
+        # What each name meant before the body introduced any of its own.
+        scope_before_body = dict(translator.variables)
         body_constraint_start = len(translator.constraints)
         if fn_body is not None:
             # Which loops run whenever the body does. Without this every loop is
@@ -3145,6 +3195,21 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # speaks about the state the function ends in, so a mutable parameter
         # in one means the value it was left with. @pre keeps the versions from
         # before the body, which is what it is about.
+        #
+        # The body's own bindings are put away first. A contract cannot name a
+        # local, and leaving them in place lets one shadow a parameter - or a
+        # verifier accessor, where a local called `field_len` turns a
+        # `list-len` postcondition into a TypeError. Names a `set!` replaced
+        # keep their final version, which is the point of translating here.
+        body_locals = {}
+        if fn_body is not None:
+            for local in self._body_bound_names(combined_body):
+                if local in translator.variables:
+                    body_locals[local] = translator.variables[local]
+                    if local in scope_before_body:
+                        translator.variables[local] = scope_before_body[local]
+                    else:
+                        del translator.variables[local]
         # Translate postconditions
         post_z3: List[z3.BoolRef] = []
         failed_posts: List[SExpr] = []
@@ -3159,19 +3224,6 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # _get_return_expr picks the trailing form. An explicit (return ...)
         # elsewhere is another exit, and what it yields is just as much $result,
         # so nothing the trailing constructor says describes the result alone.
-        # A multi-form body keeps only its last expression in fn_body, so the
-        # earlier forms have to be looked at too - both for that check and for
-        # the bindings a constructor's fields may refer to.
-        # The last element is fn_body rather than all_body_exprs[-1]: those are
-        # the same form, but fn_body has been through
-        # _desugar_callback_iterations and the other has not, and the two trees
-        # share no nodes. Anything keyed on node identity - which constructor
-        # is the returned one - has to see the same tree it was taken from.
-        combined_body = fn_body
-        if fn_body is not None and all_body_exprs and len(all_body_exprs) > 1:
-            combined_body = SList(
-                [Symbol('do')] + list(all_body_exprs[:-1]) + [fn_body],
-                fn_body.line, fn_body.col)
         # Exits other than the trailing form. `reached` is the condition under
         # which control actually gets there; None means it always does, and a
         # `return` in a shape _early_exits cannot guard leaves early_exits None,
@@ -3186,6 +3238,10 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
             # If we can translate the body, constrain $result to equal it
             # This enables path-sensitive reasoning through conditionals
+
+        # Locals come back: a @loop-invariant is written about them.
+        for local, value in body_locals.items():
+            translator.variables[local] = value
 
         # Translate assumptions (trusted axioms) - AFTER body so local vars are declared
         assume_constraint_start = len(translator.constraints)

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -696,9 +696,13 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             return
 
         # Evaluated where the binding is, but this runs long after the body was
-        # translated. If the initializer mentions a name some loop reassigned,
-        # re-translating it reads the value the loop produced rather than the
-        # one the binding was given (issue #116).
+        # translated, when every name holds its final version. If the
+        # initializer mentions a name a loop or an assignment replaced, that is
+        # not necessarily the value the binding was given (issue #116).
+        #
+        # Conservative in one direction: a binding made *after* the loop should
+        # use the post version, and is skipped too. Telling the two apart needs
+        # the program point, which this pass does not have.
         if self._mentions_loop_versioned(init_expr, translator):
             return
 

--- a/src/slop/verifier/loop_analysis.py
+++ b/src/slop/verifier/loop_analysis.py
@@ -179,6 +179,12 @@ class LoopAnalysisMixin:
         while_loops = self._analyze_while_loops(body)
 
         for ctx in while_loops:
+            # A loop the translator versioned already stated its own exit
+            # condition, about the post-loop constants. Restating it here would
+            # use whichever version of each name happened to be current, which
+            # after two loops is the wrong one.
+            if id(ctx.loop_expr) in getattr(translator, 'versioned_loops', ()):
+                continue
             # Translate the loop condition
             cond_z3 = translator.translate_expr(ctx.condition)
             if cond_z3 is not None:

--- a/src/slop/verifier/pattern_detection.py
+++ b/src/slop/verifier/pattern_detection.py
@@ -2066,6 +2066,10 @@ class PatternDetectionMixin:
         if not (z3.is_expr(counted) and counted.sort() == z3.IntSort()):
             return axioms
         if body is not None:
+            # An early return yields something the loop never counted, and the
+            # bound is asserted about $result on every path.
+            if self._contains_any_form(body, ('return',)):
+                return axioms
             returned = self._get_return_expr(body)
             if not (isinstance(returned, Symbol) and returned.name == pattern.count_var):
                 return axioms

--- a/src/slop/verifier/pattern_detection.py
+++ b/src/slop/verifier/pattern_detection.py
@@ -2081,6 +2081,18 @@ class PatternDetectionMixin:
 
         return walk(body) and found
 
+    def _count_returns(self, expr: 'SExpr') -> int:
+        """How many `(return ...)` forms this function body has of its own."""
+        if not isinstance(expr, SList) or len(expr) < 1:
+            return 0
+        head = expr[0]
+        if isinstance(head, Symbol):
+            if head.name in ('fn', 'quote'):
+                return 0
+            if head.name == 'return':
+                return 1 + sum(self._count_returns(item) for item in expr.items[1:])
+        return sum(self._count_returns(item) for item in expr.items)
+
     def _generate_count_axioms(self, pattern: CountPatternInfo,
                                translator: Z3Translator,
                                body: Optional['SExpr'] = None) -> List:
@@ -2102,11 +2114,17 @@ class PatternDetectionMixin:
         if not (z3.is_expr(counted) and counted.sort() == z3.IntSort()):
             return axioms
         if body is not None:
-            # An early return yields something the loop never counted, and the
-            # bound is asserted about $result on every path.
-            if self._contains_any_form(body, ('return',)):
-                return axioms
             returned = self._get_return_expr(body)
+            # A trailing `(return count)` is not an early exit - it is how the
+            # function ends. Unwrap it, then require that nothing else returns:
+            # any other exit yields something the loop never counted, and this
+            # bound is asserted about $result on every path.
+            trailing_return = is_form(returned, 'return') and len(returned) >= 2
+            if trailing_return:
+                returned = returned[1]
+            other_returns = self._count_returns(body) > (1 if trailing_return else 0)
+            if other_returns:
+                return axioms
             if not (isinstance(returned, Symbol) and returned.name == pattern.count_var):
                 return axioms
             # The bound is one element at most, so the counter has to be raised

--- a/src/slop/verifier/pattern_detection.py
+++ b/src/slop/verifier/pattern_detection.py
@@ -1983,7 +1983,8 @@ class PatternDetectionMixin:
         return False
 
     def _generate_count_axioms(self, pattern: CountPatternInfo,
-                               translator: Z3Translator) -> List:
+                               translator: Z3Translator,
+                               body: Optional['SExpr'] = None) -> List:
         """Generate Z3 axioms for detected count pattern.
 
         Axioms:
@@ -1991,8 +1992,21 @@ class PatternDetectionMixin:
         2. Count is bounded by collection size: $result <= (list-len collection)
         """
         axioms = []
+        # The bound describes the counter. _detect_count_pattern only finds a
+        # count-shaped loop; it does not check that the function returns the
+        # counter, and a function that returns something else would otherwise
+        # inherit the bound.
+        counted = translator.variables.get(pattern.count_var)
         result_var = translator.variables.get('$result')
-        if result_var is None:
+        if counted is None or result_var is None:
+            return axioms
+        if not (z3.is_expr(counted) and counted.sort() == z3.IntSort()):
+            return axioms
+        if body is not None:
+            returned = self._get_return_expr(body)
+            if not (isinstance(returned, Symbol) and returned.name == pattern.count_var):
+                return axioms
+        elif not z3.eq(counted, result_var):
             return axioms
 
         # Only add numeric axioms if result is an integer type

--- a/src/slop/verifier/pattern_detection.py
+++ b/src/slop/verifier/pattern_detection.py
@@ -2002,20 +2002,14 @@ class PatternDetectionMixin:
         # Axiom 1: Count is non-negative
         axioms.append(result_var >= 0)
 
-        # Axiom 2: Count is bounded by collection size
-        # Translate the collection to get its Z3 representation
-        collection_z3 = translator.translate_expr(pattern.collection)
-        if collection_z3 is not None:
-            # Get or create list-len function
-            list_len_func_name = "fn_list-len_1"
-            if list_len_func_name not in translator.variables:
-                list_len_func = z3.Function(list_len_func_name, z3.IntSort(), z3.IntSort())
-                translator.variables[list_len_func_name] = list_len_func
-            else:
-                list_len_func = translator.variables[list_len_func_name]
-
-            collection_len = list_len_func(collection_z3)
-            axioms.append(result_var <= collection_len)
+        # Axiom 2: Count is bounded by collection size.
+        # Stated with the same length terms `(list-len collection)` translates
+        # to in a contract - fn_list-len_1 was a fourth spelling that no goal
+        # ever mentioned, so the bound was unusable (see #115's length bridge).
+        length_terms, links = self._length_terms_for(pattern.collection, translator)
+        axioms.extend(links)
+        for term in length_terms:
+            axioms.append(result_var <= term)
 
         return axioms
 

--- a/src/slop/verifier/pattern_detection.py
+++ b/src/slop/verifier/pattern_detection.py
@@ -1891,13 +1891,23 @@ class PatternDetectionMixin:
         # Find mutable count binding initialized to 0
         count_var = None
         for binding in bindings.items:
+            if not isinstance(binding, SList) or len(binding) < 2:
+                continue
+            first = binding[0]
             if self._is_mutable_binding(binding) and len(binding) >= 3:
                 var_name = binding[1].name if isinstance(binding[1], Symbol) else None
                 init_expr = binding[2]
-                # Check if initialized to 0
-                if var_name and isinstance(init_expr, Number) and init_expr.value == 0:
-                    count_var = var_name
-                    break
+            elif (isinstance(first, SList) and len(first) >= 2
+                  and isinstance(first[0], Symbol) and first[0].name == 'mut'):
+                # ((mut count) 0), the spelling _translate_let also takes
+                var_name = first[1].name if isinstance(first[1], Symbol) else None
+                init_expr = binding[1]
+            else:
+                continue
+            # Check if initialized to 0
+            if var_name and isinstance(init_expr, Number) and init_expr.value == 0:
+                count_var = var_name
+                break
 
         if not count_var:
             return None
@@ -2054,6 +2064,10 @@ class PatternDetectionMixin:
                         bound, init = binding[1], binding[2]
                     elif isinstance(first, Symbol):
                         bound, init = first, binding[1]
+                    elif (isinstance(first, SList) and len(first) >= 2
+                          and isinstance(first[0], Symbol) and first[0].name == 'mut'):
+                        # ((mut name) init), the third spelling _translate_let takes
+                        bound, init = first[1], binding[1]
                     else:
                         continue
                     if isinstance(bound, Symbol) and bound.name == name:

--- a/src/slop/verifier/pattern_detection.py
+++ b/src/slop/verifier/pattern_detection.py
@@ -1982,6 +1982,69 @@ class PatternDetectionMixin:
 
         return False
 
+    def _counter_rises_by_one(self, body: 'SExpr', name: str) -> bool:
+        """True if `name` starts at zero and every write adds exactly one."""
+        writes: List = []
+
+        def walk(node):
+            if not isinstance(node, SList) or len(node) < 1:
+                return
+            head = node[0]
+            if isinstance(head, Symbol):
+                if head.name in ('fn', 'quote'):
+                    return
+                if head.name == 'set!' and len(node) >= 3 and isinstance(node[1], Symbol):
+                    if node[1].name == name:
+                        writes.append(node[2])
+                    return
+            for item in node.items:
+                walk(item)
+
+        walk(body)
+        if len(writes) != 1:
+            return False
+        value = writes[0]
+        if not (isinstance(value, SList) and len(value) == 3):
+            return False
+        head, left, right = value[0], value[1], value[2]
+        if not (isinstance(head, Symbol) and head.name == '+'):
+            return False
+        if not (isinstance(left, Symbol) and left.name == name):
+            return False
+        if not (isinstance(right, Number) and right.value == 1):
+            return False
+        return self._binding_starts_at_zero(body, name)
+
+    def _binding_starts_at_zero(self, body: 'SExpr', name: str) -> bool:
+        """True if every `let` binding of `name` initialises it to 0."""
+        found = False
+
+        def walk(node):
+            nonlocal found
+            if not isinstance(node, SList):
+                return True
+            if is_form(node, 'let') and len(node) >= 2 and isinstance(node[1], SList):
+                for binding in node[1].items:
+                    if not (isinstance(binding, SList) and len(binding) >= 2):
+                        continue
+                    first = binding[0]
+                    if isinstance(first, Symbol) and first.name == 'mut' and len(binding) >= 3:
+                        bound, init = binding[1], binding[2]
+                    elif isinstance(first, Symbol):
+                        bound, init = first, binding[1]
+                    else:
+                        continue
+                    if isinstance(bound, Symbol) and bound.name == name:
+                        found = True
+                        if not (isinstance(init, Number) and init.value == 0):
+                            return False
+            for item in node.items:
+                if not walk(item):
+                    return False
+            return True
+
+        return walk(body) and found
+
     def _generate_count_axioms(self, pattern: CountPatternInfo,
                                translator: Z3Translator,
                                body: Optional['SExpr'] = None) -> List:
@@ -2005,6 +2068,12 @@ class PatternDetectionMixin:
         if body is not None:
             returned = self._get_return_expr(body)
             if not (isinstance(returned, Symbol) and returned.name == pattern.count_var):
+                return axioms
+            # The bound is one element at most, so the counter has to be raised
+            # by exactly one at exactly one place. _detect_count_pattern matches
+            # the first increment it finds and says nothing about the rest, so a
+            # second one - or a (set! count 100) - would go unnoticed.
+            if not self._counter_rises_by_one(body, pattern.count_var):
                 return axioms
         elif not z3.eq(counted, result_var):
             return axioms

--- a/src/slop/verifier/pattern_detection.py
+++ b/src/slop/verifier/pattern_detection.py
@@ -2009,9 +2009,31 @@ class PatternDetectionMixin:
         head, left, right = value[0], value[1], value[2]
         if not (isinstance(head, Symbol) and head.name == '+'):
             return False
+        if isinstance(left, Number) and left.value == 1:
+            # (+ 1 count), which the detector accepts as well
+            left, right = right, left
         if not (isinstance(left, Symbol) and left.name == name):
             return False
         if not (isinstance(right, Number) and right.value == 1):
+            return False
+        # The assigned value may itself assign - `(do (set! count 100) 0)` looks
+        # like one write from outside.
+        nested: List = []
+
+        def nested_walk(node):
+            if not isinstance(node, SList) or len(node) < 1:
+                return
+            head_sym = node[0]
+            if isinstance(head_sym, Symbol):
+                if head_sym.name in ('fn', 'quote'):
+                    return
+                if head_sym.name == 'set!' and len(node) >= 3:
+                    nested.append(node)
+            for item in node.items:
+                nested_walk(item)
+
+        nested_walk(value)
+        if nested:
             return False
         return self._binding_starts_at_zero(body, name)
 

--- a/src/slop/verifier/translator.py
+++ b/src/slop/verifier/translator.py
@@ -1866,6 +1866,13 @@ class Z3Translator:
                     init_value = binding[1]
 
                 if var_name and init_value is not None:
+                    # A new binding of the name, whatever the old one was: the
+                    # type it was declared with and the version it held before
+                    # any assignment both belong to that other binding. Keeping
+                    # them re-states an outer parameter's bounds on this local,
+                    # which can make the context contradictory (#118).
+                    self._declared_types.pop(var_name, None)
+                    self._pre_loop_variables.pop(var_name, None)
                     # Translate initial value
                     init_z3 = self.translate_expr(init_value)
                     if init_z3 is not None:

--- a/src/slop/verifier/translator.py
+++ b/src/slop/verifier/translator.py
@@ -74,6 +74,7 @@ class Z3Translator:
         self._unconditional_assignments: Set[int] = set()
         self._in_loop_body = False
         self._in_quoted_form = False
+        self._versions_frozen = False
         self._record_new_counter = 0  # Counter for unique record-new values
         self.enum_type_variants: set = set()  # Variants from EnumType only (not UnionType)
         self._build_enum_map()
@@ -1432,6 +1433,15 @@ class Z3Translator:
         """Translate a symbol reference"""
         name = sym.name
 
+        # Once the body has been walked, `variables` holds each name's final
+        # version, and the pattern phases that run afterwards re-translate
+        # expressions from anywhere in it. A name a loop or an assignment
+        # replaced has no single value to give them - the filter that excluded
+        # `target` did so before `(set! target 999)`, not after - so it is
+        # refused rather than answered with the wrong one (issue #116).
+        if self._versions_frozen and name in self._pre_loop_variables:
+            return None
+
         # Quoted enum variant: 'Fizz -> IntVal(0)
         if name.startswith("'"):
             if name in self.enum_values:
@@ -1965,6 +1975,13 @@ class Z3Translator:
             if len(statements) <= 1 and statements and statements[0] is node:
                 return
             node = statements[-1]
+
+    def freeze_versions(self) -> None:
+        """Stop answering for names that have more than one version.
+
+        Called once the body has been walked. See _translate_symbol.
+        """
+        self._versions_frozen = True
 
     def initial_variable(self, name: str):
         """The constant `name` held before any loop or assignment replaced it.

--- a/src/slop/verifier/translator.py
+++ b/src/slop/verifier/translator.py
@@ -71,6 +71,7 @@ class Z3Translator:
         # note_body() says otherwise, so a loop nobody has placed is treated as
         # conditional and gets no facts attached to it.
         self._unconditional_loops: Set[int] = set()
+        self._unconditional_assignments: Set[int] = set()
         self._in_loop_body = False
         self._record_new_counter = 0  # Counter for unique record-new values
         self.enum_type_variants: set = set()  # Variants from EnumType only (not UnionType)
@@ -1871,6 +1872,9 @@ class Z3Translator:
         assigned: Dict[str, List['SExpr']] = {}
         self._collect_assignments(body_items, assigned)
 
+        if self._contains_early_exit(body_items):
+            unconditional = False
+
         for name, values in assigned.items():
             before = self.variables.get(name)
             if before is None or not z3.is_expr(before):
@@ -1902,6 +1906,11 @@ class Z3Translator:
         # The exit condition constrains the post-loop values, so it is stated
         # here rather than by a later pass that would not know which version of
         # each name a given loop ended with.
+        # A `break` or `return` can leave the loop with its condition still
+        # true, so the exit rule does not apply.
+        if unconditional and self._contains_early_exit(body_items):
+            unconditional = False
+
         if unconditional and is_form(expr, 'while') and len(expr) >= 2:
             cond_z3 = self.translate_expr(expr[1])
             if cond_z3 is not None and z3.is_bool(cond_z3):
@@ -1938,22 +1947,24 @@ class Z3Translator:
             for statement in statements:
                 if is_form(statement, 'while') or is_form(statement, 'for-each'):
                     self._unconditional_loops.add(id(statement))
+                elif is_form(statement, 'set!'):
+                    self._unconditional_assignments.add(id(statement))
             if len(statements) <= 1 and statements and statements[0] is node:
                 return
             node = statements[-1]
 
     def initial_variable(self, name: str):
-        """The constant `name` held before any loop gave it a new one.
+        """The constant `name` held before any loop or assignment replaced it.
 
         A phase that re-derives a binding's *initial* value has to attach it to
         that constant. Reading `variables` instead picks up whatever version is
-        current, which after a loop means asserting the starting value of the
-        thing the loop produced.
+        current, which after a loop or a `set!` means asserting the starting
+        value of the thing that replaced it.
         """
         return self._pre_loop_variables.get(name, self.variables.get(name))
 
     def is_loop_versioned(self, name: str) -> bool:
-        """True if a loop assigned `name`, so its value after differs from before."""
+        """True if a loop or a `set!` replaced `name`, so it has more than one value."""
         return name in self._pre_loop_variables
 
     def _translate_assignment(self, expr: SList) -> Optional[z3.ExprRef]:
@@ -1968,6 +1979,11 @@ class Z3Translator:
         if self._in_loop_body:
             return None
         target = expr[1]
+        # A `set!` in a branch runs only if that branch does, and both arms are
+        # translated into one shared map - so the last one translated would
+        # otherwise become the current value whatever the condition said. The
+        # name is still given a new constant, just an unconstrained one.
+        carries_value = id(expr) in self._unconditional_assignments
         if not isinstance(target, Symbol):
             return None
         name = target.name
@@ -1975,6 +1991,10 @@ class Z3Translator:
         value_z3 = self.translate_expr(expr[2])
         if before is None or not z3.is_expr(before):
             return None
+        # The constant it held before this assignment, so a phase that later
+        # re-derives the binding's initial value attaches it there rather than
+        # to what the assignment produced.
+        self._pre_loop_variables.setdefault(name, before)
         prefix = f"{name}_after_set"
         if z3.is_bool(before):
             after = z3.FreshBool(prefix)
@@ -1983,9 +2003,28 @@ class Z3Translator:
         else:
             after = z3.FreshInt(prefix)
         self.variables[name] = after
-        if value_z3 is not None and value_z3.sort() == after.sort():
+        if carries_value and value_z3 is not None and value_z3.sort() == after.sort():
             self.constraints.append(after == value_z3)
         return None
+
+    def _contains_early_exit(self, stmts) -> bool:
+        """True if these statements can leave their loop early.
+
+        Stops at a nested `(fn ...)`, whose break belongs to a loop inside it,
+        and at a `(quote ...)`, which is data.
+        """
+        for stmt in stmts:
+            if not isinstance(stmt, SList) or len(stmt) < 1:
+                continue
+            head = stmt[0]
+            if isinstance(head, Symbol):
+                if head.name in ('break', 'return'):
+                    return True
+                if head.name in ('fn', 'quote'):
+                    continue
+            if self._contains_early_exit(stmt.items):
+                return True
+        return False
 
     def _collect_assignments(self, stmts, assigned: Dict[str, List]):
         """Every `(set! name value)` under `stmts`, grouped by name.

--- a/src/slop/verifier/translator.py
+++ b/src/slop/verifier/translator.py
@@ -1124,6 +1124,11 @@ class Z3Translator:
         typ = self._declared_types.get(name)
         if typ is None:
             return
+        # A local may shadow a parameter of another sort entirely; the outer
+        # declaration's bounds do not apply to it, and asking Z3 to compare a
+        # Bool with 0 raises rather than failing to verify.
+        if not (z3.is_expr(var) and var.sort() == z3.IntSort()):
+            return
         if isinstance(typ, PrimitiveType) and typ.name.startswith('U'):
             self.constraints.append(var >= 0)
         elif isinstance(typ, RangeType):
@@ -2011,13 +2016,27 @@ class Z3Translator:
             else:
                 statements = [node]
             for statement in statements:
-                if is_form(statement, 'while') or is_form(statement, 'for-each'):
-                    self._unconditional_loops.add(id(statement))
-                elif is_form(statement, 'set!'):
-                    self._unconditional_assignments.add(id(statement))
+                self._note_statement(statement)
             if len(statements) <= 1 and statements and statements[0] is node:
                 return
             node = statements[-1]
+
+    def _note_statement(self, statement: 'SExpr') -> None:
+        """Mark one statement, and anything a plain block wraps.
+
+        A `do` or a `let` in statement position runs whenever its enclosing
+        block does, so a loop inside one is as unconditional as a bare one.
+        """
+        if is_form(statement, 'while') or is_form(statement, 'for-each'):
+            self._unconditional_loops.add(id(statement))
+        elif is_form(statement, 'set!'):
+            self._unconditional_assignments.add(id(statement))
+        elif is_form(statement, 'do') and len(statement) >= 2:
+            for inner in statement.items[1:]:
+                self._note_statement(inner)
+        elif is_form(statement, 'let') and len(statement) >= 3:
+            for inner in statement.items[2:]:
+                self._note_statement(inner)
 
     @contextmanager
     def initial_versions(self):
@@ -2083,6 +2102,10 @@ class Z3Translator:
         # re-derives the binding's initial value attaches it there rather than
         # to what the assignment produced.
         self._pre_loop_variables.setdefault(name, before)
+        # `(set! x (do (return 0) 1))` never completes: the return leaves the
+        # function before the assignment lands.
+        if self._contains_return([expr[2]]):
+            carries_value = False
         prefix = f"{name}_after_set"
         if z3.is_bool(before):
             after = z3.FreshBool(prefix)

--- a/src/slop/verifier/translator.py
+++ b/src/slop/verifier/translator.py
@@ -73,6 +73,7 @@ class Z3Translator:
         self._unconditional_loops: Set[int] = set()
         self._unconditional_assignments: Set[int] = set()
         self._in_loop_body = False
+        self._in_quoted_form = False
         self._record_new_counter = 0  # Counter for unique record-new values
         self.enum_type_variants: set = set()  # Variants from EnumType only (not UnionType)
         self._build_enum_map()
@@ -1329,8 +1330,16 @@ class Z3Translator:
                         quoted_name = f"'{name}"
                         if quoted_name in self.enum_values:
                             return z3.IntVal(self.enum_values[quoted_name])
-                    # If not found in enums, return the translated inner expression
-                    return self.translate_expr(inner)
+                    # If not found in enums, return the translated inner expression.
+                    # Whatever it looks like, it is data: an assignment or loop
+                    # inside a quote is not executed, so it must not version
+                    # anything.
+                    was_quoted = self._in_quoted_form
+                    self._in_quoted_form = True
+                    try:
+                        return self.translate_expr(inner)
+                    finally:
+                        self._in_quoted_form = was_quoted
 
                 # Control flow - path sensitive analysis
                 if op == 'if':
@@ -1865,6 +1874,8 @@ class Z3Translator:
         that only ever does `(set! i (+ i k))` for non-negative k cannot lower i,
         however many times it runs - including none - so i_after >= i_before.
         """
+        if self._in_quoted_form:
+            return None
         loop_id = id(expr)
         unconditional = loop_id in self._unconditional_loops
         body_items = expr.items[2:]
@@ -1976,7 +1987,7 @@ class Z3Translator:
         gave every name it assigns a fresh constant, and one more here would
         replace it.
         """
-        if self._in_loop_body:
+        if self._in_loop_body or self._in_quoted_form:
             return None
         target = expr[1]
         # A `set!` in a branch runs only if that branch does, and both arms are
@@ -2058,6 +2069,9 @@ class Z3Translator:
             if not (isinstance(head, Symbol) and head.name in ('+', '-')):
                 return 0
             left, right = value[1], value[2]
+            if head.name == '+' and isinstance(left, Number) and left.value >= 0:
+                # (+ 1 i) is the same step as (+ i 1)
+                left, right = right, left
             if not (isinstance(left, Symbol) and left.name == name):
                 return 0
             if not isinstance(right, Number) or right.value < 0:

--- a/src/slop/verifier/translator.py
+++ b/src/slop/verifier/translator.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import struct
+from contextlib import contextmanager
 from typing import Dict, List, Optional, Set, Tuple, Any, TYPE_CHECKING
 
 from slop.parser import SList, Symbol, String, Number, is_form
@@ -75,6 +76,7 @@ class Z3Translator:
         self._in_loop_body = False
         self._in_quoted_form = False
         self._versions_frozen = False
+        self._prefer_initial_versions = False
         self._record_new_counter = 0  # Counter for unique record-new values
         self.enum_type_variants: set = set()  # Variants from EnumType only (not UnionType)
         self._build_enum_map()
@@ -1439,6 +1441,8 @@ class Z3Translator:
         # replaced has no single value to give them - the filter that excluded
         # `target` did so before `(set! target 999)`, not after - so it is
         # refused rather than answered with the wrong one (issue #116).
+        if self._prefer_initial_versions and name in self._pre_loop_variables:
+            return self._pre_loop_variables[name]
         if self._versions_frozen and name in self._pre_loop_variables:
             return None
 
@@ -1986,6 +1990,21 @@ class Z3Translator:
             if len(statements) <= 1 and statements and statements[0] is node:
                 return
             node = statements[-1]
+
+    @contextmanager
+    def initial_versions(self):
+        """Read every name as it stood before any loop or assignment.
+
+        For a pass that runs after the body has been walked but is asking about
+        something written near the top of it - an early-return guard, say, which
+        tests the values in scope where it appears.
+        """
+        was = self._prefer_initial_versions
+        self._prefer_initial_versions = True
+        try:
+            yield
+        finally:
+            self._prefer_initial_versions = was
 
     def freeze_versions(self) -> None:
         """Stop answering for names that have more than one version.

--- a/src/slop/verifier/translator.py
+++ b/src/slop/verifier/translator.py
@@ -2036,7 +2036,9 @@ class Z3Translator:
                 continue
             head = stmt[0]
             if isinstance(head, Symbol):
-                if head.name == 'fn':
+                # A callback's assignments are its own, and a quoted form is
+                # data - neither assigns anything here.
+                if head.name in ('fn', 'quote'):
                     continue
                 if head.name == 'set!' and len(stmt) >= 3 and isinstance(stmt[1], Symbol):
                     assigned.setdefault(stmt[1].name, []).append(stmt[2])

--- a/src/slop/verifier/translator.py
+++ b/src/slop/verifier/translator.py
@@ -2042,6 +2042,9 @@ class Z3Translator:
                     continue
                 if head.name == 'set!' and len(stmt) >= 3 and isinstance(stmt[1], Symbol):
                     assigned.setdefault(stmt[1].name, []).append(stmt[2])
+                    # The assigned value can itself assign: keep walking it, or
+                    # a write nested there keeps its pre-loop constant.
+                    self._collect_assignments([stmt[2]], assigned)
                     continue
             self._collect_assignments(stmt.items, assigned)
 

--- a/src/slop/verifier/translator.py
+++ b/src/slop/verifier/translator.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import struct
-from typing import Dict, List, Optional, Tuple, Any, TYPE_CHECKING
+from typing import Dict, List, Optional, Set, Tuple, Any, TYPE_CHECKING
 
 from slop.parser import SList, Symbol, String, Number, is_form
 from slop.types import (
@@ -61,6 +61,12 @@ class Z3Translator:
         self.use_seq_encoding = use_seq_encoding
         self.list_seqs: Dict[str, z3.SeqRef] = {}
         self._seq_counter = 0  # Counter for unique seq names
+        # Post-loop versions of the names a loop assigns, keyed by (loop, name),
+        # so re-translating the same loop reuses them.
+        self._loop_versions: Dict[Tuple[int, str], z3.ExprRef] = {}
+        self._loop_version_counter = 0
+        self._pre_loop_variables: Dict[str, z3.ExprRef] = {}
+        self.versioned_loops: Set[int] = set()
         self._record_new_counter = 0  # Counter for unique record-new values
         self.enum_type_variants: set = set()  # Variants from EnumType only (not UnionType)
         self._build_enum_map()
@@ -1343,6 +1349,10 @@ class Z3Translator:
                 if op == 'let' and len(expr) >= 3:
                     return self._translate_let(expr)
 
+                # A loop gives the variables it assigns a new value
+                if op in ('while', 'for-each') and len(expr) >= 2:
+                    return self._translate_loop(expr)
+
                 # Option constructors with semantic axioms
                 if op == 'some' and len(expr) == 2:
                     inner = self.translate_expr(expr[1])
@@ -1827,6 +1837,117 @@ class Z3Translator:
             result = self.translate_expr(body_expr)
 
         return result
+
+    def _translate_loop(self, expr: SList) -> Optional[z3.ExprRef]:
+        """Give the variables a loop assigns a value of their own after it.
+
+        One Z3 constant per name cannot hold both what a counter started at and
+        what it ended at. `(let ((mut i 0)) (while (< i 10) (set! i (+ i 1))) i)`
+        asserted i == 0 and, from the loop's exit, not(i < 10) - a contradiction,
+        which discharges every contract on the function (issue #116).
+
+        So the assigned names are re-bound to fresh constants here, at the point
+        in the body where the loop runs. Reads before the loop keep the old
+        constant, reads after see the new one, and the exit condition is stated
+        about the new one because that is what it constrains.
+
+        Nothing is claimed about what the loop computed, with one exception: a
+        counter every assignment moves the same way keeps its direction. A body
+        that only ever does `(set! i (+ i k))` for non-negative k cannot lower i,
+        however many times it runs - including none - so i_after >= i_before.
+        """
+        loop_id = id(expr)
+        body_items = expr.items[2:] if is_form(expr, 'while') else expr.items[2:]
+
+        assigned: Dict[str, List['SExpr']] = {}
+        self._collect_assignments(body_items, assigned)
+
+        for name, values in assigned.items():
+            before = self.variables.get(name)
+            if before is None or not z3.is_expr(before):
+                continue
+            self._pre_loop_variables.setdefault(name, before)
+            key = (loop_id, name)
+            after = self._loop_versions.get(key)
+            if after is None:
+                self._loop_version_counter += 1
+                fresh_name = f"{name}_after_loop_{self._loop_version_counter}"
+                if z3.is_bool(before):
+                    after = z3.Bool(fresh_name)
+                elif z3.is_real(before):
+                    after = z3.Real(fresh_name)
+                else:
+                    after = z3.Int(fresh_name)
+                self._loop_versions[key] = after
+                direction = self._assignment_direction(name, values)
+                if direction > 0:
+                    self.constraints.append(after >= before)
+                elif direction < 0:
+                    self.constraints.append(after <= before)
+            self.variables[name] = after
+
+        # The exit condition constrains the post-loop values, so it is stated
+        # here rather than by a later pass that would not know which version of
+        # each name a given loop ended with.
+        if is_form(expr, 'while') and len(expr) >= 2:
+            cond_z3 = self.translate_expr(expr[1])
+            if cond_z3 is not None and z3.is_bool(cond_z3):
+                self.constraints.append(z3.Not(cond_z3))
+        self.versioned_loops.add(loop_id)
+
+        for item in body_items:
+            self.translate_expr(item)
+        return None
+
+    def initial_variable(self, name: str):
+        """The constant `name` held before any loop gave it a new one.
+
+        A phase that re-derives a binding's *initial* value has to attach it to
+        that constant. Reading `variables` instead picks up whatever version is
+        current, which after a loop means asserting the starting value of the
+        thing the loop produced.
+        """
+        return self._pre_loop_variables.get(name, self.variables.get(name))
+
+    def is_loop_versioned(self, name: str) -> bool:
+        """True if a loop assigned `name`, so its value after differs from before."""
+        return name in self._pre_loop_variables
+
+    def _collect_assignments(self, stmts, assigned: Dict[str, List]):
+        """Every `(set! name value)` under `stmts`, grouped by name.
+
+        Stops at a nested `(fn ...)`: a callback's assignments are its own.
+        """
+        for stmt in stmts:
+            if not isinstance(stmt, SList) or len(stmt) < 1:
+                continue
+            head = stmt[0]
+            if isinstance(head, Symbol):
+                if head.name == 'fn':
+                    continue
+                if head.name == 'set!' and len(stmt) >= 3 and isinstance(stmt[1], Symbol):
+                    assigned.setdefault(stmt[1].name, []).append(stmt[2])
+                    continue
+            self._collect_assignments(stmt.items, assigned)
+
+    def _assignment_direction(self, name: str, values) -> int:
+        """+1 if every assignment to `name` can only raise it, -1 to lower, else 0."""
+        directions = set()
+        for value in values:
+            if not (isinstance(value, SList) and len(value) == 3):
+                return 0
+            head = value[0]
+            if not (isinstance(head, Symbol) and head.name in ('+', '-')):
+                return 0
+            left, right = value[1], value[2]
+            if not (isinstance(left, Symbol) and left.name == name):
+                return 0
+            if not isinstance(right, Number) or right.value < 0:
+                return 0
+            directions.add(1 if head.name == '+' else -1)
+        if len(directions) != 1:
+            return 0
+        return directions.pop()
 
     def _translate_match(self, expr: SList) -> Optional[z3.ExprRef]:
         """Translate match expression for union and enum types.

--- a/src/slop/verifier/translator.py
+++ b/src/slop/verifier/translator.py
@@ -77,6 +77,7 @@ class Z3Translator:
         self._in_quoted_form = False
         self._versions_frozen = False
         self._prefer_initial_versions = False
+        self._declared_types: Dict[str, Any] = {}
         self._record_new_counter = 0  # Counter for unique record-new values
         self.enum_type_variants: set = set()  # Variants from EnumType only (not UnionType)
         self._build_enum_map()
@@ -1110,7 +1111,25 @@ class Z3Translator:
             var = z3.Int(name)
 
         self.variables[name] = var
+        self._declared_types[name] = typ
         return var
+
+    def _apply_declared_bounds(self, name: str, var: z3.ExprRef) -> None:
+        """Re-state a name's type bounds for a new version of it.
+
+        A fresh constant is fresh in every sense, including the constraints the
+        declaration put on the first one. A `U8` stays non-negative across an
+        assignment; forgetting that loses the type, not just the value.
+        """
+        typ = self._declared_types.get(name)
+        if typ is None:
+            return
+        if isinstance(typ, PrimitiveType) and typ.name.startswith('U'):
+            self.constraints.append(var >= 0)
+        elif isinstance(typ, RangeType):
+            self._add_range_constraints(var, typ.bounds)
+        elif isinstance(typ, PtrType):
+            self.constraints.append(var >= 0)
 
     def _add_range_constraints(self, var: z3.ArithRef, bounds: RangeBounds):
         """Add constraints for range type bounds"""
@@ -1908,6 +1927,14 @@ class Z3Translator:
             entry_condition = self.translate_expr(expr[1])
             if entry_condition is not None and not z3.is_bool(entry_condition):
                 entry_condition = None
+        elif is_form(expr, 'for-each') and len(expr) >= 2:
+            # The same idea for a collection loop: no elements, no iterations.
+            binder = expr[1]
+            collection = binder[1] if isinstance(binder, SList) and len(binder) >= 2 else None
+            if collection is not None:
+                length = self._collection_length_term(collection)
+                if length is not None:
+                    entry_condition = length > 0
 
         for name, values in assigned.items():
             before = self.variables.get(name)
@@ -1929,6 +1956,7 @@ class Z3Translator:
                 else:
                     after = z3.FreshInt(prefix)
                 self._loop_versions[key] = after
+                self._apply_declared_bounds(name, after)
                 if unconditional:
                     direction = self._assignment_direction(name, values)
                     if direction > 0:
@@ -2062,6 +2090,7 @@ class Z3Translator:
             after = z3.FreshReal(prefix)
         else:
             after = z3.FreshInt(prefix)
+        self._apply_declared_bounds(name, after)
         self.variables[name] = after
         if carries_value and value_z3 is not None and value_z3.sort() == after.sort():
             self.constraints.append(after == value_z3)
@@ -2103,6 +2132,23 @@ class Z3Translator:
             if self._contains_return(stmt.items):
                 return True
         return False
+
+    def _collection_length_term(self, collection: 'SExpr'):
+        """A length term for a loop's collection, if one can be named."""
+        if isinstance(collection, Symbol):
+            seq = self.list_seqs.get(collection.name)
+            if seq is not None:
+                return z3.Length(seq)
+        handle = self.translate_expr(collection)
+        if handle is None or not z3.is_expr(handle) or handle.sort() != z3.IntSort():
+            return None
+        func = self.variables.get("field_len")
+        if func is None:
+            func = z3.Function("field_len", z3.IntSort(), z3.IntSort())
+            self.variables["field_len"] = func
+        if not isinstance(func, z3.FuncDeclRef) or func.arity() != 1:
+            return None
+        return func(handle)
 
     def _collect_assignments(self, stmts, assigned: Dict[str, List]):
         """Every `(set! name value)` under `stmts`, grouped by name.

--- a/src/slop/verifier/translator.py
+++ b/src/slop/verifier/translator.py
@@ -67,6 +67,11 @@ class Z3Translator:
         self._loop_version_counter = 0
         self._pre_loop_variables: Dict[str, z3.ExprRef] = {}
         self.versioned_loops: Set[int] = set()
+        # Loops that run whenever the function body does. Empty until
+        # note_body() says otherwise, so a loop nobody has placed is treated as
+        # conditional and gets no facts attached to it.
+        self._unconditional_loops: Set[int] = set()
+        self._in_loop_body = False
         self._record_new_counter = 0  # Counter for unique record-new values
         self.enum_type_variants: set = set()  # Variants from EnumType only (not UnionType)
         self._build_enum_map()
@@ -1353,6 +1358,9 @@ class Z3Translator:
                 if op in ('while', 'for-each') and len(expr) >= 2:
                     return self._translate_loop(expr)
 
+                if op == 'set!' and len(expr) >= 3:
+                    return self._translate_assignment(expr)
+
                 # Option constructors with semantic axioms
                 if op == 'some' and len(expr) == 2:
                     inner = self.translate_expr(expr[1])
@@ -1857,7 +1865,8 @@ class Z3Translator:
         however many times it runs - including none - so i_after >= i_before.
         """
         loop_id = id(expr)
-        body_items = expr.items[2:] if is_form(expr, 'while') else expr.items[2:]
+        unconditional = loop_id in self._unconditional_loops
+        body_items = expr.items[2:]
 
         assigned: Dict[str, List['SExpr']] = {}
         self._collect_assignments(body_items, assigned)
@@ -1870,34 +1879,68 @@ class Z3Translator:
             key = (loop_id, name)
             after = self._loop_versions.get(key)
             if after is None:
-                self._loop_version_counter += 1
-                fresh_name = f"{name}_after_loop_{self._loop_version_counter}"
+                # Fresh rather than a name of our own construction:
+                # `i_after_loop_1` is a legal SLOP identifier, and colliding
+                # with a parameter of that name would tie the loop's result to
+                # an unrelated input.
+                prefix = f"{name}_after_loop"
                 if z3.is_bool(before):
-                    after = z3.Bool(fresh_name)
+                    after = z3.FreshBool(prefix)
                 elif z3.is_real(before):
-                    after = z3.Real(fresh_name)
+                    after = z3.FreshReal(prefix)
                 else:
-                    after = z3.Int(fresh_name)
+                    after = z3.FreshInt(prefix)
                 self._loop_versions[key] = after
-                direction = self._assignment_direction(name, values)
-                if direction > 0:
-                    self.constraints.append(after >= before)
-                elif direction < 0:
-                    self.constraints.append(after <= before)
+                if unconditional:
+                    direction = self._assignment_direction(name, values)
+                    if direction > 0:
+                        self.constraints.append(after >= before)
+                    elif direction < 0:
+                        self.constraints.append(after <= before)
             self.variables[name] = after
 
         # The exit condition constrains the post-loop values, so it is stated
         # here rather than by a later pass that would not know which version of
         # each name a given loop ended with.
-        if is_form(expr, 'while') and len(expr) >= 2:
+        if unconditional and is_form(expr, 'while') and len(expr) >= 2:
             cond_z3 = self.translate_expr(expr[1])
             if cond_z3 is not None and z3.is_bool(cond_z3):
                 self.constraints.append(z3.Not(cond_z3))
         self.versioned_loops.add(loop_id)
 
-        for item in body_items:
-            self.translate_expr(item)
+        # The body still gets walked so its inner bindings are declared, but its
+        # assignments have already been accounted for by the havoc above and
+        # must not version anything again.
+        was_in_loop = self._in_loop_body
+        self._in_loop_body = True
+        try:
+            for item in body_items:
+                self.translate_expr(item)
+        finally:
+            self._in_loop_body = was_in_loop
         return None
+
+    def note_body(self, body: 'SExpr') -> None:
+        """Record which loops in `body` run unconditionally.
+
+        A loop inside an `if` arm may not run at all, so its exit condition and
+        the direction of its counters say nothing about the state afterwards.
+        Only a loop on the body's own statement path can contribute those.
+        """
+        node = body
+        while True:
+            if is_form(node, 'let') and len(node) >= 3:
+                statements = node.items[2:]
+            elif is_form(node, 'do') and len(node) >= 2:
+                statements = node.items[1:]
+            else:
+                statements = [node]
+            for statement in statements:
+                if is_form(statement, 'while') or is_form(statement, 'for-each'):
+                    self._unconditional_loops.add(id(statement))
+            if len(statements) <= 1 and statements and statements[0] is node:
+                return
+            node = statements[-1]
 
     def initial_variable(self, name: str):
         """The constant `name` held before any loop gave it a new one.
@@ -1912,6 +1955,37 @@ class Z3Translator:
     def is_loop_versioned(self, name: str) -> bool:
         """True if a loop assigned `name`, so its value after differs from before."""
         return name in self._pre_loop_variables
+
+    def _translate_assignment(self, expr: SList) -> Optional[z3.ExprRef]:
+        """`(set! name value)` outside a loop: the name takes a new value.
+
+        Without this the name keeps whatever constant it had, so a `set!` after
+        a loop left the loop's facts attached to a variable the program has
+        since overwritten. Inside a loop body nothing is done - the loop already
+        gave every name it assigns a fresh constant, and one more here would
+        replace it.
+        """
+        if self._in_loop_body:
+            return None
+        target = expr[1]
+        if not isinstance(target, Symbol):
+            return None
+        name = target.name
+        before = self.variables.get(name)
+        value_z3 = self.translate_expr(expr[2])
+        if before is None or not z3.is_expr(before):
+            return None
+        prefix = f"{name}_after_set"
+        if z3.is_bool(before):
+            after = z3.FreshBool(prefix)
+        elif z3.is_real(before):
+            after = z3.FreshReal(prefix)
+        else:
+            after = z3.FreshInt(prefix)
+        self.variables[name] = after
+        if value_z3 is not None and value_z3.sort() == after.sort():
+            self.constraints.append(after == value_z3)
+        return None
 
     def _collect_assignments(self, stmts, assigned: Dict[str, List]):
         """Every `(set! name value)` under `stmts`, grouped by name.

--- a/src/slop/verifier/translator.py
+++ b/src/slop/verifier/translator.py
@@ -1897,6 +1897,14 @@ class Z3Translator:
         assigned: Dict[str, List['SExpr']] = {}
         self._collect_assignments(body_items, assigned)
 
+        # The condition as it reads on entry. If it is false there the body
+        # never runs, and every name it assigns keeps the value it came in with.
+        entry_condition = None
+        if is_form(expr, 'while') and len(expr) >= 2:
+            entry_condition = self.translate_expr(expr[1])
+            if entry_condition is not None and not z3.is_bool(entry_condition):
+                entry_condition = None
+
         for name, values in assigned.items():
             before = self.variables.get(name)
             if before is None or not z3.is_expr(before):
@@ -1923,6 +1931,9 @@ class Z3Translator:
                         self.constraints.append(after >= before)
                     elif direction < 0:
                         self.constraints.append(after <= before)
+                if entry_condition is not None:
+                    self.constraints.append(
+                        z3.Implies(z3.Not(entry_condition), after == before))
             self.variables[name] = after
 
         # The exit condition constrains the post-loop values, so it is stated

--- a/src/slop/verifier/translator.py
+++ b/src/slop/verifier/translator.py
@@ -1876,15 +1876,16 @@ class Z3Translator:
         """
         if self._in_quoted_form:
             return None
+        if self._in_loop_body:
+            # The enclosing loop's havoc already covered everything this one
+            # assigns; versioning again would replace those constants.
+            return None
         loop_id = id(expr)
         unconditional = loop_id in self._unconditional_loops
         body_items = expr.items[2:]
 
         assigned: Dict[str, List['SExpr']] = {}
         self._collect_assignments(body_items, assigned)
-
-        if self._contains_early_exit(body_items):
-            unconditional = False
 
         for name, values in assigned.items():
             before = self.variables.get(name)
@@ -1917,12 +1918,13 @@ class Z3Translator:
         # The exit condition constrains the post-loop values, so it is stated
         # here rather than by a later pass that would not know which version of
         # each name a given loop ended with.
-        # A `break` or `return` can leave the loop with its condition still
-        # true, so the exit rule does not apply.
-        if unconditional and self._contains_early_exit(body_items):
-            unconditional = False
+        # A `break` in this loop, or a `return` anywhere in it, can leave with
+        # the condition still true - so the exit rule does not apply. Neither
+        # changes the direction a counter moves, which is kept.
+        exits_early = (self._contains_own_break(body_items)
+                       or self._contains_return(body_items))
 
-        if unconditional and is_form(expr, 'while') and len(expr) >= 2:
+        if unconditional and not exits_early and is_form(expr, 'while') and len(expr) >= 2:
             cond_z3 = self.translate_expr(expr[1])
             if cond_z3 is not None and z3.is_bool(cond_z3):
                 self.constraints.append(z3.Not(cond_z3))
@@ -2018,22 +2020,40 @@ class Z3Translator:
             self.constraints.append(after == value_z3)
         return None
 
-    def _contains_early_exit(self, stmts) -> bool:
-        """True if these statements can leave their loop early.
+    def _contains_own_break(self, stmts) -> bool:
+        """True if these statements break out of *this* loop.
 
-        Stops at a nested `(fn ...)`, whose break belongs to a loop inside it,
-        and at a `(quote ...)`, which is data.
+        Stops at a nested loop, whose break belongs to that one, and at a
+        `(fn ...)` or `(quote ...)`.
         """
         for stmt in stmts:
             if not isinstance(stmt, SList) or len(stmt) < 1:
                 continue
             head = stmt[0]
             if isinstance(head, Symbol):
-                if head.name in ('break', 'return'):
+                if head.name == 'break':
+                    return True
+                if head.name in ('fn', 'quote', 'while', 'for-each'):
+                    continue
+            if self._contains_own_break(stmt.items):
+                return True
+        return False
+
+    def _contains_return(self, stmts) -> bool:
+        """True if these statements can return from the function.
+
+        A `return` leaves every enclosing loop, so nested ones are walked.
+        """
+        for stmt in stmts:
+            if not isinstance(stmt, SList) or len(stmt) < 1:
+                continue
+            head = stmt[0]
+            if isinstance(head, Symbol):
+                if head.name == 'return':
                     return True
                 if head.name in ('fn', 'quote'):
                     continue
-            if self._contains_early_exit(stmt.items):
+            if self._contains_return(stmt.items):
                 return True
         return False
 

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8770,16 +8770,46 @@ class TestLoopVariableVersions:
         ''').status == 'verified'
 
     def test_a_counter_moving_both_ways_keeps_no_direction(self):
+        """The loop is driven by k, so only the direction of the writes to i
+        could establish this - and there is no single direction."""
         assert self._result('''
         (module m
           (fn f ((arena Arena) (n Int) (c Bool))
             (@spec ((Arena Int Bool) -> Int))
-            (@post (>= $result 0))
-            (let ((mut i 0))
-              (while (< i n)
+            (@post (>= $result 5))
+            (let ((mut i 5)
+                  (mut k 0))
+              (while (< k n)
+                (set! k (+ k 1))
                 (if c (set! i (+ i 1)) (set! i (- i 1))))
               i)))
         ''').status != 'verified'
+
+    def test_a_counter_moving_one_way_keeps_its_direction(self):
+        assert self._result('''
+        (module m
+          (fn f ((arena Arena) (n Int))
+            (@spec ((Arena Int) -> Int))
+            (@post (>= $result 5))
+            (let ((mut i 5)
+                  (mut k 0))
+              (while (< k n)
+                (set! k (+ k 1))
+                (set! i (+ i 1)))
+              i)))
+        ''').status == 'verified'
+
+    def test_a_loop_that_never_runs_leaves_its_variables_alone(self):
+        assert self._result('''
+        (module m
+          (fn z ((arena Arena) (n Int))
+            (@spec ((Arena Int) -> Int))
+            (@pre (<= n 0))
+            (@post (== $result 0))
+            (let ((mut i 0))
+              (while (< i n) (set! i (+ i 1)))
+              i)))
+        ''').status == 'verified'
 
     def test_a_variable_the_loop_does_not_touch_keeps_its_value(self):
         assert self._result('''
@@ -9116,4 +9146,33 @@ class TestLoopVariableVersions:
             (let ((mut count 0))
               (for-each (x items) (if true (set! count (+ count 1))))
               (return count))))
+        ''').status != 'verified'
+
+    def test_an_exit_guard_reads_the_value_it_was_written_against(self):
+        """`(when (== i 0) (return -1))` before the loop tests i's starting
+        value. Translating it after the body would test what the loop left."""
+        assert self._result('''
+        (module m
+          (fn g ((arena Arena) (n Int))
+            (@spec ((Arena Int) -> Int))
+            (@pre (> n 3))
+            (@post (>= $result 2))
+            (let ((mut i 1))
+              (when (== i 0) (return -1))
+              (while (< i n) (set! i (+ i 1)))
+              i)))
+        ''').status == 'verified'
+
+    def test_an_exit_guard_naming_a_reassigned_variable_is_withdrawn(self):
+        """There is no program point here to say which version the guard meant,
+        so the exit modelling is given up rather than guessed."""
+        assert self._result('''
+        (module m
+          (fn h ((arena Arena))
+            (@spec ((Arena) -> Int))
+            (@post (== $result 7))
+            (let ((mut i 1))
+              (when (> i 0) (return 7))
+              (set! i 5)
+              i)))
         ''').status != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -9163,9 +9163,23 @@ class TestLoopVariableVersions:
               i)))
         ''').status == 'verified'
 
-    def test_an_exit_guard_naming_a_reassigned_variable_is_withdrawn(self):
-        """There is no program point here to say which version the guard meant,
-        so the exit modelling is given up rather than guessed."""
+    def test_a_guard_past_a_reassignment_is_withdrawn(self):
+        """Guards are read as they stood at the top. Past an assignment the
+        name they test may have changed, and there is no program point here to
+        say which version was meant - so the modelling is given up, and with it
+        the claim that the trailing form is the only result."""
+        assert self._result('''
+        (module m
+          (fn h ((arena Arena))
+            (@spec ((Arena) -> Int))
+            (@post (== $result 5))
+            (let ((mut i 0))
+              (set! i 5)
+              (when (== i 0) (return -1))
+              i)))
+        ''').status != 'verified'
+
+    def test_a_guard_before_any_reassignment_is_exact(self):
         assert self._result('''
         (module m
           (fn h ((arena Arena))
@@ -9175,4 +9189,4 @@ class TestLoopVariableVersions:
               (when (> i 0) (return 7))
               (set! i 5)
               i)))
-        ''').status != 'verified'
+        ''').status == 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -9248,3 +9248,25 @@ class TestLoopVariableVersions:
             (@post (== $result x))
             (let () (set! x 1) x)))
         ''').status == 'verified'
+
+    def test_a_local_cannot_shadow_a_parameter_in_a_postcondition(self):
+        """A contract cannot name a local, so leaving the body's bindings in
+        place while translating one lets a local stand in for a parameter."""
+        assert self._result('''
+        (module m
+          (fn f ((x Int))
+            (@spec ((Int) -> Int))
+            (@post x)
+            (let ((x true)) 1)))
+        ''').status != 'verified'
+
+    def test_a_local_named_like_a_verifier_accessor(self):
+        """`field_len` is the verifier's own length accessor and a legal local
+        name; a `list-len` postcondition must not be handed the local."""
+        assert self._result('''
+        (module m
+          (fn fl ((arena Arena) (xs (List Int)))
+            (@spec ((Arena (List Int)) -> Int))
+            (@post (>= (list-len xs) 0))
+            (let ((field_len 3)) field_len)))
+        ''').status == 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8979,3 +8979,47 @@ class TestLoopVariableVersions:
                 (set! i (do (set! j 1) (+ i 1))))
               j)))
         ''').status != 'verified'
+
+    def test_a_write_nested_in_the_counters_own_value(self):
+        assert self._result('''
+        (module m
+          (fn h ((items (List Int)))
+            (@spec (((List Int)) -> Int))
+            (@post (<= $result (list-len items)))
+            (let ((mut count 0))
+              (for-each (x items) (set! count (do (set! count 100) 0)))
+              count)))
+        ''').status != 'verified'
+
+    def test_a_quoted_assignment_outside_a_loop_is_data(self):
+        assert self._result('''
+        (module m
+          (fn q ((arena Arena))
+            (@spec ((Arena) -> Int))
+            (@post (== $result 0))
+            (let ((mut i 0))
+              (quote (set! i 5))
+              i)))
+        ''').status == 'verified'
+
+    def test_either_operand_order_counts_as_a_step(self):
+        """The detector accepts `(+ 1 count)`; the checks on top of it have to
+        as well, or a valid counter is recognised and then denied its bound."""
+        assert self._result('''
+        (module m
+          (fn c ((items (List Int)))
+            (@spec (((List Int)) -> Int))
+            (@post (<= $result (list-len items)))
+            (let ((mut count 0))
+              (for-each (x items) (if true (set! count (+ 1 count))))
+              count)))
+        ''').status == 'verified'
+        assert self._result('''
+        (module m
+          (fn d ((arena Arena) (n Int))
+            (@spec ((Arena Int) -> Int))
+            (@post (>= $result 0))
+            (let ((mut i 0))
+              (while (< i n) (set! i (+ 1 i)))
+              i)))
+        ''').status == 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8793,3 +8793,72 @@ class TestLoopVariableVersions:
                 (set! i (+ i 1)))
               k)))
         ''').status == 'verified'
+
+    def test_a_loop_inside_a_branch_says_nothing_about_after(self):
+        """It may not run, so neither its exit condition nor the direction of
+        its counters describes the state that follows."""
+        assert self._result('''
+        (module m
+          (fn f ((arena Arena) (flag Bool))
+            (@spec ((Arena Bool) -> Int))
+            (@pre (not flag))
+            (@post (>= $result 5))
+            (let ((mut i 0))
+              (if flag (while (< i 5) (set! i (+ i 1))) 0)
+              i)))
+        ''').status != 'verified'
+
+    def test_an_assignment_after_the_loop_replaces_its_result(self):
+        assert self._result('''
+        (module m
+          (fn g ((arena Arena))
+            (@spec ((Arena) -> Int))
+            (@post (>= $result 5))
+            (let ((mut i 0))
+              (while (< i 5) (set! i (+ i 1)))
+              (set! i 0)
+              i)))
+        ''').status != 'verified'
+
+    def test_an_assignment_after_the_loop_is_what_the_result_is(self):
+        assert self._result('''
+        (module m
+          (fn g ((arena Arena))
+            (@spec ((Arena) -> Int))
+            (@post (== $result 0))
+            (let ((mut i 0))
+              (while (< i 5) (set! i (+ i 1)))
+              (set! i 0)
+              i)))
+        ''').status == 'verified'
+
+    def test_a_binding_made_before_the_loop_keeps_its_value(self):
+        """`(j (ident i))` was called with i's starting value. Re-translating
+        that argument later reads the version the loop produced."""
+        from slop.verifier import verify_source
+        results = verify_source('''
+        (module m
+          (fn ident ((x Int)) (@spec ((Int) -> Int)) (@post (== $result x)) x)
+          (fn h ((arena Arena))
+            (@spec ((Arena) -> Int))
+            (@post (>= $result 5))
+            (let ((mut i 0)
+                  (j (ident i)))
+              (while (< i 5) (set! i (+ i 1)))
+              j)))
+        ''', filename="probe.slop")
+        h = [r for r in results if r.name == 'h']
+        assert len(h) == 1
+        assert h[0].status != 'verified'
+
+    def test_a_parameter_cannot_be_mistaken_for_a_loop_constant(self):
+        assert self._result('''
+        (module m
+          (fn k ((arena Arena) (i_after_loop_1 Int))
+            (@spec ((Arena Int) -> Int))
+            (@pre (== i_after_loop_1 42))
+            (@post (== $result i_after_loop_1))
+            (let ((mut i 0))
+              (while (< i 5) (set! i (+ i 1)))
+              i)))
+        ''').status != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8912,3 +8912,39 @@ class TestLoopVariableVersions:
               (for-each (x items) (if true (set! count (+ count 1))))
               100)))
         ''').status != 'verified'
+
+    def test_a_counter_written_twice_is_not_bounded_by_one_per_element(self):
+        assert self._result('''
+        (module m
+          (fn h ((items (List Int)))
+            (@spec (((List Int)) -> Int))
+            (@post (<= $result (list-len items)))
+            (let ((mut count 0))
+              (for-each (x items) (set! count (+ count 1)) (set! count (+ count 1)))
+              count)))
+        ''').status != 'verified'
+
+    def test_a_counter_overwritten_in_the_loop(self):
+        assert self._result('''
+        (module m
+          (fn h ((items (List Int)))
+            (@spec (((List Int)) -> Int))
+            (@post (<= $result (list-len items)))
+            (let ((mut count 0))
+              (for-each (x items) (if true (set! count 100)))
+              count)))
+        ''').status != 'verified'
+
+    def test_a_quoted_assignment_in_a_loop_body_is_data(self):
+        assert self._result('''
+        (module m
+          (fn q ((arena Arena) (n Int))
+            (@spec ((Arena Int) -> Int))
+            (@post (== $result 0))
+            (let ((mut i 0)
+                  (mut k 0))
+              (while (< k n)
+                (set! k (+ k 1))
+                (quote (set! i (+ i 1))))
+              i)))
+        ''').status == 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8862,3 +8862,53 @@ class TestLoopVariableVersions:
               (while (< i 5) (set! i (+ i 1)))
               i)))
         ''').status != 'verified'
+
+    def test_a_loop_that_can_break_has_no_exit_fact(self):
+        """`(break)` leaves the loop with its condition still true."""
+        assert self._result('''
+        (module m
+          (fn f ((arena Arena))
+            (@spec ((Arena) -> Int))
+            (@post (>= $result 10))
+            (let ((mut i 0))
+              (while (< i 10) (set! i (+ i 1)) (break))
+              i)))
+        ''').status != 'verified'
+
+    def test_a_branch_local_assignment_does_not_become_the_value(self):
+        """Both arms are translated into one shared map, so the last one would
+        otherwise be current whatever the condition said."""
+        assert self._result('''
+        (module m
+          (fn g ((arena Arena) (flag Bool))
+            (@spec ((Arena Bool) -> Int))
+            (@pre flag)
+            (@post (== $result 2))
+            (let ((mut i 0))
+              (if flag (set! i 1) (set! i 2))
+              i)))
+        ''').status != 'verified'
+
+    def test_an_unconditional_assignment_is_the_value(self):
+        assert self._result('''
+        (module m
+          (fn s ((arena Arena))
+            (@spec ((Arena) -> Int))
+            (@post (== $result 3))
+            (let ((mut i 0))
+              (set! i 3)
+              i)))
+        ''').status == 'verified'
+
+    def test_a_count_bound_belongs_to_the_counter(self):
+        """The count pattern only recognises a count-shaped loop; it does not
+        check that the function returns the counter."""
+        assert self._result('''
+        (module m
+          (fn h ((items (List Int)))
+            (@spec (((List Int)) -> Int))
+            (@post (<= $result (list-len items)))
+            (let ((mut count 0))
+              (for-each (x items) (if true (set! count (+ count 1))))
+              100)))
+        ''').status != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -9190,3 +9190,37 @@ class TestLoopVariableVersions:
               (set! i 5)
               i)))
         ''').status == 'verified'
+
+    def test_a_fresh_version_keeps_its_type_bounds(self):
+        """A fresh constant is fresh in every sense, including the constraints
+        the declaration put on the first one. A U8 stays non-negative."""
+        assert self._result('''
+        (module m
+          (fn u ((arena Arena) (flag Bool) (mut x U8))
+            (@spec ((Arena Bool U8) -> U8))
+            (@post (>= $result 0))
+            (do (if flag (set! x 5) 0) x)))
+        ''').status == 'verified'
+
+    def test_a_range_bound_survives_a_loop(self):
+        assert self._result('''
+        (module m
+          (type Small (Int 0 .. 9))
+          (fn r ((arena Arena) (n Int) (mut x Small))
+            (@spec ((Arena Int Small) -> Small))
+            (@post (<= $result 9))
+            (let ((mut k 0))
+              (while (< k n) (set! k (+ k 1)) (set! x 3))
+              x)))
+        ''').status == 'verified'
+
+    def test_a_for_each_over_an_unknown_collection_may_change_things(self):
+        assert self._result('''
+        (module m
+          (fn e ((arena Arena) (xs (List Int)))
+            (@spec ((Arena (List Int)) -> Int))
+            (@post (== $result 0))
+            (let ((mut i 0))
+              (for-each (x xs) (set! i 1))
+              i)))
+        ''').status != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -9023,3 +9023,40 @@ class TestLoopVariableVersions:
               (while (< i n) (set! i (+ 1 i)))
               i)))
         ''').status == 'verified'
+
+    def test_a_break_does_not_reverse_a_counter(self):
+        """It stops the loop early; it does not undo the steps already taken."""
+        assert self._result('''
+        (module m
+          (fn b ((arena Arena) (n Int))
+            (@spec ((Arena Int) -> Int))
+            (@post (>= $result 0))
+            (let ((mut i 0))
+              (while (< i n) (set! i (+ i 1)) (break))
+              i)))
+        ''').status == 'verified'
+
+    def test_an_inner_break_belongs_to_the_inner_loop(self):
+        assert self._result('''
+        (module m
+          (fn o ((arena Arena) (n Int) (m Int))
+            (@spec ((Arena Int Int) -> Int))
+            (@post (>= $result n))
+            (let ((mut i 0)
+                  (mut j 0))
+              (while (< i n)
+                (while (< j m) (set! j (+ j 1)) (break))
+                (set! i (+ i 1)))
+              i)))
+        ''').status == 'verified'
+
+    def test_the_alternative_mutable_spelling_is_a_counter_too(self):
+        assert self._result('''
+        (module m
+          (fn c ((items (List Int)))
+            (@spec (((List Int)) -> Int))
+            (@post (<= $result (list-len items)))
+            (let (((mut count) 0))
+              (for-each (x items) (if true (set! count (+ count 1))))
+              count)))
+        ''').status == 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -9307,3 +9307,28 @@ class TestLoopVariableVersions:
               (do (while (< i 5) (set! i (+ i 1))))
               i)))
         ''').status == 'verified'
+
+    def test_a_local_does_not_inherit_a_shadowed_parameters_bounds(self):
+        """The declared type belongs to the binding, not the spelling. Keeping
+        an outer `(Int 0 .. 9)` on an ordinary local made assigning 20 to it a
+        contradiction rather than a fact."""
+        assert self._result('''
+        (module m
+          (type Small (Int 0 .. 9))
+          (fn f ((x Small))
+            (@spec ((Small) -> Int))
+            (@post (== $result 20))
+            (let ((mut x 0))
+              (set! x 20)
+              x)))
+        ''').status == 'verified'
+
+    def test_a_parameter_keeps_its_own_bound(self):
+        assert self._result('''
+        (module m
+          (type Small (Int 0 .. 9))
+          (fn g ((x Small))
+            (@spec ((Small) -> Int))
+            (@post (<= x 9))
+            1))
+        ''').status == 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -9224,3 +9224,27 @@ class TestLoopVariableVersions:
               (for-each (x xs) (set! i 1))
               i)))
         ''').status != 'verified'
+
+    def test_a_postcondition_reads_the_state_the_function_ends_in(self):
+        """A @post about a mutable parameter means the value it was left with.
+        Translating postconditions before the body bound them to the version
+        the function started with, while the returned expression used the one it
+        finished with - so the two could disagree and still 'verify'."""
+        assert self._result('''
+        (module m
+          (fn f ((mut x Int))
+            (@spec ((Int) -> Int))
+            (@pre (== x 0))
+            (@post (!= $result x))
+            (let () (set! x 1) x)))
+        ''').status != 'verified'
+
+    def test_a_postcondition_true_of_the_final_state(self):
+        assert self._result('''
+        (module m
+          (fn g ((mut x Int))
+            (@spec ((Int) -> Int))
+            (@pre (== x 0))
+            (@post (== $result x))
+            (let () (set! x 1) x)))
+        ''').status == 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -9060,3 +9060,60 @@ class TestLoopVariableVersions:
               (for-each (x items) (if true (set! count (+ count 1))))
               count)))
         ''').status == 'verified'
+
+    def test_a_pattern_axiom_does_not_read_a_later_assignment(self):
+        """The filter excluded `target` before `(set! target 999)`, but the
+        pattern phases run afterwards, when the name holds its final version."""
+        assert self._result('''
+        (module m
+          (fn f ((arena Arena) (items (List Int)) (mut target Int))
+            (@spec ((Arena (List Int) Int) -> (List Int)))
+            (@alloc arena)
+            (@post (forall (x $result) (!= x 999)))
+            (let ((mut r (list-new arena Int)))
+              (for-each (x items) (when (!= x target) (list-push r x)))
+              (set! target 999)
+              r)))
+        ''').status != 'verified'
+
+    def test_a_loop_invariant_still_sees_the_value_the_loop_left(self):
+        """Contracts are translated before the freeze: a @loop-invariant is
+        about the value the loop leaves behind, so it wants the final version."""
+        assert self._result('''
+        (module test
+          (fn filter-positive ((items (List Int)))
+            (@spec (((List Int)) -> Int))
+            (@post (>= $result 0))
+            (let ((mut count 0))
+              (for-each (x items)
+                (@loop-invariant (>= count 0))
+                (when (> x 0)
+                  (set! count (+ count 1))))
+              count)))
+        ''').status == 'verified'
+
+    def test_a_trailing_return_of_the_counter(self):
+        """`(return count)` at the end is how the function ends, not an early
+        exit - rejecting every return denied this its bound."""
+        assert self._result('''
+        (module m
+          (fn c ((items (List Int)))
+            (@spec (((List Int)) -> Int))
+            (@post (<= $result (list-len items)))
+            (let ((mut count 0))
+              (for-each (x items) (if true (set! count (+ count 1))))
+              (return count))))
+        ''').status == 'verified'
+
+    def test_an_early_return_alongside_a_trailing_one(self):
+        assert self._result('''
+        (module m
+          (fn c ((items (List Int)) (flag Bool))
+            (@spec (((List Int) Bool) -> Int))
+            (@pre flag)
+            (@post (<= $result (list-len items)))
+            (when flag (return 100))
+            (let ((mut count 0))
+              (for-each (x items) (if true (set! count (+ count 1))))
+              (return count))))
+        ''').status != 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8707,3 +8707,89 @@ class TestEarlyExits:
               (record-new F (xs e)))))
         '''
         assert verify_source(src, filename="probe.slop")[0].status == 'verified'
+
+
+class TestLoopVariableVersions:
+    """Issue #116: one Z3 constant per name cannot hold both what a counter
+    started at and what it ended at.
+
+    `(let ((mut i 0)) (while (< i 10) (set! i (+ i 1))) i)` asserted i == 0 and,
+    from the loop's exit, not(i < 10) - a contradiction, so every contract on
+    the function discharged without being proved.
+    """
+
+    @staticmethod
+    def _result(src):
+        from slop.verifier import verify_source
+        return verify_source(src, filename="probe.slop")[0]
+
+    COUNTER = '''
+        (module m
+          (fn f ((arena Arena)%s)
+            (@spec ((Arena%s) -> Int))
+            %s
+            (@post %s)
+            (let ((mut i 0))
+              (while (< i %s)
+                (set! i (+ i 1)))
+              i)))
+        '''
+
+    def _counter(self, post, bound="10", params="", spec="", pre=""):
+        return self._result(self.COUNTER % (params, spec, pre, post, bound))
+
+    def test_the_context_is_no_longer_contradictory(self):
+        result = self._counter("(== $result 42)")
+        assert result.status == 'failed'
+        assert 'inconsistent' not in result.message
+
+    def test_the_exit_condition_describes_the_value_after_the_loop(self):
+        assert self._counter("(>= $result 10)").status == 'verified'
+
+    def test_a_counter_that_only_rises_cannot_end_below_its_start(self):
+        """The loop may run zero times, so this is >= rather than >."""
+        assert self._counter("(>= $result 0)", bound="n",
+                             params=" (n Int)", spec=" Int").status == 'verified'
+
+    def test_the_starting_value_is_not_the_ending_value(self):
+        result = self._counter("(== $result 0)", bound="n", params=" (n Int)",
+                               spec=" Int", pre="(@pre (> n 5))")
+        assert result.status == 'failed'
+        assert 'inconsistent' not in result.message
+
+    def test_a_counter_that_only_falls(self):
+        assert self._result('''
+        (module m
+          (fn f ((arena Arena) (n Int))
+            (@spec ((Arena Int) -> Int))
+            (@post (<= $result 100))
+            (let ((mut i 100))
+              (while (> i n)
+                (set! i (- i 1)))
+              i)))
+        ''').status == 'verified'
+
+    def test_a_counter_moving_both_ways_keeps_no_direction(self):
+        assert self._result('''
+        (module m
+          (fn f ((arena Arena) (n Int) (c Bool))
+            (@spec ((Arena Int Bool) -> Int))
+            (@post (>= $result 0))
+            (let ((mut i 0))
+              (while (< i n)
+                (if c (set! i (+ i 1)) (set! i (- i 1))))
+              i)))
+        ''').status != 'verified'
+
+    def test_a_variable_the_loop_does_not_touch_keeps_its_value(self):
+        assert self._result('''
+        (module m
+          (fn f ((arena Arena) (n Int))
+            (@spec ((Arena Int) -> Int))
+            (@post (== $result 5))
+            (let ((k 5)
+                  (mut i 0))
+              (while (< i n)
+                (set! i (+ i 1)))
+              k)))
+        ''').status == 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -9270,3 +9270,40 @@ class TestLoopVariableVersions:
             (@post (>= (list-len xs) 0))
             (let ((field_len 3)) field_len)))
         ''').status == 'verified'
+
+    def test_an_assignment_a_return_never_reaches(self):
+        """`(set! x (do (return 0) 1))` never completes. The weakest-precondition
+        pass substituted the value anyway and its result asserted the
+        postcondition outright, so it is kept away from bodies that return."""
+        assert self._result('''
+        (module m
+          (fn f ((mut x Int))
+            (@spec ((Int) -> Int))
+            (@pre (== x 0))
+            (@post (== x 1))
+            (let () (set! x (do (return 0) 1)) x)))
+        ''').status != 'verified'
+
+    def test_a_local_of_another_sort_shadowing_a_bounded_parameter(self):
+        """The outer declaration's bounds do not apply to it, and asking Z3 to
+        compare a Bool with 0 raises rather than failing to verify."""
+        assert self._result('''
+        (module m
+          (fn s ((mut x U8))
+            (@spec ((U8) -> Int))
+            (@post (>= $result 0))
+            (let ((mut x false))
+              (set! x false)
+              1)))
+        ''').status == 'verified'
+
+    def test_a_loop_wrapped_in_a_block_still_runs(self):
+        assert self._result('''
+        (module m
+          (fn w ((arena Arena))
+            (@spec ((Arena) -> Int))
+            (@post (>= $result 5))
+            (let ((mut i 0))
+              (do (while (< i 5) (set! i (+ i 1))))
+              i)))
+        ''').status == 'verified'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8948,3 +8948,34 @@ class TestLoopVariableVersions:
                 (quote (set! i (+ i 1))))
               i)))
         ''').status == 'verified'
+
+    def test_a_count_bound_does_not_cover_an_early_return(self):
+        """The bound is asserted about $result on every path, and an early
+        return yields something the loop never counted."""
+        assert self._result('''
+        (module m
+          (fn h ((items (List Int)) (flag Bool))
+            (@spec (((List Int) Bool) -> Int))
+            (@pre flag)
+            (@post (<= $result (list-len items)))
+            (when flag (return 100))
+            (let ((mut count 0))
+              (for-each (x items) (if true (set! count (+ count 1))))
+              count)))
+        ''').status != 'verified'
+
+    def test_a_write_nested_in_an_assigned_value(self):
+        """`(set! i (do (set! j 1) (+ i 1)))` writes j as well, and stopping at
+        the outer set! left j tied to what it was bound to."""
+        assert self._result('''
+        (module m
+          (fn w ((arena Arena) (n Int))
+            (@spec ((Arena Int) -> Int))
+            (@pre (> n 0))
+            (@post (== $result 0))
+            (let ((mut i 0)
+                  (mut j 0))
+              (while (< i n)
+                (set! i (do (set! j 1) (+ i 1))))
+              j)))
+        ''').status != 'verified'


### PR DESCRIPTION
Closes #116.

## The bug

One Z3 constant per name cannot hold both what a counter started at and what it ended at:

```lisp
(let ((mut i 0))
  (while (< i 10) (set! i (+ i 1)))
  i)
```

asserted `i == 0` and, from the loop's exit rule, `not(i < 10)`. That pair is unsatisfiable, so
every contract on such a function discharged without being proved. #115's guard has been reporting
these as `unknown` since it landed — honest, but it left the whole class unverifiable.

## The fix

The names a loop assigns are re-bound to fresh constants at the point in the body where the loop
runs. Reads before it keep the old constant, reads after see the new one, and the exit condition is
stated about the new one because that is what it constrains. Assignments outside a loop take a
version of their own too, so a `set!` after a loop no longer leaves the loop's facts attached to a
variable the program has overwritten.

Three things a loop still tells you, all of which the exit rule alone does not:

- **direction** — a counter every assignment moves the same way cannot end up behind where it
  started, however many times it runs, including none;
- **the frame** — a `while` whose condition is false on entry leaves its variables exactly as it
  found them;
- **bounds** — a fresh constant is fresh in every sense, so a `U8` or a range type has its
  declaration re-stated on each version.

Together with the exit condition that is enough for the two claims worth making about a counter:
that it did not go backwards, and that it reached what it was tested against.

## Where it stops, deliberately

Facts are withheld rather than guessed whenever the program point is not knowable here:

| shape | why |
|---|---|
| a loop inside an `if` arm | may not run, so its exit and direction say nothing about after |
| a `break`, or a `return` anywhere in the loop | can leave with the condition still true — the exit rule goes, the direction stays |
| a `set!` in a branch | both arms are translated into one map, so the last would otherwise win |
| a nested loop | the enclosing havoc already covered it |
| a quoted `set!` or loop | data, not statements |

## What else had to move

A pass that re-derives a binding's **initial** value has to attach it to the pre-loop constant, or
it asserts the starting value of the thing the loop produced — that alone was keeping the context
contradictory. And once the body has been walked, `variables` holds each name's final version while
the pattern phases re-translate expressions from anywhere in it: a filter that excluded `target`
before a later `(set! target 999)` came out as a filter on 999. A name with more than one version
stops answering at that point.

Two contract-ordering bugs fell out, both false-verifies on `main` today:

- **A postcondition is about the state the function ends in.** They were translated before the
  body, so a `@post` naming a mutable parameter read the version the function started with while
  the returned expression used the one it finished with: `(@pre (== x 0)) (@post (!= $result x))`
  over `(set! x 1) x` verified, though at runtime it compares 1 with 1. They are translated after
  the body now, with the body's own bindings set aside — a contract cannot name a local, and
  leaving them in place let one shadow a parameter, or hand the `field_len` accessor's slot to an
  integer.
- **The weakest-precondition pass walks straight past a `return`.** It substitutes an assignment's
  value even when a return in that value means the assignment never happens, and the precondition
  it computes then asserts the postcondition outright. It is not applied to a body that returns.

Three unrelated axioms turned out to be unsound once the counter stopped being pinned to zero and
they actually mattered: the count-pattern bound was stated in a fourth spelling of list length that
no goal mentions, was asserted about `$result` without checking the function returns the counter,
and accepted a counter with a second write.

## Tests

447 → 468 in `tests/test_verifier.py`; full suite 660 → 681; `make test-native` 50/50 unchanged.

## Downstream

Measured before and after, per function: **no change** in slop-rdf, snarl or howl.

14 rounds of `codex exec review`; every finding reproduced before fixing.

## Left for later

- **#118** — the translator gives both bindings of a shadowed name one Z3 constant. This branch
  mitigates the cases that made a context contradictory (a rebinding drops the shadowed
  declaration's type and versions) but the shared constant is still there; alpha-renaming would let
  several guards here and in #70 go.
- Merging state per exit path, so a postcondition after an early return reads the version that path
  left. Conservative today: it costs a contract rather than proving a false one.
- Teaching WP to stop at a return, rather than excluding those bodies outright.
