### PR TITLE
carry a record's field facts through a union constructor (#123)

### DIFF
--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -1808,6 +1808,138 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         return_expr = self._get_return_expr(expr)
         return is_form(return_expr, 'record-new')
 
+    @staticmethod
+    def _is_union_ctor_form(expr: SExpr) -> bool:
+        """True for (ok X) / (error X) / (some X) / (none)."""
+        if isinstance(expr, SList) and len(expr) >= 1:
+            head = expr[0]
+            return isinstance(head, Symbol) and head.name in {'ok', 'error', 'some', 'none'}
+        return False
+
+    @classmethod
+    def _union_ctor_payload(cls, expr: SExpr) -> Optional[SExpr]:
+        """The payload of (ok X) / (error X) / (some X), or None."""
+        if cls._is_union_ctor_form(expr) and len(expr) == 2:
+            return expr[1]
+        return None
+
+    @staticmethod
+    def _conditional_branch_exprs(expr: SExpr) -> List[SExpr]:
+        """The branch bodies of an `if` or `cond`; empty for anything else.
+
+        Structural, so it can be asked before there is a translator to turn the
+        guards into terms.
+        """
+        if is_form(expr, 'if') and len(expr) >= 3:
+            return list(expr.items[2:])
+        if is_form(expr, 'cond') and len(expr) >= 2:
+            return [clause[-1] for clause in expr.items[1:]
+                    if isinstance(clause, SList) and len(clause) >= 2]
+        return []
+
+    def _builds_record(self, expr: SExpr) -> bool:
+        """True when a branch ends in a record, however it is wrapped.
+
+        A branch may build the record directly, wrap it in a union constructor -
+        `(ok (record-new ...))`, which is how a function returning a Result
+        states its answer - or defer to a further conditional whose own branches
+        do either. Only the bare form counted before, so a function whose
+        branches were all wrapped contributed no field axioms at all, and
+        nothing was known about the record inside its result (#123).
+        """
+        return_expr = self._get_return_expr(expr)
+        if is_form(return_expr, 'record-new'):
+            return True
+        payload = self._union_ctor_payload(return_expr)
+        if payload is not None and self._builds_record(payload):
+            return True
+        return any(self._builds_record(branch)
+                   for branch in self._conditional_branch_exprs(return_expr))
+
+    def _names_settled_before_tail(self, body: SExpr, tail: SExpr,
+                                   translator: Z3Translator) -> Set[str]:
+        """Names whose value at the tail is the one `variables` holds.
+
+        The body is translated as one straight line with no program points, so a
+        write the run skips - inside an `if`, a `cond`, a `match`, a `when` -
+        still leaves its version behind. Reading that at the tail would attach
+        whatever the branch established to a path that never entered it.
+
+        A write on the spine is different: the `do`/`let` chain leading to the
+        tail runs on every path, and a loop there is already modelled as
+        possibly not running. Those names, and only those, are safe to read.
+        Written as a collection of the safe ones rather than an exclusion of the
+        unsafe, so an unrecognised form is refused rather than trusted.
+        """
+        settled: Set[str] = set()
+        conditional: Set[str] = set()
+
+        def writes(node) -> Set[str]:
+            found: Dict[str, List] = {}
+            translator._collect_assignments([node], found)
+            return set(found)
+
+        # The tail's own arms are one case of it: an arm with a loop in it
+        # leaves that arm's version current, which its siblings must not read.
+        conditional.update(writes(tail))
+
+        def spine(node):
+            if node is tail or not isinstance(node, SList) or len(node) < 1:
+                return
+            head = node[0]
+            if isinstance(head, Symbol):
+                if head.name in ('let', 'let*') and len(node) >= 3:
+                    conditional.update(writes(node[1]))
+                    for item in node.items[2:]:
+                        spine(item)
+                    return
+                if head.name == 'do':
+                    for item in node.items[1:]:
+                        spine(item)
+                    return
+                if head.name == 'set!' and len(node) >= 3 and isinstance(node[1], Symbol):
+                    settled.add(node[1].name)
+                    conditional.update(writes(node[2]))
+                    return
+                if head.name in ('while', 'for-each'):
+                    settled.update(writes(node))
+                    return
+            conditional.update(writes(node))
+
+        spine(body)
+        return settled - conditional
+
+    def _states_own_shape(self, branch: SExpr) -> bool:
+        """True when a branch says what the result *is*, not which value it is.
+
+        A union constructor and a conditional between constructors both do: the
+        tag, the payload and any record inside are all readable from the branch
+        itself. A plain name or a call does not - all that is known there is
+        that the result equals it, which is what the passthrough equalities say.
+        """
+        return_expr = self._get_return_expr(branch)
+        return (self._is_union_ctor_form(return_expr)
+                or bool(self._conditional_branch_exprs(return_expr)))
+
+    def _branch_record_forms(self, branch: SExpr) -> Tuple[int, ...]:
+        """Every record-new a branch may end up building.
+
+        _nested_record_forms already looks through a union constructor, but not
+        through a further `if`/`cond` - and a chain of those, in either order, is
+        the ordinary way to choose between results. Missing one means the
+        records it builds are not counted as part of the returned value, so a
+        list stored in one of them looks reachable afterwards and the binding
+        that made it is rejected as unstable.
+        """
+        return_expr = self._get_return_expr(branch)
+        forms = self._nested_record_forms(return_expr)
+        for sub in self._conditional_branch_exprs(return_expr):
+            forms += self._branch_record_forms(sub)
+        payload = self._union_ctor_payload(return_expr)
+        if payload is not None:
+            forms += self._branch_record_forms(payload)
+        return forms
+
     def _is_list_new(self, expr: SExpr) -> bool:
         """Check if expression is list-new or contains a result bound to list-new"""
         return_expr = self._get_return_expr(expr)
@@ -1858,19 +1990,15 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         return False
 
     def _is_conditional_with_record_new(self, expr: SExpr) -> bool:
-        """True for an `if` or `cond` with a record-new in at least one branch.
+        """True for an `if` or `cond` with a record-building branch.
 
         `cond` counts: it is the same shape, and a function that assembles its
         result differently under three conditions rather than two should not
-        lose its field axioms for it.
+        lose its field axioms for it. A branch counts whether it constructs the
+        record itself or wraps it - see _builds_record.
         """
-        if is_form(expr, 'if') and len(expr) >= 3:
-            return any(self._is_record_new(branch) for branch in expr.items[2:])
-        if is_form(expr, 'cond') and len(expr) >= 2:
-            return any(self._is_record_new(clause[-1])
-                       for clause in expr.items[1:]
-                       if isinstance(clause, SList) and len(clause) >= 2)
-        return False
+        branches = self._conditional_branch_exprs(expr)
+        return any(self._builds_record(branch) for branch in branches)
 
     def _find_list_push_calls(self, expr: SExpr, result: List[Tuple[SExpr, SExpr]]):
         """Find all (list-push lst item) calls in expression.
@@ -2086,8 +2214,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # to reach the list again.
         result_forms: Tuple[int, ...] = ()
         for _, branch in branches:
-            if self._is_record_new(branch):
-                result_forms += self._nested_record_forms(self._get_return_expr(branch))
+            result_forms += self._branch_record_forms(branch)
         bindings = self._tail_bindings(fn_body, param_names, result_forms=result_forms)
         # A branch-local name may shadow an enclosing binding, which shares its
         # Z3 constant. Sibling arms do not: their axioms carry mutually
@@ -2114,7 +2241,38 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     path_cond=self._conjoin(reached_guard, guard),
                     bindings=branch_bindings))
             else:
-                passthrough.append((guard, branch))
+                # The record may be wrapped - `(ok (record-new ...))` - or
+                # chosen by a further conditional, and a branch that yields no
+                # record at all still fixes the union tag, which is what makes
+                # the other branches' claims conditional on reaching them.
+                #
+                # _record_value_axioms already reads exactly these shapes for a
+                # record-valued *field*: it emits the union tag and payload,
+                # recurses into a record payload with the payload accessor as
+                # the base, and conjoins a nested conditional's guards on the
+                # way down. Handing it $result asks the same question about the
+                # result. Fields found that way hang off
+                # union_payload_ok($result) rather than $result, so they are
+                # deliberately not added to field_names - the passthrough
+                # equalities below are about the bare accessor.
+                wrapped: List = []
+                if self._states_own_shape(branch):
+                    branch_bindings = dict(bindings)
+                    branch_bindings.update(self._tail_bindings(
+                        branch, enclosing_names, stability_body=fn_body,
+                        result_forms=result_forms))
+                    # The trailing form, not the branch: an arm that binds
+                    # locals before constructing is a `let` or a `do`, and the
+                    # constructor is what states the shape. The bare path above
+                    # already reads it this way. The bindings collected from the
+                    # whole branch stay, so the locals are still followable.
+                    wrapped = self._record_value_axioms(
+                        result_var, self._get_return_expr(branch), translator,
+                        branch_bindings, self._conjoin(reached_guard, guard))
+                if wrapped:
+                    axioms.extend(wrapped)
+                else:
+                    passthrough.append((guard, branch))
 
         # A branch that yields an existing record: under its guard the result is
         # that value, so the fields the other branches name agree with it.
@@ -2700,8 +2858,12 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             head = resolved[0]
             if isinstance(head, Symbol) and head.name in {'some', 'none', 'ok', 'error'}:
                 constructor = head.name
-                # Tag index mapping (matches translator.py lines 54-92)
-                tag_idx = {'none': 0, 'some': 1, 'ok': 0, 'error': 1}.get(constructor, 0)
+                # The same map _translate_match reads, not a copy of the
+                # built-in order: a user union may declare its own `ok`/`error`
+                # or `some`/`none` the other way round, and then a fixed index
+                # here contradicts the tag the postcondition's match tests -
+                # which makes the arm unreachable and its claim vacuous.
+                tag_idx = translator.constructor_tag(constructor)
                 if "union_tag" not in translator.variables:
                     tag_func = z3.Function("union_tag", z3.IntSort(), z3.IntSort())
                     translator.variables["union_tag"] = tag_func
@@ -2709,7 +2871,11 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     tag_func = translator.variables["union_tag"]
                 add(tag_func(field_func) == z3.IntVal(tag_idx))
 
-                if len(resolved) >= 2 and constructor != 'none':
+                # len, not the constructor name: the built-in `(none)` carries
+                # no payload, but a user union may declare `(none Int)` and
+                # return `(none 7)`, and that 7 is as much a fact as any other
+                # payload.
+                if len(resolved) >= 2:
                     payload = translator.translate_expr(resolved[1])
                     if payload is not None:
                         payload_func_name = f"union_payload_{constructor}"
@@ -2721,11 +2887,15 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                             payload_func = translator.variables[payload_func_name]
                         add(payload_func(field_func) == payload)
 
-                        if is_form(resolved[1], 'record-new'):
-                            axioms.extend(self._extract_record_field_axioms(
-                                resolved[1], translator,
-                                base_accessor=payload_func(field_func),
-                                path_cond=path_cond, bindings=bindings))
+                        # Whatever is known about the payload is known about it
+                        # under the payload accessor. Recursing rather than
+                        # testing for record-new picks up a payload that is
+                        # itself a conditional between constructors, a nested
+                        # wrapper, a fresh list or a string literal - all of
+                        # which this function already reads one level up.
+                        axioms.extend(self._record_value_axioms(
+                            payload_func(field_func), resolved[1], translator,
+                            bindings, path_cond))
         return axioms
 
     @staticmethod
@@ -3776,9 +3946,23 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         if fn_body is not None and body_has_one_exit:
             return_expr = self._get_return_expr(fn_body)
             if self._is_conditional_with_record_new(return_expr):
-                cond_axioms = self._extract_conditional_record_axioms(
-                    return_expr, translator, combined_body, declared_param_names,
-                    reached_guard)
+                # The tail runs after every loop in the body, so a name a loop
+                # reassigned means its final version here. freeze_versions
+                # refuses those by default because most phases re-translate
+                # expressions from anywhere in the body and cannot tell which
+                # version was meant (#116) - this one only ever reads the tail.
+                #
+                # Only for a name every write to which is on the spine that
+                # leads here. A write the run may skip - in an arm of the tail
+                # itself, or in an `if` earlier in the body - still leaves its
+                # version current, so reading it here would put a branch's facts
+                # on a path that never took it.
+                with translator.final_versions(
+                        self._names_settled_before_tail(
+                            combined_body, return_expr, translator)):
+                    cond_axioms = self._extract_conditional_record_axioms(
+                        return_expr, translator, combined_body, declared_param_names,
+                        reached_guard)
                 for axiom in cond_axioms:
                     solver.add(axiom)
 

--- a/src/slop/verifier/translator.py
+++ b/src/slop/verifier/translator.py
@@ -77,6 +77,8 @@ class Z3Translator:
         self._in_quoted_form = False
         self._versions_frozen = False
         self._prefer_initial_versions = False
+        self._prefer_final_versions = False
+        self._final_version_names: set = set()
         self._declared_types: Dict[str, Any] = {}
         self._record_new_counter = 0  # Counter for unique record-new values
         self.enum_type_variants: set = set()  # Variants from EnumType only (not UnionType)
@@ -1423,7 +1425,8 @@ class Z3Translator:
                             self.variables[tag_func_name] = tag_func
                         else:
                             tag_func = self.variables[tag_func_name]
-                        self.constraints.append(tag_func(result) == z3.IntVal(1))
+                        self.constraints.append(
+                            tag_func(result) == z3.IntVal(self.constructor_tag('some')))
 
                         payload_func_name = "union_payload_some"
                         if payload_func_name not in self.variables:
@@ -1443,7 +1446,8 @@ class Z3Translator:
                             self.variables[tag_func_name] = tag_func
                         else:
                             tag_func = self.variables[tag_func_name]
-                        self.constraints.append(tag_func(result) == z3.IntVal(0))
+                        self.constraints.append(
+                            tag_func(result) == z3.IntVal(self.constructor_tag('none')))
                     return result
 
                 # arena-alloc always returns non-nil pointer (runtime aborts on OOM)
@@ -1477,7 +1481,9 @@ class Z3Translator:
         # refused rather than answered with the wrong one (issue #116).
         if self._prefer_initial_versions and name in self._pre_loop_variables:
             return self._pre_loop_variables[name]
-        if self._versions_frozen and name in self._pre_loop_variables:
+        if (self._versions_frozen and name in self._pre_loop_variables
+                and not (self._prefer_final_versions
+                         and name in self._final_version_names)):
             return None
 
         # Quoted enum variant: 'Fizz -> IntVal(0)
@@ -2070,6 +2076,32 @@ class Z3Translator:
         finally:
             self._prefer_initial_versions = was
 
+    @contextmanager
+    def final_versions(self, names):
+        """Read `names` as they stand once the whole body has run.
+
+        The counterpart to initial_versions. freeze_versions refuses a
+        loop-versioned name because a pattern phase re-translating an arbitrary
+        body expression cannot know which version it meant (issue #116). For a
+        name written only where every run passes, the value at the end of the
+        body is unambiguous, and it is what `variables` holds.
+
+        An allow-list rather than a deny-list, because the unsafe case is the
+        quiet one: the body is translated as one straight line with no program
+        points, so a write the run skips still leaves its version in
+        `variables`. The caller decides which names are safe; everything else
+        keeps the refusal.
+        """
+        was_prefer = self._prefer_final_versions
+        was_names = self._final_version_names
+        self._prefer_final_versions = True
+        self._final_version_names = set(names or ())
+        try:
+            yield
+        finally:
+            self._prefer_final_versions = was_prefer
+            self._final_version_names = was_names
+
     def freeze_versions(self) -> None:
         """Stop answering for names that have more than one version.
 
@@ -2086,6 +2118,19 @@ class Z3Translator:
         value of the thing that replaced it.
         """
         return self._pre_loop_variables.get(name, self.variables.get(name))
+
+    def constructor_tag(self, name: str) -> int:
+        """The tag index for a union constructor, as `match` will read it.
+
+        enum_values carries the built-in Option/Result order until a user union
+        declares variants of the same names, which the checker warns about but
+        allows - and then that union's order wins here and in _translate_match.
+        Everything that asserts a tag has to read the same map, or an arm the
+        postcondition tests becomes unreachable and its claim discharges
+        vacuously.
+        """
+        return self.enum_values.get(
+            name, self.enum_values.get(f"'{name}", hash(name) % 256))
 
     def is_loop_versioned(self, name: str) -> bool:
         """True if a loop or a `set!` replaced `name`, so it has more than one value."""

--- a/src/slop/verifier/union_handling.py
+++ b/src/slop/verifier/union_handling.py
@@ -75,10 +75,7 @@ class UnionHandlingMixin:
 
         # Use the same tag index calculation as _translate_match
         # Check enum_values first, fall back to hash
-        tag_idx = translator.enum_values.get(
-            constructor_name,
-            translator.enum_values.get(f"'{constructor_name}", hash(constructor_name) % 256)
-        )
+        tag_idx = translator.constructor_tag(constructor_name)
 
         # Get or create union_tag function
         tag_func_name = "union_tag"
@@ -112,31 +109,15 @@ class UnionHandlingMixin:
 
                 axioms.append(payload_func(result_var) == payload_z3)
 
-                # Axiom 3: If payload is a record-new, propagate field axioms
-                # For (some (record-new Type (field1 val1) ...)), add:
-                #   field_field1(union_payload_some($result)) == val1
-                #   string_len(field_field1(union_payload_some($result))) == len if val1 is string
-                if is_form(payload_expr, 'record-new') and len(payload_expr) >= 3:
-                    payload_var = payload_func(result_var)  # This is union_payload_some($result)
-                    for item in payload_expr.items[2:]:  # Skip 'record-new' and Type
-                        if isinstance(item, SList) and len(item) >= 2:
-                            field_name = item[0].name if isinstance(item[0], Symbol) else None
-                            if field_name:
-                                field_func = translator._translate_field_for_obj(payload_var, field_name)
-                                field_value = translator.translate_expr(item[1])
-                                if field_value is not None:
-                                    axioms.append(field_func == field_value)
-
-                                # If field value is a string literal, add string_len axiom
-                                if isinstance(item[1], String):
-                                    str_len_func_name = "string_len"
-                                    if str_len_func_name not in translator.variables:
-                                        str_len_func = z3.Function(str_len_func_name, z3.IntSort(), z3.IntSort())
-                                        translator.variables[str_len_func_name] = str_len_func
-                                    else:
-                                        str_len_func = translator.variables[str_len_func_name]
-                                    actual_len = len(item[1].value)
-                                    axioms.append(str_len_func(field_func) == z3.IntVal(actual_len))
+                # Axiom 3: whatever is known about the payload, known about it
+                # under the payload accessor. _record_value_axioms is the one
+                # reading of a value the rest of this file uses, so a payload
+                # that is a record picks up its nested records, its list-new
+                # field lengths and its string lengths, and a payload that
+                # chooses between records with an `if` is read through the
+                # guards rather than dropped (#123).
+                axioms.extend(self._record_value_axioms(
+                    payload_func(result_var), payload_expr, translator, {}, None))
 
         return axioms
 
@@ -172,10 +153,7 @@ class UnionHandlingMixin:
             return axioms
 
         # Get tag index using same calculation as _translate_match
-        tag_idx = translator.enum_values.get(
-            constructor_name,
-            translator.enum_values.get(f"'{constructor_name}", hash(constructor_name) % 256)
-        )
+        tag_idx = translator.constructor_tag(constructor_name)
 
         # Get or create union_tag function
         tag_func_name = "union_tag"

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -8512,6 +8512,351 @@ class TestConditionalRecordFields:
         assert verify_source(src, filename="probe.slop")[0].status != 'verified'
 
 
+_UNION_RECORD_PROBE = '''
+(module probe
+  (type Item (record (v Int)))
+  (type F (record (flag Bool) (xs (List Item)) (ys (List Item))))
+  (type St (record (iteration Int)))
+  (type G (record (state St) (tag Int)))
+  (type E (enum bad))
+
+  (fn opaque? ((n Int))
+    (@spec ((Int) -> Bool))
+    (> n 3))
+
+  (fn step ((arena Arena) (s St))
+    (@spec ((Arena St) -> St))
+    (@alloc arena)
+    (record-new St (iteration (+ (. s iteration) 1))))
+
+%s)
+'''
+
+
+class TestUnionWrappedRecordFields:
+    """Issue #123: a record a branch wraps in a union constructor.
+
+    #70 gave a branch that *is* a record-new its field axioms. A branch that
+    wraps one - `(ok (record-new ...))`, which is how a function returning a
+    Result states its answer - contributed nothing, so nothing was known about
+    the record inside the result. The nested `if` that picks between two of them
+    was not recognised as conditional at all.
+
+    Two halves: seeing through the wrapper, and reading the tail with the
+    versions a loop left behind rather than refusing a loop-versioned name.
+    """
+
+    EMPTY = "(xs (list-new arena Item)) (ys (list-new arena Item))"
+    POST = ("(@post (match $result ((ok r) {(list-len (. r xs)) == 0}) "
+            "((error _) true)))")
+
+    @staticmethod
+    def _status(fn_source, name):
+        from slop.verifier import verify_source
+        results = [r for r in verify_source(_UNION_RECORD_PROBE % fn_source,
+                                            filename="probe.slop")
+                   if r.name == name]
+        assert len(results) == 1
+        return results[0].status
+
+    def test_both_arms_wrap_a_record(self):
+        assert self._status('''
+  (fn w1 ((arena Arena) (c Bool))
+    (@spec ((Arena Bool) -> (Result F E)))
+    (@alloc arena)
+    %s
+    (if c (ok (record-new F (flag true) %s))
+          (ok (record-new F (flag false) %s))))''' % (self.POST, self.EMPTY, self.EMPTY),
+                            'w1') == 'verified'
+
+    def test_a_nested_if_under_an_error_arm(self):
+        """HOWL's `saturate`: cancel first, then pick between two results. The
+        outer `if` has no record-new in either branch, so the whole analysis
+        used to be skipped."""
+        assert self._status('''
+  (fn w2 ((arena Arena) (c Bool) (d Bool))
+    (@spec ((Arena Bool Bool) -> (Result F E)))
+    (@alloc arena)
+    %s
+    (if c (error 'bad)
+          (if d (ok (record-new F (flag true) %s))
+                (ok (record-new F (flag false) %s)))))'''
+                            % (self.POST, self.EMPTY, self.EMPTY), 'w2') == 'verified'
+
+    def test_an_option_wrapper(self):
+        """`(none)` carries a tag and no payload, and that tag is what makes the
+        `(some r)` arm's claim conditional on reaching it."""
+        assert self._status('''
+  (fn w3 ((arena Arena) (c Bool))
+    (@spec ((Arena Bool) -> (Option F)))
+    (@alloc arena)
+    (@post (match $result ((some r) {(list-len (. r xs)) == 0}) ((none) true)))
+    (if c (some (record-new F (flag true) %s))
+          (none)))''' % self.EMPTY, 'w3') == 'verified'
+
+    def test_an_opaque_condition_between_wrapped_records(self):
+        assert self._status('''
+  (fn w4 ((arena Arena) (n Int))
+    (@spec ((Arena Int) -> (Result F E)))
+    (@alloc arena)
+    %s
+    (if (opaque? n) (ok (record-new F (flag true) %s))
+                    (ok (record-new F (flag false) %s))))'''
+                            % (self.POST, self.EMPTY, self.EMPTY), 'w4') == 'verified'
+
+    def test_a_loop_invariant_reaches_the_wrapped_record(self):
+        """The tail runs after the loop, so `st` there means the version the
+        loop left behind. freeze_versions refuses a loop-versioned name by
+        default - correctly, for a pass re-translating an arbitrary body
+        expression - which severed the invariant from the field it describes."""
+        assert self._status('''
+  (fn w5 ((arena Arena) (s0 St) (cap Int) (bail Bool))
+    (@spec ((Arena St Int Bool) -> (Result G E)))
+    (@alloc arena)
+    (@post (match $result ((ok r) {(. (. r state) iteration) <= cap}) ((error _) true)))
+    (let ((mut st s0)
+          (mut stop false))
+      (do
+        (while (not stop)
+          (@loop-invariant {(. st iteration) <= cap})
+          (do
+            (if (>= (. st iteration) cap)
+              (set! stop true)
+              (set! st (step arena st)))))
+        (if bail
+          (error 'bad)
+          (if stop
+            (ok (record-new G (state st) (tag 1)))
+            (ok (record-new G (state st) (tag 2))))))))''', 'w5') == 'verified'
+
+    def test_an_arm_that_binds_locals_before_constructing(self):
+        """The constructor states the shape; the `let` around it is just where
+        the arm keeps its locals."""
+        assert self._status('''
+  (fn w6 ((arena Arena) (c Bool))
+    (@spec ((Arena Bool) -> (Result F E)))
+    (@alloc arena)
+    %s
+    (if c (let ((e (list-new arena Item))) (ok (record-new F (flag true) (xs e) (ys e))))
+          (let ((e (list-new arena Item))) (ok (record-new F (flag false) (xs e) (ys e))))))'''
+                            % self.POST, 'w6') == 'verified'
+
+    def test_a_payload_conditional_over_records_holding_a_bound_list(self):
+        """The records inside a payload conditional are part of the returned
+        value too. Not counting them leaves the local `e` looking reachable
+        after the return, so the binding that made it is rejected as
+        unstable and its length is lost."""
+        assert self._status('''
+  (fn w8 ((arena Arena) (c Bool) (d Bool))
+    (@spec ((Arena Bool Bool) -> (Result F E)))
+    (@alloc arena)
+    %s
+    (let ((e (list-new arena Item)))
+      (if c (error 'bad)
+            (ok (if d (record-new F (flag true) (xs e) (ys e))
+                      (record-new F (flag false) (xs e) (ys e)))))))'''
+                            % self.POST, 'w8') == 'verified'
+
+    def test_the_whole_result_is_one_constructor_over_a_conditional(self):
+        """No outer `if` at all: `(ok (if ...))`. Phase 4.5 handles a top-level
+        constructor, and it read only a bare record-new payload."""
+        assert self._status('''
+  (fn w9 ((arena Arena) (c Bool))
+    (@spec ((Arena Bool) -> (Result F E)))
+    (@alloc arena)
+    %s
+    (ok (if c (record-new F (flag true) %s)
+              (record-new F (flag false) %s))))'''
+                            % (self.POST, self.EMPTY, self.EMPTY), 'w9') == 'verified'
+
+    def test_a_payload_that_is_itself_a_conditional(self):
+        """`(ok (if ...))` rather than `(if ... (ok ...) (ok ...))`. The tag is
+        the same either way and the fields still belong to the payload."""
+        assert self._status('''
+  (fn w7 ((arena Arena) (c Bool) (d Bool))
+    (@spec ((Arena Bool Bool) -> (Result F E)))
+    (@alloc arena)
+    %s
+    (if c (error 'bad)
+          (ok (if d (record-new F (flag true) %s)
+                    (record-new F (flag false) %s)))))'''
+                            % (self.POST, self.EMPTY, self.EMPTY), 'w7') == 'verified'
+
+    # --- the guards have to be exact, not just present --------------------
+
+    def test_an_arm_binding_locals_with_one_arm_not_empty(self):
+        assert self._status('''
+  (fn n4 ((arena Arena) (c Bool) (zs (List Item)))
+    (@spec ((Arena Bool (List Item)) -> (Result F E)))
+    (@alloc arena)
+    %s
+    (if c (let ((e (list-new arena Item))) (ok (record-new F (flag true) (xs e) (ys e))))
+          (let ((e zs)) (ok (record-new F (flag false) (xs e) (ys e))))))'''
+                            % self.POST, 'n4') != 'verified'
+
+    def test_a_payload_conditional_over_a_bound_list_with_one_arm_not_empty(self):
+        assert self._status('''
+  (fn n7 ((arena Arena) (c Bool) (d Bool) (zs (List Item)))
+    (@spec ((Arena Bool Bool (List Item)) -> (Result F E)))
+    (@alloc arena)
+    %s
+    (let ((e (list-new arena Item)))
+      (if c (error 'bad)
+            (ok (if d (record-new F (flag true) (xs e) (ys e))
+                      (record-new F (flag false) (xs zs) (ys e)))))))'''
+                            % self.POST, 'n7') != 'verified'
+
+    def test_a_union_that_declares_its_tags_the_other_way_round(self):
+        """A user union may name its variants `error` then `ok`. The tag index
+        has to come from the same map the postcondition's match reads, or the
+        arm is unreachable and its claim discharges vacuously."""
+        from slop.verifier import verify_source
+        src = '''
+(module probe
+  (type V (record (v Int)))
+  (type Backwards (union (error Int) (ok V)))
+  (fn t ((arena Arena) (c Bool))
+    (@spec ((Arena Bool) -> Backwards))
+    (@alloc arena)
+    (@post (match $result ((ok r) {(. r v) == %d}) ((error _) true)))
+    (if c (ok (record-new V (v 9)))
+          (ok (record-new V (v 9))))))
+'''
+        assert verify_source(src % 9, filename="probe.slop")[0].status == 'verified'
+        assert verify_source(src % 1, filename="probe.slop")[0].status != 'verified'
+
+    def test_a_union_that_reverses_some_and_none(self):
+        """The translator asserted `some`'s tag from the built-in order while
+        the match read the user's, so the two contradicted each other and the
+        context came out inconsistent rather than verified."""
+        from slop.verifier import verify_source
+        src = '''
+(module probe
+  (type V (record (v Int)))
+  (type Rev (union (some V) (none Int)))
+  (fn t ((arena Arena) (c Bool))
+    (@spec ((Arena Bool) -> Rev))
+    (@alloc arena)
+    (@post (match $result ((some r) {(. r v) == %d}) ((none _) true)))
+    (if c (some (record-new V (v 9)))
+          (some (record-new V (v 9))))))
+'''
+        assert verify_source(src % 9, filename="probe.slop")[0].status == 'verified'
+        assert verify_source(src % 1, filename="probe.slop")[0].status != 'verified'
+
+    def test_a_top_level_constructor_conditional_with_one_arm_not_empty(self):
+        assert self._status('''
+  (fn n9 ((arena Arena) (c Bool) (zs (List Item)))
+    (@spec ((Arena Bool (List Item)) -> (Result F E)))
+    (@alloc arena)
+    %s
+    (ok (if c (record-new F (flag true) %s)
+              (record-new F (flag false) (xs zs) (ys (list-new arena Item))))))'''
+                            % (self.POST, self.EMPTY), 'n9') != 'verified'
+
+    def test_a_conditional_payload_with_one_arm_not_empty(self):
+        assert self._status('''
+  (fn n5 ((arena Arena) (c Bool) (d Bool) (zs (List Item)))
+    (@spec ((Arena Bool Bool (List Item)) -> (Result F E)))
+    (@alloc arena)
+    %s
+    (if c (error 'bad)
+          (ok (if d (record-new F (flag true) %s)
+                    (record-new F (flag false) (xs zs) (ys (list-new arena Item)))))))'''
+                            % (self.POST, self.EMPTY), 'n5') != 'verified'
+
+    def test_one_wrapped_arm_that_is_not_empty(self):
+        assert self._status('''
+  (fn n1 ((arena Arena) (c Bool) (zs (List Item)))
+    (@spec ((Arena Bool (List Item)) -> (Result F E)))
+    (@alloc arena)
+    %s
+    (if c (ok (record-new F (flag true) %s))
+          (ok (record-new F (flag false) (xs zs) (ys (list-new arena Item))))))'''
+                            % (self.POST, self.EMPTY), 'n1') != 'verified'
+
+    def test_a_nested_arm_that_is_not_empty(self):
+        assert self._status('''
+  (fn n2 ((arena Arena) (c Bool) (d Bool) (zs (List Item)))
+    (@spec ((Arena Bool Bool (List Item)) -> (Result F E)))
+    (@alloc arena)
+    %s
+    (if c (error 'bad)
+          (if d (ok (record-new F (flag true) %s))
+                (ok (record-new F (flag false) (xs zs) (ys (list-new arena Item)))))))'''
+                            % (self.POST, self.EMPTY), 'n2') != 'verified'
+
+    def test_a_conditional_loop_before_the_tail_is_not_final(self):
+        """The loop sits in an `if` the run skips. Its post-loop constant is
+        still what `variables` holds, because the body is translated as one
+        straight line - so the tail must not read it."""
+        assert self._status('''
+  (fn n8 ((arena Arena) (s0 St) (cap Int) (c Bool) (d Bool))
+    (@spec ((Arena St Int Bool Bool) -> (Result G E)))
+    (@alloc arena)
+    (@pre (not c))
+    (@post (match $result ((ok r) {(. (. r state) iteration) <= cap}) ((error _) true)))
+    (let ((mut st s0)
+          (mut stop false))
+      (do
+        (if c
+          (while (not stop)
+            (@loop-invariant {(. st iteration) <= cap})
+            (do
+              (if (>= (. st iteration) cap)
+                (set! stop true)
+                (set! st (step arena st)))))
+          (do))
+        (if d
+          (ok (record-new G (state st) (tag 1)))
+          (ok (record-new G (state st) (tag 2)))))))''', 'n8') != 'verified'
+
+    def test_a_loop_in_one_arm_does_not_describe_its_sibling(self):
+        """`variables` holds whichever arm was translated last, so a loop inside
+        the returned conditional leaves that arm's version there. The `c` arm
+        reads `st` before any of it runs, and nothing bounds it."""
+        assert self._status('''
+  (fn n6 ((arena Arena) (s0 St) (cap Int) (c Bool))
+    (@spec ((Arena St Int Bool) -> (Result G E)))
+    (@alloc arena)
+    (@pre c)
+    (@post (match $result ((ok r) {(. (. r state) iteration) <= cap}) ((error _) true)))
+    (let ((mut st s0)
+          (mut stop false))
+      (if c
+        (ok (record-new G (state st) (tag 1)))
+        (do
+          (while (not stop)
+            (@loop-invariant {(. st iteration) <= cap})
+            (do
+              (if (>= (. st iteration) cap)
+                (set! stop true)
+                (set! st (step arena st)))))
+          (ok (record-new G (state st) (tag 2)))))))''', 'n6') != 'verified'
+
+    def test_the_invariant_is_not_stronger_than_it_says(self):
+        """`<= cap` must not discharge `< cap`."""
+        assert self._status('''
+  (fn n3 ((arena Arena) (s0 St) (cap Int) (bail Bool))
+    (@spec ((Arena St Int Bool) -> (Result G E)))
+    (@alloc arena)
+    (@post (match $result ((ok r) {(. (. r state) iteration) < cap}) ((error _) true)))
+    (let ((mut st s0)
+          (mut stop false))
+      (do
+        (while (not stop)
+          (@loop-invariant {(. st iteration) <= cap})
+          (do
+            (if (>= (. st iteration) cap)
+              (set! stop true)
+              (set! st (step arena st)))))
+        (if bail
+          (error 'bad)
+          (if stop
+            (ok (record-new G (state st) (tag 1)))
+            (ok (record-new G (state st) (tag 2))))))))''', 'n3') != 'verified'
+
+
 class TestEarlyExits:
     """An early `(return ...)` is a second path to $result.
 


### PR DESCRIPTION
Closes #123. **This is what howl is waiting on.**

## The bug

#70 gave a conditional branch that *is* a `record-new` its field axioms. A branch
that wraps one contributed nothing. HOWL's `saturate` ends:

```lisp
(if cancelled
  (error (union-new Fault cancelled))
  (if (frontier-is-empty state)
    (ok (record-new RoundResult (saturation state) ...))
    (ok (record-new RoundResult (saturation state) ...))))
```

`_is_record_new` tests the branch itself, so neither arm of the outer `if`
counted and the whole analysis was skipped. Even reached, the arms are `(ok ...)`
rather than constructors, so they fell to the passthrough case — which has
nothing to say when no branch named a field. Nothing linked `state` to
`(. r saturation)`, and the `@loop-invariant` bounding it never reached the
result.

## The fix, in two halves

**Seeing through the wrapper.** `_record_value_axioms` already reads exactly this
shape one level down, for a record-valued *field* whose value is
`(ok (record-new ...))`: it emits the union tag, the payload, and recurses into
the payload's fields with the payload accessor as the base. Handing it `$result`
asks the same question about the result, so conditional branches now go through
it rather than through a fourth partial re-implementation. `_extract_union_constructor_axioms`
loses its own hand-rolled copy for the same reason.

Three predicates make the branches visible: `_is_union_ctor_form`,
`_conditional_branch_exprs` and `_builds_record`, which sees through a wrapper
and through a further conditional. A branch that yields no record still goes
through `_record_value_axioms` when it is a constructor, because its tag is what
makes the other branches' claims conditional on being reached — without it Z3 may
pick the error branch and the ok tag at once, and nothing constrains the fields.

**Versions.** The tail runs after every loop in the body, so a name a loop
reassigned means its final version there — but `freeze_versions` refuses those,
correctly for a pass re-translating an arbitrary body expression that cannot tell
which version was meant (#116). A new `final_versions(names)` contextmanager, the
counterpart to `initial_versions()`, lifts that for the one pass that only reads
the tail.

It is an **allow-list**, and `_names_settled_before_tail` computes it: only a name
every write to which is on the spine — the `do`/`let` chain that leads to the
tail, including a loop there, which the translator already models as possibly not
running. A write the run may skip still leaves its version current, so reading it
at the tail would put a branch's facts on a path that never took it. Two review
rounds found exactly that hole, first for an arm of the tail itself and then for
an `if` earlier in the body; both are pinned as negative tests.

**One tag map.** `constructor_tag` on the translator replaces three copies of the
lookup, including a hardcoded `some`=1 / `none`=0. A user union may declare
`(union (error Int) (ok V))` — the checker warns and allows it — and then a fixed
index here contradicts the tag the postcondition's `match` tests, which makes the
arm unreachable and its claim vacuous. Found by review; pinned both ways round.

## Result

| | before | after |
|---|---|---|
| howl `slop verify` | 30 verified, **1 failed** | **31 verified, 0 failed** |
| snarl `slop verify` | 58 verified, 22 failed | 58 verified, 22 failed (unchanged) |
| `uv run pytest` | 708 passed | 728 passed |

Negating howl's postcondition still fails, so the proof is not vacuous.

## Tests

`TestUnionWrappedRecordFields`, 20 cases. Every positive has a negative beside it
— an arm that is not empty, a guard that must not be borrowed, an invariant that
must not be read as stronger than it says, a loop whose version must not escape
its arm. Shapes covered: both arms wrapped; a nested `if` under an `error` arm
(howl's); an Option wrapper; an opaque condition; an arm that binds locals before
constructing; a payload that is itself a conditional; a top-level
`(ok (if ...))`; a loop invariant reaching the wrapped record; and a union that
declares `ok`/`error` or `some`/`none` the other way round.

## Filed along the way

**#130** — only the last form of a multi-form body is translated, so a loop or a
`@loop-invariant` in an earlier form never applies; the identical code wrapped in
one `(do ...)` verifies. Surfaced by a review probe, out of scope here.

Also noted, not fixed: a user union may declare `(none Int)` and return
`(none 7)`. The payload axiom is now emitted for it, but the `match` side does not
yet carry that arm through, so the end-to-end case still does not verify.

## Review

Six `codex exec review` rounds. Rounds 2 and 4 each found a real soundness hole in
`final_versions` — both reproduced against `origin/main` before being fixed, and
both are now negative tests. Round 6 clean.
