### PR TITLE
declare $result when a function has only a @property (#125)

### DIFF
--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -3356,6 +3356,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         # Extract loop invariants from function body and treat them as assumptions
         # @loop-invariant provides axioms that help verify loops
+        propagated_range: range = range(0)
         if fn_body is not None:
             loop_invariants = self._extract_loop_invariants(fn_body)
             if loop_invariants:
@@ -3368,6 +3369,12 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 propagated = self._propagate_properties_as_loop_invariants(
                     fn_body, properties
                 )
+                # Where they land, so the property solver can leave them out.
+                # A propagated invariant is a property restated with the
+                # returned local's name in place of $result; trusting it while
+                # checking that property proves it from itself (#125).
+                propagated_range = range(len(assumptions),
+                                         len(assumptions) + len(propagated))
                 assumptions.extend(propagated)
 
         # Skip if no contracts to verify
@@ -3391,10 +3398,13 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 location=SourceLocation(self.filename, fn_form.line, fn_form.col)
             )
 
-        # Determine if array or sequence encoding is needed for postconditions or properties
-        use_array_encoding = self._needs_array_encoding(postconditions)
-        # Check both postconditions and properties for seq encoding need
+        # Determine if array or sequence encoding is needed for postconditions or
+        # properties. Both annotations, for both encodings: a property gets the
+        # same list model as the postcondition making the same claim, or the two
+        # disagree about a claim only because of how it was spelled (#125).
         property_exprs = [prop_expr for _, prop_expr in properties]
+        use_array_encoding = (self._needs_array_encoding(postconditions) or
+                              self._needs_array_encoding(property_exprs))
         use_seq_encoding = (self._needs_seq_encoding(postconditions) or
                            self._needs_seq_encoding(property_exprs))
 
@@ -3423,8 +3433,15 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     param_type = _parse_type_expr_simple(param_type_expr, self.type_env.type_registry)
                     translator.declare_variable(param_name, param_type)
 
-        # Declare $result for postconditions and assumptions
-        if postconditions or assumptions:
+        # Declare $result for postconditions, assumptions and properties.
+        #
+        # A @property is a claim about the result just as a @post is, and one
+        # naming $result is the ordinary case - the length of a list a function
+        # returns is among the most basic things to state about it. Without
+        # this the name has nothing behind it, translate_expr answers None, and
+        # every such property reports "Could not translate", which reads as a
+        # verifier failure rather than an unsupported form (#125).
+        if postconditions or assumptions or properties:
             if spec_return_type:
                 # For enum return types, use Int and constrain to valid range
                 if isinstance(spec_return_type, EnumType):
@@ -3505,7 +3522,12 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             for form in (list(all_body_exprs[:-1]) + [fn_body]
                          if all_body_exprs else [fn_body]):
                 translator.note_body(form)
-        if fn_body is not None and postconditions:
+        # Properties too: a @property naming $result needs the body behind it
+        # exactly as a @post does, and the property solver already wires the
+        # equality up - it just never had a body to wire (#125). What the body
+        # *establishes* is what a property gets; the side conditions translating
+        # it raised stay behind, filtered out where the property solver is built.
+        if fn_body is not None and (postconditions or properties):
             body_z3 = translator.translate_expr(fn_body)
         body_constraint_end = len(translator.constraints)
 
@@ -3564,11 +3586,16 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # Translate assumptions (trusted axioms) - AFTER body so local vars are declared
         assume_constraint_start = len(translator.constraints)
         assume_z3: List[z3.BoolRef] = []
+        # Whether each translated assumption is a propagated property. Kept
+        # alongside rather than as indices into `assumptions`, because one that
+        # does not translate is dropped and the positions no longer line up.
+        assume_is_propagated: List[bool] = []
         failed_assumes: List[SExpr] = []
-        for assume in assumptions:
+        for assume_index, assume in enumerate(assumptions):
             z3_assume = translator.translate_expr(assume)
             if z3_assume is not None:
                 assume_z3.append(self._ensure_bool(z3_assume))
+                assume_is_propagated.append(assume_index in propagated_range)
             else:
                 failed_assumes.append(assume)
         assume_constraint_end = len(translator.constraints)
@@ -3577,12 +3604,61 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # properties is List[Tuple[Optional[str], SExpr]] - (name, expr) tuples
         prop_z3: List[z3.BoolRef] = []
         failed_props: List[Tuple[Optional[str], SExpr]] = []
-        for prop_name, prop_expr in properties:
-            z3_prop = translator.translate_expr(prop_expr)
-            if z3_prop is not None:
-                prop_z3.append(self._ensure_bool(z3_prop))
+        # Body locals go away again, as they do for postconditions: a contract
+        # cannot name one. They were put back for the assumptions above, where a
+        # @loop-invariant is written about them. Without this a property-only
+        # function - whose body is now translated, so its locals exist - could
+        # state `(== x 1)` about a local and have it verify, and a local called
+        # `field_len` would shadow the accessor and take translation down.
+        for local in body_locals:
+            # A local may shadow a parameter, and a contract naming it means the
+            # parameter. Putting the outer value back is what makes `(== x x)`
+            # about the parameter rather than untranslatable.
+            outer = scope_before_body.get(local)
+            if outer is None:
+                translator.variables.pop(local, None)
             else:
-                failed_props.append((prop_name, prop_expr))
+                translator.variables[local] = outer
+        try:
+            for prop_name, prop_expr in properties:
+                # Each property gets the namespace back as it found it. A
+                # property may bind names of its own - `(let (($result 1)) ...)`
+                # - or make the translator claim one for an accessor, and either
+                # would otherwise outlive it: the next property, the body
+                # equality and the axiom phases all read the same dict. The
+                # constraints it raised stay, since the property solver is built
+                # from them; only the bindings are rolled back.
+                scope_before_property = dict(translator.variables)
+                try:
+                    z3_prop = translator.translate_expr(prop_expr)
+                finally:
+                    # The bindings go, the declarations stay. Translating a
+                    # property may claim a name for a function the phases below
+                    # also need - `fn_foo-eq_2` for a reflexivity axiom, an
+                    # accessor for a field - and those are the translator's, not
+                    # the property's.
+                    declared = {name: value
+                                for name, value in translator.variables.items()
+                                if name not in scope_before_property
+                                and isinstance(value, z3.FuncDeclRef)}
+                    translator.variables.clear()
+                    translator.variables.update(scope_before_property)
+                    translator.variables.update(declared)
+                if z3_prop is not None:
+                    prop_z3.append(self._ensure_bool(z3_prop))
+                else:
+                    failed_props.append((prop_name, prop_expr))
+        finally:
+            for local, value in body_locals.items():
+                # Not over a declaration. `variables` holds user bindings and
+                # the verifier's own helpers in one namespace, so a local named
+                # like one - `fn_foo-eq_2` - would be restored where a phase
+                # below expects something callable. Losing such a local costs
+                # precision on a name nobody writes; calling an ArithRef costs
+                # the file.
+                if isinstance(translator.variables.get(local), z3.FuncDeclRef):
+                    continue
+                translator.variables[local] = value
 
         # Report translation failures
         if failed_pres:
@@ -3705,11 +3781,31 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # The tail's own side conditions - a non-zero divisor, a string length -
         # only hold because the tail ran. An early return bypasses it, so they
         # travel under the same guard as everything else derived from it.
-        constraint_terms = list(translator.constraints)
-        if reached_guard is not None:
-            for i in range(body_constraint_start, min(body_constraint_end,
-                                                      len(constraint_terms))):
-                constraint_terms[i] = z3.Implies(reached_guard, constraint_terms[i])
+        def guard_body_constraints(terms) -> List[z3.BoolRef]:
+            """`terms` with the tail's own side conditions put under its guard.
+
+            Index-based because that is the only record of which constraints the
+            body contributed; every solver built from translator.constraints has
+            to apply it, or it assumes a divisor is non-zero on a path that
+            never reached the division.
+            """
+            guarded = list(terms)
+            if reached_guard is None:
+                return guarded
+            for i in range(body_constraint_start,
+                           min(body_constraint_end, len(guarded))):
+                guarded[i] = z3.Implies(reached_guard, guarded[i])
+            return guarded
+
+        constraint_terms = guard_body_constraints(translator.constraints)
+        # Which of them are obligations rather than facts, positionally. The
+        # index into constraint_terms is not the index into
+        # translator.constraints for long - the phases below append to the
+        # latter - so the flags travel alongside rather than being looked up.
+        constraint_is_obligation = [
+            i in translator.definedness_constraints
+            and not (assume_constraint_start <= i < assume_constraint_end)
+            for i in range(len(constraint_terms))]
 
         # Check: can we satisfy preconditions but violate postconditions?
         # If (pre AND NOT post) is SAT, then contract can be violated
@@ -3727,6 +3823,14 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # Add assumptions as trusted axioms
         for a in assume_z3:
             solver.add(a)
+
+        # Everything asserted from here to the end of the body phases is what
+        # the body establishes. A @property omits the preconditions - that is
+        # what makes it universal rather than conditional - but not these, and
+        # the property solver below is built from them (#125). The mark sits
+        # after the assumptions too, so the property solver picks which of those
+        # it takes rather than receiving them all through here.
+        pre_mark = len(solver.assertions())
 
         # Phase 1: Add type invariants for parameters
         # For (type T (record ...) (@invariant cond)), when param has type T,
@@ -3751,6 +3855,10 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # Add body constraint for path-sensitive analysis
         # This constrains $result to equal the translated function body
         body_equality: List[z3.BoolRef] = []
+        # Definedness obligations an early exit's value raised, guarded with that
+        # exit. They go to the solver like everything else, but a universal
+        # property must not read them as evidence.
+        guarded_definedness: List[z3.BoolRef] = []
         # early_exits is None when the body returns somewhere this cannot guard,
         # or when a guard turned out to name something later reassigned. Either
         # way the trailing form is not the only thing $result can be, so it is
@@ -3765,6 +3873,25 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                             else z3.Implies(reached_guard, result_var == body_z3))
                 body_equality.append(equality)
                 solver.add(equality)
+
+        def add_tail_axiom(axiom):
+            """Assert a fact taken from the trailing form, if it describes $result.
+
+            The trailing form is only what the function returns on the path that
+            gets there; an early `(return ...)` yields something else. The value
+            equality above already carries that guard - the structural facts
+            taken from the same form need it too, or a claim true only of the
+            trailing constructor is asserted for every exit (#132).
+
+            `early_exits is None` means a return the analysis could not guard,
+            and then the trailing form is not known to describe the result at
+            all. body_equality drops the value equality outright in that case;
+            these are dropped for the same reason.
+            """
+            if early_exits is None:
+                return
+            solver.add(axiom if reached_guard is None
+                       else z3.Implies(reached_guard, axiom))
 
         # What each early exit yields is $result on its own path.
         if early_exits:
@@ -3782,13 +3909,20 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     # would otherwise assert n != 0 for the path that did not.
                     before = len(translator.constraints)
                     value_z3 = translator.translate_expr(value)
-                    for constraint in translator.constraints[before:]:
+                    for offset, constraint in enumerate(translator.constraints[before:]):
                         guarded_constraint = z3.Implies(guard, constraint)
+                        if before + offset in translator.definedness_constraints:
+                            # Still asserted, because the postcondition solver
+                            # has always had it (#133) - but noted, so it is not
+                            # copied into the property solver as evidence.
+                            guarded_definedness.append(guarded_constraint)
                         solver.add(guarded_constraint)
                         # constraint_terms is what the inconsistency diagnosis
                         # replays; a condition only the solver knows about would
                         # come out as a verifier defect.
                         constraint_terms.append(guarded_constraint)
+                        constraint_is_obligation.append(
+                            before + offset in translator.definedness_constraints)
                     if value_z3 is None or value_z3.sort() != result_var.sort():
                         continue
                     exit_equality = z3.Implies(guard, result_var == value_z3)
@@ -3810,8 +3944,10 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         # Phase 2: Add reflexivity axioms for equality functions
         # For any function ending in -eq, add axiom: fn_eq(x, x) == true
-        # Include -eq functions from both postconditions AND body
-        eq_funcs = self._find_eq_function_calls(postconditions)
+        # Include -eq functions from the postconditions, the properties and the
+        # body; without the function's own reflexivity nothing knows that
+        # (foo-eq x x) holds.
+        eq_funcs = self._find_eq_function_calls(list(postconditions) + list(property_exprs))
         if fn_body is not None:
             eq_funcs = eq_funcs.union(self._find_eq_function_calls([fn_body]))
         for eq_fn in eq_funcs:
@@ -3870,11 +4006,11 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             return_expr = self._get_return_expr(fn_body)
             tag_axiom = self._extract_union_tag_axiom(return_expr, translator)
             if tag_axiom is not None:
-                solver.add(tag_axiom)
+                add_tail_axiom(tag_axiom)
             # Also add field axioms for record-new payloads
             field_axioms = self._extract_union_new_field_axioms(return_expr, translator)
             for axiom in field_axioms:
-                solver.add(axiom)
+                add_tail_axiom(axiom)
 
         # Phase 4.5: Add union constructor axioms for (ok result), (error e), etc.
         # For the final return, add UNCONDITIONAL axioms (tag == X, payload == value).
@@ -3882,46 +4018,100 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         if fn_body is not None and self._is_union_constructor(fn_body):
             constructor_axioms = self._extract_union_constructor_axioms(fn_body, translator)
             for axiom in constructor_axioms:
-                solver.add(axiom)
+                add_tail_axiom(axiom)
 
         # Phase 4.6: Add CONDITIONAL axioms for early return statements
         # For functions with multiple return paths like cax-dw:
         #   (return (some (record-new ...))) ... (none)
         # Add conditional axioms: tag == some => field_reason(...) == "..."
         # This allows Z3 to use the axioms when exploring the 'some' case.
+        #
+        # Conditional in the name only, until now: the tag an early return
+        # yields was asserted flat, so it described every path. That used to
+        # contradict the trailing form's own flat tag, which #115's guard caught
+        # as an inconsistent context - so guarding the tail (above) without
+        # guarding these would leave the early one standing alone and proving
+        # what only its path establishes.
         if fn_body is not None:
+            exit_guards = {id(value): guard
+                           for guard, value, *_ in (early_exits or [])
+                           if value is not None}
             all_returns = self._collect_all_return_exprs(fn_body)
             final_return = self._get_return_expr(fn_body)
+            # _collect_all_return_exprs also yields the arms of a trailing
+            # `match`. Those are not early exits and have no entry in
+            # early_exits; their own guards would be the match's arm conditions,
+            # which nothing here derives. Left as they were - asserted flat -
+            # rather than dropped, which would lose the facts every arm agrees
+            # on. Same family as #132.
+            trailing_arms = set()
+            if not is_form(final_return, 'return') and is_form(final_return, 'match') \
+                    and len(final_return) >= 3:
+                for branch in final_return.items[2:]:
+                    if isinstance(branch, SList) and len(branch) >= 2:
+                        trailing_arms.add(id(self._get_return_expr(branch[-1])))
+            def union_axioms_for(return_expr) -> List:
+                """The tag, payload and field facts one return path establishes."""
+                if not isinstance(return_expr, SList) or not return_expr.items:
+                    return []
+                head = return_expr[0]
+                if not isinstance(head, Symbol):
+                    return []
+                if head.name in {'ok', 'error', 'some', 'none'}:
+                    return list(self._extract_union_constructor_axioms_for_expr(
+                        return_expr, translator))
+                if head.name == 'union-new':
+                    found = []
+                    tag_axiom = self._extract_union_tag_axiom(return_expr, translator)
+                    if tag_axiom is not None:
+                        found.append(tag_axiom)
+                    found.extend(self._extract_union_new_field_axioms(return_expr, translator))
+                    return found
+                return []
+
             for return_expr in all_returns:
-                # Skip the final return (already handled by Phase 4.5)
-                if return_expr is final_return:
+                # Skip the final return (already handled by Phase 4.5), and the
+                # arms of a trailing match, which are dealt with together below.
+                if return_expr is final_return or id(return_expr) in trailing_arms:
                     continue
-                # Check if this return is a union constructor or union-new
-                if isinstance(return_expr, SList) and len(return_expr) >= 1:
-                    head = return_expr[0]
-                    if isinstance(head, Symbol):
-                        if head.name in {'ok', 'error', 'some', 'none'}:
-                            constructor_axioms = self._extract_union_constructor_axioms_for_expr(
-                                return_expr, translator
-                            )
-                            for axiom in constructor_axioms:
-                                solver.add(axiom)
-                        elif head.name == 'union-new':
-                            # Handle union-new returns from match branches
-                            tag_axiom = self._extract_union_tag_axiom(return_expr, translator)
-                            if tag_axiom is not None:
-                                solver.add(tag_axiom)
-                            field_axioms = self._extract_union_new_field_axioms(return_expr, translator)
-                            for axiom in field_axioms:
-                                solver.add(axiom)
+                exit_guard = exit_guards.get(id(return_expr))
+                if exit_guard is None:
+                    # An early return _early_exits could not guard. What it
+                    # yields is $result on some path, and nothing here can say
+                    # which.
+                    continue
+                for axiom in union_axioms_for(return_expr):
+                    solver.add(z3.Implies(exit_guard, axiom))
+
+            # A trailing match's arms are alternatives: what they establish holds
+            # as a disjunction, and asserting each conjunctively makes them
+            # contradict one another - one arm's `tag == a` against another's
+            # `tag == b`. Under a shared guard that is worse than useless, since
+            # Z3 concludes the guard is false and the tail unreachable, which
+            # proves whatever the early exits yield. Only what every arm agrees
+            # on describes the tail.
+            if trailing_arms:
+                per_arm = [union_axioms_for(r) for r in all_returns
+                           if id(r) in trailing_arms]
+                if per_arm:
+                    common = per_arm[0]
+                    for other in per_arm[1:]:
+                        elsewhere = {str(axiom) for axiom in other}
+                        common = [axiom for axiom in common
+                                  if str(axiom) in elsewhere]
+                    for axiom in common:
+                        add_tail_axiom(axiom)
 
         # Phase 4.7: Add match exhaustiveness constraints
         # For match postconditions like (match $result ((none) true) ((some r) cond)),
         # add constraint: union_tag($result) == none_tag OR union_tag($result) == some_tag
         # This prevents Z3 from finding counterexamples with invalid tag values.
-        if postconditions:
+        # Properties as well: `(match $result ...)` is as ordinary a shape for
+        # one as for a postcondition, and without this Z3 may answer with a tag
+        # no constructor produces.
+        if postconditions or property_exprs:
             exhaustiveness_constraints = self._extract_match_exhaustiveness_constraints(
-                postconditions, translator
+                list(postconditions) + list(property_exprs), translator
             )
             for constraint in exhaustiveness_constraints:
                 solver.add(constraint)
@@ -3938,6 +4128,9 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 if union_new_form is not None:
                     tag_axiom = self._extract_union_tag_axiom(union_new_form, translator)
                     if tag_axiom is not None:
+                        # Not a tail axiom: the (set! (deref v) (union-new ...))
+                        # this comes from runs before either exit, so the tag
+                        # holds whichever one the call takes.
                         solver.add(tag_axiom)
 
         # Phase 5: Add conditional record-new axioms
@@ -4040,8 +4233,9 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # Phase 12b: String operation axioms
         # Add semantic connections between string-concat, starts-with, and string-len.
         # Without these, Z3 treats them as uninterpreted functions with no relationships.
-        if fn_body is not None and postconditions:
-            string_axioms = self._generate_string_operation_axioms(fn_body, postconditions, translator)
+        if fn_body is not None and (postconditions or property_exprs):
+            string_axioms = self._generate_string_operation_axioms(
+                fn_body, list(postconditions) + list(property_exprs), translator)
             for axiom in string_axioms:
                 solver.add(axiom)
 
@@ -4230,6 +4424,12 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     if total_pushes > pattern_pushes:
                         has_unaxiomatized_pushes = True
 
+        # The body phases are done; what follows is about the postconditions
+        # themselves.
+        obligations = {str(axiom) for axiom in guarded_definedness}
+        body_axioms = [axiom for axiom in list(solver.assertions())[pre_mark:]
+                       if str(axiom) not in obligations]
+
         # Phase 15: Weakest Precondition Calculus
         # Use backward reasoning to generate stronger verification conditions.
         # WP(body, postcondition) computes what must be true before the body
@@ -4300,12 +4500,35 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     prop_solver = z3.Solver()
                     prop_solver.set("timeout", self.timeout_ms)
 
-                    # Add type constraints only (not preconditions)
-                    for c in translator.constraints:
+                    # The same constraint set the postcondition solver got -
+                    # type constraints with the tail's side conditions under the
+                    # guard that reaches them, and each early exit's under its
+                    # own. Not a fresh read of translator.constraints: the
+                    # phases below appended to it after this list was built, and
+                    # taking those live would assume unguarded what the solver
+                    # above asserts guarded.
+                    for j, c in enumerate(constraint_terms):
+                        # Not what the body is obliged to establish. A divisor
+                        # being non-zero is a proof obligation, not a fact, and
+                        # a universal property must not take it as given (#133)
+                        # - while the semantic facts beside it in the same list,
+                        # a string's length or a constructor's tag, are exactly
+                        # what a property about the result needs.
+                        #
+                        # Unless a trusted assumption raised it: `(@assume
+                        # (== (/ n n) 1))` is taken as given, and it cannot be
+                        # unless its own divisor is non-zero.
+                        if constraint_is_obligation[j]:
+                            continue
                         prop_solver.add(c)
 
-                    # Add assumptions (including loop invariants) as trusted axioms
-                    for a in assume_z3:
+                    # Add assumptions (including loop invariants) as trusted
+                    # axioms - but not a property propagated into one. That copy
+                    # is a claim restated about the returned local, so trusting
+                    # it here lets a property be proved from itself.
+                    for a, is_propagated in zip(assume_z3, assume_is_propagated):
+                        if is_propagated:
+                            continue
                         prop_solver.add(a)
 
                     # Equate $result sequence with the actual return variable's sequence
@@ -4315,6 +4538,14 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                         for equality in self._result_sequence_equality(
                                 fn_body, translator, contents_rewritten):
                             prop_solver.add(equality)
+
+                    # Everything the body establishes: the length of the list
+                    # it returns, the fields of the record it builds, the tag of
+                    # the constructor it applies. Without these a property could
+                    # only ever be as strong as the type constraints, so the
+                    # same claim verified as a @post and failed as a @property.
+                    for axiom in body_axioms:
+                        prop_solver.add(axiom)
 
                     # Add pattern axioms (filter/map/fold axioms derived from loop analysis)
                     # These are needed for properties that reason about collection contents
@@ -4349,11 +4580,15 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                     for axiom in imported_postcond_axioms:
                         prop_solver.add(axiom)
 
-                    # Add body constraint to connect $result to function body
-                    if body_z3 is not None:
-                        result_var = translator.variables.get('$result')
-                        if result_var is not None:
-                            prop_solver.add(result_var == body_z3)
+                    # Connect $result to the body - the same guarded
+                    # equalities the postcondition solver got, not a fresh
+                    # unconditional one. The trailing form is only $result on
+                    # the path that reaches it, and each early (return ...)
+                    # yields it on its own (#119); asserting `$result == body`
+                    # flat proved whatever the trailing form yields even for a
+                    # call that returned earlier.
+                    for equality in body_equality:
+                        prop_solver.add(equality)
 
                     prop_str = pretty_print(prop_expr)
 

--- a/src/slop/verifier/translator.py
+++ b/src/slop/verifier/translator.py
@@ -78,6 +78,12 @@ class Z3Translator:
         self._versions_frozen = False
         self._prefer_initial_versions = False
         self._prefer_final_versions = False
+        # Indices into `constraints` of the ones that are *obligations* rather
+        # than facts: a divisor being non-zero is something the code has to
+        # establish, not something a contract may assume. They sit in the same
+        # list as the semantic facts - a string's length, a constructor's tag -
+        # so anything wanting to tell the two apart reads this (#133).
+        self.definedness_constraints: set = set()
         self._final_version_names: set = set()
         self._declared_types: Dict[str, Any] = {}
         self._record_new_counter = 0  # Counter for unique record-new values
@@ -1534,7 +1540,15 @@ class Z3Translator:
 
         # Look up in variables
         if name in self.variables:
-            return self.variables[name]
+            bound = self.variables[name]
+            # A function declaration is not a value. `variables` holds user
+            # bindings and the verifier's own helpers in one namespace, so a
+            # name may have been claimed for an accessor since the binding was
+            # made. Handing that back leaves Z3 a declaration where a term
+            # belongs, which raises rather than answering.
+            if isinstance(bound, z3.FuncDeclRef):
+                return None
+            return bound
 
         # Try to look up type and create variable
         typ = self.type_env.lookup_var(name)
@@ -1696,12 +1710,12 @@ class Z3Translator:
         if op == '/':
             # Add constraint that divisor is non-zero
             if isinstance(right, z3.ArithRef):
-                self.constraints.append(right != 0)
+                self.add_definedness_constraint(right != 0)
             return left / right
         if op == '%':
             # Add constraint that divisor is non-zero
             if isinstance(right, z3.ArithRef):
-                self.constraints.append(right != 0)
+                self.add_definedness_constraint(right != 0)
             return left % right
 
         return None
@@ -1771,11 +1785,20 @@ class Z3Translator:
         is_bool_field = field_name.startswith('is-') or field_name.startswith('has-') or field_name in ('open', 'closed', 'valid', 'enabled', 'active')
         return_sort = z3.BoolSort() if is_bool_field else z3.IntSort()
 
-        if func_name not in self.variables:
+        func = self.variables.get(func_name)
+        if func is not None and not isinstance(func, z3.FuncDeclRef):
+            # The name is taken by a user binding - `variables` holds user
+            # variables and the verifier's own accessors in one namespace, so a
+            # local called `field_x` sits exactly where this wants to be.
+            # Calling it raises and takes the whole file down, so the accessor
+            # moves aside to a name no SLOP identifier can spell. Derived the
+            # same way every time, so every phase asking about this field gets
+            # the same function. Same reasoning as field_len_term above.
+            func_name = f"{func_name}!accessor"
+            func = self.variables.get(func_name)
+        if not isinstance(func, z3.FuncDeclRef):
             func = z3.Function(func_name, z3.IntSort(), return_sort)
             self.variables[func_name] = func
-        else:
-            func = self.variables[func_name]
 
         return func(obj)
 
@@ -2118,6 +2141,16 @@ class Z3Translator:
         value of the thing that replaced it.
         """
         return self._pre_loop_variables.get(name, self.variables.get(name))
+
+    def add_definedness_constraint(self, constraint) -> None:
+        """Record a constraint the code must establish, not one it may assume.
+
+        Kept apart from the semantic facts so a universal @property can be given
+        what the body *establishes* without also being handed what it is
+        obliged to prove.
+        """
+        self.definedness_constraints.add(len(self.constraints))
+        self.constraints.append(constraint)
 
     def constructor_tag(self, name: str) -> int:
         """The tag index for a union constructor, as `match` will read it.

--- a/src/slop/verifier/union_handling.py
+++ b/src/slop/verifier/union_handling.py
@@ -32,7 +32,12 @@ class UnionHandlingMixin:
         Handles do blocks by checking the return expression.
         """
         return_expr = self._get_return_expr(expr)
-        if not isinstance(return_expr, SList) or len(return_expr) < 2:
+        # One element is enough: `(none)` carries no payload, and its tag is as
+        # much a fact about the result as `(some x)`'s is. Requiring two meant
+        # Phase 4.5 skipped it, leaving the tag only in translator.constraints -
+        # where the postcondition solver picked it up and the property solver,
+        # which does not take the body's raw constraints, could not (#125).
+        if not isinstance(return_expr, SList) or not return_expr.items:
             return False
 
         head = return_expr[0]

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -10073,3 +10073,516 @@ class TestUnmodelledResultContents:
                   (while (< i n) (list-push r i) (set! i (+ i 1)))
                   r))))
         ''', filename="probe.slop")[0].status == 'failed'
+
+
+class TestPropertyAboutResult:
+    """Issue #125: a @property naming $result.
+
+    $result was declared only when a function had a @post or an @assume, so a
+    function carrying nothing but a @property had no such variable. Every
+    property mentioning it reported "Could not translate", which reads as a
+    verifier failure rather than as an unsupported form - and it meant the two
+    annotations disagreed about the same claim, one giving a verdict and the
+    other not getting far enough to be judged.
+
+    The body follows: it was translated only when there were postconditions, so
+    even with the name declared nothing connected it to what the function
+    returns.
+    """
+
+    @staticmethod
+    def _result(body):
+        from slop.verifier import verify_source
+        results = verify_source("(module m\n%s)\n" % body, filename="probe.slop")
+        assert len(results) == 1
+        return results[0]
+
+    def _status(self, body):
+        return self._result(body).status
+
+    LIST_FN = '''
+  (fn f ((arena Arena))
+    (@spec ((Arena) -> (List Int)))
+    (@alloc arena)
+    %s
+    (list-new arena Int))'''
+
+    def test_issue_125_repro_is_not_a_translation_failure(self):
+        """The issue's own probe. `unknown` is the honest answer - the pushes
+        are not modelled - but it has to be reached, not reported as an
+        untranslatable form."""
+        result = self._result('''
+  (fn h ((arena Arena) (n Int))
+    (@spec ((Arena Int) -> (List Int)))
+    (@alloc arena)
+    (@property one (>= (list-len $result) 1))
+    (let ((mut r (list-new arena Int))
+          (mut i 0))
+      (do (while (< i n) (list-push r i) (set! i (+ i 1))) r)))''')
+        assert result.status == 'unknown'
+        assert 'Could not translate' not in (result.message or '')
+
+    def test_the_two_annotations_agree(self):
+        """Whatever the verdict, a @property and the same claim as a @post
+        should reach it together."""
+        claims = ['(== (list-len $result) 0)',
+                  '(>= (list-len $result) 0)',
+                  '(== (list-len $result) 5)']
+        for claim in claims:
+            as_property = self._status(self.LIST_FN % ('(@property p %s)' % claim))
+            as_post = self._status(self.LIST_FN % ('(@post %s)' % claim))
+            assert as_property == as_post, (claim, as_property, as_post)
+
+    def test_a_true_length_property_verifies(self):
+        assert self._status(
+            self.LIST_FN % '(@property p (== (list-len $result) 0))') == 'verified'
+
+    def test_a_false_length_property_fails(self):
+        assert self._status(
+            self.LIST_FN % '(@property p (== (list-len $result) 5))') != 'verified'
+
+    def test_a_scalar_result_property(self):
+        assert self._status('''
+  (fn d ((n Int))
+    (@spec ((Int) -> Int))
+    (@property p (== $result 7))
+    7)''') == 'verified'
+        assert self._status('''
+  (fn e ((n Int))
+    (@spec ((Int) -> Int))
+    (@property p (== $result 8))
+    7)''') != 'verified'
+
+    def test_a_property_naming_no_result_still_works(self):
+        assert self._status('''
+  (fn a ((n (Int 0 .. 9)))
+    (@spec (((Int 0 .. 9)) -> Int))
+    (@property p (>= n 0))
+    1)''') == 'verified'
+
+    def test_an_early_return_is_another_path_to_the_result(self):
+        """The body equality has to be the guarded one the postcondition solver
+        uses. Asserting `$result == body` flat proves whatever the trailing form
+        yields even for a call that returned earlier (#119) - which nothing had
+        exercised on this path, because the property solver never had a body."""
+        assert self._status('''
+  (fn g ((flag Bool))
+    (@spec ((Bool) -> Int))
+    (@property p (== $result 7))
+    (do (when flag (return 3)) 7))''') != 'verified'
+
+    def test_a_side_condition_of_the_tail_travels_under_its_guard(self):
+        """`(/ 7 n)` asserts n != 0, and it does so only because the tail ran.
+        Assuming it flat proves a claim about a path the early return took."""
+        assert self._status('''
+  (fn s ((flag Bool) (n Int))
+    (@spec ((Bool Int) -> Int))
+    (@property p (implies flag (and (== $result 3) (!= n 0))))
+    (do (when flag (return 3)) (/ 7 n)))''') != 'verified'
+
+    def test_a_record_field_property(self):
+        """A property omits the preconditions, not what the body establishes.
+        The record's field axioms went to the postcondition solver alone, so
+        this claim verified as a @post and failed as a @property."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (type Pair (record (x Int)))
+  (fn r ((arena Arena) (n Int))
+    (@spec ((Arena Int) -> Pair))
+    (@alloc arena)
+    (@property p (== (. $result x) %s))
+    (record-new Pair (x n))))
+'''
+        assert verify_source(src % 'n', filename="probe.slop")[0].status == 'verified'
+        assert verify_source(src % '(+ n 1)', filename="probe.slop")[0].status != 'verified'
+
+    def test_an_equality_function_is_reflexive_for_a_property_too(self):
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn int-eq ((a Int) (b Int))
+    (@spec ((Int Int) -> Bool))
+    (== a b))
+  (fn f ((n Int))
+    (@spec ((Int) -> Int))
+    (@property p (int-eq $result $result))
+    n))
+'''
+        results = [r for r in verify_source(src, filename="probe.slop")
+                   if r.name == 'f']
+        assert results[0].status == 'verified'
+
+    def test_a_property_is_not_proved_from_its_own_propagated_invariant(self):
+        """With no explicit @loop-invariant, a @property is auto-propagated as
+        one, with the returned local's name in place of $result. Trusting that
+        copy while checking the property proves it from itself - and once the
+        body is translated, the local is tied to $result, so anything at all
+        would verify."""
+        assert self._status('''
+  (fn f ((arena Arena) (xs (List Int)))
+    (@spec ((Arena (List Int)) -> Int))
+    (@alloc arena)
+    (@property p (== $result 999))
+    (let ((mut result 0))
+      (for-each (x xs)
+        (set! result (+ result 1)))
+      result))''') != 'verified'
+
+    def test_the_trailing_constructor_does_not_speak_for_an_early_exit(self):
+        """The structural facts taken from the trailing form - its union tag,
+        its payload - hold only on the path that reaches it, exactly as the
+        value equality does. Both annotations, because both read the same
+        axioms (#132)."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn h ((flag Bool))
+    (@spec ((Bool) -> (Option Int)))
+    %s
+    (do (when flag (return %s)) (some 7))))
+'''
+        claim = "(match $result ((some v) (== v 7)) ((none) false))"
+        for annotation in ["(@post %s)" % claim, "(@property p %s)" % claim]:
+            for early in ["(some 1)", "(none)"]:
+                status = verify_source(src % (annotation, early),
+                                       filename="probe.slop")[0].status
+                assert status != 'verified', (annotation, early, status)
+
+    def test_a_return_the_analysis_cannot_guard_withholds_the_tail(self):
+        """`early_exits is None` means a return in a shape the guard analysis
+        does not model. The trailing form is then not known to describe the
+        result at all, so its facts are dropped rather than asserted flat."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn h ((flag Bool))
+    (@spec ((Bool) -> (Option Int)))
+    %s
+    (do (while flag (return (none))) (some 7))))
+'''
+        claim = "(match $result ((some v) (== v 7)) ((none) false))"
+        for annotation in ["(@post %s)" % claim, "(@property p %s)" % claim]:
+            status = verify_source(src % annotation, filename="probe.slop")[0].status
+            assert status != 'verified', (annotation, status)
+
+    def test_a_property_naming_no_result_does_not_get_the_body(self):
+        """Translating a body raises its own side conditions - here `n != 0`
+        for the division. A @post takes those as given (#133); a @property is
+        universal, so it must not."""
+        assert self._status('''
+  (fn f ((n Int))
+    (@spec ((Int) -> Int))
+    (@property p (!= n 0))
+    (/ 1 n))''') != 'verified'
+
+    def test_a_union_set_before_the_exits_still_describes_both(self):
+        """Phase 4.8's tag comes from a `set!` that dominates every exit, not
+        from the trailing form, so it is not one of the facts that travel under
+        the tail's guard."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (type Payload (record (v Int)))
+  (type Node (union (leaf Payload) (branch Payload)))
+  (fn build ((arena Arena) (flag Bool))
+    (@spec ((Arena Bool) -> (Ptr Node)))
+    (@alloc arena)
+    (@post (match (deref $result) ((leaf _) true) ((branch _) false)))
+    (let ((n (cast (Ptr Node) (arena-alloc arena (sizeof Node)))))
+      (set! (deref n) (union-new Node leaf (record-new Payload (v 1))))
+      (when flag (return n))
+      n)))
+'''
+        assert verify_source(src, filename="probe.slop")[0].status == 'verified'
+
+    def test_a_property_that_binds_the_name_is_not_about_the_result(self):
+        """`(forall ($result Int) ...)` talks about its own variable, and the
+        division's `n != 0` is not something a universal property may assume
+        however the name is spelled."""
+        assert self._status('''
+  (fn f ((n Int))
+    (@spec ((Int) -> Int))
+    (@property p (forall ($result Int) (!= n 0)))
+    (/ 1 n))''') != 'verified'
+
+    def test_a_free_result_inside_a_quantifier_still_counts(self):
+        """The source a quantifier ranges over is read in the outer scope, so
+        `(forall (v $result) ...)` is about the result after all."""
+        assert self._status('''
+  (fn g ((arena Arena))
+    (@spec ((Arena) -> (List Int)))
+    (@alloc arena)
+    (@property p (forall (v $result) (>= v 0)))
+    (list-new arena Int))''') == 'verified'
+
+    def test_a_sibling_property_does_not_hand_over_the_body(self):
+        """The body is translated once for the function. What it *establishes*
+        every property may use; the side conditions raised on the way are not
+        facts any of them may assume."""
+        assert self._status('''
+  (fn f ((n Int))
+    (@spec ((Int) -> Int))
+    (@property q (== $result $result))
+    (@property p (!= n 0))
+    (/ 1 n))''') != 'verified'
+
+    def test_the_quantifier_shorthand_binds_too(self):
+        """`(forall var body)` with no source to range over."""
+        assert self._status('''
+  (fn f ((n Int))
+    (@spec ((Int) -> Int))
+    (@property p (forall $result (!= n 0)))
+    (/ 1 n))''') != 'verified'
+
+    def test_a_property_keeps_the_constraints_it_raised_itself(self):
+        """Only the body's own side conditions are withheld. What translating
+        the property raised - a let binding's value, a constructor's tag - lands
+        after them and is the property's own."""
+        assert self._status('''
+  (fn f ((n Int))
+    (@spec ((Int) -> Int))
+    (@property p (let ((x 1)) (== x 1)))
+    n)''') == 'verified'
+
+    def test_an_early_returns_tag_describes_only_its_own_path(self):
+        """Phase 4.6 is named for conditional axioms but asserted them flat. That
+        used to contradict the trailing form's own flat tag, which #115's guard
+        reported as an inconsistent context - so guarding the tail without
+        guarding these would leave the early one standing alone."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (type Tag (union (a Int) (b Int)))
+  (fn pick ((flag Bool))
+    (@spec ((Bool) -> Tag))
+    %s
+    (do
+      (when flag (return (union-new Tag a 1)))
+      (union-new Tag b 2))))
+'''
+        only_a = "(match $result ((a _) true) ((b _) false))"
+        either = "(match $result ((a _) true) ((b _) true))"
+        for annotation in ["(@post %s)", "(@property p %s)"]:
+            assert verify_source(src % (annotation % only_a),
+                                 filename="probe.slop")[0].status != 'verified'
+            assert verify_source(src % (annotation % either),
+                                 filename="probe.slop")[0].status == 'verified'
+
+    def test_a_binding_of_the_name_is_not_a_use_of_it(self):
+        """A binding of the name is not a use of it, and either way the
+        division's side condition is not the property's to assume."""
+        for binding in ["(mut $result 1)", "($result 1)"]:
+            assert self._status('''
+  (fn f ((n Int))
+    (@spec ((Int) -> Int))
+    (@property p (let (%s) (!= n 0)))
+    (/ 1 n))''' % binding) != 'verified'
+
+    def test_a_binding_whose_value_is_the_result_does_count(self):
+        assert self._status('''
+  (fn g ((arena Arena))
+    (@spec ((Arena) -> (List Int)))
+    (@alloc arena)
+    (@property p (let ((x $result)) (== (list-len x) 0)))
+    (list-new arena Int))''') == 'verified'
+
+    def test_the_arms_of_a_trailing_match_are_not_early_exits(self):
+        """_collect_all_return_exprs also yields them, and they have no entry in
+        early_exits - their guards would be the arm conditions, which nothing
+        here derives. Dropping them would lose what every arm agrees on."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (type V (record (v Int)))
+  (type Tag (enum lo hi))
+  (fn pick ((arena Arena) (t Tag))
+    (@spec ((Arena Tag) -> (Option V)))
+    (@alloc arena)
+    (@post (match $result ((some r) {(. r v) == 9}) ((none) true)))
+    (match t
+      ('lo (some (record-new V (v 9))))
+      ('hi (some (record-new V (v 9)))))))
+'''
+        assert verify_source(src, filename="probe.slop")[0].status == 'verified'
+
+    def test_trailing_arms_that_disagree_contribute_nothing(self):
+        """Arms are alternatives: what they establish holds as a disjunction.
+        Asserting each conjunctively sets one arm's `tag == a` against another's
+        `tag == b`, and under a shared guard Z3 concludes the guard is false and
+        the tail unreachable - which proves whatever the early exit yields. On
+        `origin/main` the same function reports an inconsistent context."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (type Tag (union (a Int) (b Int)))
+  (type Sel (enum lo hi))
+  (fn pick ((flag Bool) (s Sel))
+    (@spec ((Bool Sel) -> Tag))
+    (@post (match $result ((a _) true) ((b _) false)))
+    (do
+      (when flag (return (union-new Tag a 1)))
+      (match s
+        ('lo (union-new Tag a 2))
+        ('hi (union-new Tag b 3))))))
+'''
+        assert verify_source(src, filename="probe.slop")[0].status == 'failed'
+
+    def test_a_payloadless_constructor_is_a_fact_about_the_result(self):
+        """`(none)` carries no payload, and _is_union_constructor wanted two
+        elements - so Phase 4.5 skipped it and its tag stayed in the raw body
+        constraints, which a property does not take."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn f ()
+    (@spec (() -> (Option Int)))
+    %s
+    %s))
+'''
+        claim = "(match $result ((none) true) ((some _) false))"
+        for annotation in ["(@post %s)" % claim, "(@property p %s)" % claim]:
+            assert verify_source(src % (annotation, "(none)"),
+                                 filename="probe.slop")[0].status == 'verified'
+            assert verify_source(src % (annotation, "(some 1)"),
+                                 filename="probe.slop")[0].status != 'verified'
+
+    def test_a_trusted_assumption_keeps_its_own_definedness(self):
+        """`(@assume (== (/ n n) 1))` is taken as given, and it cannot be unless
+        its divisor is non-zero. Only the obligations the *body* raises are
+        withheld."""
+        assert self._status('''
+  (fn f ((n Int))
+    (@spec ((Int) -> Int))
+    (@assume (== (/ n n) 1))
+    (@property p (!= n 0))
+    n)''') == 'verified'
+        assert self._status('''
+  (fn g ((n Int))
+    (@spec ((Int) -> Int))
+    (@property p (!= n 0))
+    (/ 1 n))''') != 'verified'
+
+    def test_a_property_cannot_name_a_body_local(self):
+        """Contracts speak about parameters and the result. Postconditions
+        already translate with the locals put away; once the body is translated
+        for a property-only function, its locals exist and properties need the
+        same treatment."""
+        assert self._status('''
+  (fn f ()
+    (@spec (() -> Int))
+    (@property p (== x 1))
+    (let ((x 1)) x))''') != 'verified'
+
+    def test_an_early_exits_definedness_is_not_evidence(self):
+        """The obligation is guarded with that exit and still asserted, because
+        the postcondition solver has always had it (#133) - but it must not
+        reach a universal property through the body axioms."""
+        assert self._status('''
+  (fn g ((flag Bool) (n Int))
+    (@spec ((Bool Int) -> Int))
+    (@property p (implies flag (!= n 0)))
+    (do (when flag (return (/ 1 n))) 7))''') != 'verified'
+
+    def test_a_local_shadowing_a_parameter_leaves_the_parameter(self):
+        """Putting the locals away must put the outer value back, or a property
+        naming a parameter the body happens to shadow cannot be translated."""
+        assert self._status('''
+  (fn f ((x Int))
+    (@spec ((Int) -> Int))
+    (@property p (== x x))
+    (let ((x 1)) x))''') == 'verified'
+
+    def test_a_property_binding_does_not_outlive_it(self):
+        """`translate_expr` writes into the translator's one namespace, and the
+        next property, the body equality and every axiom phase read the same
+        dict. What a property binds is the property's."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn f ()
+    (@spec (() -> Int))
+    (@property p (let (($result 1)) true))
+    7))
+'''
+        # Whatever the verdict, `$result == 1` must not have leaked into it.
+        assert verify_source(src, filename="probe.slop")[0].status in {
+            'verified', 'failed', 'unknown'}
+
+    def test_a_local_named_like_a_helper_does_not_take_it_down(self):
+        """`variables` holds user bindings and the verifier's own helpers in one
+        namespace, so a local can land where a phase expects something
+        callable."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn int-eq ((a Int) (b Int))
+    (@spec ((Int Int) -> Bool))
+    (== a b))
+  (fn f ((n Int))
+    (@spec ((Int) -> Int))
+    (@property p (int-eq $result $result))
+    (let ((fn_int-eq_2 n)) fn_int-eq_2)))
+'''
+        results = [r for r in verify_source(src, filename="probe.slop")
+                   if r.name == 'f']
+        assert results[0].status in {'verified', 'failed', 'unknown'}
+
+    def test_a_local_named_like_an_accessor_does_not_take_it_down(self):
+        """Translating the property may claim `field_x` for the record
+        accessor. Restoring a local of that name over it leaves the phases below
+        calling an ArithRef."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (type R (record (x Int)))
+  (fn g ((arena Arena) (n Int))
+    (@spec ((Arena Int) -> R))
+    (@alloc arena)
+    (@property p (== (. $result x) n))
+    (let ((field_x n)) (record-new R (x field_x)))))
+'''
+        # The verdict is not the point - not raising is.
+        assert verify_source(src, filename="probe.slop")[0].status in {
+            'verified', 'failed', 'unknown'}
+
+    def test_a_trailing_arm_does_not_speak_for_an_earlier_return(self):
+        """The arms of a trailing match run only if no early return fired, so
+        what they agree on holds under the tail's guard, not flat."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (type V (record (v Int)))
+  (type Tag (enum lo hi))
+  (fn pick ((arena Arena) (t Tag) (flag Bool))
+    (@spec ((Arena Tag Bool) -> (Option V)))
+    (@alloc arena)
+    (@post (match $result ((some r) {(. r v) == 7}) ((none) true)))
+    (do
+      (when flag (return (some (record-new V (v 1)))))
+      (match t
+        ('lo (some (record-new V (v 7))))
+        ('hi (some (record-new V (v 7))))))))
+'''
+        assert verify_source(src, filename="probe.slop")[0].status != 'verified'
+
+    def test_a_sibling_propertys_side_conditions_stay_its_own(self):
+        """One property's division must not tell another that the divisor is
+        non-zero. They are facts at all only because of #133."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn f ((n Int))
+    (@spec ((Int) -> Int))
+    (@property a (== (/ 1 n) (/ 1 n)))
+    (@property b (!= n 0))
+    n))
+'''
+        assert verify_source(src, filename="probe.slop")[0].status != 'verified'
+
+    def test_an_early_return_that_satisfies_the_property_too(self):
+        assert self._status('''
+  (fn h ((flag Bool))
+    (@spec ((Bool) -> Int))
+    (@property p (>= $result 3))
+    (do (when flag (return 3)) 7))''') == 'verified'


### PR DESCRIPTION
Closes #125.

## The bug

`$result` was declared for postconditions and assumptions:

```python
if postconditions or assumptions:
    translator.declare_variable('$result', spec_return_type)
```

so a function carrying nothing but a `@property` had no such variable.
`translate_expr` answered `None` for the name and every property mentioning it
reported **"Could not translate"** — which reads as a verifier failure rather
than as an unsupported form. Adding a `@post` that says nothing about the result
was enough to make the same property translate, which is how the gate was found.

## Why it did not stop there

Declaring the name is not sufficient. Four more places read `postconditions`
where they meant *a contract about the result*: the body translation, the array
encoding choice, the `-eq` reflexivity axioms and the match exhaustiveness
constraints. Until each of those included properties, a property as simple as
`(== $result 7)` on a body of `7` still failed.

The property solver already wired the body equality up — it just never had a body
to wire. It did so **unconditionally**, though, and that is the shape #119 fixed
for postconditions: the trailing form is only `$result` on the path that reaches
it, and each early `(return ...)` yields it on its own. Nothing had exercised that
here because `body_z3` was always `None`; making it available would have opened
the hole. It now takes the same guarded equalities the postcondition solver gets.
Reverting that one change makes a property of `(== $result 7)` verify for a
function that can return `3`.

## What a property is allowed to assume

A `@property` omits the **preconditions** — that is what makes it universal rather
than conditional. Not what the body establishes, so the property solver now
carries the body-derived axioms too, and the same claim no longer verifies as a
`@post` and fails as a `@property`.

Three things it may *not* assume, all found by review:

- **Its own propagated loop invariant.** With no explicit `@loop-invariant`, a
  `@property` is auto-propagated as one, restated with the returned local's name
  in place of `$result`. Trusting that copy while checking that property proves it
  from itself — once the body ties the local to `$result`, *anything at all*
  verifies. A counting loop verified `(@property p (== $result 999))`.
- **What the body is *obliged* to establish.** `(/ 1 n)` appends `n != 0` to
  `translator.constraints`, and from there it reaches the solver as a fact — so
  `(@property p (!= n 0))` verified for an unconstrained `n`. A `@post` takes
  these as given (#133); a universal property must not.

  That list mixes two kinds of thing, though: `n != 0` is an obligation, while
  `string_len("abc") == 3` and `union_tag($result) == none` beside it are facts a
  property about the result genuinely needs. Excluding the body's whole span
  dropped both, and three review rounds went to that — a `(none)` body, a string
  literal, a conditional union. So the translator now marks the obligations as it
  raises them (`add_definedness_constraint`), and the property solver excludes
  exactly those. #133 gets a handle out of it: deciding to *check* definedness
  rather than assume it is now a question about a set that exists.

## Guards on facts taken from an exit

Making the body reachable from a second direction exposed three phases that
assert structural facts with no guard at all, and fixing them **also fixes
pre-existing `@post` false-verifies**:

| fact | was | now |
|---|---|---|
| the trailing form's union tag and payload (Phases 4, 4.5) | flat, so it described every exit | under `reached_guard` |
| an early return's tag — Phase 4.6, "CONDITIONAL" in the comment only | flat, so it described the tail too | under that exit's own guard |
| the arms of a trailing `match` | each asserted flat | only what **every arm agrees on**, under `reached_guard` |
| any of the above, when `_early_exits` returned `None` | asserted, though nothing knows what `$result` is | dropped |

The trailing-`match` row is the subtle one. Arms are *alternatives*, so what they
establish holds as a disjunction; asserting each conjunctively sets one arm's
`tag == a` against another's `tag == b`. Flat, that is a contradiction #115's
guard catches — `origin/main` reports such a function `unknown`. Under a shared
guard it is worse: Z3 concludes the guard is false, the tail is unreachable, and
whatever the early exits yield is proved. Intersecting the arms leaves the facts
they agree on and nothing else, and the function reports `failed` with a real
counterexample.

One property's side conditions are its own, too: a `@property` containing a
division must not tell a sibling `(!= n 0)` that the divisor is non-zero.

Phase 4.8 stays unguarded on purpose: its `(set! (deref v) (union-new ...))` runs
before either exit, so the tag holds whichever one the call takes.

The 4.6 case is worth naming. On `origin/main` a function returning tag `a` early
and tag `b` at the tail reports **`unknown` — inconsistent axioms**, because the
two flat tags contradict each other and #115's guard catches it. Guarding the tail
without guarding the early return would have left the early one standing alone and
proving what only its path establishes.

## Result

| | before | after |
|---|---|---|
| `uv run pytest` | 728 passed | **752 passed** |
| howl `slop verify` | 31 verified, 0 failed | 31 verified, 0 failed |
| snarl `slop verify` | 58 verified, 22 failed | **57** verified, 22 failed |

The snarl contract is `check-closed`, whose two `@property` annotations were being
proved from their own propagated copies. Its source already carries the author's
note: `;; VERIFIER: fails — term-eq lacks equality axiom; path-predicate
destructure not supported in contracts`. It now reports `unknown`, which is what
that comment says it should.

End state for the issue's probe: `unknown` rather than "Could not translate",
matching what the equivalent `@post` reports under #69's gate. The two annotations
agree on every claim tested.

## Two guards for a shared namespace

`translator.variables` holds user bindings and the verifier's own helpers in one
dict. Translating the body for a property-only function makes that collide in
ways nothing had reached before — a body local called `field_x` sitting where the
record accessor wants to be, a property's `let` outliving the property. Two
defensive changes, both following the pattern `field_len_term` already set:

- an accessor whose name is taken moves aside to `field_{name}!accessor`,
  derived the same way every time so every phase agrees;
- `_translate_symbol` answers `None` for a name bound to a `FuncDeclRef` rather
  than handing Z3 a declaration where a term belongs.

Each property is also translated with the namespace rolled back afterwards —
bindings dropped, declarations kept, since a phase below may need the
`fn_foo-eq_2` a property caused to exist.

## Filed along the way

- **#130** — only the last form of a multi-form body is translated, so a loop or a
  `@loop-invariant` in an earlier form never applies. The identical code wrapped in
  one `(do ...)` verifies.
- **#132** — a side condition from an early return is guarded with the *trailing*
  path's condition. Two comments added: the same root cause reaches structural
  axioms, and now that the tail is guarded the two halves (`!flag => n != 0` and
  `flag => n != 0`) **combine** into the unguarded fact.
- **#133** — a side condition raised by the body is asserted as a fact, so a
  `@post` restating it verifies for free. This is why properties are kept away
  from the body unless they need it.

- **#134** — a callee's `@post` is propagated into the caller without its `@pre`,
  so a caller can rely on a promise the call does not earn.
- **#135** — a local named like a verifier helper (`union_tag`, `string_len`)
  aborts verification of the whole file with a `TypeError`. The two guards above
  cover the `field_*` half; the issue proposes one accessor for all of them.

All five reproduce on `origin/main` and are untouched here. Review also produced a
smaller, *live* repro for **#118**, which the milestone already carries: a local
shadowing a **parameter** shares its Z3 constant, so `(@post (== x 1))` verifies
for an unconstrained `x` given a body of `(let ((x 1)) x)`. The issue described
itself as latent; it is not. Commented there, and left alone here — alpha-renaming
is what fixes it, and that is #118's PR.

## Review

Twenty-four `codex exec review` rounds. Twelve found real defects in this change — the
unguarded body equality, the self-proving propagated invariant, the unguarded tail
axioms, the unguarded early-return axioms, side conditions leaking between sibling
properties, body side conditions reaching a property at all, a regression where
guarding the early returns dropped the arms of a trailing `match` along with them,
the arms contradicting one another under a shared guard, a payload-less `(none)`
not counting as a constructor, body locals reaching properties, and an early
exit's definedness obligation arriving as evidence. Each is now a test, positive
or negative.

Two of them collapsed machinery rather than adding it. Excluding body side
conditions outright left the scope analysis built to keep them away from
`$result`-free properties with nothing to do — about 70 lines out, along with the
four findings its edge cases had generated. Marking definedness constraints at
their source then subsumed both the span exclusion and the per-property
isolation, and those came out too. The tests they prompted stayed, since they pin
behaviour rather than mechanism.

The rest bottomed out in #132 and #133, which affect `@post` identically and are
filed with repros.
