### PR TITLE
give a shadowing let binding a constant of its own (#118)

### DIFF
--- a/src/slop/verifier/contract_verifier.py
+++ b/src/slop/verifier/contract_verifier.py
@@ -13,6 +13,7 @@ functionality:
 """
 from __future__ import annotations
 
+from contextlib import ExitStack
 from typing import Dict, List, Optional, Set, Tuple, Any, TYPE_CHECKING
 
 from slop.parser import SList, Symbol, String, Number, is_form
@@ -546,7 +547,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         axioms: list = []
 
         # Collect all string-concat calls from body
-        concat_calls: List[SList] = []
+        concat_calls: List[Tuple[SList, List]] = []
         self._collect_string_concat_calls(fn_body, concat_calls)
 
         if not concat_calls and not self._postconditions_use_string_ops(postconditions):
@@ -569,16 +570,19 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             sl_func = translator.variables[sl_key]
 
         # For each string-concat call, add ground axioms
-        for concat_call in concat_calls:
+        for concat_call, concat_scope in concat_calls:
             if len(concat_call) < 4:
                 continue
 
             first_arg = concat_call[2]   # a in (string-concat arena a b)
             second_arg = concat_call[3]  # b
 
-            concat_z3 = translator.translate_expr(concat_call)
-            first_z3 = translator.translate_expr(first_arg)
-            second_z3 = translator.translate_expr(second_arg)
+            with ExitStack() as scope:
+                for binding, name in concat_scope:
+                    scope.enter_context(translator.binding_in_scope(binding, name))
+                concat_z3 = translator.translate_expr(concat_call)
+                first_z3 = translator.translate_expr(first_arg)
+                second_z3 = translator.translate_expr(second_arg)
 
             if concat_z3 is None or first_z3 is None:
                 continue
@@ -626,12 +630,15 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # Axiom 5: Transitivity — starts-with(a, prefix) → starts-with(concat(arena, a, ...), prefix)
         # For each concat call and each prefix used in postcondition starts-with calls
         post_prefixes = self._extract_starts_with_prefix_z3(postconditions, translator)
-        for concat_call in concat_calls:
+        for concat_call, concat_scope in concat_calls:
             if len(concat_call) < 4:
                 continue
             first_arg = concat_call[2]
-            first_z3 = translator.translate_expr(first_arg)
-            concat_z3 = translator.translate_expr(concat_call)
+            with ExitStack() as scope:
+                for binding, name in concat_scope:
+                    scope.enter_context(translator.binding_in_scope(binding, name))
+                first_z3 = translator.translate_expr(first_arg)
+                concat_z3 = translator.translate_expr(concat_call)
             if first_z3 is None or concat_z3 is None:
                 continue
             for prefix_z3 in post_prefixes:
@@ -644,17 +651,42 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
         return axioms
 
-    def _collect_string_concat_calls(self, expr: SExpr, result: List):
-        """Recursively collect all (string-concat ...) call expressions from AST."""
+    def _collect_string_concat_calls(self, expr: SExpr, result: List,
+                                     enclosing: Optional[List] = None):
+        """Recursively collect all (string-concat ...) call expressions from AST.
+
+        Each is paired with the `let` bindings it sits inside. The axioms are
+        generated long after the body was translated, when a shadowing scope has
+        been put away, so an operand naming one of its locals would otherwise be
+        read as whatever that local shadowed (#118).
+        """
+        if enclosing is None:
+            enclosing = []
         if not isinstance(expr, SList) or len(expr) == 0:
             return
         head = expr[0]
         if isinstance(head, Symbol) and head.name == 'string-concat' and len(expr) >= 4:
-            result.append(expr)
+            result.append((expr, list(enclosing)))
+        if is_form(expr, 'let') and len(expr) >= 3 and isinstance(expr[1], SList):
+            # An initializer runs before its own binding exists.
+            inner = list(enclosing)
+            for binding in expr[1].items:
+                if not (isinstance(binding, SList) and len(binding) >= 2):
+                    continue
+                for item in binding.items[1:]:
+                    if isinstance(item, SList):
+                        self._collect_string_concat_calls(item, result, inner)
+                name = self._binding_name(binding)
+                if name:
+                    inner.append((binding, name))
+            for item in expr.items[2:]:
+                if isinstance(item, SList):
+                    self._collect_string_concat_calls(item, result, inner)
+            return
         # Recurse into subexpressions
         for item in expr.items:
             if isinstance(item, SList):
-                self._collect_string_concat_calls(item, result)
+                self._collect_string_concat_calls(item, result, enclosing)
 
     def _collect_string_literals(self, expr: SExpr, result: List[str]):
         """Recursively collect all string literal values from AST."""
@@ -733,8 +765,47 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         self._collect_call_postconditions(body, translator, axioms)
         return axioms
 
-    def _collect_call_postconditions(self, expr: SExpr, translator: Z3Translator, axioms: List):
-        """Recursively collect postcondition axioms from let-bound function calls."""
+    def _walk_scope_body(self, items, translator: Z3Translator, axioms: List,
+                         enclosing: List, assigned: Optional[Set[str]] = None):
+        """Walk a statement sequence, keeping track of what has been assigned.
+
+        The enclosing bindings are put back for each statement, but only as they
+        stood *there*: a call before a `set!` to the same name reads the value
+        the binding was given, and one after it reads a value this pass cannot
+        pin down. Ordering within the sequence is the only program point
+        available, and it is enough to tell those two apart (#118).
+        """
+        assigned = set(assigned or ())
+        for item in items:
+            with ExitStack() as scope:
+                for binding, name in enclosing:
+                    scope.enter_context(translator.binding_in_scope(
+                        binding, name,
+                        final=name in assigned,
+                        after_assignment=name in assigned))
+                self._collect_call_postconditions(item, translator, axioms,
+                                                  enclosing, assigned)
+            written: Dict[str, List] = {}
+            translator._collect_assignments([item], written)
+            assigned.update(written)
+
+    def _collect_call_postconditions(self, expr: SExpr, translator: Z3Translator,
+                                     axioms: List, enclosing: Optional[List] = None,
+                                     assigned: Optional[Set[str]] = None):
+        """Recursively collect postcondition axioms from let-bound function calls.
+
+        `enclosing` is the `let` bindings this expression sits inside, innermost
+        last. This walk happens long after the body was translated, when
+        `variables` holds whatever was in scope at the end of it - so the scope
+        is rebuilt as the walk descends (#118).
+
+        `assigned` is what those scopes have assigned by the time this
+        expression runs. A nested `let` inherits it: entering one does not undo
+        a `set!` that happened before it.
+        """
+        if enclosing is None:
+            enclosing = []
+        assigned = set(assigned or ())
         if not isinstance(expr, SList) or len(expr) < 1:
             return
 
@@ -756,39 +827,70 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # Handle let expressions
         if head.name == 'let' and len(expr) >= 3:
             bindings = expr[1]
+            # The body runs inside these bindings' scope, and so does each
+            # binding after the first: a call there may take an argument naming
+            # an earlier one, and a `set!` may target one. This walk happens
+            # long after the body was translated, when `variables` holds
+            # whatever was in scope at the *end* - so the scope is rebuilt as
+            # the walk descends (#118).
+            inner = list(enclosing)
             if isinstance(bindings, SList):
                 for binding in bindings.items:
-                    self._process_let_binding(binding, translator, axioms)
-            # Recurse into body expressions
-            for body_expr in expr.items[2:]:
-                self._collect_call_postconditions(body_expr, translator, axioms)
+                    # Each initializer is read where it is: inside the bindings
+                    # before it, and past whatever those assigned.
+                    with ExitStack() as so_far:
+                        for b, n in inner:
+                            so_far.enter_context(translator.binding_in_scope(
+                                b, n, final=n in assigned,
+                                after_assignment=n in assigned))
+                        self._process_let_binding(binding, translator, axioms)
+                    written: Dict[str, List] = {}
+                    translator._collect_assignments([binding], written)
+                    assigned.update(written)
+                    if not (isinstance(binding, SList) and len(binding) >= 2):
+                        continue
+                    name = self._binding_name(binding)
+                    if name:
+                        inner.append((binding, name))
+                        assigned.discard(name)
+            self._walk_scope_body(expr.items[2:], translator, axioms, inner, assigned)
 
         # Handle set! expressions: (set! var (fn-call ...))
         elif head.name == 'set!' and len(expr) >= 3:
             var_sym = expr[1]
             value_expr = expr[2]
             if isinstance(var_sym, Symbol) and isinstance(value_expr, SList):
-                self._process_set_binding(var_sym.name, value_expr, translator, axioms)
+                # What the assignment produces is the name's *later* version, so
+                # this one wants the end-of-scope value rather than the binding's
+                # initial one. Only the target: the arguments are read where the
+                # assignment is.
+                target = None
+                for binding, name in reversed(enclosing):
+                    if name == var_sym.name:
+                        target = binding
+                        break
+                with ExitStack() as assigned:
+                    if target is not None:
+                        assigned.enter_context(translator.binding_in_scope(
+                            target, var_sym.name, final=True))
+                    self._process_set_binding(var_sym.name, value_expr, translator, axioms)
 
         # Handle do blocks
         elif head.name == 'do':
-            for item in expr.items[1:]:
-                self._collect_call_postconditions(item, translator, axioms)
+            self._walk_scope_body(expr.items[1:], translator, axioms, enclosing, assigned)
 
         # Handle for-each loops
         elif head.name == 'for-each' and len(expr) >= 3:
-            for item in expr.items[2:]:
-                self._collect_call_postconditions(item, translator, axioms)
+            self._walk_scope_body(expr.items[2:], translator, axioms, enclosing, assigned)
 
         # Handle if expressions
         elif head.name == 'if':
             for item in expr.items[2:]:
-                self._collect_call_postconditions(item, translator, axioms)
+                self._walk_scope_body([item], translator, axioms, enclosing, assigned)
 
         # Handle when expressions
         elif head.name == 'when' and len(expr) >= 3:
-            for item in expr.items[2:]:
-                self._collect_call_postconditions(item, translator, axioms)
+            self._walk_scope_body(expr.items[2:], translator, axioms, enclosing, assigned)
 
         # Handle match expressions - recurse into arm bodies
         # This enables postcondition propagation for dispatch functions like:
@@ -798,14 +900,16 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             for clause in expr.items[2:]:
                 if isinstance(clause, SList) and len(clause) >= 2:
                     arm_body = clause[-1]
-                    self._collect_call_postconditions(arm_body, translator, axioms)
+                    self._collect_call_postconditions(arm_body, translator, axioms,
+                                                      enclosing, assigned)
 
         # Handle cond expressions - recurse into branch bodies
         elif head.name == 'cond':
             for clause in expr.items[1:]:
                 if isinstance(clause, SList) and len(clause) >= 2:
                     arm_body = clause[-1]
-                    self._collect_call_postconditions(arm_body, translator, axioms)
+                    self._collect_call_postconditions(arm_body, translator, axioms,
+                                                      enclosing, assigned)
 
     def _process_let_binding(self, binding: SExpr, translator: Z3Translator, axioms: List):
         """Process a single let binding, extracting postcondition axioms if it's a function call.
@@ -850,7 +954,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # Add axiom: var == init_expr
         if not isinstance(init_expr, SList) or len(init_expr) < 1:
             # Simple value binding (number, symbol)
-            self._add_binding_axiom(var_name, init_expr, translator, axioms)
+            self._add_binding_axiom(var_name, init_expr, translator, axioms, binding)
             return
 
         # Check if init_expr is a function call
@@ -865,7 +969,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         operators = {'+', '-', '*', '/', 'mod', '.', 'and', 'or', 'not',
                      '==', '!=', '<', '<=', '>', '>='}
         if fn_name in operators:
-            self._add_binding_axiom(var_name, init_expr, translator, axioms)
+            self._add_binding_axiom(var_name, init_expr, translator, axioms, binding)
             return
 
         # Check local functions first
@@ -887,8 +991,13 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                 params = imported_sig.params
 
         if not postconditions:
-            # Handle built-in functions with known semantics
-            self._add_builtin_function_axioms(var_name, fn_name, init_expr, translator, axioms)
+            # Handle built-in functions with known semantics. The *result* takes
+            # this binding's constant; the arguments beside it are read where
+            # the call is, outside the new binding - `(let ((x (make-triple
+            # arena s x o))) ...)` passes the outer x (#118).
+            self._add_builtin_function_axioms(
+                var_name, fn_name, init_expr, translator, axioms,
+                translator.binding_constant(binding, var_name))
             return
 
         # Get the actual arguments to the function call
@@ -898,10 +1007,41 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         if len(call_args) != len(params):
             return
 
-        # For each postcondition, substitute $result and parameters, then translate
+        # For each postcondition, substitute $result and parameters, then
+        # translate. $result becomes the bound *name*, so the translation has to
+        # happen with that name meaning this binding - after a shadowing scope
+        # ends it means whatever it shadowed (#118).
+        # $result becomes the bound *name*, so the translation has to happen with
+        # that name meaning this binding - after a shadowing scope ends it means
+        # whatever it shadowed (#118). The arguments are substituted in too, and
+        # they are read where the *call* is, outside the new binding: for
+        # `(let ((x (relay x))) ...)` the argument is the outer x, and binding
+        # both would make the axiom the tautology `x_local == x_local`. So the
+        # arguments go in first, in the outer scope, and only what is left -
+        # $result - is translated inside.
+        result_z3 = translator.binding_constant(binding, var_name)
         for post in postconditions:
-            subst_post = self._substitute_postcondition(post, var_name, params, call_args)
-            z3_axiom = translator.translate_expr(subst_post)
+            # $result is left as $result and bound to this binding's constant,
+            # rather than substituted with the bound *name*. The name would be
+            # read wherever the translation happens, and after a shadowing scope
+            # ends it means whatever it shadowed - while the arguments beside it
+            # are read where the *call* is. For `(let ((x (relay x))) ...)` the
+            # two are different values, and substituting the name for both made
+            # the axiom the tautology `x_local == x_local` (#118).
+            subst_post = self._substitute_postcondition(
+                post, '$result', params, call_args)
+            had = '$result' in translator.variables
+            outer_result = translator.variables.get('$result')
+            if result_z3 is not None:
+                translator.variables['$result'] = result_z3
+            try:
+                z3_axiom = translator.translate_expr(subst_post)
+            finally:
+                if result_z3 is not None:
+                    if had:
+                        translator.variables['$result'] = outer_result
+                    else:
+                        translator.variables.pop('$result', None)
             if z3_axiom is not None:
                 axioms.append(z3_axiom)
 
@@ -949,7 +1089,8 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
                        for item in expr.items)
         return False
 
-    def _add_binding_axiom(self, var_name: str, expr: SExpr, translator: Z3Translator, axioms: List):
+    def _add_binding_axiom(self, var_name: str, expr: SExpr, translator: Z3Translator,
+                           axioms: List, binding: Optional[SExpr] = None):
         """Add axiom: var == expr for simple let bindings.
 
         This enables tracking of computed values like:
@@ -964,7 +1105,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         # The constant the name held before any loop reassigned it: this is the
         # binding's *initial* value, and after a loop `variables` holds the
         # version the loop produced instead (issue #116).
-        var_z3 = translator.initial_variable(var_name)
+        var_z3 = translator.binding_constant(binding, var_name)
         if var_z3 is None:
             return
 
@@ -982,7 +1123,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
 
     def _add_builtin_function_axioms(self, var_name: str, fn_name: str,
                                       call_expr: SList, translator: Z3Translator,
-                                      axioms: List):
+                                      axioms: List, result_z3=None):
         """Add axioms for built-in functions with known semantics.
 
         For make-triple: field_predicate(var) == predicate_arg
@@ -994,7 +1135,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             if var_name not in translator.variables:
                 translator.declare_variable(var_name, PrimitiveType('Int'))
 
-            var_z3 = translator.variables.get(var_name)
+            var_z3 = result_z3 if result_z3 is not None else translator.variables.get(var_name)
             if var_z3 is None:
                 return
 
@@ -1020,7 +1161,7 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
             if var_name not in translator.variables:
                 translator.declare_variable(var_name, PrimitiveType('Int'))
 
-            var_z3 = translator.variables.get(var_name)
+            var_z3 = result_z3 if result_z3 is not None else translator.variables.get(var_name)
             if var_z3 is None:
                 return
 
@@ -3592,7 +3733,13 @@ class ContractVerifier(PatternDetectionMixin, AxiomGenerationMixin,
         assume_is_propagated: List[bool] = []
         failed_assumes: List[SExpr] = []
         for assume_index, assume in enumerate(assumptions):
-            z3_assume = translator.translate_expr(assume)
+            # A @loop-invariant may be written about a local that shadows a
+            # parameter, and this runs long after that scope ended (#118).
+            with ExitStack() as invariant_scope:
+                for binding, name in self.invariant_scope(assume):
+                    invariant_scope.enter_context(
+                        translator.binding_in_scope(binding, name, final=True))
+                z3_assume = translator.translate_expr(assume)
             if z3_assume is not None:
                 assume_z3.append(self._ensure_bool(z3_assume))
                 assume_is_propagated.append(assume_index in propagated_range)

--- a/src/slop/verifier/loop_analysis.py
+++ b/src/slop/verifier/loop_analysis.py
@@ -29,21 +29,54 @@ class LoopAnalysisMixin:
         and collects the invariant conditions.
         """
         result: List[SExpr] = []
+        self._invariant_scopes: Dict[int, List] = {}
         self._collect_loop_invariants(expr, result)
         return result
 
-    def _collect_loop_invariants(self, expr: SExpr, result: List[SExpr]):
-        """Recursively collect @loop-invariant conditions from expressions"""
+    def invariant_scope(self, invariant: SExpr) -> List:
+        """The `let` bindings an invariant was written inside, innermost last."""
+        return getattr(self, '_invariant_scopes', {}).get(id(invariant), [])
+
+    def _collect_loop_invariants(self, expr: SExpr, result: List[SExpr],
+                                 enclosing: Optional[List] = None):
+        """Recursively collect @loop-invariant conditions from expressions.
+
+        `enclosing` accumulates the (binding, name) pairs of the `let` scopes an
+        invariant sits inside. An invariant may be written about a local that
+        shadows a parameter, and it is translated long after that scope ended -
+        so where it came from has to travel with it (#118).
+        """
+        if enclosing is None:
+            enclosing = []
+        if not hasattr(self, '_invariant_scopes'):
+            self._invariant_scopes = {}
         if isinstance(expr, SList) and len(expr) > 0:
             head = expr[0]
             if isinstance(head, Symbol):
                 # Check for @loop-invariant annotation
                 if head.name == '@loop-invariant' and len(expr) >= 2:
                     result.append(expr[1])
+                    self._invariant_scopes[id(expr[1])] = list(enclosing)
                 # Recurse into for-each, let, do, if, etc.
+            if is_form(expr, 'let') and len(expr) >= 3 and isinstance(expr[1], SList):
+                # An initializer is evaluated before its own binding exists, and
+                # before any binding after it - so each is walked with only what
+                # came before, and the whole scope applies to the body alone.
+                inner = list(enclosing)
+                for binding in expr[1].items:
+                    if not (isinstance(binding, SList) and len(binding) >= 2):
+                        continue
+                    for item in binding.items[1:]:
+                        self._collect_loop_invariants(item, result, inner)
+                    name = self._binding_name(binding)
+                    if name:
+                        inner.append((binding, name))
+                for item in expr.items[2:]:
+                    self._collect_loop_invariants(item, result, inner)
+                return
             # Recurse into subexpressions
             for item in expr.items:
-                self._collect_loop_invariants(item, result)
+                self._collect_loop_invariants(item, result, enclosing)
 
     def _analyze_loops(self, body: SExpr) -> List[LoopContext]:
         """Analyze function body to extract information about all for-each loops.

--- a/src/slop/verifier/translator.py
+++ b/src/slop/verifier/translator.py
@@ -65,6 +65,20 @@ class Z3Translator:
         # Post-loop versions of the names a loop assigns, keyed by (loop, name),
         # so re-translating the same loop reuses them.
         self._loop_versions: Dict[Tuple[int, str], z3.ExprRef] = {}
+        # One constant per shadowing `let` binding, keyed by the binding node so
+        # a phase re-translating the same tree gets the same one back (#118).
+        self._let_versions: Dict[Tuple[int, str], z3.ExprRef] = {}
+        # What each shadowing binding's name held where its scope ended - after
+        # any `set!` inside it. The initial constant above is what the binding
+        # was *given*; this is what code further down the scope reads.
+        self._let_final: Dict[Tuple[int, str], z3.ExprRef] = {}
+        # Bindings something assigned inside their own scope. The name then has
+        # more than one value there, and a pass with no program points cannot
+        # say which one a given call saw.
+        self._let_assigned: Set[Tuple[int, str]] = set()
+        # Bindings that shadow one already in scope. Only these have a constant
+        # of their own, and only these need their scope replayed.
+        self._let_shadowing: Set[Tuple[int, str]] = set()
         self._loop_version_counter = 0
         self._pre_loop_variables: Dict[str, z3.ExprRef] = {}
         self.versioned_loops: Set[int] = set()
@@ -1882,6 +1896,12 @@ class Z3Translator:
         if not isinstance(bindings, SList):
             return None
 
+        # What each shadowing binding covers up, to be put back when the body
+        # ends. A binding that shadows nothing is left in place: the phases that
+        # run after the body re-translate expressions from inside it and read
+        # its locals out of `variables`.
+        shadowed: List[Tuple[str, Any, Any, Any]] = []
+
         # Process bindings - declare each variable
         for binding in bindings.items:
             if isinstance(binding, SList) and len(binding) >= 2:
@@ -1910,24 +1930,66 @@ class Z3Translator:
                     # any assignment both belong to that other binding. Keeping
                     # them re-states an outer parameter's bounds on this local,
                     # which can make the context contradictory (#118).
+                    key = (id(binding), var_name)
+                    outer = self.variables.get(var_name)
+                    # `outer is not None` alone would call this binding a
+                    # shadowing one on a *re-translation*: a binding that shadows
+                    # nothing is deliberately left in `variables` when its scope
+                    # ends, so the second walk over the same tree finds it there.
+                    # It is only shadowing if what is there belongs to someone
+                    # else.
+                    shadowing = outer is not None and outer is not self._let_versions.get(key)
+                    if shadowing and self._assigns_name(init_value, var_name):
+                        # The initializer assigns the very name it is about to
+                        # shadow. Whatever that did to the outer binding happens
+                        # before this one exists, and separating the two needs a
+                        # program point this has no way to place - so the name
+                        # keeps one constant, as it did before, rather than the
+                        # rename quietly losing the assignment.
+                        shadowing = False
+                    if shadowing:
+                        self._let_shadowing.add(key)
+                        shadowed.append((var_name, outer,
+                                         self._declared_types.get(var_name),
+                                         self._pre_loop_variables.get(var_name),
+                                         key))
                     self._declared_types.pop(var_name, None)
                     self._pre_loop_variables.pop(var_name, None)
-                    # Translate initial value
+                    # Translate initial value, while the name still means
+                    # whatever it meant outside: `(let ((x (+ x 1))) ...)` reads
+                    # the outer x.
                     init_z3 = self.translate_expr(init_value)
+                    # A binding that shadows one already in scope needs a
+                    # constant of its own. Sharing `z3.Int(name)` with the outer
+                    # binding makes this initializer a claim about *that* value -
+                    # so `(let ((x 1)) x)` in a function taking a parameter x
+                    # asserted the parameter is 1, and any contract saying so
+                    # verified (#118). Keyed by the binding node, so a phase
+                    # re-translating the same tree gets the same constant.
+                    fresh = shadowing
                     if init_z3 is not None:
                         # Declare variable with same sort as initial value
                         if z3.is_bool(init_z3):
-                            var = z3.Bool(var_name)
+                            var = (self._shadow_constant(key, var_name, z3.BoolSort())
+                                   if fresh else z3.Bool(var_name))
                         elif z3.is_real(init_z3):
-                            var = z3.Real(var_name)
+                            var = (self._shadow_constant(key, var_name, z3.RealSort())
+                                   if fresh else z3.Real(var_name))
                         else:
-                            var = z3.Int(var_name)
+                            var = (self._shadow_constant(key, var_name, z3.IntSort())
+                                   if fresh else z3.Int(var_name))
                         self.variables[var_name] = var
                         # Add constraint that variable equals initial value
                         self.constraints.append(var == init_z3)
                     else:
                         # Can't translate init value - just declare as Int
-                        self.variables[var_name] = z3.Int(var_name)
+                        self.variables[var_name] = (
+                            self._shadow_constant(key, var_name, z3.IntSort())
+                            if fresh else z3.Int(var_name))
+                    # Recorded whether or not it is shadowing, so a second walk
+                    # over the same tree can tell that this variable is this
+                    # binding's own.
+                    self._let_versions[key] = self.variables[var_name]
 
         # Translate body expressions - value is the last one
         body_exprs = expr.items[2:]
@@ -1938,7 +2000,188 @@ class Z3Translator:
         for body_expr in body_exprs:
             result = self.translate_expr(body_expr)
 
+        # The names this scope covered up mean what they meant again - and only
+        # that. An assignment or a loop inside the scope may have given the
+        # *local* a pre-loop entry or a declared type of its own; leaving those
+        # behind would have `initial_versions()` read the local's starting value
+        # for code that runs after the scope.
+        for var_name, outer, declared, pre_loop, key in reversed(shadowed):
+            current = self.variables.get(var_name)
+            if current is not None:
+                self._let_final[key] = current
+                if current is not self._let_versions.get(key):
+                    self._let_assigned.add(key)
+            self.variables[var_name] = outer
+            if declared is None:
+                self._declared_types.pop(var_name, None)
+            else:
+                self._declared_types[var_name] = declared
+            if pre_loop is None:
+                self._pre_loop_variables.pop(var_name, None)
+            else:
+                self._pre_loop_variables[var_name] = pre_loop
+
         return result
+
+    @contextmanager
+    def binding_in_scope(self, binding, name: str, final: bool = False,
+                         after_assignment: bool = False):
+        """Read `name` as this binding meant it, for the length of the block.
+
+        For a pass that re-derives what a binding was given long after its scope
+        ended - `variables` holds whichever binding of the name is in scope where
+        that pass happens to be looking, which for a shadowing binding is the one
+        it shadowed (#118).
+
+        `final` picks the value the name held where the scope *ended*, after any
+        `set!` inside it, rather than what the binding was initialised to. A pass
+        deriving what the binding was given wants the other.
+
+        `after_assignment` says the reader is past a `set!` to this name. The
+        binding then has more than one value and this pass has no program points
+        fine enough to say which, so the name is marked versioned and the guards
+        that already refuse a name in that state take over (#116's machinery).
+        """
+        key = (id(binding), name)
+        if final:
+            # Only a shadowing binding records one, and only that case needs
+            # moving: for anything else `variables` already holds the right
+            # version - the one a loop or an assignment left behind, which is
+            # exactly what a pass over the whole scope should read.
+            own = self._let_final.get(key)
+        else:
+            own = self._let_versions.get(key)
+        if own is None:
+            yield
+            return
+        had = name in self.variables
+        outer = self.variables.get(name)
+        # If something assigned this binding inside its own scope, the name has
+        # more than one value there and nothing here can say which one a given
+        # expression saw. Marking it versioned puts it behind the guards that
+        # already refuse a name in that state - the same ones a loop's
+        # reassignment goes behind (#116).
+        assigned = after_assignment and key in self._let_assigned
+        had_pre_loop = name in self._pre_loop_variables
+        outer_pre_loop = self._pre_loop_variables.get(name)
+        self.variables[name] = own
+        # The outer binding's version marker goes with it. Leaving it would have
+        # the frozen-version check refuse a perfectly ordinary reference to the
+        # *inner* binding, which nothing assigned.
+        # Only a shadowing binding has a scope to replay, and only for one is
+        # the outer binding's version marker about a different value. For any
+        # other binding the marker is its own and must stay.
+        shadowing = key in self._let_shadowing
+        touched_marker = shadowing
+        if shadowing:
+            if assigned:
+                self._pre_loop_variables[name] = self._let_versions.get(key, own)
+            else:
+                # Nothing assigned this binding, so the name has one value here
+                # and the outer binding's marker does not describe it. Leaving
+                # it would have the frozen-version check refuse a perfectly
+                # ordinary reference to the inner binding.
+                self._pre_loop_variables.pop(name, None)
+        try:
+            yield
+        finally:
+            if had:
+                self.variables[name] = outer
+            else:
+                self.variables.pop(name, None)
+            # Only if entering touched it; otherwise something inside the
+            # block owns whatever is there now.
+            if touched_marker:
+                if had_pre_loop:
+                    self._pre_loop_variables[name] = outer_pre_loop
+                else:
+                    self._pre_loop_variables.pop(name, None)
+
+    def binding_constant(self, binding, name: str):
+        """The constant a particular `let` binding of `name` was given.
+
+        A binding that shadows one already in scope has a constant of its own,
+        so a phase re-deriving what it was initialised to has to attach that to
+        the right one - `variables` holds whichever binding of the name is in
+        scope where the phase happens to be looking (#118).
+        """
+        own = self._let_versions.get((id(binding), name))
+        if own is not None:
+            return own
+        return self.initial_variable(name)
+
+    def _assigns_name(self, expr, name: str) -> bool:
+        """Whether anything under `expr` assigns the `name` bound *here*.
+
+        A nested binding of the same name is a different variable, so an
+        assignment under it is not to this one - and treating it as one would
+        give up the rename for a binding that never touches the outer value.
+        """
+        if not isinstance(expr, SList) or not expr.items:
+            return False
+        head = expr[0]
+        if isinstance(head, Symbol):
+            if head.name in ('fn', 'quote'):
+                # A callback's assignments are its own; a quoted form is data.
+                return False
+            if head.name == 'set!' and len(expr) >= 3:
+                target = expr[1]
+                if isinstance(target, Symbol) and target.name == name:
+                    return True
+                return self._assigns_name(expr[2], name)
+            if head.name in ('let', 'let*') and len(expr) >= 3 and isinstance(expr[1], SList):
+                rebinds = False
+                for binding in expr[1].items:
+                    if not (isinstance(binding, SList) and len(binding) >= 2):
+                        continue
+                    # Only until the name is rebound: after that an assignment
+                    # in a later initializer targets the new binding.
+                    if not rebinds:
+                        for item in binding.items[1:]:
+                            if self._assigns_name(item, name):
+                                return True
+                    if self._bound_name(binding) == name:
+                        rebinds = True
+                if rebinds:
+                    return False
+                return any(self._assigns_name(item, name) for item in expr.items[2:])
+            if (head.name == 'for-each' and len(expr) >= 2
+                    and isinstance(expr[1], SList) and expr[1].items
+                    and isinstance(expr[1][0], Symbol)
+                    and expr[1][0].name == name):
+                return False
+        return any(self._assigns_name(item, name) for item in expr.items)
+
+    @staticmethod
+    def _bound_name(binding) -> Optional[str]:
+        """The name a `let` binding introduces, across the three spellings."""
+        head = binding[0]
+        if isinstance(head, Symbol):
+            target = binding[1] if head.name == 'mut' and len(binding) >= 3 else head
+        elif isinstance(head, SList) and len(head) >= 2:
+            if not (isinstance(head[0], Symbol) and head[0].name == 'mut'):
+                return None
+            target = head[1]
+        else:
+            return None
+        return target.name if isinstance(target, Symbol) else None
+
+    def _shadow_constant(self, key, name: str, sort) -> z3.ExprRef:
+        """A constant of this binding's own, stable across re-translations."""
+        existing = self._let_versions.get(key)
+        if existing is not None and existing.sort() == sort:
+            return existing
+        # Fresh rather than a name of our own construction: `x_shadow_1` is a
+        # legal SLOP identifier, and colliding with a binding of that name would
+        # tie the two together - the very thing this is here to prevent.
+        if sort == z3.BoolSort():
+            fresh = z3.FreshBool(f"{name}_shadowed")
+        elif sort == z3.RealSort():
+            fresh = z3.FreshReal(f"{name}_shadowed")
+        else:
+            fresh = z3.FreshInt(f"{name}_shadowed")
+        self._let_versions[key] = fresh
+        return fresh
 
     def _translate_loop(self, expr: SList) -> Optional[z3.ExprRef]:
         """Give the variables a loop assigns a value of their own after it.

--- a/src/slop/verifier/wp.py
+++ b/src/slop/verifier/wp.py
@@ -6,6 +6,7 @@ backward reasoning for verification.
 """
 from __future__ import annotations
 
+from contextlib import ExitStack
 from typing import Optional, TYPE_CHECKING
 
 from slop.parser import SList, Symbol, Number, String, is_form
@@ -111,10 +112,22 @@ class WeakestPrecondition:
         if not body_exprs:
             return Q
 
-        # First compute WP of body (process body as a sequence)
+        # First compute WP of body (process body as a sequence), with the
+        # bindings in scope. A `set!` inside substitutes the name it assigns,
+        # and for a binding that shadows a parameter that name means the *local*
+        # - a contract cannot name a local, so the occurrence in Q is the
+        # parameter and nothing inside the scope may rewrite it (#118).
         inner_wp = Q
-        for body_item in reversed(body_exprs):
-            inner_wp = self.wp(body_item, inner_wp)
+        with ExitStack() as scope:
+            for binding in bindings.items:
+                if not (isinstance(binding, SList) and len(binding) >= 2):
+                    continue
+                name = self._binding_name(binding)
+                if name:
+                    scope.enter_context(
+                        self.translator.binding_in_scope(binding, name, final=True))
+            for body_item in reversed(body_exprs):
+                inner_wp = self.wp(body_item, inner_wp)
 
         # Then substitute each binding (in reverse order for nested let)
         for binding in reversed(bindings.items):
@@ -140,7 +153,7 @@ class WeakestPrecondition:
 
                 if var_name and init_expr is not None:
                     inner_wp = self._substitute_var_with_expr(
-                        inner_wp, var_name, init_expr
+                        inner_wp, var_name, init_expr, binding
                     )
 
         return inner_wp
@@ -411,12 +424,36 @@ class WeakestPrecondition:
             return pattern.name == '_'
         return False
 
+    @staticmethod
+    def _binding_name(binding: 'SList') -> Optional[str]:
+        """The name a `let` binding introduces, across the three spellings."""
+        head = binding[0]
+        if isinstance(head, Symbol):
+            if head.name == 'mut' and len(binding) >= 3:
+                target = binding[1]
+            else:
+                target = head
+        elif isinstance(head, SList) and len(head) >= 2:
+            if not (isinstance(head[0], Symbol) and head[0].name == 'mut'):
+                return None
+            target = head[1]
+        else:
+            return None
+        return target.name if isinstance(target, Symbol) else None
+
     def _substitute_var_with_expr(
-        self, formula: 'z3.BoolRef', var_name: str, expr: 'SExpr'
+        self, formula: 'z3.BoolRef', var_name: str, expr: 'SExpr',
+        binding: 'Optional[SExpr]' = None
     ) -> 'z3.BoolRef':
         """Substitute a variable with an expression in a Z3 formula.
 
         This is the core of WP: Q[x/e] replaces all occurrences of x with e.
+
+        `binding` is the `let` binding the substitution comes from, when there
+        is one. A binding that shadows a parameter has a constant of its own,
+        and the `x` in a postcondition is the parameter - a contract cannot name
+        a local. Substituting the local's value there would rewrite a claim
+        about the parameter into one about the local (#118).
         """
         self._substitution_depth += 1
         if self._substitution_depth > self._max_substitution_depth:
@@ -425,7 +462,10 @@ class WeakestPrecondition:
 
         try:
             # Get the Z3 variable to replace
-            old_var = self.translator.variables.get(var_name)
+            if binding is not None:
+                old_var = self.translator.binding_constant(binding, var_name)
+            else:
+                old_var = self.translator.variables.get(var_name)
             if old_var is None:
                 return formula
 

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -10586,3 +10586,439 @@ class TestPropertyAboutResult:
     (@spec ((Bool) -> Int))
     (@property p (>= $result 3))
     (do (when flag (return 3)) 7))''') == 'verified'
+
+
+class TestShadowedBindings:
+    """Issue #118: a binding that shadows one already in scope.
+
+    Every binding of a name shared one Z3 constant, so an inner `let`'s
+    initializer was a claim about the outer binding - or about a parameter. The
+    issue called itself latent; a shadowed *parameter* reaches it in three lines,
+    and `(@post (== x 1))` verified for an unconstrained `x`.
+
+    Two halves, and both were needed: the constant itself, and the weakest
+    precondition, which substitutes a binding's value into the postcondition and
+    was rewriting a claim about the parameter into one about the local.
+    """
+
+    @staticmethod
+    def _status(body, prelude=""):
+        from slop.verifier import verify_source
+        results = verify_source("(module m\n%s%s)\n" % (prelude, body),
+                                filename="probe.slop")
+        assert len(results) == 1
+        return results[0].status
+
+    def test_a_local_shadowing_a_parameter_says_nothing_about_it(self):
+        assert self._status('''
+  (fn f ((x Int))
+    (@spec ((Int) -> Int))
+    (@post (== x 1))
+    (let ((x 1)) x))''') != 'verified'
+
+    def test_the_result_is_still_the_locals_value(self):
+        assert self._status('''
+  (fn g ((x Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result 1))
+    (let ((x 1)) x))''') == 'verified'
+
+    def test_an_inner_binding_shadows_the_outer(self):
+        assert self._status('''
+  (fn h ((n Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result 2))
+    (let ((y n)) (let ((y 2)) y)))''') == 'verified'
+        assert self._status('''
+  (fn k ((n Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result n))
+    (let ((y n)) (let ((y 2)) y)))''') != 'verified'
+
+    def test_the_outer_binding_comes_back_after_the_inner_scope(self):
+        """A shadowing binding is put away when its body ends. One that shadows
+        nothing stays: the phases that run after the body re-translate
+        expressions from inside it and read the locals out of `variables`."""
+        assert self._status('''
+  (fn p ((n Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result n))
+    (let ((y n))
+      (do (let ((y 2)) y) y)))''') == 'verified'
+        assert self._status('''
+  (fn q ((n Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result 2))
+    (let ((y n))
+      (do (let ((y 2)) y) y)))''') != 'verified'
+
+    def test_an_unshadowed_binding_still_reaches_the_postcondition(self):
+        """The renaming is for shadowing bindings only, so the ordinary case is
+        unchanged - including the weakest precondition's substitution."""
+        assert self._status('''
+  (fn r ((n Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result (+ n 1)))
+    (let ((y (+ n 1))) y))''') == 'verified'
+
+    def test_an_initializer_reads_the_name_it_shadows(self):
+        """`(let ((x (+ x 1))) ...)` is the outer x plus one - the new binding is
+        not in scope in its own initializer."""
+        assert self._status('''
+  (fn s ((x Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result (+ x 1)))
+    (let ((x (+ x 1))) x))''') == 'verified'
+
+    def test_a_callee_postcondition_lands_on_the_shadowing_binding(self):
+        """`(let ((x (one))) x)` gets `one`'s promise. The pass that propagates
+        it substitutes $result with the bound *name*, and by then the scope has
+        ended and the name means the parameter again."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn one ()
+    (@spec (() -> Int))
+    (@post (== $result 1))
+    1)
+  (fn f ((x Int))
+    (@spec ((Int) -> Int))
+    (@post %s)
+    (let ((x (one))) x)))
+'''
+        def status(claim):
+            return [r for r in verify_source(src % claim, filename="probe.slop")
+                    if r.name == 'f'][0].status
+        assert status('(== $result 1)') == 'verified'
+        assert status('(== $result 2)') != 'verified'
+        # ...and it says nothing about the parameter it shadows.
+        assert status('(== x 1)') != 'verified'
+
+    def test_a_loop_inside_a_shadowing_scope_keeps_its_invariant(self):
+        """The scope is put away when its body ends, which is before the phases
+        that translate an extracted @loop-invariant run."""
+        assert self._status('''
+  (fn g ((x Int) (n Int))
+    (@spec ((Int Int) -> Int))
+    (@post (>= $result 0))
+    (do
+      (let ((mut x 0)
+            (mut i 0))
+        (while (< i n)
+          (@loop-invariant (>= x 0))
+          (do (set! x (+ x 1)) (set! i (+ i 1))))
+        x)
+      0))''') == 'verified'
+
+    def test_an_assignment_inside_a_shadowing_scope_stays_there(self):
+        """`(set! x ...)` on a shadowing local changes the local. Both the
+        postcondition propagation and the weakest precondition resolve the
+        target by name, and by then the name means the parameter again."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn one ()
+    (@spec (() -> Int))
+    (@post (== $result 1))
+    1)
+  (fn f ((x Int))
+    (@spec ((Int) -> Int))
+    (@post %s)
+    (let ((mut x 0)) (set! x (one)) x)))
+'''
+        def status(claim):
+            return [r for r in verify_source(src % claim, filename="probe.slop")
+                    if r.name == 'f'][0].status
+        assert status('(== $result 1)') == 'verified'
+        assert status('(== x 1)') != 'verified'
+
+    def test_an_assignment_to_an_unshadowed_local_still_reaches_the_result(self):
+        assert self._status('''
+  (fn h ((n Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result 5))
+    (let ((mut y 0)) (set! y 5) y))''') == 'verified'
+
+    def test_a_call_argument_naming_an_enclosing_local(self):
+        """The propagation walk happens after the body was translated, so it has
+        to put the enclosing scope back to read the argument."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn inc ((a Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result (+ a 1)))
+    (+ a 1))
+  (fn k ((y Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result 3))
+    (let ((y 2)) (let ((x (inc y))) x))))
+'''
+        assert [r for r in verify_source(src, filename="probe.slop")
+                if r.name == 'k'][0].status == 'verified'
+
+    def test_a_later_binding_sees_an_earlier_one(self):
+        """`(let ((x 1) (y (inc x))) y)` - the second initializer reads the
+        first binding, not the parameter it shadows."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn inc ((a Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result (+ a 1)))
+    (+ a 1))
+  (fn f ((x Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result 2))
+    (let ((x 1) (y (inc x))) y)))
+'''
+        assert [r for r in verify_source(src, filename="probe.slop")
+                if r.name == 'f'][0].status == 'verified'
+
+    def test_an_invariant_about_a_shadowing_local_survives_its_scope(self):
+        """The invariant is extracted from inside the scope and translated long
+        after it ended, so where it came from travels with it."""
+        assert self._status('''
+  (fn g ((x Int) (n Int))
+    (@spec ((Int Int) -> Int))
+    (@post (>= $result 0))
+    (let ((mut x 0) (mut i 0))
+      (while (< i n)
+        (@loop-invariant (>= x 0))
+        (do (set! x 0) (set! i (+ i 1))))
+      x))''') == 'verified'
+
+    def test_a_call_reads_the_value_in_scope_where_it_runs(self):
+        """`(let ((y (inc x))) (set! x 5) y)` calls with x = 1, not 5. There are
+        no program points here, so the walk replays each binding's *initial*
+        value - the one that cannot be wrong in that direction - and only a
+        `set!` target takes the end-of-scope one."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn inc ((a Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result (+ a 1)))
+    (+ a 1))
+  (fn f ((x Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result %s))
+    (let ((mut x 1)) (let ((y (inc x))) (set! x 5) y))))
+'''
+        def status(claim):
+            return [r for r in verify_source(src % claim, filename="probe.slop")
+                    if r.name == 'f'][0].status
+        assert status('2') == 'verified'
+        assert status('6') != 'verified'
+
+    def test_a_call_after_an_assignment_does_not_read_the_earlier_value(self):
+        """The mirror of the case above. Ordering within a statement sequence is
+        the only program point this pass has; before a `set!` the binding still
+        holds what it was given, after one it holds something this pass cannot
+        pin down, and the guards that already refuse such a name take over."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn relay ((a Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result a))
+    a)
+  (fn f ((x Int) (z Int))
+    (@spec ((Int Int) -> Int))
+    (@post (== $result z))
+    (let ((mut x z)) (set! x 5) (relay x))))
+'''
+        assert [r for r in verify_source(src, filename="probe.slop")
+                if r.name == 'f'][0].status != 'verified'
+
+    def test_an_argument_is_read_outside_the_binding_it_initialises(self):
+        """`(let ((x (relay x))) x)` - the argument is the outer x. Reading both
+        it and $result as the new binding made the axiom a tautology."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn relay ((a Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result a))
+    a)
+  (fn f ((x Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result x))
+    (let ((x (relay x))) x)))
+'''
+        assert [r for r in verify_source(src, filename="probe.slop")
+                if r.name == 'f'][0].status == 'verified'
+
+    def test_a_when_body_is_a_sequence_like_any_other(self):
+        """Every multi-form body tracks its own assignments, not just `do`."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn relay ((a Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result a))
+    a)
+  (fn f ((z Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result z))
+    (let ((mut x z) (mut y 0))
+      (when true (set! x 5) (set! y (relay x)))
+      y)))
+'''
+        assert [r for r in verify_source(src, filename="probe.slop")
+                if r.name == 'f'][0].status != 'verified'
+
+    def test_a_builtins_arguments_are_read_outside_the_binding(self):
+        """`(let ((x (make-triple arena s x o))) ...)` passes the outer x."""
+        assert self._status('''
+  (fn mk ((arena Arena) (s Int) (x Int) (o Int))
+    (@spec ((Arena Int Int Int) -> Triple))
+    (@alloc arena)
+    (@post (== (. $result predicate) x))
+    (let ((x (make-triple arena s x o))) x))''',
+            prelude="  (type Triple (record (subject Int) (predicate Int) (object Int)))\n") == 'verified'
+
+    def test_a_string_operand_is_read_in_its_own_scope(self):
+        """The string axioms are generated after the body was translated, so an
+        operand naming a shadowing local needs the scope back."""
+        assert self._status('''
+  (fn f ((arena Arena) (x String))
+    (@spec ((Arena String) -> String))
+    (@alloc arena)
+    (@post (starts-with $result "?"))
+    (let ((x "?")) (string-concat arena x "tail")))''') == 'verified'
+
+    def test_an_initializer_that_assigns_the_name_it_shadows(self):
+        """`(let ((x (do (set! x 1) 1))) ...)` changes the outer binding on its
+        way past. Separating the two needs a program point this has no way to
+        place, so the name keeps one constant rather than the rename quietly
+        losing the assignment."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn f ((mut x Int))
+    (@spec ((Int) -> Int))
+    (@pre (== x 5))
+    (@post (== x 5))
+    (let ((x (do (set! x 1) 1))) 0)))
+'''
+        assert verify_source(src, filename="probe.slop")[0].status != 'verified'
+
+    def test_shadowing_a_name_an_assignment_versioned(self):
+        """The outer binding's version marker is about the outer value. Leaving
+        it in place while the inner binding is current has the frozen-version
+        check refuse an ordinary reference to the inner one."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn relay ((a Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result a))
+    a)
+  (fn g ((mut x Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result 0))
+    (do (set! x 9) (let ((x 0)) (relay x)))))
+'''
+        assert [r for r in verify_source(src, filename="probe.slop")
+                if r.name == 'g'][0].status == 'verified'
+
+    def test_a_nested_rebinding_is_not_an_assignment_to_the_outer(self):
+        """The scan for "does this initializer assign the name it shadows" has
+        to respect scopes, or a nested `let` of the same name gives up the
+        rename for a binding that never touches the outer value."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn f ((x Int))
+    (@spec ((Int) -> Int))
+    (@post (== x 1))
+    (let ((x (let ((mut x 0)) (set! x 1) 1))) 0)))
+'''
+        assert verify_source(src, filename="probe.slop")[0].status != 'verified'
+
+    def test_a_mutation_between_initializers_is_seen(self):
+        """Sequential initializers are a statement sequence too: the second is
+        read past whatever the first assigned."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn relay ((a Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result a))
+    a)
+  (fn g ((q Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result 0))
+    (let ((mut x 0))
+      (let ((a (do (set! x 5) 0))
+            (y (relay x)))
+        y))))
+'''
+        assert [r for r in verify_source(src, filename="probe.slop")
+                if r.name == 'g'][0].status != 'verified'
+
+    def test_a_nested_scope_inherits_what_was_already_assigned(self):
+        """Entering a `let` does not undo a `set!` that happened before it."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn relay ((a Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result a))
+    a)
+  (fn f ((x Int) (z Int))
+    (@spec ((Int Int) -> Int))
+    (@post (== $result z))
+    (let ((mut x z)) (set! x 5) (let ((y (relay x))) y))))
+'''
+        assert [r for r in verify_source(src, filename="probe.slop")
+                if r.name == 'f'][0].status != 'verified'
+
+    def test_a_rebinding_earlier_in_the_same_list_takes_the_assignment(self):
+        """`(let ((mut x 0) (a (do (set! x 1) 0))) ...)` assigns the new x, not
+        the one being shadowed."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn g ((x Int))
+    (@spec ((Int) -> Int))
+    (@post (== x 1))
+    (let ((x (let ((mut x 0) (a (do (set! x 1) 0))) 1))) 0)))
+'''
+        assert verify_source(src, filename="probe.slop")[0].status != 'verified'
+
+    def test_every_nested_statement_form_inherits_it(self):
+        """`do`, `when`, `if` and `for-each` bodies too, not just a nested
+        `let`."""
+        from slop.verifier import verify_source
+        src = '''
+(module m
+  (fn relay ((a Int))
+    (@spec ((Int) -> Int))
+    (@post (== $result a))
+    a)
+  (fn f ((x Int) (z Int))
+    (@spec ((Int Int) -> Int))
+    (@post (== $result z))
+    (let ((mut x z)) (set! x 5) (do (let ((y (relay x))) y)))))
+'''
+        assert [r for r in verify_source(src, filename="probe.slop")
+                if r.name == 'f'][0].status != 'verified'
+
+    def test_issue_118_verbatim(self):
+        from slop.verifier import verify_source
+        src = '''
+(module probe
+  (type Item (record (v Int)))
+  (type F (record (flag Bool) (xs (List Item))))
+
+  (fn shadow ((arena Arena) (zs (List Item)))
+    (@spec ((Arena (List Item)) -> F))
+    (@alloc arena)
+    (@post {(list-len zs) == 0})
+    (let ((x zs))
+      (let ((x (list-new arena Item)))
+        (record-new F (flag true) (xs x))))))
+'''
+        assert verify_source(src, filename="probe.slop")[0].status != 'verified'


### PR DESCRIPTION
Closes #118.

## The bug, and it was not latent

Every binding of a name got `z3.Int(name)`, so an inner `let` shared its constant
with the binding it shadows — or with a parameter. The initializer then said
something about *that* value:

```lisp
(fn f ((x Int))
  (@spec ((Int) -> Int))
  (@post (== x 1))
  (let ((x 1)) x))
```

verified, for an unconstrained `x`. The issue's Status section says this is "not
currently reachable through a released path", because #70's binding resolution
refuses to follow a name bound more than once. A shadowed **parameter** reaches
it in three lines, and reproduces on the released 0.2.1.

## The constant

A binding that shadows one already in scope takes a fresh constant, keyed by the
binding node so a phase re-translating the same tree gets the same one back. A
binding that shadows nothing keeps the plain name: the phases that run after the
body re-translate expressions from inside it and read its locals out of
`variables`, so those have to stay there. The shadowing ones are put away when
their scope ends, and what they covered up — the constant, the declared type, the
pre-loop version — comes back.

Four subtleties, all found by review:

- **Re-translation.** `outer is not None` alone calls a binding shadowing on the
  *second* walk over the same tree, because a non-shadowing binding is
  deliberately left in `variables`. It is only shadowing if what is there belongs
  to someone else.
- **Assignment inside the scope.** Then the name has more than one value there.
  Past the assignment it is marked versioned, and the guards that already refuse a
  name in that state — #116's machinery — take over.
- **An initializer that assigns the name it shadows.** `(let ((x (do (set! x 1)
  1))) …)` changes the outer binding on its way past, and separating the two needs
  a program point this has no way to place. That binding is left un-renamed, so
  the name keeps one constant as before rather than the rename quietly losing the
  assignment.
- **The outer binding's version marker.** It describes the outer value, so it
  goes away while the inner binding is current — otherwise the frozen-version
  check refuses an ordinary reference to the inner one. Only for a shadowing
  binding: for any other the marker is its own and has to stay.

## Five delayed passes had to learn where they were looking

The constant alone fixes nothing on its own: every pass that re-derives a fact
from the body runs long after the body was translated, when `variables` holds
whatever was in scope at the *end*.

| pass | was |
|---|---|
| `_add_binding_axiom` | asserted `initial_variable(name) == initializer`, which after the restore is the outer binding |
| callee postconditions | substituted `$result` with the bound *name*, read wherever the translation happened |
| `_collect_call_postconditions` | walked the body with no scope at all |
| `_extract_loop_invariants` | an invariant about a shadowing local was translated against what it shadowed |
| `_generate_string_operation_axioms` | same, for a `string-concat` operand |
| the weakest precondition | `Q[x := e]` rewrote a claim about the **parameter** into one about the local — a contract cannot name a local, so the `x` in `Q` is the parameter |

The WP one is why the renaming alone left `(@post (== x 1))` verifying.

Two of these needed more than a scope: `$result` is now **bound** to the
binding's constant rather than substituted by name, so a call's arguments stay in
the outer scope — `(let ((x (relay x))) x)` passes the outer `x`, and binding
both made the axiom the tautology `x_local == x_local`. The same for a builtin's
arguments.

## Ordering is the only program point there is

`_collect_call_postconditions` replays the enclosing scopes **in statement
order**. A call before a `set!` to the same name reads what the binding was
given; one after it reads a value this pass cannot pin down, so the name goes
behind the guards that already refuse such a name. Both directions came out of
review as false verdicts — reading the later value backwards, and then refusing a
case `origin/main` gets right — and ordering separates them.

Getting that right took four rounds of widening, each a place the state was being
dropped: every multi-form body rather than just `do`; the binding list itself,
since a later initializer runs after an earlier one's `set!`; nested `let`s; and
then `do`, `when`, `if` and `for-each` bodies, which were starting a fresh walk.
The scan for "does this initializer assign the name it shadows" needed the same
treatment in the other direction — it has to respect lexical scope, or a nested
`let` of the same name gives up the rename for a binding that never touches the
outer value.

## Left alone

The guards in `_tail_bindings` and `_count_bindings_of` that refuse a name bound
more than once. The shared constant was only half their reason: `_tail_bindings`
maps a *name* to one initializer, so it still cannot hold two, and
`_count_bindings_of` is about whether two pushes reach the same list rather than
about Z3 identity.

## Result

| | before | after |
|---|---|---|
| `uv run pytest` | 764 passed | **791 passed** |
| howl `slop verify` | 31 verified, 0 failed | 31 verified, 0 failed |
| snarl `slop verify` | 57 verified, 22 failed | 57 verified, 22 failed |

## Review

Twelve `codex exec review` rounds; the last one clean. Every round but the last
found something real — three soundness holes I had introduced (the mutating
initializer, reading a later assignment backwards, the assignment state dropped
at each kind of nested scope) and a run of precision regressions where a delayed
pass was reading a name in the wrong scope. Each is now a test, positive or
negative.

## Tests

`TestShadowedBindings`, 27 cases, each positive paired with its negative: the
result is still the local's value, the outer binding comes back after the inner
scope, an initializer reads the name it shadows, a later binding sees an earlier
one, a call reads the value in scope where it runs and not the one assigned after
it, an invariant about a shadowing local survives its scope, a `string-concat`
operand is read in its own.
