### PR TITLE
report unknown, not failed, when the result is not modelled (#69)

### DIFF
--- a/src/slop/verifier/axiom_generation.py
+++ b/src/slop/verifier/axiom_generation.py
@@ -432,8 +432,21 @@ class AxiomGenerationMixin:
             if not starts_empty:
                 return axioms
             early_exit = self._contains_any_form(scope, ('break', 'continue'))
-            axioms.extend(self._loop_result_length_axioms(
-                scope, sites, terms, translator, early_exit))
+            loop_axioms = self._loop_result_length_axioms(
+                scope, sites, terms, translator, early_exit)
+            if loop_axioms:
+                axioms.extend(loop_axioms)
+                return axioms
+            # No bound from the loop, but the pushes outside it still happened
+            # and a loop only ever adds - so the floor they set holds whatever
+            # the loop did. Without this a straight push before a while loop
+            # left the result looking possibly empty.
+            floor = sum(
+                1 for site in sites
+                if site.loop_depth == 0
+                and not site.guard_conditions and not site.conditional)
+            if floor:
+                axioms.extend(t >= z3.IntVal(floor) for t in terms)
             return axioms
 
         upper = len(sites)

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -221,6 +221,23 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     return True
         return False
 
+    def _expr_references_result_length(self, expr: SExpr) -> bool:
+        """True if `expr` constrains the length of $result, or of a field of it."""
+        if not isinstance(expr, SList):
+            return False
+        if is_form(expr, 'list-len') and len(expr) >= 2:
+            if self._is_rooted_at_result(expr[1]):
+                return True
+        return any(self._expr_references_result_length(item) for item in expr.items)
+
+    def _is_rooted_at_result(self, expr: SExpr) -> bool:
+        """True for $result itself, or a chain of field accesses starting there."""
+        if isinstance(expr, Symbol):
+            return expr.name == '$result'
+        if is_form(expr, '.') and len(expr) >= 2:
+            return self._is_rooted_at_result(expr[1])
+        return False
+
     def _references_result_collection(self, exprs: List[SExpr]) -> bool:
         """Check if any expression references $result as a collection in forall/exists."""
         for expr in exprs:
@@ -3536,6 +3553,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         # Phase 3.5: Length of a returned list, derived from its push sites.
         result_length_axioms: List[z3.BoolRef] = []
+        result_length_bounded = False
         # This used to assert a flat field_len($result) == 0 whenever the body
         # bound a list with (mut r (list-new ...)), ignoring every push, which
         # contradicted the push-count axiom in Phase 7 - issue #115.
@@ -3550,6 +3568,13 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             result_length_axioms = self._result_length_axioms(combined_body, translator)
             for axiom in result_length_axioms:
                 solver.add(axiom)
+            # Whether a bound was actually derived, as opposed to only the
+            # equalities that tie the length vocabularies together. Without one
+            # the result's length is as unconstrained as its contents, and a
+            # counterexample about it says as little.
+            result_length_bounded = (
+                len(result_length_axioms)
+                > len(translator.link_list_length_terms('$result')))
 
         # Phase 4: Add union tag axiom if body is union-new
         # For (union-new Type tag payload), add: union_tag($result) == tag_index
@@ -4044,6 +4069,17 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                             continue
 
                     if prop_result == z3.sat:
+                        # A counterexample drawn from a result nothing describes
+                        # is not evidence the property is false - it is evidence
+                        # that nothing was said about the elements (issue #69).
+                        # Both directions have to be gated, or the same missing
+                        # axioms read as a pass one way and a failure the other.
+                        if (has_unaxiomatized_pushes
+                                and self._expr_references_result_collection(prop_expr)):
+                            unknown_properties.append((prop_name, prop_str,
+                                "the body's pushes are not modelled, so nothing is known "
+                                "about the elements either way"))
+                            continue
                         model = prop_solver.model()
                         counterexample = {str(decl.name()): str(model[decl])
                                          for decl in model.decls()
@@ -4051,9 +4087,11 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                         failed_properties.append((prop_name, prop_str, counterexample))
                     elif prop_result == z3.unsat and has_unaxiomatized_pushes:
                         # Z3 says "verified" but result was unconstrained — vacuous truth.
-                        # Check if this property quantifies over $result (forall over result).
-                        prop_str_check = pretty_print(prop_expr)
-                        if '$result' in prop_str_check:
+                        # Whether the property quantifies over the result, asked
+                        # of the expression rather than of its printed form: a
+                        # substring test for "$result" also matched a property
+                        # that merely mentions its length.
+                        if self._expr_references_result_collection(prop_expr):
                             unknown_properties.append((prop_name, prop_str,
                                 "no push axioms for list-push body (vacuous)"))
                     elif prop_result == z3.unsat and has_only_structural_axioms:
@@ -4146,6 +4184,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             # Some postcondition(s) failed - check each individually to identify which
             failed_posts: List[str] = []
             verified_posts: List[str] = []
+            unmodelled_posts: List[str] = []
 
             for i, (post_expr, post_z3_expr) in enumerate(zip(postconditions, post_z3)):
                 solver.push()
@@ -4159,8 +4198,35 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
                 if individual_result == z3.unsat:
                     verified_posts.append(post_str)
+                elif ((has_unaxiomatized_pushes
+                       and self._expr_references_result_collection(post_expr))
+                      or (not result_length_bounded
+                          and self._expr_references_result_length(post_expr))):
+                    # A counterexample drawn from a result nothing describes is
+                    # not evidence the contract is false (issue #69). Two ways
+                    # for it to describe nothing: the elements are unmodelled,
+                    # or - for a while loop, or a push through an alias - the
+                    # length was never bounded either.
+                    unmodelled_posts.append(post_str)
                 else:
                     failed_posts.append(post_str)
+
+            if unmodelled_posts and not failed_posts:
+                if len(unmodelled_posts) == 1:
+                    detail = unmodelled_posts[0]
+                else:
+                    detail = "\n" + "\n".join(f"  • {p}" for p in unmodelled_posts)
+                return VerificationResult(
+                    name=fn_name,
+                    verified=False,
+                    status="unknown",
+                    message=(
+                        "Could not verify: the body's pushes are not modelled, so "
+                        "nothing is known about the result's elements either way: "
+                        + detail
+                    ),
+                    location=SourceLocation(self.filename, fn_form.line, fn_form.col)
+                )
 
             # Build detailed message
             if failed_posts:

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -253,6 +253,19 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         solver.add(contract)
         return solver.check() == z3.unsat
 
+    def _result_is_pushed_to(self, body: SExpr) -> bool:
+        """True if anything pushes onto the list this body returns.
+
+        Through an alias too: `_result_length_axioms` withholds a bound when the
+        list escapes into one, so the length is as unknown there as it is for a
+        push to the name itself.
+        """
+        returned = self._get_return_expr(body)
+        if not isinstance(returned, Symbol):
+            return False
+        names = [returned.name] + self._aliases_of(body, returned.name)
+        return any(self._count_push_to_var([body], name) > 0 for name in names)
+
     def _expr_references_result_length(self, expr: SExpr) -> bool:
         """True if `expr` constrains the length of $result, or of a field of it."""
         if not isinstance(expr, SList):
@@ -3840,11 +3853,12 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # parameter derives no numeric bound and needs none - the result is that
         # list. It is a push the analysis could not account for that leaves the
         # length genuinely unknown.
+        # A list-set does not change a length, so it has no bearing here even
+        # for the returned list, let alone for some scratch one.
         result_length_unmodelled = (
             not result_length_bounded
             and fn_body is not None
-            and (contents_rewritten
-                 or self._body_has_list_push_to_result(combined_body)))
+            and self._result_is_pushed_to(combined_body))
 
         # Phase 14: List element property invariants (with array encoding)
         # For postconditions like (all-triples-have-predicate $result RDF_TYPE),
@@ -4116,9 +4130,15 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                         # that nothing was said about the elements (issue #69).
                         # Both directions have to be gated, or the same missing
                         # axioms read as a pass one way and a failure the other.
-                        if (has_unaxiomatized_pushes
-                                and self._is_single_claim(prop_expr)
-                                and self._expr_references_result_collection(prop_expr)
+                        # The same two ways the result can describe nothing as
+                        # on the postcondition path: unmodelled elements, or a
+                        # length no push analysis could bound. A @property and
+                        # an equivalent @post should not disagree about which.
+                        if (self._is_single_claim(prop_expr)
+                                and ((has_unaxiomatized_pushes
+                                      and self._expr_references_result_collection(prop_expr))
+                                     or (result_length_unmodelled
+                                         and self._expr_references_result_length(prop_expr)))
                                 and not self._contract_is_refuted(prop_axioms, prop_z3_expr)):
                             unknown_properties.append((prop_name, prop_str,
                                 "the body's pushes are not modelled, so nothing is known "

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -236,22 +236,68 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             return expr[0].name not in self._LOGICAL_CONNECTIVES
         return True
 
-    def _contract_is_refuted(self, axioms, contract) -> bool:
-        """True if the axioms rule the contract out, not merely fail to imply it.
+    def _failure_survives_any_result(self, axioms, contract, result_terms) -> bool:
+        """True if the contract fails whatever the unmodelled result turns out to be.
 
-        A counterexample on its own does not distinguish the two. When the
-        axioms permit the contract as well as its negation they simply do not
-        decide it, and calling that a violation sends the author to rewrite code
-        that may be correct (issue #69). When they refute it, the contract is
-        false on every model they admit and the failure stands however little
-        else is known.
+        A counterexample on its own does not say whether it depends on the part
+        that is unmodelled. `(forall (m $result) ...)` on a result nothing
+        describes does - pick the right elements and it holds - and reporting
+        that as a violation sends the author to rewrite correct code (issue
+        #69). `(== (+ (list-len $result) root) (list-len $result))` does not: it
+        reduces to root == 0 and is false for every other input, whatever the
+        length.
+
+        Asked by replacing the result's terms with a bound variable, in the
+        goal and in whichever axioms mention them - keeping the axioms that
+        constrain it, such as a push-derived lower bound, in force - and asking
+        whether the negation then holds for every value:
+
+            other axioms  and  forall r. (axioms about r -> not contract)
+
+        Satisfiable means no result would have saved the contract. Anything
+        else - including a solver that cannot say - leaves the failure resting
+        on what is not modelled.
         """
+        if not result_terms:
+            return False
+
+        bound = []
+        substitutions = []
+        for i, term in enumerate(result_terms):
+            placeholder = z3.FreshConst(term.sort(), '_any_result')
+            bound.append(placeholder)
+            substitutions.append((term, placeholder))
+
+        def mentions_result(expr) -> bool:
+            return any(not z3.eq(z3.substitute(expr, sub), expr)
+                       for sub in substitutions)
+
+        about_result = []
+        independent = []
+        for axiom in axioms:
+            (about_result if mentions_result(axiom) else independent).append(axiom)
+
+        goal = z3.Not(contract)
+        premise = z3.And(*about_result) if about_result else z3.BoolVal(True)
+        quantified = z3.ForAll(
+            bound,
+            z3.Implies(z3.substitute(premise, *substitutions),
+                       z3.substitute(goal, *substitutions)))
+
         solver = z3.Solver()
         solver.set("timeout", self.timeout_ms)
-        for axiom in axioms:
+        for axiom in independent:
             solver.add(axiom)
-        solver.add(contract)
-        return solver.check() == z3.unsat
+        solver.add(quantified)
+        return solver.check() == z3.sat
+
+    def _result_terms(self, translator: Z3Translator) -> List:
+        """The Z3 terms standing for the result's length and contents."""
+        terms = list(translator.list_length_terms('$result'))
+        seq = translator.list_seqs.get('$result')
+        if seq is not None and not any(z3.eq(seq, t) for t in terms):
+            terms.append(seq)
+        return terms
 
     def _result_is_pushed_to(self, body: SExpr) -> bool:
         """True if anything pushes onto the list this body returns.
@@ -260,11 +306,36 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         list escapes into one, so the length is as unknown there as it is for a
         push to the name itself.
         """
+        return self._result_is_touched_by(body, 'list-push')
+
+    def _result_is_touched_by(self, body: SExpr, op: str) -> bool:
+        """True if `op` is applied to the returned list, or to an alias of it.
+
+        Scoped the way _result_length_axioms scopes its push scan: an earlier
+        `let` may bind the same name to a different list, and what happens to
+        that one says nothing about the result.
+        """
         returned = self._get_return_expr(body)
         if not isinstance(returned, Symbol):
             return False
-        names = [returned.name] + self._aliases_of(body, returned.name)
-        return any(self._count_push_to_var([body], name) > 0 for name in names)
+        _, scope = self._binding_in_scope_at_tail(body, returned.name)
+        names = [returned.name] + self._aliases_of(scope, returned.name)
+        return any(self._count_op_on_var([scope], name, op) > 0 for name in names)
+
+    def _count_op_on_var(self, stmts: list, var_name: str, op: str) -> int:
+        """How many times `op` is applied to `var_name` in these statements."""
+        count = 0
+        for stmt in stmts:
+            if not isinstance(stmt, SList):
+                continue
+            if is_form(stmt, op) and len(stmt) >= 2:
+                target = stmt[1]
+                if isinstance(target, Symbol) and target.name == var_name:
+                    count += 1
+            for item in stmt.items:
+                if isinstance(item, SList):
+                    count += self._count_op_on_var([item], var_name, op)
+        return count
 
     def _expr_references_result_length(self, expr: SExpr) -> bool:
         """True if `expr` constrains the length of $result, or of a field of it."""
@@ -3855,6 +3926,15 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # length genuinely unknown.
         # A list-set does not change a length, so it has no bearing here even
         # for the returned list, let alone for some scratch one.
+        # Whether the *result* was rewritten, as opposed to any list anywhere.
+        # The axiom gate above stays body-wide on purpose - a set on a loop's
+        # source, or on something aliased in from outside, invalidates the
+        # provenance just as surely and is not tracked - but a verdict should
+        # not call the result unmodelled because some scratch list was written.
+        result_contents_rewritten = (
+            fn_body is not None
+            and self._result_is_touched_by(combined_body, 'list-set'))
+
         result_length_unmodelled = (
             not result_length_bounded
             and fn_body is not None
@@ -3948,7 +4028,10 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # (b) push axioms exist but there are extra push sites outside the
         #     detected pattern that the axioms don't model (unsound axiom).
         has_unaxiomatized_pushes = False
-        if contents_rewritten:
+        # Only a rewrite of the returned list, or of something aliased to it,
+        # says anything about the result's elements. A list-set on some scratch
+        # list is none of the result's business.
+        if result_contents_rewritten:
             has_unaxiomatized_pushes = True
         if fn_body is not None and translator.use_seq_encoding:
             if self._body_has_list_push_to_result(fn_body):
@@ -4139,7 +4222,9 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                                       and self._expr_references_result_collection(prop_expr))
                                      or (result_length_unmodelled
                                          and self._expr_references_result_length(prop_expr)))
-                                and not self._contract_is_refuted(prop_axioms, prop_z3_expr)):
+                                and not self._failure_survives_any_result(
+                                    prop_axioms, prop_z3_expr,
+                                    self._result_terms(translator))):
                             unknown_properties.append((prop_name, prop_str,
                                 "the body's pushes are not modelled, so nothing is known "
                                 "about the elements either way"))
@@ -4267,8 +4352,9 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                             and self._expr_references_result_collection(post_expr))
                            or (result_length_unmodelled
                                and self._expr_references_result_length(post_expr)))
-                      and not self._contract_is_refuted(solver.assertions(),
-                                                        post_z3_expr)):
+                      and not self._failure_survives_any_result(
+                          solver.assertions(), post_z3_expr,
+                          self._result_terms(translator))):
                     # A counterexample drawn from a result nothing describes is
                     # not evidence the contract is false (issue #69). Two ways
                     # for it to describe nothing: the elements are unmodelled,

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -4223,7 +4223,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                                      or (result_length_unmodelled
                                          and self._expr_references_result_length(prop_expr)))
                                 and not self._failure_survives_any_result(
-                                    prop_axioms, prop_z3_expr,
+                                    list(prop_axioms) + list(result_length_axioms),
+                                    prop_z3_expr,
                                     self._result_terms(translator))):
                             unknown_properties.append((prop_name, prop_str,
                                 "the body's pushes are not modelled, so nothing is known "

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -221,6 +221,23 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     return True
         return False
 
+    def _contract_is_refuted(self, axioms, contract) -> bool:
+        """True if the axioms rule the contract out, not merely fail to imply it.
+
+        A counterexample on its own does not distinguish the two. When the
+        axioms permit the contract as well as its negation they simply do not
+        decide it, and calling that a violation sends the author to rewrite code
+        that may be correct (issue #69). When they refute it, the contract is
+        false on every model they admit and the failure stands however little
+        else is known.
+        """
+        solver = z3.Solver()
+        solver.set("timeout", self.timeout_ms)
+        for axiom in axioms:
+            solver.add(axiom)
+        solver.add(contract)
+        return solver.check() == z3.unsat
+
     def _expr_references_result_length(self, expr: SExpr) -> bool:
         """True if `expr` constrains the length of $result, or of a field of it."""
         if not isinstance(expr, SList):
@@ -4075,7 +4092,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                         # Both directions have to be gated, or the same missing
                         # axioms read as a pass one way and a failure the other.
                         if (has_unaxiomatized_pushes
-                                and self._expr_references_result_collection(prop_expr)):
+                                and self._expr_references_result_collection(prop_expr)
+                                and not self._contract_is_refuted(prop_axioms, prop_z3_expr)):
                             unknown_properties.append((prop_name, prop_str,
                                 "the body's pushes are not modelled, so nothing is known "
                                 "about the elements either way"))
@@ -4198,15 +4216,19 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
                 if individual_result == z3.unsat:
                     verified_posts.append(post_str)
-                elif ((has_unaxiomatized_pushes
-                       and self._expr_references_result_collection(post_expr))
-                      or (not result_length_bounded
-                          and self._expr_references_result_length(post_expr))):
+                elif (((has_unaxiomatized_pushes
+                        and self._expr_references_result_collection(post_expr))
+                       or (not result_length_bounded
+                           and self._expr_references_result_length(post_expr)))
+                      and not self._contract_is_refuted(solver.assertions(),
+                                                        post_z3_expr)):
                     # A counterexample drawn from a result nothing describes is
                     # not evidence the contract is false (issue #69). Two ways
                     # for it to describe nothing: the elements are unmodelled,
                     # or - for a while loop, or a push through an alias - the
-                    # length was never bounded either.
+                    # length was never bounded either. Unless what *is* known
+                    # refutes the contract outright, in which case the failure
+                    # does not depend on the missing part at all.
                     unmodelled_posts.append(post_str)
                 else:
                     failed_posts.append(post_str)

--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -221,6 +221,21 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     return True
         return False
 
+    _LOGICAL_CONNECTIVES = ('and', 'or', 'implies', 'not')
+
+    def _is_single_claim(self, expr: SExpr) -> bool:
+        """True if the contract makes one claim rather than several joined ones.
+
+        A conjunction can fail for a reason that has nothing to do with the
+        unmodelled part - `(and (> root 0) (forall (x $result) ...))` is false
+        at root = 0 whatever the elements are - and downgrading the whole thing
+        would hide that. Only a contract that is entirely about the result is
+        undecidable because the result is.
+        """
+        if isinstance(expr, SList) and len(expr) >= 1 and isinstance(expr[0], Symbol):
+            return expr[0].name not in self._LOGICAL_CONNECTIVES
+        return True
+
     def _contract_is_refuted(self, axioms, contract) -> bool:
         """True if the axioms rule the contract out, not merely fail to imply it.
 
@@ -3821,6 +3836,16 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 for axiom in emptiness_axioms:
                     solver.add(axiom)
 
+        # Unmodelled is not the same as unbounded. A function that returns a
+        # parameter derives no numeric bound and needs none - the result is that
+        # list. It is a push the analysis could not account for that leaves the
+        # length genuinely unknown.
+        result_length_unmodelled = (
+            not result_length_bounded
+            and fn_body is not None
+            and (contents_rewritten
+                 or self._body_has_list_push_to_result(combined_body)))
+
         # Phase 14: List element property invariants (with array encoding)
         # For postconditions like (all-triples-have-predicate $result RDF_TYPE),
         # detect that all pushed elements have the required property and add
@@ -4092,6 +4117,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                         # Both directions have to be gated, or the same missing
                         # axioms read as a pass one way and a failure the other.
                         if (has_unaxiomatized_pushes
+                                and self._is_single_claim(prop_expr)
                                 and self._expr_references_result_collection(prop_expr)
                                 and not self._contract_is_refuted(prop_axioms, prop_z3_expr)):
                             unknown_properties.append((prop_name, prop_str,
@@ -4216,10 +4242,11 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
                 if individual_result == z3.unsat:
                     verified_posts.append(post_str)
-                elif (((has_unaxiomatized_pushes
-                        and self._expr_references_result_collection(post_expr))
-                       or (not result_length_bounded
-                           and self._expr_references_result_length(post_expr)))
+                elif (self._is_single_claim(post_expr)
+                      and ((has_unaxiomatized_pushes
+                            and self._expr_references_result_collection(post_expr))
+                           or (result_length_unmodelled
+                               and self._expr_references_result_length(post_expr)))
                       and not self._contract_is_refuted(solver.assertions(),
                                                         post_z3_expr)):
                     # A counterexample drawn from a result nothing describes is

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -9614,3 +9614,23 @@ class TestUnmodelledResultContents:
         '''
         assert verify_source(guaranteed, filename="probe.slop")[0].status == 'failed'
         assert self._result("    (@post (forall (m $result) false))").status == 'unknown'
+
+    def test_returning_a_parameter_is_not_unmodelled(self):
+        """No numeric bound is derived and none is needed - the result is that
+        list. Unmodelled means a push the analysis could not account for, not
+        merely the absence of a fixed length."""
+        from slop.verifier import verify_source
+        assert verify_source('''
+        (module m
+          (fn f ((xs (List Int)))
+            (@spec (((List Int)) -> (List Int)))
+            (@post (== (list-len $result) 4))
+            xs))
+        ''', filename="probe.slop")[0].status == 'failed'
+
+    def test_a_conjunction_keeps_its_independently_false_clause(self):
+        """`(and (> root 0) (forall ...))` is false at root = 0 whatever the
+        elements are, so downgrading the whole contract would hide it."""
+        result = self._result(
+            "    (@post (and (> root 0) (forall (m $result) (== (. m to) root))))")
+        assert result.status == 'failed', result.message

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -9664,3 +9664,32 @@ class TestUnmodelledResultContents:
               (let ((alias r))
                 (do (list-push alias 1) r)))))
         ''', filename="probe.slop")[0].status == 'unknown'
+
+    def test_a_failure_that_does_not_depend_on_the_result(self):
+        """`(== (+ (list-len $result) root) (list-len $result))` reduces to
+        root == 0: false for every other input whatever the length is."""
+        from slop.verifier import verify_source
+        assert verify_source('''
+        (module m
+          (fn k ((arena Arena) (n Int) (root Int))
+            (@spec ((Arena Int Int) -> (List Int)))
+            (@alloc arena)
+            (@post (== (+ (list-len $result) root) (list-len $result)))
+            (let ((mut r (list-new arena Int))
+                  (mut i 0))
+              (do (while (< i n) (list-push r i) (set! i (+ i 1))) r))))
+        ''', filename="probe.slop")[0].status == 'failed'
+
+    def test_a_shadowed_name_pushed_elsewhere_is_not_the_result(self):
+        """An earlier `let` may bind the same name to a different list, and what
+        happens to that one says nothing about what is returned."""
+        from slop.verifier import verify_source
+        assert verify_source('''
+        (module m
+          (fn g ((arena Arena) (r (List Int)))
+            (@spec ((Arena (List Int)) -> (List Int)))
+            (@alloc arena)
+            (@post (== (list-len $result) 4))
+            (do (let ((mut r (list-new arena Int))) (list-push r 1))
+                r)))
+        ''', filename="probe.slop")[0].status == 'failed'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -9559,9 +9559,13 @@ class TestUnmodelledResultContents:
         ''', filename="probe.slop")[0]
         assert result.status == 'unknown', result.message
 
-    def test_a_length_claim_about_a_field_of_the_result(self):
-        """snarl's report-add-result: the list is reached through a field of the
-        returned record, and pushing through an alias is not modelled at all."""
+    def test_a_refuted_length_claim_about_a_field_stays_a_failure(self):
+        """snarl's report-add-result. The list is reached through a field of the
+        returned record and pushing through an alias is not modelled - but the
+        record field axiom says $result.results *is* report.results, so their
+        lengths are equal and len == len + 1 is refuted outright. The contract
+        is only true if the second reads as the pre-state, which the language
+        has no way to say, so a failure is the honest verdict."""
         from slop.verifier import verify_source
         result = verify_source('''
         (module m
@@ -9574,4 +9578,39 @@ class TestUnmodelledResultContents:
             (do (list-push (. report results) v)
                 (record-new Report (results (. report results))))))
         ''', filename="probe.slop")[0]
-        assert result.status == 'unknown', result.message
+        assert result.status == 'failed', result.message
+
+    def test_what_the_axioms_refute_is_still_a_failure(self):
+        """A counterexample that does not depend on the missing part at all.
+        The precondition pins the length, so the claim is false on every model
+        the axioms admit and the unmodelled elements are beside the point."""
+        from slop.verifier import verify_source
+        assert verify_source('''
+        (module m
+          (fn f ((xs (List Int)))
+            (@spec (((List Int)) -> (List Int)))
+            (@pre (== (list-len xs) 3))
+            (@post (== (list-len $result) 4))
+            xs))
+        ''', filename="probe.slop")[0].status == 'failed'
+
+    def test_a_quantifier_false_whatever_the_elements_are(self):
+        """A straight push guarantees a non-empty result, so this is refuted
+        without knowing anything about what is in it. The same claim on a body
+        whose only push is conditional is *not* refuted - it holds vacuously of
+        the empty list - and stays unknown."""
+        from slop.verifier import verify_source
+        guaranteed = '''
+        (module m
+          (type Ax (union (a Int) (b Int)))
+          (fn g ((arena Arena) (ax Ax))
+            (@spec ((Arena Ax) -> (List Int)))
+            (@alloc arena)
+            (@post (forall (x $result) false))
+            (let ((mut r (list-new arena Int)))
+              (do (list-push r 1)
+                  (match ax ((a n) (list-push r n)) ((b _) (do)))
+                  r))))
+        '''
+        assert verify_source(guaranteed, filename="probe.slop")[0].status == 'failed'
+        assert self._result("    (@post (forall (m $result) false))").status == 'unknown'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -9457,3 +9457,121 @@ class TestListSet:
             (@post (== x 0))
             (do (set! x 5) 1)))
         ''') != 'verified'
+
+
+_UNMODELLED_PUSH = '''
+(module probe
+  (type Msg (record (v Int) (to Int)))
+  (type Ax  (union (a Int) (b Int)))
+
+  (fn build ((arena Arena) (ax Ax) (root Int))
+    (@spec ((Arena Ax Int) -> (List Msg)))
+    (@alloc arena)
+%s
+    (let ((mut r (list-new arena Msg)))
+      (do (match ax
+            ((a n) (list-push r (record-new Msg (v n) (to root))))
+            ((b _) (do)))
+          r))))
+'''
+
+
+class TestUnmodelledResultContents:
+    """Issue #69: a counterexample drawn from a result nothing describes.
+
+    A push in a `match` arm is not a shape any pattern detector recognises, so
+    the elements of the result are unconstrained. Z3 then produces a model where
+    they are anything at all, and reporting that as a contract violation sends
+    the author to rewrite code that is correct. The `unsat` direction was
+    already downgraded to unknown for this reason; `sat` was not, so the same
+    missing axioms read as a pass one way and a failure the other.
+
+    The gate is narrow on purpose: it covers what quantifies over the elements,
+    not what the length model can still decide.
+    """
+
+    @staticmethod
+    def _result(contracts):
+        from slop.verifier import verify_source
+        results = verify_source(_UNMODELLED_PUSH % contracts, filename="probe.slop")
+        assert len(results) == 1
+        return results[0]
+
+    def test_a_property_over_the_elements_is_unknown(self):
+        result = self._result(
+            "    (@property addressed (forall (m $result) (== (. m to) root)))")
+        assert result.status == 'unknown', result.message
+        assert 'not modelled' in result.message
+
+    def test_a_postcondition_over_the_elements_is_unknown(self):
+        result = self._result("    (@post (forall (m $result) (== (. m to) root)))")
+        assert result.status == 'unknown', result.message
+        assert 'not modelled' in result.message
+
+    def test_a_length_claim_that_holds_still_verifies(self):
+        """The length model does describe this result, so its claims are
+        decidable and must not be swept into the same unknown."""
+        assert self._result("    (@post {(list-len $result) <= 1})").status == 'verified'
+
+    def test_a_length_claim_that_is_false_still_fails(self):
+        result = self._result("    (@post {(list-len $result) == 5})")
+        assert result.status == 'failed', result.message
+
+    def test_the_two_together_report_the_property(self):
+        """issue #69's q3: the @post holds and the @property is unknown, so the
+        function reports the property rather than blaming the postcondition."""
+        result = self._result(
+            "    (@post {(list-len $result) <= 1})\n"
+            "    (@property addressed (forall (m $result) (== (. m to) root)))")
+        assert result.status == 'unknown', result.message
+        assert 'addressed' in result.message
+
+    def test_a_modelled_result_still_reports_a_real_failure(self):
+        """A filter loop is a shape the provenance axioms do describe, so a
+        false claim about its elements is a genuine counterexample."""
+        from slop.verifier import verify_source
+        src = '''
+        (fn filter-positive ((items (List Int)))
+          (@spec (((List Int)) -> (List Int)))
+          (@post (forall (t $result) (< t 0)))
+          (let ((mut result (list-new arena Int)))
+            (for-each (x items)
+              (when (> x 0)
+                (list-push result x)))
+            result))
+        '''
+        assert verify_source(src)[0].status == 'failed'
+
+    def test_a_length_claim_over_an_unbounded_result(self):
+        """A while loop gives the length no bound, so a counterexample about it
+        says as little as one about the elements. snarl's find-subclasses is
+        this shape: the claim is true, and nothing here can derive it."""
+        from slop.verifier import verify_source
+        result = verify_source('''
+        (module m
+          (fn f ((arena Arena) (n Int))
+            (@spec ((Arena Int) -> (List Int)))
+            (@alloc arena)
+            (@post (>= (list-len $result) 1))
+            (let ((mut r (list-new arena Int))
+                  (mut i 0))
+              (do (while (< i n) (list-push r i) (set! i (+ i 1))) r))))
+        ''', filename="probe.slop")[0]
+        assert result.status == 'unknown', result.message
+
+    def test_a_length_claim_about_a_field_of_the_result(self):
+        """snarl's report-add-result: the list is reached through a field of the
+        returned record, and pushing through an alias is not modelled at all."""
+        from slop.verifier import verify_source
+        result = verify_source('''
+        (module m
+          (type Report (record (results (List Int))))
+          (fn add ((arena Arena) (report Report) (v Int))
+            (@spec ((Arena Report Int) -> Report))
+            (@alloc arena)
+            (@post (== (list-len (. $result results))
+                       (+ (list-len (. report results)) 1)))
+            (do (list-push (. report results) v)
+                (record-new Report (results (. report results))))))
+        ''', filename="probe.slop")[0]
+        assert result.status == 'unknown', result.message

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -9693,3 +9693,38 @@ class TestUnmodelledResultContents:
             (do (let ((mut r (list-new arena Int))) (list-push r 1))
                 r)))
         ''', filename="probe.slop")[0].status == 'failed'
+
+    def test_a_property_sees_the_length_facts_too(self):
+        """The property recheck was given the property solver's axioms alone,
+        which omit the push-derived length - so a @property and an equivalent
+        @post disagreed about a result the pushes guarantee is non-empty."""
+        from slop.verifier import verify_source
+        assert verify_source('''
+        (module m
+          (type Ax (union (a Int) (b Int)))
+          (fn g ((arena Arena) (ax Ax))
+            (@spec ((Arena Ax) -> (List Int)))
+            (@alloc arena)
+            (@property p (forall (x $result) false))
+            (let ((mut r (list-new arena Int)))
+              (do (list-push r 1)
+                  (match ax ((a n) (list-push r n)) ((b _) (do)))
+                  r))))
+        ''', filename="probe.slop")[0].status == 'failed'
+
+    def test_a_push_before_an_unbounded_loop_keeps_its_floor(self):
+        """The loop bounds nothing, but the push before it happened and a loop
+        only ever adds - so the result is not empty, whatever the loop did."""
+        from slop.verifier import verify_source
+        assert verify_source('''
+        (module m
+          (fn k ((arena Arena) (n Int))
+            (@spec ((Arena Int) -> (List Int)))
+            (@alloc arena)
+            (@post (== (list-len $result) 0))
+            (let ((mut r (list-new arena Int))
+                  (mut i 0))
+              (do (list-push r 1)
+                  (while (< i n) (list-push r i) (set! i (+ i 1)))
+                  r))))
+        ''', filename="probe.slop")[0].status == 'failed'

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -9634,3 +9634,33 @@ class TestUnmodelledResultContents:
         result = self._result(
             "    (@post (and (> root 0) (forall (m $result) (== (. m to) root))))")
         assert result.status == 'failed', result.message
+
+    def test_a_scratch_list_set_does_not_cloud_the_result(self):
+        """A list-set does not change a length, so it has no bearing on whether
+        the result's length is known - least of all when it touches some other
+        list entirely."""
+        from slop.verifier import verify_source
+        assert verify_source('''
+        (module m
+          (fn f ((arena Arena) (xs (List Int)))
+            (@spec ((Arena (List Int)) -> (List Int)))
+            (@alloc arena)
+            (@post (== (list-len $result) 4))
+            (let ((scratch (list-new arena Int)))
+              (do (list-set scratch 0 1) xs))))
+        ''', filename="probe.slop")[0].status == 'failed'
+
+    def test_a_push_through_an_alias_leaves_the_length_unknown(self):
+        """The push analysis withholds a bound when the list escapes into an
+        alias, so the length is as unknown there as for a push to the name."""
+        from slop.verifier import verify_source
+        assert verify_source('''
+        (module m
+          (fn g ((arena Arena))
+            (@spec ((Arena) -> (List Int)))
+            (@alloc arena)
+            (@post (>= (list-len $result) 1))
+            (let ((mut r (list-new arena Int)))
+              (let ((alias r))
+                (do (list-push alias 1) r)))))
+        ''', filename="probe.slop")[0].status == 'unknown'


### PR DESCRIPTION
Closes #69.

## The bug

A push in a `match` arm is not a shape any pattern detector recognises, so the elements of the
result are unconstrained. Z3 duly produces a model where they are anything at all, and that came
back as a contract violation with a counterexample drawn from a sequence nothing describes —
sending the author to rewrite code that is correct. #69's q2 is exactly that, and the issue's own
suggestion was to report *unknown* instead.

The `unsat` direction was already downgraded for this reason. `sat` was not, so the same missing
axioms read as a pass one way and a failure the other.

## The judgement it makes

A counterexample on its own does not say whether it depends on the part that is unmodelled. So when
the result is unmodelled and the contract is about it, the axioms are asked a second question:

    other axioms  and  forall r. (axioms about r -> not contract)

with the result's terms replaced by a bound variable in the goal and in whichever axioms mention
them — so a push-derived bound stays in force. **Satisfiable** means no result would have saved the
contract, and the failure stands. Anything else, including a solver that cannot say, leaves the
failure resting on what is not modelled, and it reports `unknown`.

That distinction is what the whole change turns on:

| | |
|---|---|
| `(forall (m $result) (== (. m to) root))`, elements unmodelled | **unknown** — the right elements would satisfy it |
| `(forall (x $result) false)`, one guaranteed push | **failed** — no contents save it |
| `(== (+ (list-len $result) root) (list-len $result))` | **failed** — reduces to `root == 0`, nothing to do with the length |
| `(== (list-len $result) 5)` where the bound is `0..1` | **failed** — the length model does describe this |

## When the gate applies at all

Two ways for the result to describe nothing — its elements are unmodelled, or its length was never
bounded (a `while` loop, a push through an alias) — and three conditions that keep it narrow:

- the contract makes a **single claim**, since `(and (> root 0) (forall ...))` is false at
  `root = 0` whatever the elements are;
- **unmodelled is not unbounded** — a function returning a list parameter derives no numeric bound
  and needs none;
- the push, or the `list-set`, has to touch **the returned list or an alias of it**, resolved in the
  binding's own scope so an earlier `let` reusing the name does not count.

A push before an unboundable loop also keeps the floor it sets: the loop only ever adds.

## Result

#69's probe now reads **q1 verified, q2 unknown, q3 the property unknown with the postcondition
untouched** — no counterexample invented from an unconstrained sequence, and no sibling contaminated.

477 → 495 tests in `tests/test_verifier.py`; full suite 696 → 708; `make test-native` unchanged.

Downstream: slop-rdf and howl unchanged; snarl's `find-subclasses` moves failed → unknown. It
pushes from a `while` loop, so its `(>= (list-len $result) 1)` is true and underivable — which is
what #117's report said it was. `report-add-result` stays **failed**, correctly: the record field
axiom makes `$result.results` and `report.results` the same list, so `len == len + 1` is refuted
outright. That contract is only true if the second reads as the pre-state, which SLOP cannot say.

Filed **#125** on the way past: a `@property` about `(list-len $result)` cannot be translated at
all while the same `@post` can, so the two annotations still disagree about that one claim.

5 rounds of `codex exec review`; every finding reproduced before fixing.
